### PR TITLE
docs(projectatlas): add GitHub rules file (#96)

### DIFF
--- a/.codex/rules/projectatlas/.purpose
+++ b/.codex/rules/projectatlas/.purpose
@@ -1,0 +1,1 @@
+Purpose: ProjectAtlas-specific rule files and practices.

--- a/.codex/rules/projectatlas/github-rules.md
+++ b/.codex/rules/projectatlas/github-rules.md
@@ -1,0 +1,25 @@
+# ProjectAtlas GitHub Rules
+
+Purpose: Document the ProjectAtlas GitHub workflow so agents follow the same release and issue discipline.
+
+## Branches
+- `dev` is for active development.
+- `main` is for stable releases only.
+- All changes flow through PRs; direct pushes to protected branches are blocked.
+
+## Issues and milestones
+- Every PR must reference a GitHub issue (`#NNN`) in the title or body.
+- Any issue referenced by a PR must be assigned to the target release milestone (CI enforces this).
+- Apply `type:*`, `priority:*`, and `status:*` labels to every issue.
+
+## Release workflow
+- Use `python scripts/prepare_release.py --issue <NNN> --bump patch` to prepare a release from `dev`.
+- Merge the release PR into `main` after CI is green; auto-release publishes the tag with generated notes.
+- The post-release PR bumps `dev` to the next `.dev` version.
+
+## Local verification
+- Run `python scripts/check_all.py` before pushing (pre-push hook enforces this).
+- If checks fail, fix issues before pushing or opening a PR.
+
+## Public info hygiene
+- Keep public issues/PRs/release notes free of private or internal-only details.

--- a/.projectatlas/projectatlas-nonsource-files.toon
+++ b/.projectatlas/projectatlas-nonsource-files.toon
@@ -23,6 +23,8 @@ nonsource_files[]:
   .codex/rules/memory/activeContext.md,ProjectAtlas active context
   .codex/rules/memory/systemPatterns.md,ProjectAtlas system patterns
   .codex/rules/memory/techContext.md,ProjectAtlas tech context
+  .codex/rules/projectatlas/.purpose,ProjectAtlas rule folder purpose
+  .codex/rules/projectatlas/github-rules.md,ProjectAtlas GitHub workflow rules
   .codex/rules/memory/progress.md,ProjectAtlas progress log
   .codex/rules/memory/ruleIndex.md,ProjectAtlas memory bank index
   docs/agent-integration.md,Agent integration instructions for ProjectAtlas

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,9 +1,9 @@
 version: 1
-generated_at: 2026-01-03T11:10:07Z
-file_hash: "c8af21a026e213ea58e58a1aad005d23f3179416eba9dd6b5731240f535a2ff8"
-folder_hash: "d8e554805feb298a8977e058a017b09ad7ddf7972e3155af1a8977070ac49d1f"
+generated_at: 2026-01-03T11:38:01Z
+file_hash: "185b949899e28526aff43bbf4e152332f30426d621fd1e9e2163b8a7417ff0a5"
+folder_hash: "103200be353e1ea8bf0e41456d3c8bb3727a67ea7a32a7b621a9f63a427bd6a7"
 root: .
-overview: tracked_files=22 tracked_folders=18 source_extensions=10 exclude_dir_names=8 exclude_path_prefixes=0
+overview: tracked_files=22 tracked_folders=19 source_extensions=10 exclude_dir_names=8 exclude_path_prefixes=0
 source_extensions[]:
   - .cjs
   - .css
@@ -25,11 +25,12 @@ exclude_dir_names[]:
   - dist
   - node_modules
 exclude_path_prefixes[]:
-folders[18]{path,summary,source}:
+folders[19]{path,summary,source}:
   .,ProjectAtlas repository root.,purpose
   .codex,Codex configuration and skills for ProjectAtlas.,purpose
   .codex/rules,ProjectAtlas rules for Codex usage.,purpose
   .codex/rules/memory,ProjectAtlas Memory Bank files.,purpose
+  .codex/rules/projectatlas,ProjectAtlas-specific rule files and practices.,purpose
   .codex/skills,Codex skill copies for ProjectAtlas adoption.,purpose
   .githooks,Git hook scripts for ProjectAtlas commits.,purpose
   .github,ProjectAtlas GitHub metadata and workflows.,purpose
@@ -44,7 +45,7 @@ folders[18]{path,summary,source}:
   src/projectatlas,Core ProjectAtlas package implementation.,purpose
   templates,Reusable agent templates and snippets.,purpose
   tests,Unit tests for ProjectAtlas.,purpose
-files[56]{path,summary,source}:
+files[58]{path,summary,source}:
   .codex/rules/memory/activeContext.md,ProjectAtlas active context,nonsource
   .codex/rules/memory/productContext.md,ProjectAtlas product context,nonsource
   .codex/rules/memory/progress.md,ProjectAtlas progress log,nonsource
@@ -52,6 +53,8 @@ files[56]{path,summary,source}:
   .codex/rules/memory/ruleIndex.md,ProjectAtlas memory bank index,nonsource
   .codex/rules/memory/systemPatterns.md,ProjectAtlas system patterns,nonsource
   .codex/rules/memory/techContext.md,ProjectAtlas tech context,nonsource
+  .codex/rules/projectatlas/.purpose,ProjectAtlas rule folder purpose,nonsource
+  .codex/rules/projectatlas/github-rules.md,ProjectAtlas GitHub workflow rules,nonsource
   .codex/skills/ProjectAtlas.md,Codex skill instructions for ProjectAtlas,nonsource
   .githooks/commit-msg,Git hook to enforce issue references in commits,nonsource
   .githooks/pre-push,Git hook to run full local checks before push,nonsource
@@ -109,6 +112,7 @@ folder_tree[]:
   - .codex/ - Codex configuration and skills for ProjectAtlas.
   -   rules/ - ProjectAtlas rules for Codex usage.
   -     memory/ - ProjectAtlas Memory Bank files.
+  -     projectatlas/ - ProjectAtlas-specific rule files and practices.
   -   skills/ - Codex skill copies for ProjectAtlas adoption.
   - .githooks/ - Git hook scripts for ProjectAtlas commits.
   - .github/ - ProjectAtlas GitHub metadata and workflows.


### PR DESCRIPTION
## Summary
- add ProjectAtlas-specific GitHub rules under .codex/rules/projectatlas
- track new rules files in the non-source list and refresh the atlas

Closes #96