### PR TITLE
chore(release): add post-release dev bump option (#48)

### DIFF
--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-01-02T09:51:03Z
+generated_at: 2026-01-02T12:41:34Z
 file_hash: "03dc9c35a7aa6c15e985e682bbc7b0bcc2c912e90ebfa435947f46b512e94d51"
 folder_hash: "15ed59bb790e2c49f129e710d3cbf644bf18813fdf12d7b56f272e63aa017639"
 root: .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ If you spot a bug or have a suggestion, please open an issue with clear reproduc
 - Feature work lands on `dev`.
 - Releases are merged from `dev` into `main` via PR.
 - Use `python scripts/prepare_release.py --issue <NNN> --bump patch` to create the release branch and PR.
+- Add `--post-release` if you want the next `.dev` bump PR on `dev`.
 - CI checks must pass before merge.
 - PR titles or bodies must reference a GitHub issue (for example `#123`).
 - Install git hooks with `python scripts/install_hooks.py` so commits require issue references.

--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ Release flow:
 
 1. Merge feature branches into `dev`.
 2. Run `python scripts/prepare_release.py --issue <NNN> --bump patch` to create a release branch and PR.
-3. Merge to `main` after CI is green.
-4. Auto-release runs on `main` pushes and creates a GitHub release if the version is not a `.dev` build.
-5. Use the manual Release workflow if you need to re-run tagging.
+3. Optional: add `--post-release` to open a dev PR that bumps to the next `.dev` version.
+4. Merge to `main` after CI is green.
+5. Auto-release runs on `main` pushes and creates a GitHub release if the version is not a `.dev` build.
+6. Use the manual Release workflow if you need to re-run tagging.
 
 ## Versioning
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -35,6 +35,7 @@ ProjectAtlas is designed to run locally and produce a deterministic map.
 - `main` for stable releases only.
 - Merge `dev` -> `main` via pull request after CI is green.
 - Use `python scripts/prepare_release.py --issue <NNN> --bump patch` to create a release branch and PR.
+- Add `--post-release` to open a dev PR that bumps to the next `.dev` version.
 - Pushes to `main` create a GitHub release when the version is not a `.dev` build.
 
 ## CI behavior

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -8,6 +8,7 @@ import unittest
 
 from scripts.prepare_release import (
     build_release_plan,
+    compute_post_release_version,
     compute_release_version,
     normalize_issue,
 )
@@ -37,6 +38,10 @@ class PrepareReleaseTests(unittest.TestCase):
     def test_compute_release_version(self) -> None:
         self.assertEqual(compute_release_version("0.1.0.dev0", "patch"), "0.1.0")
         self.assertEqual(compute_release_version("0.1.0", "patch"), "0.1.1")
+
+    def test_compute_post_release_version(self) -> None:
+        self.assertEqual(compute_post_release_version("0.1.0", "patch"), "0.1.1.dev0")
+        self.assertEqual(compute_post_release_version("1.2.0", "minor"), "1.3.0.dev0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add --post-release option to prepare_release.
- Update docs and tests.

## Issue
- Closes #48