### PR TITLE
docs(skills): expand ProjectAtlas skill guidance (#53)

### DIFF
--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-01-02T12:54:24Z
+generated_at: 2026-01-02T13:06:18Z
 file_hash: "03dc9c35a7aa6c15e985e682bbc7b0bcc2c912e90ebfa435947f46b512e94d51"
 folder_hash: "15ed59bb790e2c49f129e710d3cbf644bf18813fdf12d7b56f272e63aa017639"
 root: .

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ ProjectAtlas is designed for the first 60 seconds of an agent session.
 Why this matters:
 
 - Agents read the atlas at startup (via AGENTS.md) to decide where to look next.
-- The atlas tells you *which* files to open with code-index or language servers, so you only deep-index what you
-  actually need (lower context usage, faster navigation).
+- The atlas tells you *which* files to open with deep-indexing tools (for example code-index MCP or language
+  servers) so you only deep-index what you actually need. Deep indexing here means full-file or symbol-level
+  analysis that can consume a lot of context if you run it blindly.
 - The lint gate keeps structure healthy over time by preventing silent drift.
 
 ProjectAtlas also supports non-source files (README, workflows, configs) via
@@ -127,7 +128,10 @@ python -m build --sdist --wheel
 ## Related projects
 
 - TOON format: `docs/format.md` (link the TOON GitHub spec here if you have one).
-- code-index (deep code summaries): https://github.com/johnhuang316/code-index-mcp
+- code-index (deep code summaries / symbol extraction): https://github.com/johnhuang316/code-index-mcp
+
+If you do not use a deep indexing tool, ProjectAtlas still provides the atlas and lint gate, but you will need to
+open source files manually for deeper context.
 
 ## Branches and releases
 

--- a/skills/claude/ProjectAtlas.md
+++ b/skills/claude/ProjectAtlas.md
@@ -1,24 +1,60 @@
 # ProjectAtlas (Claude skill)
 
-## Purpose
+## Goal
 
-ProjectAtlas generates a concise project map so Claude can reason about repo structure before editing.
+Give Claude a fast structure map before deep indexing so it can pick the right files and avoid wasting context.
 
-## Quick use
+## When to use
 
-1. Run `projectatlas init --seed-purpose` once.
-2. Run `projectatlas map` at session start.
-3. Open `.projectatlas/projectatlas.toon` and scan the folder tree + summaries.
-4. Use `projectatlas lint --strict-folders --report-untracked` to surface issues.
+- At session start (before deep indexing).
+- After creating or moving folders.
+- After adding new source files.
+- When `projectatlas lint` reports missing Purpose headers or missing `.purpose` files.
+- Before refactors or cleanup passes.
 
-## Notes
+## Definitions
 
-- Purpose headers must start with `Purpose:` and remain one line.
-- Folder summaries live in `.purpose` files at each directory level.
-- Use `projectatlas map --force` to run in CI if needed.
-- Set `PROJECTATLAS_ALLOW_UNTRACKED=1` to allow local builds while still reporting.
-- PR titles or bodies must reference a GitHub issue (`#NNN`) for CI to pass.
+- Deep indexing = full-file or symbol-level analysis via tools like code-index MCP or language servers.
+
+## First-time setup (repo adoption)
+
+1. Install locally: `pip install -e .`
+2. Initialize: `projectatlas init --seed-purpose`
+3. Fill each `.purpose` file with a one-line summary (ASCII, no commas).
+4. Add Purpose headers to every tracked source file.
+5. Add non-source files to `.projectatlas/projectatlas-manual-files.toon`.
+6. Run `projectatlas map`.
+7. Run `projectatlas lint --strict-folders --report-untracked` and fix issues.
+
+## Startup workflow (every session)
+
+1. Run `projectatlas map` (unless `PROJECTATLAS_SKIP_UPDATE=1` is set).
+2. Read `.projectatlas/projectatlas.toon`.
+3. Scan `folder_tree[]` and `folders[]` to pick where to work.
+4. Check duplicate summary lists for structural drift.
+5. Use deep indexing tools only for the specific files you chose from the atlas.
+6. Fix missing Purpose headers or `.purpose` files before continuing.
+
+## AGENTS.md integration
+
+Add a startup snippet so the atlas is always read:
+
+```
+## Startup
+1. Run `projectatlas map`.
+2. Read `.projectatlas/projectatlas.toon`.
+3. Use the atlas to select files before deep indexing.
+4. Fix missing Purpose headers or `.purpose` files if lint fails.
+```
+
+## Companion tools
+
+- code-index (deep code summaries): https://github.com/johnhuang316/code-index-mcp
+- Without deep indexing, open files manually using the atlas to guide selection.
 
 ## References
 
-- See `docs/workflow.md` for schema and troubleshooting details.
+- ProjectAtlas repo: https://github.com/styler-ai/ProjectAtlas
+- `docs/agent-integration.md` for the AGENTS.md snippet.
+- `docs/format.md` for TOON schema.
+- `docs/workflow.md` for troubleshooting.


### PR DESCRIPTION
## Summary
- Expand Codex/Claude skill guidance with detailed workflow and deep indexing context.
- Add code-index recommendations to README.

## Issue
- Closes #53