### PR TITLE
chore(memory): log v0.1.9 release (#121)

### DIFF
--- a/.codex/rules/memory/activeContext.md
+++ b/.codex/rules/memory/activeContext.md
@@ -2,5 +2,5 @@
 
 Purpose: Capture current focus areas and any in-flight tasks for ProjectAtlas.
 
-- Prepare the v0.1.9 release that includes clarified atlas overview counts (issue #118).
+- Dev is now v0.1.10.dev0 after the v0.1.9 release; keep CI green.
 - Track the upcoming config-inspection CLI improvement (issue #109).

--- a/.codex/rules/memory/progress.md
+++ b/.codex/rules/memory/progress.md
@@ -4,6 +4,7 @@
 - 2026-01-03: Added auto-detect language extensions for `projectatlas init`, updated docs/skills/tests, and removed dead config text from `detect_purpose_styles` (issue #111).
 - 2026-01-03: Released v0.1.8 and published Highlights in the GitHub Release; merged post-release bump to v0.1.9.dev0 (issue #114).
 - 2026-01-03: Clarified atlas overview counts (source/nonsource/total) and documented the nonsource tracking model in docs/skills (issue #118).
+- 2026-01-04: Released v0.1.9 with the overview-count changes and merged the post-release bump to v0.1.10.dev0 (issue #121).
 - 2026-01-02: Added ProjectAtlas Memory Bank files under `.codex/rules/memory` and tracked them in the non-source list.
 - 2026-01-02: Switched auto-release to `--generate-notes` and enforced issue milestones in PR checks (CI).
 - 2026-01-02: Released v0.1.4 with updated release notes linking PRs/issues.
@@ -15,6 +16,5 @@
 - 2026-01-03: Required Highlights in release notes via GitHub rules updates (issue #108).
 
 ## Pending Work
-- Release v0.1.9 after validating the overview-count changes (issue #118).
 - Evaluate and implement the config-inspection CLI enhancement (issue #109).
 


### PR DESCRIPTION
## Summary
- Update ProjectAtlas memory bank after v0.1.9 release.

## Testing
- python scripts/check_all.py
