### PR TITLE
chore(projectatlas): rename non-source file list (#71)

### DIFF
--- a/.codex/skills/ProjectAtlas.md
+++ b/.codex/skills/ProjectAtlas.md
@@ -22,7 +22,7 @@ files. ProjectAtlas is the layer above code-index tools.
 
 - `.projectatlas/projectatlas.toon` (the atlas snapshot).
 - `.projectatlas/config.toml` (scan rules).
-- `.projectatlas/projectatlas-manual-files.toon` (summaries for non-source files).
+- `.projectatlas/projectatlas-nonsource-files.toon` (agent-maintained summaries for non-source files).
 
 ## First-time setup (repo adoption)
 
@@ -30,7 +30,7 @@ files. ProjectAtlas is the layer above code-index tools.
 2. Initialize: `projectatlas init --seed-purpose`
 3. Fill each `.purpose` file with a one-line summary (ASCII, no commas).
 4. Add Purpose headers to every tracked source file.
-5. Add non-source files to `.projectatlas/projectatlas-manual-files.toon`.
+5. Add non-source files to `.projectatlas/projectatlas-nonsource-files.toon`.
 6. Run `projectatlas map` to generate `.projectatlas/projectatlas.toon`.
 7. Run `projectatlas lint --strict-folders --report-untracked` and fix issues.
 8. (Optional) Install git hooks: `python scripts/install_hooks.py` to enforce issue references in commits.

--- a/.projectatlas/config.toml
+++ b/.projectatlas/config.toml
@@ -4,7 +4,7 @@
 #  */
 root = "."
 map_path = ".projectatlas/projectatlas.toon"
-manual_files_path = ".projectatlas/projectatlas-manual-files.toon"
+nonsource_files_path = ".projectatlas/projectatlas-nonsource-files.toon"
 purpose_filename = ".purpose"
 
 [scan]

--- a/.projectatlas/projectatlas-nonsource-files.toon
+++ b/.projectatlas/projectatlas-nonsource-files.toon
@@ -1,6 +1,6 @@
-manual_files[]:
+nonsource_files[]:
   # /**
-  #  * Purpose: Manual file summaries for non-source files.
+  #  * Purpose: Non-source file summaries for ProjectAtlas input.
   #  */
   # path,summary
   README.md,ProjectAtlas overview and usage guide

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-01-02T14:48:05Z
+generated_at: 2026-01-02T15:20:54Z
 file_hash: "03dc9c35a7aa6c15e985e682bbc7b0bcc2c912e90ebfa435947f46b512e94d51"
 folder_hash: "15ed59bb790e2c49f129e710d3cbf644bf18813fdf12d7b56f272e63aa017639"
 root: .
@@ -43,29 +43,29 @@ folders[16]{path,summary,source}:
   templates,Reusable agent templates and snippets.,purpose
   tests,Unit tests for ProjectAtlas.,purpose
 files[47]{path,summary,source}:
-  .codex/skills/ProjectAtlas.md,Codex skill instructions for ProjectAtlas,manual
-  .githooks/commit-msg,Git hook to enforce issue references in commits,manual
-  .github/pull_request_template.md,Pull request checklist for ProjectAtlas,manual
-  .github/workflows/03-auto-release.yml,ProjectAtlas auto release workflow,manual
-  .github/workflows/04-docs.yml,ProjectAtlas docs site workflow,manual
-  .github/workflows/ci.yml,ProjectAtlas CI workflow,manual
-  .github/workflows/release.yml,ProjectAtlas release workflow,manual
-  .gitignore,Ignored files for ProjectAtlas repository,manual
-  CODE_OF_CONDUCT.md,Community conduct expectations for ProjectAtlas,manual
-  CONTRIBUTING.md,Contribution policy for ProjectAtlas,manual
-  LICENSE,ProjectAtlas MIT license,manual
-  README.md,ProjectAtlas overview and usage guide,manual
-  SECURITY.md,Security contact information for ProjectAtlas,manual
-  docs/adoption.md,Adoption checklist for ProjectAtlas,manual
-  docs/agent-integration.md,Agent integration instructions for ProjectAtlas,manual
-  docs/api.md,Generated ProjectAtlas API documentation,manual
-  docs/concepts.md,Core concepts for ProjectAtlas usage,manual
-  docs/configuration.md,Configuration reference for ProjectAtlas,manual
-  docs/format.md,ProjectAtlas TOON schema reference,manual
-  docs/index.md,Documentation landing page for ProjectAtlas,manual
-  docs/workflow.md,ProjectAtlas workflow and troubleshooting guide,manual
-  mkdocs.yml,MkDocs site configuration for ProjectAtlas,manual
-  pyproject.toml,ProjectAtlas packaging and CLI metadata,manual
+  .codex/skills/ProjectAtlas.md,Codex skill instructions for ProjectAtlas,nonsource
+  .githooks/commit-msg,Git hook to enforce issue references in commits,nonsource
+  .github/pull_request_template.md,Pull request checklist for ProjectAtlas,nonsource
+  .github/workflows/03-auto-release.yml,ProjectAtlas auto release workflow,nonsource
+  .github/workflows/04-docs.yml,ProjectAtlas docs site workflow,nonsource
+  .github/workflows/ci.yml,ProjectAtlas CI workflow,nonsource
+  .github/workflows/release.yml,ProjectAtlas release workflow,nonsource
+  .gitignore,Ignored files for ProjectAtlas repository,nonsource
+  CODE_OF_CONDUCT.md,Community conduct expectations for ProjectAtlas,nonsource
+  CONTRIBUTING.md,Contribution policy for ProjectAtlas,nonsource
+  LICENSE,ProjectAtlas MIT license,nonsource
+  README.md,ProjectAtlas overview and usage guide,nonsource
+  SECURITY.md,Security contact information for ProjectAtlas,nonsource
+  docs/adoption.md,Adoption checklist for ProjectAtlas,nonsource
+  docs/agent-integration.md,Agent integration instructions for ProjectAtlas,nonsource
+  docs/api.md,Generated ProjectAtlas API documentation,nonsource
+  docs/concepts.md,Core concepts for ProjectAtlas usage,nonsource
+  docs/configuration.md,Configuration reference for ProjectAtlas,nonsource
+  docs/format.md,ProjectAtlas TOON schema reference,nonsource
+  docs/index.md,Documentation landing page for ProjectAtlas,nonsource
+  docs/workflow.md,ProjectAtlas workflow and troubleshooting guide,nonsource
+  mkdocs.yml,MkDocs site configuration for ProjectAtlas,nonsource
+  pyproject.toml,ProjectAtlas packaging and CLI metadata,nonsource
   scripts/check_commit_issue.py,Enforce GitHub issue references in commit messages.,header
   scripts/check_docstrings.py,Enforce module and public symbol docstrings for ProjectAtlas code.,header
   scripts/check_pr_issue_reference.py,Enforce issue references in pull request titles or bodies.,header
@@ -74,8 +74,8 @@ files[47]{path,summary,source}:
   scripts/next_version.py,Compute the next ProjectAtlas version and optionally update files.,header
   scripts/prepare_release.py,Bump the ProjectAtlas version and open a release PR.,header
   scripts/verify_version.py,Validate that ProjectAtlas versions match the requested tag.,header
-  skills/claude/ProjectAtlas.md,Claude skill instructions for ProjectAtlas,manual
-  skills/codex/ProjectAtlas.md,Codex skill instructions for ProjectAtlas,manual
+  skills/claude/ProjectAtlas.md,Claude skill instructions for ProjectAtlas,nonsource
+  skills/codex/ProjectAtlas.md,Codex skill instructions for ProjectAtlas,nonsource
   src/projectatlas/__init__.py,Define the ProjectAtlas package metadata.,header
   src/projectatlas/__main__.py,Allow `python -m projectatlas` to run the CLI.,header
   src/projectatlas/atlas.py,Scan repositories and build ProjectAtlas record entries.,header
@@ -83,7 +83,7 @@ files[47]{path,summary,source}:
   src/projectatlas/config.py,Load and normalize ProjectAtlas configuration from TOML.,header
   src/projectatlas/models.py,Define data models used across ProjectAtlas.,header
   src/projectatlas/output.py,Write ProjectAtlas snapshots to TOON or JSON outputs.,header
-  templates/AGENTS.md,Agent startup snippet for ProjectAtlas,manual
+  templates/AGENTS.md,Agent startup snippet for ProjectAtlas,nonsource
   tests/test_atlas.py,Validate basic ProjectAtlas scanning behavior.,header
   tests/test_commit_issue.py,Validate commit message issue reference checks.,header
   tests/test_docstrings.py,Validate the ProjectAtlas docstring enforcement script.,header

--- a/README.md
+++ b/README.md
@@ -53,24 +53,26 @@ Why this matters:
 - The lint gate keeps structure healthy over time by preventing silent drift.
 
 ProjectAtlas also supports non-source files (README, workflows, configs) via
-`.projectatlas/projectatlas-manual-files.toon` so the snapshot stays complete even for files without headers.
+`.projectatlas/projectatlas-nonsource-files.toon` so the snapshot stays complete even for files without headers.
 
 ### Why there are two TOON files
 
 - `.projectatlas/projectatlas.toon` is **generated output**. It is safe to rebuild on every run.
-- `.projectatlas/projectatlas-manual-files.toon` is **input** for non-source files that cannot carry a `Purpose:`
-  header (for example YAML, TOML, images, or configs you do not want to edit).
+- `.projectatlas/projectatlas-nonsource-files.toon` is **agent-maintained input** for non-source files that cannot
+  carry a `Purpose:` header (for example YAML, TOML, images, or configs you do not want to edit).
 
-ProjectAtlas merges the manual entries into the generated atlas, so **agents only read the generated atlas**. The
-manual file exists only to preserve those non-source summaries across regenerations.
+ProjectAtlas merges the non-source entries into the generated atlas, so **agents only read the generated atlas**.
+The input file exists only to preserve those non-source summaries across regenerations. Agents update it when
+`projectatlas lint` reports missing non-source entries or when new config/doc files are added.
 
 ## Workflow (agent-focused)
 
 1. Run `projectatlas init --seed-purpose` once to scaffold missing `.purpose` files.
 2. For every new folder, write a one-line purpose in its `.purpose` file (this is your folder contract).
 3. For every new source file, add a `Purpose:` header or module docstring (this is your file contract).
-4. Regenerate the map with `projectatlas map`.
-5. Read `.projectatlas/projectatlas.toon` at startup and look for:
+4. Add non-source summaries to `.projectatlas/projectatlas-nonsource-files.toon`.
+5. Regenerate the map with `projectatlas map`.
+6. Read `.projectatlas/projectatlas.toon` at startup and look for:
    - the folder tree to locate the right area of the repo
    - duplicate summaries to spot drift or overlap
    - file summaries to pick targets for deeper inspection
@@ -174,7 +176,7 @@ python scripts/prepare_release.py --issue <NNN> --bump patch
 Default outputs:
 
 - `.projectatlas/config.toml`
-- `.projectatlas/projectatlas-manual-files.toon`
+- `.projectatlas/projectatlas-nonsource-files.toon`
 - `.projectatlas/projectatlas.toon`
 
 ## Folder structure (ProjectAtlas repo)
@@ -183,7 +185,7 @@ Default outputs:
 .
 |-- .projectatlas/
 |   |-- config.toml
-|   |-- projectatlas-manual-files.toon
+|   |-- projectatlas-nonsource-files.toon
 |   `-- projectatlas.toon
 |-- .codex/
 |   `-- skills/
@@ -206,7 +208,7 @@ Use this tree when contributing to ProjectAtlas itself.
 your-repo/
 |-- .projectatlas/
 |   |-- config.toml
-|   |-- projectatlas-manual-files.toon
+|   |-- projectatlas-nonsource-files.toon
 |   `-- projectatlas.toon
 |-- .purpose
 `-- (your source and docs)

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -26,7 +26,7 @@ module docstring with `Purpose:`.
 
 ## 5. Track non-source files
 
-Add summaries for non-source files in `.projectatlas/projectatlas-manual-files.toon`.
+Add summaries for non-source files in `.projectatlas/projectatlas-nonsource-files.toon` (agent-maintained input).
 
 ## 6. Generate the map
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -18,8 +18,8 @@ ProjectAtlas is designed to be read at agent startup so you can:
 6. If lint fails, add missing Purpose headers or `.purpose` files (or remove stale items) before continuing.
 7. Only then run deep indexing (code-index, LSPs) on the files you selected from the atlas.
 
-Note: the manual file list (`.projectatlas/projectatlas-manual-files.toon`) is input for non-source summaries and
-is merged into the atlas. Agents still read only the generated atlas.
+Note: the non-source file list (`.projectatlas/projectatlas-nonsource-files.toon`) is agent-maintained input for
+non-source summaries and is merged into the atlas. Agents still read only the generated atlas.
 ```
 
 ## Codex skills

--- a/docs/api.md
+++ b/docs/api.md
@@ -86,13 +86,13 @@ Validate a Purpose summary against map rules.
 
 Build file records and error lists for Purpose headers.
 
-### Function `read_manual_file_entries`
+### Function `read_nonsource_file_entries`
 
-Read manual file entries for non-source config files.
+Read non-source file list entries for files without headers.
 
-### Function `merge_manual_file_records`
+### Function `merge_nonsource_file_records`
 
-Merge manual file records into the auto-discovered list.
+Merge non-source file records into the auto-discovered list.
 
 ### Function `read_folder_purpose`
 
@@ -156,7 +156,7 @@ Create missing .purpose files for tracked folders.
 
 ### Function `write_default_files`
 
-Write default configuration and manual file template.
+Write default configuration and non-source file template.
 
 ### Function `run_map`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ ProjectAtlas reads `projectatlas.toml` or `.projectatlas/config.toml`. All paths
 [project]
 root = "."
 map_path = ".projectatlas/projectatlas.toon"
-manual_files_path = ".projectatlas/projectatlas-manual-files.toon"
+nonsource_files_path = ".projectatlas/projectatlas-nonsource-files.toon"
 purpose_filename = ".purpose"
 
 [scan]
@@ -30,13 +30,14 @@ asset_allowed_prefixes = []
 asset_extensions = [".png", ".jpg", ".jpeg", ".svg", ".gif", ".webp", ".ico", ".pdf"]
 ```
 
-### Manual files
+### Non-source file list
 
-If you set `project.manual_files_path`, ProjectAtlas reads a TOON file with a `manual_files[]:` section. This file
-is treated as input for non-source summaries and is merged into the generated atlas:
+If you set `project.nonsource_files_path`, ProjectAtlas reads a TOON file with a `nonsource_files[]:` section. This
+file is agent-maintained input for non-source summaries (configs, docs, assets) and is merged into the generated
+atlas. The legacy `project.manual_files_path` key is still accepted for backward compatibility.
 
 ```
-manual_files[]:
+nonsource_files[]:
   path/to/file.txt,One line purpose summary
 ```
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -78,7 +78,8 @@ projectatlas seed-purpose
 
 Use `--report-untracked` to list non-source files. Either:
 
-- add to the manual file list
+- add to the non-source file list (`.projectatlas/projectatlas-nonsource-files.toon`)
+  (agent-maintained input for non-source summaries)
 - add to allowlists/exclusions
 - move into an approved asset root
 

--- a/skills/claude/ProjectAtlas.md
+++ b/skills/claude/ProjectAtlas.md
@@ -22,7 +22,7 @@ Give Claude a fast structure map before deep indexing so it can pick the right f
 2. Initialize: `projectatlas init --seed-purpose`
 3. Fill each `.purpose` file with a one-line summary (ASCII, no commas).
 4. Add Purpose headers to every tracked source file.
-5. Add non-source files to `.projectatlas/projectatlas-manual-files.toon`.
+5. Add non-source files to `.projectatlas/projectatlas-nonsource-files.toon`.
 6. Run `projectatlas map`.
 7. Run `projectatlas lint --strict-folders --report-untracked` and fix issues.
 

--- a/skills/codex/ProjectAtlas.md
+++ b/skills/codex/ProjectAtlas.md
@@ -22,7 +22,7 @@ files. ProjectAtlas is the layer above code-index tools.
 
 - `.projectatlas/projectatlas.toon` (the atlas snapshot).
 - `.projectatlas/config.toml` (scan rules).
-- `.projectatlas/projectatlas-manual-files.toon` (summaries for non-source files).
+- `.projectatlas/projectatlas-nonsource-files.toon` (agent-maintained summaries for non-source files).
 
 ## First-time setup (repo adoption)
 
@@ -30,7 +30,7 @@ files. ProjectAtlas is the layer above code-index tools.
 2. Initialize: `projectatlas init --seed-purpose`
 3. Fill each `.purpose` file with a one-line summary (ASCII, no commas).
 4. Add Purpose headers to every tracked source file.
-5. Add non-source files to `.projectatlas/projectatlas-manual-files.toon`.
+5. Add non-source files to `.projectatlas/projectatlas-nonsource-files.toon`.
 6. Run `projectatlas map` to generate `.projectatlas/projectatlas.toon`.
 7. Run `projectatlas lint --strict-folders --report-untracked` and fix issues.
 8. (Optional) Install git hooks: `python scripts/install_hooks.py` to enforce issue references in commits.

--- a/src/projectatlas/config.py
+++ b/src/projectatlas/config.py
@@ -13,7 +13,7 @@ import tomllib
 
 DEFAULT_PURPOSE_FILENAME = ".purpose"
 DEFAULT_MAP_PATH = Path(".projectatlas/projectatlas.toon")
-DEFAULT_MANUAL_FILES_PATH = Path(".projectatlas/projectatlas-manual-files.toon")
+DEFAULT_NONSOURCE_FILES_PATH = Path(".projectatlas/projectatlas-nonsource-files.toon")
 DEFAULT_SOURCE_EXTENSIONS = {
     ".ts",
     ".tsx",
@@ -84,7 +84,7 @@ class AtlasConfig:
 
     root: Path
     map_path: Path
-    manual_files_path: Path | None
+    nonsource_files_path: Path | None
     purpose_filename: str
     source_extensions: set[str]
     exclude_dir_names: set[str]
@@ -168,12 +168,16 @@ def load_config(config_path: Path | None, root: Path | None = None) -> AtlasConf
     map_path = project.get("map_path", DEFAULT_MAP_PATH)
     map_path = _as_path(map_path, "project.map_path", root_path)
 
-    manual_files_path = project.get("manual_files_path")
-    if manual_files_path is None:
-        manual_path = None
+    nonsource_files_path = project.get("nonsource_files_path")
+    if nonsource_files_path is None:
+        nonsource_files_path = project.get("manual_files_path")
+    if nonsource_files_path is None:
+        nonsource_path = None
     else:
-        manual_path = _as_path(
-            manual_files_path, "project.manual_files_path", root_path
+        nonsource_path = _as_path(
+            nonsource_files_path,
+            "project.nonsource_files_path",
+            root_path,
         )
 
     purpose_filename = str(project.get("purpose_filename", DEFAULT_PURPOSE_FILENAME))
@@ -250,7 +254,7 @@ def load_config(config_path: Path | None, root: Path | None = None) -> AtlasConf
     return AtlasConfig(
         root=root_path,
         map_path=map_path,
-        manual_files_path=manual_path,
+        nonsource_files_path=nonsource_path,
         purpose_filename=purpose_filename,
         source_extensions=source_extensions,
         exclude_dir_names=exclude_dir_names,
@@ -276,7 +280,7 @@ def default_config_text() -> str:
             "[project]",
             'root = "."',
             'map_path = ".projectatlas/projectatlas.toon"',
-            'manual_files_path = ".projectatlas/projectatlas-manual-files.toon"',
+            'nonsource_files_path = ".projectatlas/projectatlas-nonsource-files.toon"',
             'purpose_filename = ".purpose"',
             "",
             "[scan]",

--- a/tests/test_atlas.py
+++ b/tests/test_atlas.py
@@ -17,7 +17,7 @@ def make_config(root: Path) -> AtlasConfig:
     return AtlasConfig(
         root=root,
         map_path=root / ".projectatlas" / "atlas.toon",
-        manual_files_path=None,
+        nonsource_files_path=None,
         purpose_filename=".purpose",
         source_extensions={".py"},
         exclude_dir_names=set(),


### PR DESCRIPTION
## Summary
- rename manual file list to non-source file list
- update docs/skills/config to new name and clarify agent-maintained input
- keep legacy manual_files_path support

Closes #71