### PR TITLE
chore(atlas): clarify overview counts (#118)

### DIFF
--- a/.codex/skills/ProjectAtlas.md
+++ b/.codex/skills/ProjectAtlas.md
@@ -48,9 +48,17 @@ files. ProjectAtlas is the layer above code-index tools.
 ## How to interpret the map
 
 - `overview:` shows tracked counts so you can spot drift quickly.
+- `overview` now distinguishes source vs non-source (`tracked_source_files`,
+  `tracked_nonsource_files`, `tracked_files_total`) so the totals match the merged list.
 - `folder_tree[]` provides a tree with summaries for fast navigation.
 - `folders[]` and `files[]` are the authoritative summaries for lookup.
 - `*_summary_duplicates[]` highlight likely overlap to clean up.
+
+## Why non-source files live in a separate TOON file
+
+- Some files cannot safely carry inline `Purpose:` headers (JSON, lockfiles, images, generated outputs).
+- Those entries live in `.projectatlas/projectatlas-nonsource-files.toon` and are merged into the atlas at map time.
+- Agents read only the generated atlas; the nonsource list is the durable input so the merged snapshot stays complete.
 
 ## AGENTS.md integration
 

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,9 +1,9 @@
 version: 1
-generated_at: 2026-01-03T22:38:39Z
+generated_at: 2026-01-04T11:49:20Z
 file_hash: "455f4a857c2ed8f563252d606b94d412823d7f62cb934f50f963621a87c8d7fd"
 folder_hash: "103200be353e1ea8bf0e41456d3c8bb3727a67ea7a32a7b621a9f63a427bd6a7"
 root: .
-overview: tracked_files=23 tracked_folders=19 source_extensions=33 exclude_dir_names=8 exclude_path_prefixes=0
+overview: tracked_source_files=23 tracked_nonsource_files=41 tracked_files_total=64 tracked_folders=19 source_extensions=33 exclude_dir_names=8 exclude_path_prefixes=0
 source_extensions[]:
   - .bash
   - .c

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ ProjectAtlas merges the non-source entries into the generated atlas, so **agents
 The input file exists only to preserve those non-source summaries across regenerations. Agents update it when
 `projectatlas lint` reports missing non-source entries or when new config/doc files are added.
 
+The atlas header makes the split explicit: `tracked_source_files` counts files scanned for Purpose headers,
+`tracked_nonsource_files` counts the manual entries, and `tracked_files_total` is the combined list shown in
+`files[]`.
+
 ## Workflow (agent-focused)
 
 1. Run `projectatlas init --seed-purpose` once to scaffold missing `.purpose` files.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -18,6 +18,13 @@ This allows:
 - early detection of duplicate responsibilities
 - consistent, low-overhead documentation
 
+## Non-source summaries
+
+Some files cannot safely carry inline Purpose headers (JSON, lockfiles, images, generated outputs). Those live in
+`.projectatlas/projectatlas-nonsource-files.toon`, which is merged into the atlas at map time. The generated
+`projectatlas.toon` still shows a single `files[]` list, but the header distinguishes
+`tracked_source_files`, `tracked_nonsource_files`, and the combined `tracked_files_total`.
+
 ## Health signals
 
 ProjectAtlas surfaces:

--- a/docs/format.md
+++ b/docs/format.md
@@ -8,7 +8,7 @@ generated_at: 2026-01-01T12:00:00Z
 file_hash: "..."
 folder_hash: "..."
 root: .
-overview: tracked_files=12 tracked_folders=8 source_extensions=9 exclude_dir_names=6 exclude_path_prefixes=0
+overview: tracked_source_files=12 tracked_nonsource_files=4 tracked_files_total=16 tracked_folders=8 source_extensions=9 exclude_dir_names=6 exclude_path_prefixes=0
 source_extensions[]:
   - .py
 exclude_dir_names[]:
@@ -29,3 +29,15 @@ folder_tree[]:
 ```
 
 Sections are stable so agents can scan quickly and tooling can diff.
+
+## Overview fields
+
+- `tracked_source_files` counts files scanned for Purpose headers (source extensions).
+- `tracked_nonsource_files` counts entries supplied by `projectatlas-nonsource-files.toon`.
+- `tracked_files_total` is the combined total shown in `files[]`.
+- The remaining fields (`tracked_folders`, `source_extensions`, `exclude_*`) describe the scan surface.
+
+## Non-source list
+
+The generated atlas merges the manual `.projectatlas/projectatlas-nonsource-files.toon` entries into `files[]`
+so the snapshot stays complete without forcing headers into formats that cannot safely accept them.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -74,6 +74,9 @@ If lint reports stale hashes or an overview mismatch, re-run:
 projectatlas map
 ```
 
+The `overview:` line in the atlas now reports `tracked_source_files`,
+`tracked_nonsource_files`, and `tracked_files_total` so you can see the split at a glance.
+
 ### Missing Purpose headers
 
 Add a `Purpose:` header using the comment style configured for that file extension

--- a/skills/claude/ProjectAtlas.md
+++ b/skills/claude/ProjectAtlas.md
@@ -35,6 +35,20 @@ Give Claude a fast structure map before deep indexing so it can pick the right f
 5. Use deep indexing tools only for the specific files you chose from the atlas.
 6. Fix missing Purpose headers or `.purpose` files before continuing.
 
+## How to interpret the map
+
+- `overview:` shows tracked counts so you can spot drift quickly. It reports
+  `tracked_source_files`, `tracked_nonsource_files`, and `tracked_files_total`.
+- `folder_tree[]` gives a tree with summaries for navigation.
+- `folders[]` and `files[]` are the authoritative summaries for lookup.
+- `*_summary_duplicates[]` highlight likely overlap to clean up.
+
+## Why non-source files are tracked separately
+
+- Some files cannot safely carry inline `Purpose:` headers (JSON, lockfiles, images, generated outputs).
+- Those entries live in `.projectatlas/projectatlas-nonsource-files.toon` and are merged into the atlas.
+- Agents read only the generated atlas; the nonsource file is the durable input list.
+
 ## AGENTS.md integration
 
 Add a startup snippet so the atlas is always read:

--- a/skills/codex/ProjectAtlas.md
+++ b/skills/codex/ProjectAtlas.md
@@ -47,10 +47,17 @@ files. ProjectAtlas is the layer above code-index tools.
 
 ## How to interpret the map
 
-- `overview:` shows tracked counts so you can spot drift quickly.
+- `overview:` shows tracked counts so you can spot drift quickly. It now reports
+  `tracked_source_files`, `tracked_nonsource_files`, and `tracked_files_total`.
 - `folder_tree[]` provides a tree with summaries for fast navigation.
 - `folders[]` and `files[]` are the authoritative summaries for lookup.
 - `*_summary_duplicates[]` highlight likely overlap to clean up.
+
+## Why non-source files are tracked separately
+
+- Some files cannot safely carry inline `Purpose:` headers (JSON, lockfiles, images, generated outputs).
+- Those entries live in `.projectatlas/projectatlas-nonsource-files.toon` and are merged into the atlas.
+- Agents read only the generated atlas; the nonsource file is the durable input list.
 
 ## AGENTS.md integration
 

--- a/src/projectatlas/atlas.py
+++ b/src/projectatlas/atlas.py
@@ -23,7 +23,9 @@ BLOCK_END_RE = re.compile(r"\*/")
 PY_DOCSTRING_START_RE = re.compile(r'^[rubfRUBF]*("""|\'\'\')')
 PY_CODING_RE = re.compile(r"^#.*coding[:=]")
 OVERVIEW_KEY_ORDER = (
-    "tracked_files",
+    "tracked_source_files",
+    "tracked_nonsource_files",
+    "tracked_files_total",
     "tracked_folders",
     "source_extensions",
     "exclude_dir_names",
@@ -592,11 +594,18 @@ def compute_folder_hash(paths: Sequence[Path], config: AtlasConfig) -> str:
 
 
 def compute_overview(
-    folders: Sequence[Path], files: Sequence[Path], config: AtlasConfig
+    folders: Sequence[Path],
+    files: Sequence[Path],
+    config: AtlasConfig,
+    nonsource_count: int = 0,
 ) -> dict[str, int]:
     """Compute overview counts for the map header."""
+    source_count = len(files)
+    total_count = source_count + nonsource_count
     return {
-        "tracked_files": len(files),
+        "tracked_source_files": source_count,
+        "tracked_nonsource_files": nonsource_count,
+        "tracked_files_total": total_count,
         "tracked_folders": len(folders),
         "source_extensions": len(config.source_extensions),
         "exclude_dir_names": len(config.exclude_dir_names),

--- a/src/projectatlas/cli.py
+++ b/src/projectatlas/cli.py
@@ -68,7 +68,7 @@ def build_snapshot(config: AtlasConfig) -> AtlasSnapshot:
     file_duplicates = build_summary_duplicates(file_records)
     file_hash = compute_file_hash(file_records)
     folder_hash = compute_folder_hash(folders, config)
-    overview = compute_overview(folders, files, config)
+    overview = compute_overview(folders, files, config, len(nonsource_records))
     generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     return AtlasSnapshot(
         folder_records=folder_records,
@@ -271,7 +271,9 @@ def run_lint(
             errors.append("Untracked files detected.")
 
     map_overview, overview_issues = read_overview(config.map_path)
-    expected_overview = compute_overview(folders, files, config)
+    expected_overview = compute_overview(
+        folders, files, config, len(nonsource_records)
+    )
     if map_overview is None:
         errors.append("Atlas map missing overview. Run: projectatlas map")
     elif overview_issues:


### PR DESCRIPTION
## Summary
- report source vs nonsource vs total counts in atlas overview
- document why nonsource files live in the manual list

## Testing
- python scripts/check_all.py
