### PR TITLE
docs: align ProjectAtlas skills with codebase-map workflow

### DIFF
--- a/.projectatlas/projectatlas-manual-files.toon
+++ b/.projectatlas/projectatlas-manual-files.toon
@@ -11,3 +11,11 @@ manual_files[]:
   SECURITY.md,Security contact information for ProjectAtlas
   .github/workflows/ci.yml,ProjectAtlas CI workflow
   .github/workflows/release.yml,ProjectAtlas release workflow
+  docs/agent-integration.md,Agent integration instructions for ProjectAtlas
+  docs/concepts.md,Core concepts for ProjectAtlas usage
+  docs/configuration.md,Configuration reference for ProjectAtlas
+  docs/format.md,ProjectAtlas TOON schema reference
+  docs/workflow.md,ProjectAtlas workflow and troubleshooting guide
+  skills/codex/ProjectAtlas.md,Codex skill instructions for ProjectAtlas
+  skills/claude/ProjectAtlas.md,Claude skill instructions for ProjectAtlas
+  templates/AGENTS.md,Agent startup snippet for ProjectAtlas

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,6 +1,6 @@
 version: 1
-generated_at: 2026-01-01T15:34:23Z
-file_hash: "9dfbc82f0d3fd9e0ea9f431c483519de3780f71f691cbc1a16c8713ce4252b29"
+generated_at: 2026-01-01T15:47:43Z
+file_hash: "502490c327fb2ded263071755221fc4b5327306d622993090c1913074dcde8c6"
 folder_hash: "001959defd4312e2fdf710531dbe5007e1d10467919d12b3662e92259777fbf2"
 root: .
 overview: tracked_files=9 tracked_folders=13 source_extensions=10 exclude_dir_names=8 exclude_path_prefixes=0
@@ -39,7 +39,7 @@ folders[13]{path,summary,source}:
   src/projectatlas,Core ProjectAtlas package implementation.,purpose
   templates,Reusable agent templates and snippets.,purpose
   tests,Unit tests for ProjectAtlas.,purpose
-files[17]{path,summary,source}:
+files[25]{path,summary,source}:
   .github/workflows/ci.yml,ProjectAtlas CI workflow,manual
   .github/workflows/release.yml,ProjectAtlas release workflow,manual
   .gitignore,Ignored files for ProjectAtlas repository,manual
@@ -47,8 +47,15 @@ files[17]{path,summary,source}:
   LICENSE,ProjectAtlas MIT license,manual
   README.md,ProjectAtlas overview and usage guide,manual
   SECURITY.md,Security contact information for ProjectAtlas,manual
+  docs/agent-integration.md,Agent integration instructions for ProjectAtlas,manual
+  docs/concepts.md,Core concepts for ProjectAtlas usage,manual
+  docs/configuration.md,Configuration reference for ProjectAtlas,manual
+  docs/format.md,ProjectAtlas TOON schema reference,manual
+  docs/workflow.md,ProjectAtlas workflow and troubleshooting guide,manual
   pyproject.toml,ProjectAtlas packaging and CLI metadata,manual
   scripts/verify_version.py,Validate that ProjectAtlas versions match the requested tag.,header
+  skills/claude/ProjectAtlas.md,Claude skill instructions for ProjectAtlas,manual
+  skills/codex/ProjectAtlas.md,Codex skill instructions for ProjectAtlas,manual
   src/projectatlas/__init__.py,Define the ProjectAtlas package metadata.,header
   src/projectatlas/__main__.py,Allow `python -m projectatlas` to run the CLI.,header
   src/projectatlas/atlas.py,Scan repositories and build ProjectAtlas record entries.,header
@@ -56,6 +63,7 @@ files[17]{path,summary,source}:
   src/projectatlas/config.py,Load and normalize ProjectAtlas configuration from TOML.,header
   src/projectatlas/models.py,Define data models used across ProjectAtlas.,header
   src/projectatlas/output.py,Write ProjectAtlas snapshots to TOON or JSON outputs.,header
+  templates/AGENTS.md,Agent startup snippet for ProjectAtlas,manual
   tests/test_atlas.py,Validate basic ProjectAtlas scanning behavior.,header
 folder_summary_duplicates[]:
 file_summary_duplicates[]:

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -22,4 +22,4 @@ Drop the `skills/claude/ProjectAtlas.md` into your Claude skills folder and refe
 ## Lint and CI
 
 ProjectAtlas `lint` is meant for local workflows. Many teams skip map generation in CI, but still run
-lint on PRs to surface missing headers.
+lint on PRs to surface missing headers. Use `projectatlas map --force` if CI must regenerate the map.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,56 @@
+# Workflow and Troubleshooting
+
+ProjectAtlas is designed to run locally and produce a deterministic map.
+
+## Recommended workflow
+
+1. `projectatlas init --seed-purpose` (first-time setup).
+2. Add Purpose headers to new source files.
+3. Add or update `.purpose` summaries for new folders.
+4. Run `projectatlas map`.
+5. Run `projectatlas lint --strict-folders --report-untracked`.
+6. Commit map updates and any Purpose changes.
+
+## CI behavior
+
+- `projectatlas map` skips in CI unless you pass `--force`.
+- `projectatlas lint` validates that the map is current.
+
+Environment toggles:
+
+- `PROJECTATLAS_SKIP_UPDATE=1` skips map generation locally.
+- `PROJECTATLAS_ALLOW_UNTRACKED=1` allows local builds while still reporting untracked files.
+
+## Troubleshooting
+
+### Map is stale
+
+If lint reports stale hashes or an overview mismatch, re-run:
+
+```bash
+projectatlas map
+```
+
+### Missing Purpose headers
+
+Add a Javadoc-style header with `Purpose:` to the file. For Python, use a module docstring.
+
+### Missing .purpose files
+
+Create a `.purpose` file in the folder and add a one-line summary. You can seed them with:
+
+```bash
+projectatlas seed-purpose
+```
+
+### Untracked files
+
+Use `--report-untracked` to list non-source files. Either:
+
+- add to the manual file list
+- add to allowlists/exclusions
+- move into an approved asset root
+
+## Schema reference
+
+The TOON schema is documented in `docs/format.md`.

--- a/skills/claude/ProjectAtlas.md
+++ b/skills/claude/ProjectAtlas.md
@@ -4,15 +4,20 @@
 
 ProjectAtlas generates a concise project map so Claude can reason about repo structure before editing.
 
-## How to use
+## Quick use
 
-1. Run `projectatlas map` at session start.
-2. Open `.projectatlas/atlas.toon` and scan the folder tree + summaries.
-3. Use `projectatlas lint --strict-folders` to enforce missing `.purpose` files.
-4. Refresh the map after structural changes.
+1. Run `projectatlas init --seed-purpose` once.
+2. Run `projectatlas map` at session start.
+3. Open `.projectatlas/projectatlas.toon` and scan the folder tree + summaries.
+4. Use `projectatlas lint --strict-folders --report-untracked` to surface issues.
 
 ## Notes
 
-- Purpose headers should be one-line summaries starting with `Purpose:`.
-- Folder summaries come from `.purpose` files at each directory level.
-- Update the config file to tune exclusions or asset roots.
+- Purpose headers must start with `Purpose:` and remain one line.
+- Folder summaries live in `.purpose` files at each directory level.
+- Use `projectatlas map --force` to run in CI if needed.
+- Set `PROJECTATLAS_ALLOW_UNTRACKED=1` to allow local builds while still reporting.
+
+## References
+
+- See `docs/workflow.md` for schema and troubleshooting details.

--- a/skills/codex/ProjectAtlas.md
+++ b/skills/codex/ProjectAtlas.md
@@ -2,23 +2,61 @@
 
 ## Purpose
 
-Use ProjectAtlas to generate and validate an agent-first map of a repo, with one-line purposes for every folder and file.
+Maintain and evolve ProjectAtlas maps (Purpose headers, folder summaries, generated map files).
 
-## When to use
+## Quick start
 
-- At startup to understand the repo layout before deep indexing.
-- Before refactors to detect duplicate folder responsibilities.
-- In local builds to fail on missing Purpose headers or `.purpose` files.
+1. Run `projectatlas init --seed-purpose` once.
+2. Regenerate the map with `projectatlas map` (output: `.projectatlas/projectatlas.toon`).
+3. Validate locally with `projectatlas lint --strict-folders --report-untracked`.
+4. Commit the updated map and any Purpose header or folder summary changes.
 
-## Core workflow
+## Purpose headers
 
-1. Run `projectatlas map` (or `projectatlas init --seed-purpose` once).
-2. Read `.projectatlas/atlas.toon`.
-3. If lint fails, add/repair Purpose headers or `.purpose` files.
-4. Re-run `projectatlas map` to refresh hashes and the folder tree.
+- Ensure each source file has the required Purpose header format (Javadoc-style block with a `Purpose:` line).
+- Update headers before re-running the map so the generator captures intent.
 
-## Tips
+## Documentation accuracy
 
-- Keep Purpose summaries ASCII, comma-free, and under 140 characters.
-- Use `projectatlas lint --report-untracked` to spot assets outside approved roots.
-- Update `projectatlas.toml` (or `.projectatlas/config.toml`) for custom exclusions.
+- Document generator changes using the repo's preferred style (Javadoc-style headers or Python docstrings).
+- Keep map-related rules, skills, and Memory Bank notes aligned with generator behavior.
+
+## Folder summaries
+
+- Add or update `.purpose` summaries for new folders as required by the schema or lint rules.
+
+## Build and CI integration
+
+- If the map must stay current, wire `projectatlas map` into a local build step.
+- Keep updates deterministic so builds remain reproducible.
+
+## Health check intent
+
+- Treat the map and untracked report as a structure health check.
+- Every local build forces a decision to document, exclude, or reorganize files and folders.
+
+## Startup navigation
+
+- Use map summaries to prioritize which source files to inspect with code indexing at startup.
+- Follow repo rules for markdown and non-source files; the map is for source intent, not content.
+
+## Overview line
+
+- The map includes an overview line with tracked counts; it is emitted by the generator and validated by lint.
+- Do not edit the overview line manually; regenerate the map instead.
+
+## Untracked report
+
+- Use `--report-untracked` to list non-source files and excluded paths.
+- Use `--strict-untracked` only when you want untracked files to fail the build.
+- The report distinguishes allowed vs disallowed untracked files and flags asset files outside approved roots.
+
+## CI behavior
+
+- Map generation skips when `CI` or `GITHUB_ACTIONS` is truthy (use `projectatlas map --force` to override).
+- Set `PROJECTATLAS_SKIP_UPDATE=1` to skip updates locally.
+- Set `PROJECTATLAS_ALLOW_UNTRACKED=1` to allow local builds to pass while still reporting untracked files.
+
+## References
+
+- See `docs/workflow.md` for schema and troubleshooting details.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -2,5 +2,5 @@
 
 ## Startup
 1. Run `projectatlas map` (or ensure it runs as part of local build scripts).
-2. Read `.projectatlas/atlas.toon` to pick files before deep indexing.
+2. Read `.projectatlas/projectatlas.toon` to pick files before deep indexing.
 3. Run `projectatlas lint --strict-folders --report-untracked` to catch missing purposes.


### PR DESCRIPTION
Brings ProjectAtlas skills/docs in line with the codebase-map workflow, adds workflow guide, updates map output references.