### PR TITLE
chore(memory): close out v0.1.7 release (#101)

### DIFF
--- a/.codex/rules/memory/activeContext.md
+++ b/.codex/rules/memory/activeContext.md
@@ -2,5 +2,4 @@
 
 Purpose: Capture current focus areas and any in-flight tasks for ProjectAtlas.
 
-- Deliver language-agnostic Purpose headers (line/block comment support + per-extension config) and release v0.1.7-00 (issue #101).
-- Ensure docs, skills, and configuration examples match the new Purpose-style support.
+- Monitor CI and issues after the v0.1.7 release; keep docs and templates aligned with any follow-up fixes.

--- a/.codex/rules/memory/progress.md
+++ b/.codex/rules/memory/progress.md
@@ -8,7 +8,7 @@
 - 2026-01-03: Added pre-push hook to run the full check suite before pushes and documented it.
 - 2026-01-03: Released v0.1.5 (milestone closed, tag published, dev bumped to v0.1.6.dev0).
 - 2026-01-03: Aligned config template and configuration docs with the default asset extensions list (fonts included); full check suite passed.
+- 2026-01-03: Released v0.1.7 with language-agnostic Purpose header support (line/block comment styles), expanded default language coverage, updated docs/skills/config, and added unit tests (issue #101).
 
 ## Pending Work
-- Deliver language-agnostic Purpose header support and release v0.1.7-00 (issue #101).
 


### PR DESCRIPTION
## Summary
- Update Memory Bank entries after the v0.1.7 release.

## Testing
- Not applicable (documentation update).