### PR TITLE
Fix Windows release config assertions (#168)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,15 +313,15 @@ jobs:
           }
 
           function Assert-McpArgs {
-            param([object[]]$Args)
-            Assert-Equal $Args[0] "--require-version" "Missing require-version flag"
-            Assert-Equal $Args[1] $expectedVersion "Runtime version mismatch"
-            $dbIndex = [Array]::IndexOf($Args, "--db")
+            param([object[]]$McpArgs)
+            Assert-Equal $McpArgs[0] "--require-version" "Missing require-version flag"
+            Assert-Equal $McpArgs[1] $expectedVersion "Runtime version mismatch"
+            $dbIndex = [Array]::IndexOf($McpArgs, "--db")
             if ($dbIndex -lt 0) {
               throw "Missing --db argument."
             }
-            Assert-Equal ([System.IO.Path]::GetFullPath($Args[$dbIndex + 1])) $expectedDb "Database path mismatch"
-            Assert-Equal $Args[-1] "mcp" "Missing mcp command"
+            Assert-Equal ([System.IO.Path]::GetFullPath($McpArgs[$dbIndex + 1])) $expectedDb "Database path mismatch"
+            Assert-Equal $McpArgs[-1] "mcp" "Missing mcp command"
           }
 
           $atlasDir = Join-Path $projectRoot ".projectatlas"
@@ -493,15 +493,15 @@ jobs:
           }
 
           function Assert-McpArgs {
-            param([object[]]$Args)
-            Assert-Equal $Args[0] "--require-version" "Missing require-version flag"
-            Assert-Equal $Args[1] $expectedVersion "Runtime version mismatch"
-            $dbIndex = [Array]::IndexOf($Args, "--db")
+            param([object[]]$McpArgs)
+            Assert-Equal $McpArgs[0] "--require-version" "Missing require-version flag"
+            Assert-Equal $McpArgs[1] $expectedVersion "Runtime version mismatch"
+            $dbIndex = [Array]::IndexOf($McpArgs, "--db")
             if ($dbIndex -lt 0) {
               throw "Missing --db argument."
             }
-            Assert-Equal ([System.IO.Path]::GetFullPath($Args[$dbIndex + 1])) $expectedDb "Database path mismatch"
-            Assert-Equal $Args[-1] "mcp" "Missing mcp command"
+            Assert-Equal ([System.IO.Path]::GetFullPath($McpArgs[$dbIndex + 1])) $expectedDb "Database path mismatch"
+            Assert-Equal $McpArgs[-1] "mcp" "Missing mcp command"
           }
 
           $atlasDir = Join-Path $projectRoot ".projectatlas"


### PR DESCRIPTION
## Summary
- fixes the Windows release smoke helper that collided with PowerShell's automatic `$args` variable
- applies the fix to both prepublish and postpublish Windows installer/config validation blocks
- preserves the Codex, Claude Code, and OpenCode generated config assertions before v0.3.5 can publish

## Context
Release run https://github.com/styler-ai/ProjectAtlas/actions/runs/28329076639 stopped before `publish` in the Windows prepublish installer smoke after the installer succeeded. The failing assertion was:

```text
Missing require-version flag. Expected '--require-version', found ''.
```

The cause was the helper parameter named `$Args`, which is case-insensitive with PowerShell's automatic `$args` variable. Renaming it to `$McpArgs` makes the array binding explicit.

## Verification
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/release.yml').read_text()); print('release workflow yaml parsed')"`
- local PowerShell `Assert-McpArgs @('--require-version','0.3.5','--db','.projectatlas\\projectatlas.db','mcp')` smoke
- `git diff --check`
- gpt-5.5 xhigh correctness review: no blockers
- gpt-5.5 xhigh release/process review: no issues found

Refs #168
