### PR TITLE
chore: add build checks and doc headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+# /**
+#  * Purpose: Run ProjectAtlas linting, tests, and build checks.
+#  */
+
 on:
   push:
     branches: [main]
@@ -27,3 +31,8 @@ jobs:
 
       - name: Unit tests
         run: python -m unittest discover -s tests
+
+      - name: Build package
+        run: |
+          python -m pip install build
+          python -m build --sdist --wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+# /**
+#  * Purpose: Tag and validate ProjectAtlas releases.
+#  */
+
 on:
   workflow_dispatch:
     inputs:
@@ -32,6 +36,11 @@ jobs:
 
       - name: Verify version
         run: python scripts/verify_version.py "${{ inputs.version }}"
+
+      - name: Build package
+        run: |
+          python -m pip install build
+          python -m build --sdist --wheel
 
       - name: Create tag
         run: |

--- a/.projectatlas/config.toml
+++ b/.projectatlas/config.toml
@@ -1,4 +1,7 @@
 [project]
+# /**
+#  * Purpose: ProjectAtlas configuration defaults.
+#  */
 root = "."
 map_path = ".projectatlas/projectatlas.toon"
 manual_files_path = ".projectatlas/projectatlas-manual-files.toon"

--- a/.projectatlas/projectatlas-manual-files.toon
+++ b/.projectatlas/projectatlas-manual-files.toon
@@ -1,4 +1,7 @@
 manual_files[]:
+  # /**
+  #  * Purpose: Manual file summaries for non-source files.
+  #  */
   # path,summary
   README.md,ProjectAtlas overview and usage guide
   LICENSE,ProjectAtlas MIT license

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-01-01T15:16:39Z
+generated_at: 2026-01-01T15:34:23Z
 file_hash: "9dfbc82f0d3fd9e0ea9f431c483519de3780f71f691cbc1a16c8713ce4252b29"
 folder_hash: "001959defd4312e2fdf710531dbe5007e1d10467919d12b3662e92259777fbf2"
 root: .

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ projectatlas map
 projectatlas lint --strict-folders --report-untracked
 ```
 
+Run tests and build artifacts locally:
+
+```bash
+python -m unittest discover -s tests
+python -m pip install build
+python -m build --sdist --wheel
+```
+
 Default outputs:
 
 - `.projectatlas/config.toml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 description = "Agent-first project map + health index — one-line purpose for every file and folder."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "ProjectAtlas Contributors" }]
 dependencies = []
 


### PR DESCRIPTION
Adds build verification to CI/release, updates license metadata, and annotates workflow/config headers.