### PR TITLE
docs: add public info hygiene guidance (#83)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,4 @@ Closes #NNN
 - [ ] `python scripts/check_docstrings.py` clean.
 - [ ] `python scripts/generate_api_docs.py` clean and committed.
 - [ ] Tests updated or added.
+- [ ] PR text contains no private or internal-only details (release notes are generated from PR text).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,4 @@ If you spot a bug or have a suggestion, please open an issue with clear reproduc
 - PR titles or bodies must reference a GitHub issue (for example `#123`).
 - Install git hooks with `python scripts/install_hooks.py` so commits require issue references.
 - Apply `type:*`, `priority:*`, and `status:*` labels to every issue.
+- Keep public issues/PRs/release notes free of private or internal-only details.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -18,6 +18,7 @@ ProjectAtlas is designed to run locally and produce a deterministic map.
 - Every issue should carry a `type:*` label plus a `priority:*` and `status:*` label.
 - Use `status:backlog` for unscheduled work.
 - Any issue referenced by a PR must be assigned to the target release milestone (CI enforces this).
+- Keep public issues/PRs/release notes free of private or internal-only details (release notes are generated from PR text).
 
 ## Review expectations
 


### PR DESCRIPTION
## Summary
- add a privacy reminder to CONTRIBUTING, workflow docs, and PR checklist

Closes #83