### PR TITLE
docs(readme): expand how-it-works guidance (#51)

### DIFF
--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-01-02T12:41:34Z
+generated_at: 2026-01-02T12:54:24Z
 file_hash: "03dc9c35a7aa6c15e985e682bbc7b0bcc2c912e90ebfa435947f46b512e94d51"
 folder_hash: "15ed59bb790e2c49f129e710d3cbf644bf18813fdf12d7b56f272e63aa017639"
 root: .


### PR DESCRIPTION
## Summary
- Expand README how-it-works with agent startup rationale.
- Add related links section.

## Issue
- Closes #51