### PR TITLE
chore(projectatlas): memory bank + release notes automation (#78)

### DIFF
--- a/.codex/rules/.purpose
+++ b/.codex/rules/.purpose
@@ -1,0 +1,1 @@
+Purpose: ProjectAtlas rules for Codex usage.

--- a/.codex/rules/memory/.purpose
+++ b/.codex/rules/memory/.purpose
@@ -1,0 +1,1 @@
+Purpose: ProjectAtlas Memory Bank files.

--- a/.codex/rules/memory/activeContext.md
+++ b/.codex/rules/memory/activeContext.md
@@ -1,0 +1,5 @@
+# Active Context
+
+Purpose: Capture current focus areas and any in-flight tasks for ProjectAtlas.
+
+- Keep empty unless actively working on a specific change.

--- a/.codex/rules/memory/productContext.md
+++ b/.codex/rules/memory/productContext.md
@@ -1,0 +1,6 @@
+# Product Context
+
+Purpose: Describe the user problem ProjectAtlas solves and the target workflow.
+
+- Agents and humans need a quick structural overview before deep indexing.
+- The atlas guides file selection and keeps folder intent explicit over time.

--- a/.codex/rules/memory/progress.md
+++ b/.codex/rules/memory/progress.md
@@ -1,0 +1,6 @@
+# Progress Log
+
+## Completed
+
+## Pending Work
+

--- a/.codex/rules/memory/projectbrief.md
+++ b/.codex/rules/memory/projectbrief.md
@@ -1,0 +1,6 @@
+# Project Brief
+
+Purpose: High-level summary of ProjectAtlas goals and scope.
+
+- ProjectAtlas provides an agent-first structure map and lint gate for repository hygiene.
+- Scope is limited to atlas generation and validation (no memory extensions yet).

--- a/.codex/rules/memory/ruleIndex.md
+++ b/.codex/rules/memory/ruleIndex.md
@@ -1,0 +1,8 @@
+# Memory Bank Index
+
+- projectbrief.md: Project goals and scope.
+- productContext.md: User problem and workflow intent.
+- activeContext.md: Current focus and in-flight tasks.
+- systemPatterns.md: Architecture patterns.
+- techContext.md: Tooling and constraints.
+- progress.md: Completed work and pending tasks.

--- a/.codex/rules/memory/systemPatterns.md
+++ b/.codex/rules/memory/systemPatterns.md
@@ -1,0 +1,6 @@
+# System Patterns
+
+Purpose: Record key architectural patterns in ProjectAtlas.
+
+- Atlas generation reads Purpose headers and .purpose files.
+- Non-source summaries are supplied via projectatlas-nonsource-files.toon.

--- a/.codex/rules/memory/techContext.md
+++ b/.codex/rules/memory/techContext.md
@@ -1,0 +1,6 @@
+# Tech Context
+
+Purpose: Note technical constraints or tooling requirements for ProjectAtlas.
+
+- Python 3.11+ required.
+- Uses TOON for atlas output.

--- a/.github/workflows/03-auto-release.yml
+++ b/.github/workflows/03-auto-release.yml
@@ -61,4 +61,4 @@ jobs:
         run: |
           gh release create "v${{ steps.version.outputs.version }}" \
             --title "v${{ steps.version.outputs.version }}" \
-            --notes "ProjectAtlas v${{ steps.version.outputs.version }}"
+            --generate-notes

--- a/.projectatlas/projectatlas-nonsource-files.toon
+++ b/.projectatlas/projectatlas-nonsource-files.toon
@@ -17,6 +17,13 @@ nonsource_files[]:
   .github/pull_request_template.md,Pull request checklist for ProjectAtlas
   .githooks/commit-msg,Git hook to enforce issue references in commits
   .codex/skills/ProjectAtlas.md,Codex skill instructions for ProjectAtlas
+  .codex/rules/memory/projectbrief.md,ProjectAtlas project brief
+  .codex/rules/memory/productContext.md,ProjectAtlas product context
+  .codex/rules/memory/activeContext.md,ProjectAtlas active context
+  .codex/rules/memory/systemPatterns.md,ProjectAtlas system patterns
+  .codex/rules/memory/techContext.md,ProjectAtlas tech context
+  .codex/rules/memory/progress.md,ProjectAtlas progress log
+  .codex/rules/memory/ruleIndex.md,ProjectAtlas memory bank index
   docs/agent-integration.md,Agent integration instructions for ProjectAtlas
   docs/adoption.md,Adoption checklist for ProjectAtlas
   docs/index.md,Documentation landing page for ProjectAtlas

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,9 +1,9 @@
 version: 1
-generated_at: 2026-01-02T18:25:09Z
-file_hash: "03dc9c35a7aa6c15e985e682bbc7b0bcc2c912e90ebfa435947f46b512e94d51"
-folder_hash: "15ed59bb790e2c49f129e710d3cbf644bf18813fdf12d7b56f272e63aa017639"
+generated_at: 2026-01-02T20:05:05Z
+file_hash: "9f0bec1fb84ca90c6259672f425602c9e93e07b5c4d6d3ab301a22033e1ea444"
+folder_hash: "d8e554805feb298a8977e058a017b09ad7ddf7972e3155af1a8977070ac49d1f"
 root: .
-overview: tracked_files=21 tracked_folders=16 source_extensions=10 exclude_dir_names=8 exclude_path_prefixes=0
+overview: tracked_files=21 tracked_folders=18 source_extensions=10 exclude_dir_names=8 exclude_path_prefixes=0
 source_extensions[]:
   - .cjs
   - .css
@@ -25,9 +25,11 @@ exclude_dir_names[]:
   - dist
   - node_modules
 exclude_path_prefixes[]:
-folders[16]{path,summary,source}:
+folders[18]{path,summary,source}:
   .,ProjectAtlas repository root.,purpose
   .codex,Codex configuration and skills for ProjectAtlas.,purpose
+  .codex/rules,ProjectAtlas rules for Codex usage.,purpose
+  .codex/rules/memory,ProjectAtlas Memory Bank files.,purpose
   .codex/skills,Codex skill copies for ProjectAtlas adoption.,purpose
   .githooks,Git hook scripts for ProjectAtlas commits.,purpose
   .github,ProjectAtlas GitHub metadata and workflows.,purpose
@@ -42,7 +44,14 @@ folders[16]{path,summary,source}:
   src/projectatlas,Core ProjectAtlas package implementation.,purpose
   templates,Reusable agent templates and snippets.,purpose
   tests,Unit tests for ProjectAtlas.,purpose
-files[47]{path,summary,source}:
+files[54]{path,summary,source}:
+  .codex/rules/memory/activeContext.md,ProjectAtlas active context,nonsource
+  .codex/rules/memory/productContext.md,ProjectAtlas product context,nonsource
+  .codex/rules/memory/progress.md,ProjectAtlas progress log,nonsource
+  .codex/rules/memory/projectbrief.md,ProjectAtlas project brief,nonsource
+  .codex/rules/memory/ruleIndex.md,ProjectAtlas memory bank index,nonsource
+  .codex/rules/memory/systemPatterns.md,ProjectAtlas system patterns,nonsource
+  .codex/rules/memory/techContext.md,ProjectAtlas tech context,nonsource
   .codex/skills/ProjectAtlas.md,Codex skill instructions for ProjectAtlas,nonsource
   .githooks/commit-msg,Git hook to enforce issue references in commits,nonsource
   .github/pull_request_template.md,Pull request checklist for ProjectAtlas,nonsource
@@ -96,6 +105,8 @@ file_summary_duplicates[]:
 folder_tree[]:
   - . - ProjectAtlas repository root.
   - .codex/ - Codex configuration and skills for ProjectAtlas.
+  -   rules/ - ProjectAtlas rules for Codex usage.
+  -     memory/ - ProjectAtlas Memory Bank files.
   -   skills/ - Codex skill copies for ProjectAtlas adoption.
   - .githooks/ - Git hook scripts for ProjectAtlas commits.
   - .github/ - ProjectAtlas GitHub metadata and workflows.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -39,6 +39,7 @@ ProjectAtlas is designed to run locally and produce a deterministic map.
 - If `dev` is behind `main`, the script will stop unless you pass `--allow-base-divergence`.
 - Add `--post-release` to open a dev PR that bumps to the next `.dev` version.
 - Pushes to `main` create a GitHub release when the version is not a `.dev` build.
+- The auto-release workflow generates GitHub release notes from merged PRs.
 
 ## CI behavior
 


### PR DESCRIPTION
## Summary
- add a dedicated ProjectAtlas memory bank under .codex/rules/memory
- track new memory files in projectatlas-nonsource-files.toon
- auto-generate release notes in 03-Auto-Release

Closes #78