### PR TITLE
fix(release): allow tag push in workflow (#16)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: release


### PR DESCRIPTION
Promotes release workflow permission fix. References #16.