### PR TITLE
chore(git): add pre-push full checks (#88)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Purpose: Run the full local ProjectAtlas check suite before pushing.
+
+set -e
+
+python scripts/check_all.py

--- a/.projectatlas/projectatlas-nonsource-files.toon
+++ b/.projectatlas/projectatlas-nonsource-files.toon
@@ -16,6 +16,7 @@ nonsource_files[]:
   .github/workflows/04-docs.yml,ProjectAtlas docs site workflow
   .github/pull_request_template.md,Pull request checklist for ProjectAtlas
   .githooks/commit-msg,Git hook to enforce issue references in commits
+  .githooks/pre-push,Git hook to run full local checks before push
   .codex/skills/ProjectAtlas.md,Codex skill instructions for ProjectAtlas
   .codex/rules/memory/projectbrief.md,ProjectAtlas project brief
   .codex/rules/memory/productContext.md,ProjectAtlas product context

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,6 +1,6 @@
 version: 1
-generated_at: 2026-01-03T10:41:15Z
-file_hash: "8a40a3b91d6ae0b5455d8f10245aca044bf6c8ef91292d042e0f143c683204aa"
+generated_at: 2026-01-03T11:10:07Z
+file_hash: "c8af21a026e213ea58e58a1aad005d23f3179416eba9dd6b5731240f535a2ff8"
 folder_hash: "d8e554805feb298a8977e058a017b09ad7ddf7972e3155af1a8977070ac49d1f"
 root: .
 overview: tracked_files=22 tracked_folders=18 source_extensions=10 exclude_dir_names=8 exclude_path_prefixes=0
@@ -44,7 +44,7 @@ folders[18]{path,summary,source}:
   src/projectatlas,Core ProjectAtlas package implementation.,purpose
   templates,Reusable agent templates and snippets.,purpose
   tests,Unit tests for ProjectAtlas.,purpose
-files[55]{path,summary,source}:
+files[56]{path,summary,source}:
   .codex/rules/memory/activeContext.md,ProjectAtlas active context,nonsource
   .codex/rules/memory/productContext.md,ProjectAtlas product context,nonsource
   .codex/rules/memory/progress.md,ProjectAtlas progress log,nonsource
@@ -54,6 +54,7 @@ files[55]{path,summary,source}:
   .codex/rules/memory/techContext.md,ProjectAtlas tech context,nonsource
   .codex/skills/ProjectAtlas.md,Codex skill instructions for ProjectAtlas,nonsource
   .githooks/commit-msg,Git hook to enforce issue references in commits,nonsource
+  .githooks/pre-push,Git hook to run full local checks before push,nonsource
   .github/pull_request_template.md,Pull request checklist for ProjectAtlas,nonsource
   .github/workflows/03-auto-release.yml,ProjectAtlas auto release workflow,nonsource
   .github/workflows/04-docs.yml,ProjectAtlas docs site workflow,nonsource

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,4 @@ If you spot a bug or have a suggestion, please open an issue with clear reproduc
 - Install git hooks with `python scripts/install_hooks.py` so commits require issue references.
 - Apply `type:*`, `priority:*`, and `status:*` labels to every issue.
 - Keep public issues/PRs/release notes free of private or internal-only details.
+- The pre-push hook runs `python scripts/check_all.py`; install the `build` module first.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ python scripts/install_hooks.py
 ```
 
 Issue hygiene: label every issue with `type:*`, `priority:*`, and `status:*`.
+The pre-push hook runs `python scripts/check_all.py` to validate the full local suite before pushes.
 Assign issues you are actively working on to the target release milestone; CI enforces that referenced issues have a milestone.
 
 Run tests, docs, and build artifacts locally:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -12,6 +12,7 @@ ProjectAtlas is designed to run locally and produce a deterministic map.
 6. Open a PR that references the GitHub issue (CI requires `#NNN` in title or body).
 7. Commit map updates and any Purpose changes.
 8. Install git hooks with `python scripts/install_hooks.py` to enforce issue references in commit messages.
+   - The pre-push hook runs `python scripts/check_all.py` to validate map/lint/tests/build.
 
 ## One-command local verification
 


### PR DESCRIPTION
## Summary
- add pre-push hook to run scripts/check_all.py
- document the hook in README/CONTRIBUTING/workflow
- track the new hook in the non-source list and refresh the atlas

Closes #88