### PR TITLE
docs(agents): expand startup snippet guidance (#67)

### DIFF
--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-01-02T14:05:17Z
+generated_at: 2026-01-02T14:13:11Z
 file_hash: "03dc9c35a7aa6c15e985e682bbc7b0bcc2c912e90ebfa435947f46b512e94d51"
 folder_hash: "15ed59bb790e2c49f129e710d3cbf644bf18813fdf12d7b56f272e63aa017639"
 root: .

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -12,7 +12,11 @@ ProjectAtlas is designed to be read at agent startup so you can:
 ## Startup
 1. Run `projectatlas map` (or ensure your build does).
 2. Read `.projectatlas/projectatlas.toon`.
-3. Use the folder tree + purpose summaries to pick files before deep indexing.
+3. Scan `folder_tree[]` for where to work and `folders[]`/`files[]` for precise targets.
+4. Check `folder_summary_duplicates[]` / `file_summary_duplicates[]` and flag drift.
+5. Run `projectatlas lint --strict-folders --report-untracked`.
+6. If lint fails, add missing Purpose headers or `.purpose` files (or remove stale items) before continuing.
+7. Only then run deep indexing (code-index, LSPs) on the files you selected from the atlas.
 ```
 
 ## Codex skills

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -2,6 +2,9 @@
 
 ## Startup
 1. Run `projectatlas map` (or ensure it runs as part of local build scripts).
-2. Read `.projectatlas/projectatlas.toon` to pick files before deep indexing.
-3. Run `projectatlas lint --strict-folders --report-untracked` to catch missing purposes.
-4. If using Codex, load `.codex/skills/ProjectAtlas.md` for the map workflow.
+2. Read `.projectatlas/projectatlas.toon` and scan the folder tree + summaries.
+3. Check duplicate summaries for drift, then select files to inspect.
+4. Run `projectatlas lint --strict-folders --report-untracked`.
+5. Fix missing Purpose headers or `.purpose` files before deeper work.
+6. Only then use deep indexing (code-index, LSPs) on selected files.
+7. If using Codex, load `.codex/skills/ProjectAtlas.md` for the map workflow.


### PR DESCRIPTION
## Summary
- Expand the AGENTS.md snippet to cover lint, duplicates, and deep-index gating.
- Keep the template and docs in sync.

## Issue
- Closes #67