### PR TITLE
chore(release): enforce base sync before releases (#59)

### DIFF
--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-01-02T13:06:18Z
+generated_at: 2026-01-02T13:42:06Z
 file_hash: "03dc9c35a7aa6c15e985e682bbc7b0bcc2c912e90ebfa435947f46b512e94d51"
 folder_hash: "15ed59bb790e2c49f129e710d3cbf644bf18813fdf12d7b56f272e63aa017639"
 root: .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ If you spot a bug or have a suggestion, please open an issue with clear reproduc
 
 - Feature work lands on `dev`.
 - Releases are merged from `dev` into `main` via PR.
+- Ensure `dev` includes the latest `main` changes before releasing.
 - Use `python scripts/prepare_release.py --issue <NNN> --bump patch` to create the release branch and PR.
 - Add `--post-release` if you want the next `.dev` bump PR on `dev`.
 - CI checks must pass before merge.

--- a/README.md
+++ b/README.md
@@ -141,11 +141,13 @@ open source files manually for deeper context.
 Release flow:
 
 1. Merge feature branches into `dev`.
-2. Run `python scripts/prepare_release.py --issue <NNN> --bump patch` to create a release branch and PR.
-3. Optional: add `--post-release` to open a dev PR that bumps to the next `.dev` version.
-4. Merge to `main` after CI is green.
-5. Auto-release runs on `main` pushes and creates a GitHub release if the version is not a `.dev` build.
-6. Use the manual Release workflow if you need to re-run tagging.
+2. Ensure `dev` includes the latest `main` changes (sync if needed).
+3. Run `python scripts/prepare_release.py --issue <NNN> --bump patch` to create a release branch and PR.
+4. If `dev` is behind `main`, the script will stop unless you pass `--allow-base-divergence`.
+5. Optional: add `--post-release` to open a dev PR that bumps to the next `.dev` version.
+6. Merge to `main` after CI is green.
+7. Auto-release runs on `main` pushes and creates a GitHub release if the version is not a `.dev` build.
+8. Use the manual Release workflow if you need to re-run tagging.
 
 ## Versioning
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -34,7 +34,9 @@ ProjectAtlas is designed to run locally and produce a deterministic map.
 - `dev` for active development.
 - `main` for stable releases only.
 - Merge `dev` -> `main` via pull request after CI is green.
+- Ensure `dev` includes the latest `main` changes before releasing.
 - Use `python scripts/prepare_release.py --issue <NNN> --bump patch` to create a release branch and PR.
+- If `dev` is behind `main`, the script will stop unless you pass `--allow-base-divergence`.
 - Add `--post-release` to open a dev PR that bumps to the next `.dev` version.
 - Pushes to `main` create a GitHub release when the version is not a `.dev` build.
 


### PR DESCRIPTION
## Summary
- Add base sync checks to prepare_release and document the requirement.
- Add optional --allow-base-divergence flag.

## Issue
- Closes #59