### PR TITLE
chore(ci): enforce issue milestones in PRs (#80)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
 
       - name: Issue reference check
         if: github.event_name == 'pull_request'
+        env:
+          PROJECTATLAS_REQUIRE_ISSUE_MILESTONE: "1"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/check_pr_issue_reference.py
 
       - name: Lint atlas

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ python scripts/install_hooks.py
 ```
 
 Issue hygiene: label every issue with `type:*`, `priority:*`, and `status:*`.
+Assign issues you are actively working on to the target release milestone; CI enforces that referenced issues have a milestone.
 
 Run tests, docs, and build artifacts locally:
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -17,6 +17,7 @@ ProjectAtlas is designed to run locally and produce a deterministic map.
 
 - Every issue should carry a `type:*` label plus a `priority:*` and `status:*` label.
 - Use `status:backlog` for unscheduled work.
+- Any issue referenced by a PR must be assigned to the target release milestone (CI enforces this).
 
 ## Review expectations
 

--- a/scripts/check_pr_issue_reference.py
+++ b/scripts/check_pr_issue_reference.py
@@ -8,11 +8,14 @@ import json
 import os
 import re
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 
-ISSUE_RE = re.compile(r"#\d+")
+ISSUE_RE = re.compile(r"#(\d+)")
+TRUTHY = {"1", "true", "yes", "on"}
 
 
 def load_event_payload(event_path: Path) -> dict[str, Any]:
@@ -35,6 +38,57 @@ def has_issue_reference(text: str) -> bool:
     return bool(ISSUE_RE.search(text))
 
 
+def extract_issue_numbers(text: str) -> list[str]:
+    """Return distinct issue numbers referenced in the text."""
+    matches = ISSUE_RE.findall(text)
+    return sorted({match for match in matches})
+
+
+def requires_milestone() -> bool:
+    """Return True when milestone enforcement is enabled."""
+    raw = os.environ.get("PROJECTATLAS_REQUIRE_ISSUE_MILESTONE")
+    if raw is None:
+        return False
+    return raw.strip().lower() in TRUTHY
+
+
+def issue_has_milestone(payload: dict[str, Any]) -> bool:
+    """Return True when an issue payload includes a milestone."""
+    milestone = payload.get("milestone")
+    if milestone is None:
+        return False
+    return bool(milestone.get("title"))
+
+
+def fetch_issue(
+    repository: str, issue_number: str, token: str
+) -> dict[str, Any]:
+    """Fetch issue metadata from the GitHub API."""
+    url = f"https://api.github.com/repos/{repository}/issues/{issue_number}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "projectatlas-ci",
+        },
+    )
+    with urllib.request.urlopen(request) as response:
+        payload = response.read().decode("utf-8")
+    return json.loads(payload)
+
+
+def ensure_issue_milestones(
+    issue_numbers: Iterable[str], repository: str, token: str
+) -> bool:
+    """Return True if any referenced issue has a milestone."""
+    for issue_number in issue_numbers:
+        payload = fetch_issue(repository, issue_number, token)
+        if issue_has_milestone(payload):
+            return True
+    return False
+
+
 def main(argv: list[str]) -> int:
     """Exit non-zero if a PR event lacks an issue reference."""
     _ = argv
@@ -50,6 +104,36 @@ def main(argv: list[str]) -> int:
             "PR title/body must reference an issue (example: #123).\n"
         )
         return 1
+    if requires_milestone():
+        repository = os.environ.get("GITHUB_REPOSITORY")
+        token = os.environ.get("GITHUB_TOKEN")
+        if not repository or not token:
+            sys.stderr.write(
+                "Milestone enforcement requires GITHUB_REPOSITORY and GITHUB_TOKEN.\n"
+            )
+            return 1
+        issue_numbers = extract_issue_numbers(text)
+        if not issue_numbers:
+            sys.stderr.write(
+                "Milestone enforcement enabled but no issue numbers found.\n"
+            )
+            return 1
+        try:
+            if not ensure_issue_milestones(issue_numbers, repository, token):
+                sys.stderr.write(
+                    "Referenced issues must have a milestone for the current release.\n"
+                )
+                return 1
+        except urllib.error.HTTPError as exc:
+            sys.stderr.write(
+                f"Failed to fetch issue milestone data ({exc.code}).\n"
+            )
+            return 1
+        except urllib.error.URLError as exc:
+            sys.stderr.write(
+                f"Failed to fetch issue milestone data ({exc.reason}).\n"
+            )
+            return 1
     return 0
 
 

--- a/tests/test_pr_issue_reference.py
+++ b/tests/test_pr_issue_reference.py
@@ -12,7 +12,9 @@ from pathlib import Path
 
 from scripts.check_pr_issue_reference import (
     extract_pr_text,
+    extract_issue_numbers,
     has_issue_reference,
+    issue_has_milestone,
     main,
 )
 
@@ -30,6 +32,18 @@ class PullRequestIssueReferenceTests(unittest.TestCase):
     def test_has_issue_reference(self) -> None:
         self.assertTrue(has_issue_reference("Handles #9."))
         self.assertFalse(has_issue_reference("No issue here."))
+
+    def test_extract_issue_numbers(self) -> None:
+        self.assertEqual(
+            extract_issue_numbers("Fixes #12 and refs #7."),
+            ["12", "7"],
+        )
+        self.assertEqual(extract_issue_numbers("No refs."), [])
+
+    def test_issue_has_milestone(self) -> None:
+        self.assertFalse(issue_has_milestone({"milestone": None}))
+        self.assertFalse(issue_has_milestone({}))
+        self.assertTrue(issue_has_milestone({"milestone": {"title": "v0.1.5"}}))
 
     def test_main_requires_issue_reference(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- require milestone on referenced issues when PROJECTATLAS_REQUIRE_ISSUE_MILESTONE=1
- set the milestone requirement env in CI
- document the milestone policy in README/workflow docs

Closes #80