### PR TITLE
feat(atlas): language-agnostic purpose styles (#101)

### DIFF
--- a/.codex/rules/memory/activeContext.md
+++ b/.codex/rules/memory/activeContext.md
@@ -2,4 +2,5 @@
 
 Purpose: Capture current focus areas and any in-flight tasks for ProjectAtlas.
 
-- Align configuration docs and templates with the default asset extensions list (issue #98).
+- Deliver language-agnostic Purpose headers (line/block comment support + per-extension config) and release v0.1.7-00 (issue #101).
+- Ensure docs, skills, and configuration examples match the new Purpose-style support.

--- a/.codex/rules/memory/progress.md
+++ b/.codex/rules/memory/progress.md
@@ -10,4 +10,5 @@
 - 2026-01-03: Aligned config template and configuration docs with the default asset extensions list (fonts included); full check suite passed.
 
 ## Pending Work
+- Deliver language-agnostic Purpose header support and release v0.1.7-00 (issue #101).
 

--- a/.projectatlas/config.toml
+++ b/.projectatlas/config.toml
@@ -8,12 +8,16 @@ nonsource_files_path = ".projectatlas/projectatlas-nonsource-files.toon"
 purpose_filename = ".purpose"
 
 [scan]
-source_extensions = [".py", ".js", ".ts", ".tsx", ".jsx", ".vue", ".css", ".mjs", ".cjs", ".d.ts"]
+source_extensions = [".py", ".js", ".ts", ".tsx", ".jsx", ".vue", ".css", ".mjs", ".cjs", ".d.ts", ".java", ".kt", ".scala", ".cs", ".go", ".rs", ".rb", ".php", ".c", ".h", ".cpp", ".hpp", ".cc", ".cxx", ".swift", ".lua", ".sh", ".bash", ".zsh", ".ps1", ".psm1", ".psd1", ".sql"]
 exclude_dir_names = [".git", ".projectatlas", ".venv", "__pycache__", ".egg-info", "node_modules", "dist", "build"]
 exclude_dir_suffixes = [".egg-info"]
 exclude_path_prefixes = []
 non_source_path_prefixes = []
 max_scan_lines = 80
+
+[purpose]
+default_style = "javadoc"
+line_comment_prefixes = ["//", "#", "--", ";"]
 
 [summary_rules]
 ascii_only = true

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,20 +1,43 @@
 version: 1
-generated_at: 2026-01-03T13:31:23Z
+generated_at: 2026-01-03T20:27:54Z
 file_hash: "185b949899e28526aff43bbf4e152332f30426d621fd1e9e2163b8a7417ff0a5"
 folder_hash: "103200be353e1ea8bf0e41456d3c8bb3727a67ea7a32a7b621a9f63a427bd6a7"
 root: .
-overview: tracked_files=22 tracked_folders=19 source_extensions=10 exclude_dir_names=8 exclude_path_prefixes=0
+overview: tracked_files=22 tracked_folders=19 source_extensions=33 exclude_dir_names=8 exclude_path_prefixes=0
 source_extensions[]:
+  - .bash
+  - .c
+  - .cc
   - .cjs
+  - .cpp
+  - .cs
   - .css
+  - .cxx
   - .d.ts
+  - .go
+  - .h
+  - .hpp
+  - .java
   - .js
   - .jsx
+  - .kt
+  - .lua
   - .mjs
+  - .php
+  - .ps1
+  - .psd1
+  - .psm1
   - .py
+  - .rb
+  - .rs
+  - .scala
+  - .sh
+  - .sql
+  - .swift
   - .ts
   - .tsx
   - .vue
+  - .zsh
 exclude_dir_names[]:
   - .egg-info
   - .git

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It answers "where should I look?" and "where should I put this?" before running 
 - TOON output for fast agent consumption.
 - Duplicate summary detection for early structure drift.
 - Lint mode that fails when headers or `.purpose` files are missing.
+- Language-aware Purpose styles for common languages (line, block, or Javadoc).
 - Configurable exclusions, asset roots, and allowlists.
 
 ## How it works
@@ -228,7 +229,8 @@ For Codex, copy `.codex/skills/ProjectAtlas.md` into your local Codex skills fol
 
 ## Purpose headers
 
-ProjectAtlas expects a one-line `Purpose:` entry at the top of each tracked file:
+ProjectAtlas expects a one-line `Purpose:` entry near the top of each tracked file.
+The comment style is configurable per extension.
 
 ```txt
 /**
@@ -236,8 +238,17 @@ ProjectAtlas expects a one-line `Purpose:` entry at the top of each tracked file
  */
 ```
 
-Python files should use a module docstring with `Purpose:` on the first lines. Vue files should place the
-Javadoc-style block at the top of the first `<script>` or `<style>` block.
+Line-comment and block-comment styles are also supported when configured:
+
+```txt
+// Purpose: Describe the file in one sentence.
+# Purpose: Describe the file in one sentence.
+/* Purpose: Describe the file in one sentence. */
+```
+
+Python files use a module docstring with `Purpose:` on the first lines. Vue files place a Javadoc-style
+block at the top of the first `<script>` or `<style>` block. The default mapping already covers major
+languages; override it in `purpose.styles_by_extension` if needed.
 
 ## Configuration
 
@@ -247,6 +258,9 @@ See `docs/configuration.md` for all available settings. Most teams only need to 
 - `scan.exclude_dir_names`
 - `untracked.asset_allowed_prefixes`
 - `project.map_path`
+- `purpose.default_style`
+- `purpose.styles_by_extension`
+- `purpose.line_comment_prefixes`
 
 ## Agent integration
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -21,8 +21,8 @@ projectatlas init --seed-purpose
 
 ## 4. Add Purpose headers
 
-Add a Javadoc-style `Purpose:` header to every tracked source file. Python modules should use a
-module docstring with `Purpose:`.
+Add a `Purpose:` header to every tracked source file using the configured comment style.
+Python modules should use a module docstring with `Purpose:`.
 
 ## 5. Track non-source files
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,6 +58,10 @@ Check whether a file is considered an asset.
 
 List asset root prefixes that exist in the repo.
 
+### Function `strip_line_comment_prefix`
+
+Remove the first matching line-comment prefix and trim whitespace.
+
 ### Function `extract_purpose_from_lines`
 
 Extract the Purpose summary from a sequence of lines.
@@ -66,6 +70,10 @@ Extract the Purpose summary from a sequence of lines.
 
 Extract Purpose from a Javadoc-style header block.
 
+### Function `extract_block_comment_purpose`
+
+Extract Purpose from a block comment header.
+
 ### Function `extract_python_docstring_purpose`
 
 Extract Purpose from a Python module docstring.
@@ -73,6 +81,14 @@ Extract Purpose from a Python module docstring.
 ### Function `extract_vue_purpose`
 
 Extract Purpose from the first Vue <script> or <style> block.
+
+### Function `extract_line_comment_purpose`
+
+Extract Purpose from a line-comment header block.
+
+### Function `resolve_purpose_style`
+
+Resolve the Purpose style for a file extension.
 
 ### Function `extract_purpose_header`
 
@@ -191,6 +207,14 @@ Define the normalized configuration for ProjectAtlas.
 Locate the first ProjectAtlas config file under the root.
 
 ### Function `_as_set`
+
+_No docstring provided._
+
+### Function `_as_list`
+
+_No docstring provided._
+
+### Function `_as_map`
 
 _No docstring provided._
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -9,7 +9,10 @@ ProjectAtlas treats missing `.purpose` files as a lint error when `--strict-fold
 
 ## File Purpose headers
 
-Each tracked source file carries a one-line `Purpose:` header at the top of the file. This allows:
+Each tracked source file carries a one-line `Purpose:` header near the top of the file. The comment
+style is configurable per extension (Javadoc blocks, block comments, or line comments).
+
+This allows:
 
 - quick file selection before deep indexing
 - early detection of duplicate responsibilities

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,12 +10,17 @@ nonsource_files_path = ".projectatlas/projectatlas-nonsource-files.toon"
 purpose_filename = ".purpose"
 
 [scan]
-source_extensions = [".py", ".js", ".ts", ".tsx", ".jsx", ".vue", ".css", ".mjs", ".cjs", ".d.ts"]
+source_extensions = [".py", ".js", ".ts", ".tsx", ".jsx", ".vue", ".css", ".mjs", ".cjs", ".d.ts", ".java", ".kt", ".scala", ".cs", ".go", ".rs", ".rb", ".php", ".c", ".h", ".cpp", ".hpp", ".cc", ".cxx", ".swift", ".lua", ".sh", ".bash", ".zsh", ".ps1", ".psm1", ".psd1", ".sql"]
 exclude_dir_names = [".git", ".projectatlas", ".venv", "__pycache__", "node_modules", "dist", "build"]
 exclude_dir_suffixes = [".egg-info"]
 exclude_path_prefixes = []
 non_source_path_prefixes = []
 max_scan_lines = 80
+
+[purpose]
+default_style = "javadoc"
+line_comment_prefixes = ["//", "#", "--", ";"]
+# styles_by_extension = { ".go" = "line-comment", ".c" = "block-comment" }
 
 [summary_rules]
 ascii_only = true
@@ -28,6 +33,25 @@ allowlist_dir_prefixes = []
 allowlist_files = []
 asset_allowed_prefixes = []
 asset_extensions = [".png", ".jpg", ".jpeg", ".svg", ".gif", ".webp", ".ico", ".pdf", ".ttf", ".woff", ".woff2"]
+```
+
+### Purpose styles
+
+- `purpose.default_style` controls the fallback header style (`javadoc`, `block-comment`, or `line-comment`).
+- `purpose.styles_by_extension` maps specific extensions to a style.
+- `purpose.line_comment_prefixes` controls which line-comment prefixes are recognized.
+
+Example:
+
+```toml
+[purpose]
+default_style = "javadoc"
+line_comment_prefixes = ["//", "#", "--", ";"]
+
+[purpose.styles_by_extension]
+".go" = "line-comment"
+".rs" = "line-comment"
+".c" = "block-comment"
 ```
 
 ### Non-source file list

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -76,7 +76,9 @@ projectatlas map
 
 ### Missing Purpose headers
 
-Add a Javadoc-style header with `Purpose:` to the file. For Python, use a module docstring.
+Add a `Purpose:` header using the comment style configured for that file extension
+(Javadoc block, block comment, or line comment). For Python, use a module docstring.
+If the file uses a different style, update `purpose.styles_by_extension` in the config.
 
 ### Missing .purpose files
 

--- a/skills/claude/ProjectAtlas.md
+++ b/skills/claude/ProjectAtlas.md
@@ -21,7 +21,7 @@ Give Claude a fast structure map before deep indexing so it can pick the right f
 1. Install locally: `pip install -e .`
 2. Initialize: `projectatlas init --seed-purpose`
 3. Fill each `.purpose` file with a one-line summary (ASCII, no commas).
-4. Add Purpose headers to every tracked source file.
+4. Add Purpose headers to every tracked source file (comment style per extension; see `purpose.styles_by_extension`).
 5. Add non-source files to `.projectatlas/projectatlas-nonsource-files.toon`.
 6. Run `projectatlas map`.
 7. Run `projectatlas lint --strict-folders --report-untracked` and fix issues.

--- a/skills/codex/ProjectAtlas.md
+++ b/skills/codex/ProjectAtlas.md
@@ -29,7 +29,7 @@ files. ProjectAtlas is the layer above code-index tools.
 1. Install locally: `pip install -e .`
 2. Initialize: `projectatlas init --seed-purpose`
 3. Fill each `.purpose` file with a one-line summary (ASCII, no commas).
-4. Add Purpose headers to every tracked source file.
+4. Add Purpose headers to every tracked source file (comment style per extension; see `purpose.styles_by_extension`).
 5. Add non-source files to `.projectatlas/projectatlas-nonsource-files.toon`.
 6. Run `projectatlas map` to generate `.projectatlas/projectatlas.toon`.
 7. Run `projectatlas lint --strict-folders --report-untracked` and fix issues.


### PR DESCRIPTION
## Summary
- Add configurable Purpose styles (line/block/Javadoc) with per-extension mapping.
- Expand default language coverage and update docs/config/skills.
- Add unit tests for line and block comment headers.

## Testing
- python scripts/check_all.py