### PR TITLE
chore(memory): log release + milestone policy (#78)

### DIFF
--- a/.codex/rules/memory/progress.md
+++ b/.codex/rules/memory/progress.md
@@ -1,6 +1,9 @@
 # Progress Log
 
 ## Completed
+- 2026-01-02: Added ProjectAtlas Memory Bank files under `.codex/rules/memory` and tracked them in the non-source list.
+- 2026-01-02: Switched auto-release to `--generate-notes` and enforced issue milestones in PR checks (CI).
+- 2026-01-02: Released v0.1.4 with updated release notes linking PRs/issues.
 
 ## Pending Work
 


### PR DESCRIPTION
## Summary
- record recent release + milestone policy work in the ProjectAtlas Memory Bank

Refs #78