### PR TITLE
docs(readme): add TOON spec link (#65)

### DIFF
--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-01-02T13:42:06Z
+generated_at: 2026-01-02T14:05:17Z
 file_hash: "03dc9c35a7aa6c15e985e682bbc7b0bcc2c912e90ebfa435947f46b512e94d51"
 folder_hash: "15ed59bb790e2c49f129e710d3cbf644bf18813fdf12d7b56f272e63aa017639"
 root: .

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ python -m build --sdist --wheel
 
 ## Related projects
 
-- TOON format: `docs/format.md` (link the TOON GitHub spec here if you have one).
+- TOON format: https://github.com/toon-format/toon
 - code-index (deep code summaries / symbol extraction): https://github.com/johnhuang316/code-index-mcp
 
 If you do not use a deep indexing tool, ProjectAtlas still provides the atlas and lint gate, but you will need to


### PR DESCRIPTION
## Summary
- Link to the official TOON GitHub repo in README.

## Issue
- Closes #65