### PR TITLE
docs: explain manual file split (#69)

### DIFF
--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-01-02T14:13:11Z
+generated_at: 2026-01-02T14:48:05Z
 file_hash: "03dc9c35a7aa6c15e985e682bbc7b0bcc2c912e90ebfa435947f46b512e94d51"
 folder_hash: "15ed59bb790e2c49f129e710d3cbf644bf18813fdf12d7b56f272e63aa017639"
 root: .

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Why this matters:
 ProjectAtlas also supports non-source files (README, workflows, configs) via
 `.projectatlas/projectatlas-manual-files.toon` so the snapshot stays complete even for files without headers.
 
+### Why there are two TOON files
+
+- `.projectatlas/projectatlas.toon` is **generated output**. It is safe to rebuild on every run.
+- `.projectatlas/projectatlas-manual-files.toon` is **input** for non-source files that cannot carry a `Purpose:`
+  header (for example YAML, TOML, images, or configs you do not want to edit).
+
+ProjectAtlas merges the manual entries into the generated atlas, so **agents only read the generated atlas**. The
+manual file exists only to preserve those non-source summaries across regenerations.
+
 ## Workflow (agent-focused)
 
 1. Run `projectatlas init --seed-purpose` once to scaffold missing `.purpose` files.

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -17,6 +17,9 @@ ProjectAtlas is designed to be read at agent startup so you can:
 5. Run `projectatlas lint --strict-folders --report-untracked`.
 6. If lint fails, add missing Purpose headers or `.purpose` files (or remove stale items) before continuing.
 7. Only then run deep indexing (code-index, LSPs) on the files you selected from the atlas.
+
+Note: the manual file list (`.projectatlas/projectatlas-manual-files.toon`) is input for non-source summaries and
+is merged into the atlas. Agents still read only the generated atlas.
 ```
 
 ## Codex skills

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,8 @@ asset_extensions = [".png", ".jpg", ".jpeg", ".svg", ".gif", ".webp", ".ico", ".
 
 ### Manual files
 
-If you set `project.manual_files_path`, ProjectAtlas reads a TOON file with a `manual_files[]:` section:
+If you set `project.manual_files_path`, ProjectAtlas reads a TOON file with a `manual_files[]:` section. This file
+is treated as input for non-source summaries and is merged into the generated atlas:
 
 ```
 manual_files[]:


### PR DESCRIPTION
## Summary
- Explain manual vs generated TOON files and how they merge.
- Clarify that agents still read the generated atlas.

## Issue
- Closes #69