### PR TITLE
chore(memory): post-release update (#114)

### DIFF
--- a/.codex/rules/memory/activeContext.md
+++ b/.codex/rules/memory/activeContext.md
@@ -2,6 +2,5 @@
 
 Purpose: Capture current focus areas and any in-flight tasks for ProjectAtlas.
 
-- Ship v0.1.8 with auto-detected language extensions in `projectatlas init` (issue #111).
-- Confirm docs/skills/CLI remain aligned with the auto-detect behavior after the release.
-- Keep CI green and close out any resolved release issues with self-review notes.
+- Monitor CI after the v0.1.8 release and keep dev at v0.1.9.dev0.
+- Track the upcoming config-inspection CLI improvement (issue #109).

--- a/.codex/rules/memory/progress.md
+++ b/.codex/rules/memory/progress.md
@@ -2,6 +2,7 @@
 
 ## Completed
 - 2026-01-03: Added auto-detect language extensions for `projectatlas init`, updated docs/skills/tests, and removed dead config text from `detect_purpose_styles` (issue #111).
+- 2026-01-03: Released v0.1.8 and published Highlights in the GitHub Release; merged post-release bump to v0.1.9.dev0 (issue #114).
 - 2026-01-02: Added ProjectAtlas Memory Bank files under `.codex/rules/memory` and tracked them in the non-source list.
 - 2026-01-02: Switched auto-release to `--generate-notes` and enforced issue milestones in PR checks (CI).
 - 2026-01-02: Released v0.1.4 with updated release notes linking PRs/issues.
@@ -13,5 +14,5 @@
 - 2026-01-03: Required Highlights in release notes via GitHub rules updates (issue #108).
 
 ## Pending Work
-- Release v0.1.8 after confirming CI on the auto-detect changes (issue #111).
+- Evaluate and implement the config-inspection CLI enhancement (issue #109).
 

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-01-03T22:09:55Z
+generated_at: 2026-01-03T22:38:39Z
 file_hash: "455f4a857c2ed8f563252d606b94d412823d7f62cb934f50f963621a87c8d7fd"
 folder_hash: "103200be353e1ea8bf0e41456d3c8bb3727a67ea7a32a7b621a9f63a427bd6a7"
 root: .


### PR DESCRIPTION
## Summary
- Update ProjectAtlas memory bank after v0.1.8 release.

## Testing
- python scripts/check_all.py
