### PR TITLE
chore(build): add one-command local checks (#85)

### DIFF
--- a/.projectatlas/projectatlas-nonsource-files.toon
+++ b/.projectatlas/projectatlas-nonsource-files.toon
@@ -35,6 +35,7 @@ nonsource_files[]:
   skills/claude/ProjectAtlas.md,Claude skill instructions for ProjectAtlas
   templates/AGENTS.md,Agent startup snippet for ProjectAtlas
   mkdocs.yml,MkDocs site configuration for ProjectAtlas
+  scripts/check_all.py,Run the full local ProjectAtlas verification suite
   scripts/check_docstrings.py,Docstring enforcement for ProjectAtlas code
   scripts/check_commit_issue.py,Commit message issue reference enforcement
   scripts/generate_api_docs.py,Generate API documentation for ProjectAtlas

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,9 +1,9 @@
 version: 1
-generated_at: 2026-01-02T20:05:05Z
-file_hash: "9f0bec1fb84ca90c6259672f425602c9e93e07b5c4d6d3ab301a22033e1ea444"
+generated_at: 2026-01-03T10:41:15Z
+file_hash: "8a40a3b91d6ae0b5455d8f10245aca044bf6c8ef91292d042e0f143c683204aa"
 folder_hash: "d8e554805feb298a8977e058a017b09ad7ddf7972e3155af1a8977070ac49d1f"
 root: .
-overview: tracked_files=21 tracked_folders=18 source_extensions=10 exclude_dir_names=8 exclude_path_prefixes=0
+overview: tracked_files=22 tracked_folders=18 source_extensions=10 exclude_dir_names=8 exclude_path_prefixes=0
 source_extensions[]:
   - .cjs
   - .css
@@ -44,7 +44,7 @@ folders[18]{path,summary,source}:
   src/projectatlas,Core ProjectAtlas package implementation.,purpose
   templates,Reusable agent templates and snippets.,purpose
   tests,Unit tests for ProjectAtlas.,purpose
-files[54]{path,summary,source}:
+files[55]{path,summary,source}:
   .codex/rules/memory/activeContext.md,ProjectAtlas active context,nonsource
   .codex/rules/memory/productContext.md,ProjectAtlas product context,nonsource
   .codex/rules/memory/progress.md,ProjectAtlas progress log,nonsource
@@ -75,6 +75,7 @@ files[54]{path,summary,source}:
   docs/workflow.md,ProjectAtlas workflow and troubleshooting guide,nonsource
   mkdocs.yml,MkDocs site configuration for ProjectAtlas,nonsource
   pyproject.toml,ProjectAtlas packaging and CLI metadata,nonsource
+  scripts/check_all.py,Run the full local ProjectAtlas verification workflow in one command.,header
   scripts/check_commit_issue.py,Enforce GitHub issue references in commit messages.,header
   scripts/check_docstrings.py,Enforce module and public symbol docstrings for ProjectAtlas code.,header
   scripts/check_pr_issue_reference.py,Enforce issue references in pull request titles or bodies.,header

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Assign issues you are actively working on to the target release milestone; CI en
 Run tests, docs, and build artifacts locally:
 
 ```bash
+python scripts/check_all.py
+```
+
+Or run the steps individually:
+
+```bash
 python -m unittest discover -s tests
 python scripts/check_docstrings.py
 python scripts/generate_api_docs.py

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -13,6 +13,14 @@ ProjectAtlas is designed to run locally and produce a deterministic map.
 7. Commit map updates and any Purpose changes.
 8. Install git hooks with `python scripts/install_hooks.py` to enforce issue references in commit messages.
 
+## One-command local verification
+
+Run the full local check suite with:
+
+```bash
+python scripts/check_all.py
+```
+
 ## Issue hygiene
 
 - Every issue should carry a `type:*` label plus a `priority:*` and `status:*` label.

--- a/scripts/check_all.py
+++ b/scripts/check_all.py
@@ -1,0 +1,65 @@
+"""
+Purpose: Run the full local ProjectAtlas verification workflow in one command.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Step:
+    """Represent a check step in the local verification run."""
+
+    label: str
+    command: list[str]
+
+
+def run_step(step: Step) -> None:
+    """Run a single verification step."""
+    print(f"==> {step.label}")
+    subprocess.run(step.command, check=True)
+
+
+def ensure_build_module() -> None:
+    """Ensure the Python build module is available."""
+    try:
+        import build  # noqa: F401
+    except ImportError as exc:
+        raise SystemExit(
+            "Missing build module. Install with: python -m pip install build"
+        ) from exc
+
+
+def main() -> int:
+    """Run the full local verification sequence."""
+    ensure_build_module()
+    python = sys.executable
+    steps = [
+        Step("ProjectAtlas map", [python, "-m", "projectatlas", "map"]),
+        Step(
+            "ProjectAtlas lint",
+            [
+                python,
+                "-m",
+                "projectatlas",
+                "lint",
+                "--strict-folders",
+                "--report-untracked",
+            ],
+        ),
+        Step("Docstring check", [python, "scripts/check_docstrings.py"]),
+        Step("API docs", [python, "scripts/generate_api_docs.py"]),
+        Step("Unit tests", [python, "-m", "unittest", "discover", "-s", "tests"]),
+        Step("Build package", [python, "-m", "build", "--sdist", "--wheel"]),
+    ]
+    for step in steps:
+        run_step(step)
+    print("All ProjectAtlas checks succeeded.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add scripts/check_all.py to run map/lint/docs/tests/build in one call
- document the one-command workflow in README and docs/workflow
- track the script in the non-source list and refresh the atlas

Closes #85