### PR TITLE
feat(projectatlas): complete v0.3.6 issue sweep

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Report something in ProjectAtlas that is broken or behaving incorrectly.
+title: "bug: "
+labels:
+  - type:bug
+  - priority:medium
+  - status:ready
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a ProjectAtlas bug. Please include enough detail for someone else to reproduce it without access to your private repository.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: "ProjectAtlas reports stale file purposes after..."
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: List the smallest steps that reproduce the behavior.
+      placeholder: |
+        1. Run `projectatlas scan`
+        2. Run `projectatlas summary ...`
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should ProjectAtlas have done?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead? Include relevant output if possible.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, shell, ProjectAtlas version, host agent, and install method.
+      placeholder: |
+        - OS: Windows / Linux / macOS
+        - Shell: PowerShell / bash / zsh
+        - ProjectAtlas version: `projectatlas --version`
+        - Agent host: Codex / Claude Code / OpenCode / other
+        - Install method: plugin / release asset / cargo install
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output
+      description: Paste relevant terminal output. Redact secrets and private paths.
+      render: shell
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy check
+      options:
+        - label: I removed secrets, tokens, private repository names, and private filesystem paths from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ProjectAtlas documentation
+    url: https://github.com/styler-ai/ProjectAtlas#readme
+    about: Read the current quickstart and workflow documentation.

--- a/.github/ISSUE_TEMPLATE/improvement_request.yml
+++ b/.github/ISSUE_TEMPLATE/improvement_request.yml
@@ -1,0 +1,72 @@
+name: Improvement request
+description: Suggest a ProjectAtlas feature, workflow improvement, or usability change.
+title: "feat: "
+labels:
+  - type:feature
+  - priority:medium
+  - status:backlog
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. ProjectAtlas is agent-first, so the best requests explain what the agent should do better.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or opportunity
+      description: What is hard, slow, confusing, or missing today?
+      placeholder: "I want ProjectAtlas to show token savings trends across sessions..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed improvement
+      description: What should ProjectAtlas do?
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - Agent workflow
+        - CLI
+        - MCP tools
+        - Plugin installer
+        - Documentation
+        - Performance
+        - Token telemetry
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Agent workflow
+      description: If this affects agent behavior, describe the ideal ProjectAtlas funnel.
+      placeholder: "overview -> folders -> files -> summary -> slice"
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What would make this clearly done?
+      placeholder: |
+        - CLI output includes ...
+        - MCP output includes ...
+        - Tests cover ...
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints or non-goals
+      description: Anything ProjectAtlas should avoid?
+      placeholder: "Do not require network calls or provider credentials by default."
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy check
+      options:
+        - label: I removed secrets, tokens, private repository names, and private filesystem paths from this request.
+          required: true

--- a/.projectatlas/projectatlas-nonsource-files.toon
+++ b/.projectatlas/projectatlas-nonsource-files.toon
@@ -11,6 +11,8 @@ nonsource_files[]:
   SECURITY.md,Security contact information for ProjectAtlas
   CODE_OF_CONDUCT.md,Community conduct expectations for ProjectAtlas
   docs/assets/projectatlas-brand.png,ProjectAtlas README brand image
+  docs/assets/agent-harness-funnel.svg,README diagram explaining the ProjectAtlas agent harness workflow from folder purpose to exact source slice
+  docs/assets/token-savings-bar.svg,README bar chart visualizing ProjectAtlas token savings benchmark results
   .github/workflows/ci.yml,ProjectAtlas CI workflow
   .github/workflows/release.yml,ProjectAtlas release workflow
   .github/workflows/03-auto-release.yml,ProjectAtlas auto release workflow

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,9 +1,9 @@
 version: 1
-generated_at: unix:1782671446
-file_hash: "2feb0aeef888a6f8e8b8f7ca505dfd2604bbb9f2548f7ab64e3ed5417a600d1c"
-folder_hash: "39e84b5b8f8717fb2b914e743cc0033600882dbeb89fdcd70b32270d29f43b3c"
+generated_at: unix:1782676748
+file_hash: "2d29b1755323da9a73c46d8d98ccb1baaef64c0e515d5d21f5af4db2b5053830"
+folder_hash: "f5ec84a38eaa8b9ee18c1d22563973db7217f346e2815ff1fa6abb9273e95036"
 root: .
-overview: tracked_source_files=93 tracked_nonsource_files=35 tracked_files_total=128 tracked_folders=57 source_extensions=122 exclude_dir_names=9 exclude_path_prefixes=0
+overview: tracked_source_files=96 tracked_nonsource_files=35 tracked_files_total=131 tracked_folders=58 source_extensions=122 exclude_dir_names=9 exclude_path_prefixes=0
 source_extensions[]:
   - .astro
   - .bash
@@ -138,12 +138,13 @@ exclude_dir_names[]:
   - node_modules
   - target
 exclude_path_prefixes[]:
-folders[57]{path,summary,source}:
+folders[58]{path,summary,source}:
   .,ProjectAtlas repository root.,database
   .agents,Agent marketplace metadata for ProjectAtlas.,database
   .agents/plugins,Codex plugin marketplace catalog for ProjectAtlas.,database
   .githooks,Git hook scripts for ProjectAtlas commits.,database
   .github,ProjectAtlas GitHub metadata and workflows.,database
+  .github/ISSUE_TEMPLATE,GitHub issue forms for public bug reports and improvement requests.,database
   .github/workflows,ProjectAtlas CI and release workflows.,database
   crates,Rust workspace crates for ProjectAtlas 3.,database
   crates/projectatlas-cli,Command-line adapter for ProjectAtlas 3.,database
@@ -196,11 +197,14 @@ folders[57]{path,summary,source}:
   skills/claude,Claude guidance for ProjectAtlas usage.,database
   skills/codex,Codex guidance for ProjectAtlas usage.,database
   templates,Reusable agent templates and snippets.,database
-files[99]{path,summary,source}:
+files[102]{path,summary,source}:
   .agents/plugins/marketplace.json,Codex plugin marketplace catalog for ProjectAtlas,database
   .gitattributes,Line-ending policy for ProjectAtlas repository fixtures,nonsource
   .githooks/commit-msg,Git hook to enforce issue references in commits,nonsource
   .githooks/pre-push,Git hook to run full local checks before push,nonsource
+  .github/ISSUE_TEMPLATE/bug_report.yml,GitHub issue form for public ProjectAtlas bug reports.,database
+  .github/ISSUE_TEMPLATE/config.yml,GitHub issue template chooser configuration for ProjectAtlas.,database
+  .github/ISSUE_TEMPLATE/improvement_request.yml,GitHub issue form for public ProjectAtlas improvement requests.,database
   .github/pull_request_template.md,Pull request checklist for ProjectAtlas,database
   .github/workflows/03-auto-release.yml,ProjectAtlas auto release workflow,database
   .github/workflows/04-docs.yml,ProjectAtlas docs site workflow,database
@@ -249,7 +253,7 @@ files[99]{path,summary,source}:
   docs/adoption.md,Adoption checklist for ProjectAtlas,database
   docs/agent-integration.md,Agent integration instructions for ProjectAtlas,database
   docs/assets/projectatlas-brand.png,ProjectAtlas README brand image,nonsource
-  docs/benchmarks/large-application-token-savings.md,Document large-application benchmark evidence for token-savings and responsiveness checks.,database
+  docs/benchmarks/large-application-token-savings.md,Document large-application benchmark evidence for token savings and responsiveness checks.,database
   docs/concepts.md,Core concepts for ProjectAtlas usage,database
   docs/configuration.md,Configuration reference for ProjectAtlas,database
   docs/format.md,ProjectAtlas TOON schema reference,database
@@ -293,8 +297,8 @@ files[99]{path,summary,source}:
   plugins/projectatlas/scripts/install-runtime.ps1,Install and verify the ProjectAtlas native runtime on Windows.,database
   plugins/projectatlas/scripts/install-runtime.sh,POSIX installer for the native ProjectAtlas runtime.,database
   plugins/projectatlas/skills/projectatlas/SKILL.md,ProjectAtlas installable Codex skill,database
-  skills/claude/ProjectAtlas.md,Claude skill instructions for ProjectAtlas,database
-  skills/codex/ProjectAtlas.md,Packaged Codex skill instructions for ProjectAtlas,database
+  skills/claude/ProjectAtlas.md,Claude skill guidance for using ProjectAtlas as an atlas-first repository workflow.,database
+  skills/codex/ProjectAtlas.md,Codex skill guidance for using ProjectAtlas as an atlas-first repository workflow.,database
   templates/AGENTS.md,Agent startup snippet for ProjectAtlas,database
 folder_summary_duplicates[]:
 file_summary_duplicates[]:
@@ -304,6 +308,7 @@ folder_tree[]:
   - "  plugins/ - Codex plugin marketplace catalog for ProjectAtlas."
   - .githooks/ - Git hook scripts for ProjectAtlas commits.
   - .github/ - ProjectAtlas GitHub metadata and workflows.
+  - "  ISSUE_TEMPLATE/ - GitHub issue forms for public bug reports and improvement requests."
   - "  workflows/ - ProjectAtlas CI and release workflows."
   - crates/ - Rust workspace crates for ProjectAtlas 3.
   - "  projectatlas-cli/ - Command-line adapter for ProjectAtlas 3."

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,9 +1,9 @@
 version: 1
-generated_at: unix:1782676748
-file_hash: "2d29b1755323da9a73c46d8d98ccb1baaef64c0e515d5d21f5af4db2b5053830"
+generated_at: unix:1782677236
+file_hash: "9d4d5199b9466ac3eb9af45e46fa7ddad9a37290a9e0d147bf7464571c60661d"
 folder_hash: "f5ec84a38eaa8b9ee18c1d22563973db7217f346e2815ff1fa6abb9273e95036"
 root: .
-overview: tracked_source_files=96 tracked_nonsource_files=35 tracked_files_total=131 tracked_folders=58 source_extensions=122 exclude_dir_names=9 exclude_path_prefixes=0
+overview: tracked_source_files=96 tracked_nonsource_files=37 tracked_files_total=133 tracked_folders=58 source_extensions=122 exclude_dir_names=9 exclude_path_prefixes=0
 source_extensions[]:
   - .astro
   - .bash
@@ -197,7 +197,7 @@ folders[58]{path,summary,source}:
   skills/claude,Claude guidance for ProjectAtlas usage.,database
   skills/codex,Codex guidance for ProjectAtlas usage.,database
   templates,Reusable agent templates and snippets.,database
-files[102]{path,summary,source}:
+files[104]{path,summary,source}:
   .agents/plugins/marketplace.json,Codex plugin marketplace catalog for ProjectAtlas,database
   .gitattributes,Line-ending policy for ProjectAtlas repository fixtures,nonsource
   .githooks/commit-msg,Git hook to enforce issue references in commits,nonsource
@@ -252,7 +252,9 @@ files[102]{path,summary,source}:
   deny.toml,Cargo dependency and license policy for ProjectAtlas,database
   docs/adoption.md,Adoption checklist for ProjectAtlas,database
   docs/agent-integration.md,Agent integration instructions for ProjectAtlas,database
+  docs/assets/agent-harness-funnel.svg,README diagram explaining the ProjectAtlas agent harness workflow from folder purpose to exact source slice,nonsource
   docs/assets/projectatlas-brand.png,ProjectAtlas README brand image,nonsource
+  docs/assets/token-savings-bar.svg,README bar chart visualizing ProjectAtlas token savings benchmark results,nonsource
   docs/benchmarks/large-application-token-savings.md,Document large-application benchmark evidence for token savings and responsiveness checks.,database
   docs/concepts.md,Core concepts for ProjectAtlas usage,database
   docs/configuration.md,Configuration reference for ProjectAtlas,database

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,4 +17,5 @@ If you spot a bug or have a suggestion, please open an issue with clear reproduc
 - Install git hooks by copying or linking files from `.githooks/` into `.git/hooks/`.
 - Apply `type:*`, `priority:*`, and `status:*` labels to every issue.
 - Keep public issues/PRs/release notes free of private or internal-only details.
+- Anonymize benchmark corpora, fixtures, reproduction paths, and public issue examples before committing or referencing them publicly.
 - The pre-push hook runs the Rust verification stack: format, check, clippy, tests, rustdoc, map, and lint.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "regex",
  "serde",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-db"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "projectatlas-core",
  "rusqlite",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-fs"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "blake3",
  "ignore",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-service"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "globset",
  "projectatlas-core",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-symbols"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "projectatlas-core",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/styler-ai/ProjectAtlas"
@@ -68,11 +68,11 @@ must_use_candidate = "allow"
 missing_inline_in_public_items = "allow"
 
 [workspace.dependencies]
-projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.5" }
-projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.5" }
-projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.5" }
-projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.5" }
-projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.5" }
+projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.6" }
+projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.6" }
+projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.6" }
+projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.6" }
+projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.6" }
 blake3 = "1.5"
 clap = { version = "4.5", features = ["derive"] }
 cssparser = "0.37"

--- a/README.md
+++ b/README.md
@@ -87,9 +87,25 @@ codex plugin add projectatlas --marketplace projectatlas
 
 Then tell Codex: "Use ProjectAtlas for this repo."
 
-That is the intended path. The plugin gives the agent the workflow skill, runtime installer, and MCP config templates. The agent maps the repo, chooses the right folder, chooses the right file, and only then reads exact source.
+That is the intended path. The plugin gives the agent the workflow skill, native runtime installer, and MCP config templates. The agent does the rest: install or verify the runtime, map the repo, keep the atlas fresh, choose the right folder, choose the right file, and read exact source only after the target is known.
 
-## Manual CLI
+## What Happens Next
+
+ProjectAtlas is intentionally agent-first. In normal use you should not have to memorize command syntax.
+
+The agent follows this loop:
+
+1. Build or refresh the local atlas.
+2. Read folder purposes before opening source.
+3. Read file purposes and content summaries inside the likely folder.
+4. Use the detailed summary, outline, symbols, or search when compressed context is enough.
+5. Open exact slices only when real code is needed.
+
+For active sessions, the agent can run the watcher so file edits continuously refresh the database. For cleanup sessions, it can ask ProjectAtlas for missing purposes, stale metadata, duplicate folder roles, and structure drift.
+
+## CLI Reference
+
+Most users can stop at the plugin install. The CLI is here for local debugging, automation, and release verification.
 
 Only need the CLI yourself? Install it from the released tag:
 
@@ -111,9 +127,9 @@ projectatlas scan
 projectatlas overview
 ```
 
-## The Manual Funnel
+## Manual Funnel
 
-Most users should let the agent run this. It is shown here so the product is understandable:
+This is the workflow the agent runs for you:
 
 ```bash
 projectatlas overview

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.3.5"><img alt="release" src="https://img.shields.io/badge/release-v0.3.5-blue"></a>
+  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.3.6"><img alt="release" src="https://img.shields.io/badge/release-v0.3.6-blue"></a>
   <img alt="rust" src="https://img.shields.io/badge/Rust-2024-orange">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-green">
 </p>
@@ -49,7 +49,7 @@ Warm CLI reads from that audit stayed interactive:
 | `token` | ~161 ms |
 | `overview` | ~166 ms |
 
-Token numbers are workflow estimates, not billing-grade provider counts. The default estimator is the offline `chars/bytes / 4` heuristic. That is deliberate: normal agent orientation stays local, fast, and credential-free.
+Token numbers are workflow estimates, not billing-grade provider counts. The default estimator is the offline `chars/bytes / 4` heuristic, reported with bucket, baseline, and confidence metadata so observed full-file compression is not silently mixed with modeled navigation savings. That is deliberate: normal agent orientation stays local, fast, and credential-free.
 
 ## The Funnel
 
@@ -81,7 +81,7 @@ Most agent waste happens before code is edited: broad search, wrong folder, wron
 ## Quickstart
 
 ```bash
-codex plugin marketplace add styler-ai/ProjectAtlas --ref main
+codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.6
 codex plugin add projectatlas --marketplace projectatlas
 ```
 
@@ -94,7 +94,7 @@ That is the intended path. The plugin gives the agent the workflow skill, runtim
 Only need the CLI yourself? Install it from the released tag:
 
 ```bash
-cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.3.5 --package projectatlas-cli --locked
+cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.3.6 --package projectatlas-cli --locked
 ```
 
 From this checkout:
@@ -184,7 +184,7 @@ ProjectAtlas scans with `.gitignore` awareness, hashes files with BLAKE3, stores
 
 ## Release Quality
 
-`v0.3.5` shipped through the full release matrix:
+`v0.3.6` ships through the full release matrix:
 
 - Rust format, check, clippy, dependency policy, tests, doctests, and rustdoc.
 - ProjectAtlas scan, parity, lint, and map drift checks.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,49 @@ It keeps a fast local SQLite atlas of folders, files, one-line purposes, determi
 
 No required `.purpose` files. No source-header tax. No hosted index. The project lives beside your repo in `.projectatlas/`, returns compact TOON by default, and runs as a native Rust CLI plus MCP server.
 
+## Quickstart
+
+```bash
+codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.6
+codex plugin add projectatlas --marketplace projectatlas
+```
+
+Then tell Codex: "Use ProjectAtlas for this repo."
+
+That is the intended path. The plugin gives the agent the workflow skill, native runtime installer, and MCP config templates. The agent does the rest: install or verify the runtime, map the repo, keep the atlas fresh, choose the right folder, choose the right file, and read exact source only after the target is known.
+
+## What Happens Next
+
+ProjectAtlas is intentionally agent-first. In normal use you should not have to memorize command syntax.
+
+The agent follows this loop:
+
+1. Build or refresh the local atlas.
+2. Read folder purposes before opening source.
+3. Read file purposes and content summaries inside the likely folder.
+4. Use the detailed summary, outline, symbols, or search when compressed context is enough.
+5. Open exact slices only when real code is needed.
+
+For active sessions, the agent can run the watcher so file edits continuously refresh the database. For cleanup sessions, it can ask ProjectAtlas for missing purposes, stale metadata, duplicate folder roles, and structure drift.
+
+<p align="center">
+  <img src="docs/assets/agent-harness-funnel.svg" alt="ProjectAtlas agent harness workflow from folder purpose overview to file purpose, detailed summary, symbols, bounded search, exact source slice, and watch refresh" width="860">
+</p>
+
 ## What It Saves
 
-The current benchmark record is intentionally neutral: a representative large application audit, not a marketing toy.
+The current benchmark record is intentionally neutral: a representative large application audit, not a marketing toy. The savings rate is not a universal constant. It depends on repository size, how often the agent asks for orientation, and how much source code ProjectAtlas prevents the agent from opening.
+
+The estimate is:
+
+```text
+without ProjectAtlas = avoided candidate files, directory walks, and full-file reads
+with ProjectAtlas    = compact TOON payloads returned by overview, folders, files, summaries, search, symbols, and slices
+saved                = without ProjectAtlas - with ProjectAtlas
+savings rate         = saved / without ProjectAtlas
+```
+
+The default estimator is deliberately simple and local: `ceil(chars_or_bytes / 4)`. It is a workflow estimate, not provider billing telemetry.
 
 | Signal | Result |
 | --- | ---: |
@@ -35,12 +75,43 @@ The current benchmark record is intentionally neutral: a representative large ap
 | Symbols | 5,145 |
 | Relations | 12,122 |
 | Token telemetry calls | 142 |
-| Estimated without ProjectAtlas | 221,114,448 tokens |
-| Estimated with ProjectAtlas | 425,622 tokens |
+| Average baseline avoided per call | 1,557,144 tokens |
+| Average ProjectAtlas payload per call | 2,997 tokens |
+| Total estimated without ProjectAtlas | 221,114,448 tokens |
+| Total estimated with ProjectAtlas | 425,622 tokens |
 | Estimated saved | 220,688,826 tokens |
-| Estimated savings rate | 99.8% |
+| Observed savings rate for this workload | 99.8% |
 
-Warm CLI reads from that audit stayed interactive:
+<p align="center">
+  <img src="docs/assets/token-savings-bar.svg" alt="Token savings benchmark bar chart: without ProjectAtlas 221.1 million estimated tokens, with ProjectAtlas 0.4 million estimated tokens across 142 calls" width="820">
+</p>
+
+That bar chart is intentionally lopsided. The point of ProjectAtlas is not that every repository magically saves 99.8%; the point is that repeated agent lookups in a large repo should read compact folder/file intelligence first, not broad source trees first.
+
+Sizing intuition:
+
+| Workload shape | What usually happens |
+| --- | --- |
+| Small repo, few lookups | Savings are real but modest because there is less wrong code to avoid. |
+| Medium repo, repeated feature work | Savings grow when folder and file purpose prevent wrong-file reads. |
+| Large repo, many exploratory lookups | Savings can become very high because each lookup avoids broad candidate sets and repeated full-file reads. |
+
+## Expected Large-Repo Latency
+
+The latency sample below is for warm indexed reads after ProjectAtlas has already scanned the repo. Initial scan/watch refresh is a different operation because it hashes files, updates SQLite, refreshes text, and parses symbol candidates.
+
+Benchmark scale:
+
+| Repo shape | Size |
+| --- | ---: |
+| Files | 679 |
+| Folders | 206 |
+| Indexed text files | 554 |
+| Indexed text bytes | 7.1 MB |
+| Symbols | 5,145 |
+| Relations | 12,122 |
+
+Warm CLI reads from that audit stayed around 160-166 ms:
 
 | Command shape | Sample latency |
 | --- | ---: |
@@ -49,7 +120,9 @@ Warm CLI reads from that audit stayed interactive:
 | `token` | ~161 ms |
 | `overview` | ~166 ms |
 
-Token numbers are workflow estimates, not billing-grade provider counts. The default estimator is the offline `chars/bytes / 4` heuristic, reported with bucket, baseline, and confidence metadata so observed full-file compression is not silently mixed with modeled navigation savings. That is deliberate: normal agent orientation stays local, fast, and credential-free.
+For a comparable large application, the practical expectation is that warm orientation commands stay comfortably sub-second and usually feel like ordinary CLI reads. The scan/build step can take longer, but the agent should not pay that full cost for every lookup; it should use `watch` or `watch --once` to keep the database fresh and then read from the indexed atlas.
+
+Token reports expose bucket, baseline, and confidence metadata so observed full-file compression is not silently mixed with modeled navigation savings. That is deliberate: normal agent orientation stays local, fast, and credential-free.
 
 ## The Funnel
 
@@ -77,31 +150,6 @@ Most agent waste happens before code is edited: broad search, wrong folder, wron
 - `slice`: exact source after the target is known.
 - `watch`: continuous local refresh while files change.
 - `token`: estimated context saved by the atlas-first workflow.
-
-## Quickstart
-
-```bash
-codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.6
-codex plugin add projectatlas --marketplace projectatlas
-```
-
-Then tell Codex: "Use ProjectAtlas for this repo."
-
-That is the intended path. The plugin gives the agent the workflow skill, native runtime installer, and MCP config templates. The agent does the rest: install or verify the runtime, map the repo, keep the atlas fresh, choose the right folder, choose the right file, and read exact source only after the target is known.
-
-## What Happens Next
-
-ProjectAtlas is intentionally agent-first. In normal use you should not have to memorize command syntax.
-
-The agent follows this loop:
-
-1. Build or refresh the local atlas.
-2. Read folder purposes before opening source.
-3. Read file purposes and content summaries inside the likely folder.
-4. Use the detailed summary, outline, symbols, or search when compressed context is enough.
-5. Open exact slices only when real code is needed.
-
-For active sessions, the agent can run the watcher so file edits continuously refresh the database. For cleanup sessions, it can ask ProjectAtlas for missing purposes, stale metadata, duplicate folder roles, and structure drift.
 
 ## CLI Reference
 

--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -29,9 +29,10 @@ use runtime::{
     default_mcp_project_root, defaultable_cli_project_root,
     estimated_source_tokens_for_indexed_files, estimated_source_tokens_for_paths,
     file_summary_usage_baseline, lint_database_if_present, normalized_folder_filter,
-    open_atlas_store, ranked_file_nodes, read_indexed_file_content, record_usage_estimate,
-    record_usage_text, reset_index_files, resolved_mcp_config_path, run_scan_pipeline,
-    run_watch_loop, strip_legacy_purpose, validated_indexed_file_key, watcher_status_report,
+    open_atlas_store, ranked_file_nodes, read_indexed_file_content,
+    record_directory_walk_usage_estimate, record_usage_estimate, record_usage_text,
+    reset_index_files, resolved_mcp_config_path, run_scan_pipeline, run_watch_loop,
+    strip_legacy_purpose, validated_indexed_file_key, watcher_status_report,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -608,7 +609,7 @@ fn run() -> Result<(), CliError> {
             let store = open_atlas_store(&cli.db)?;
             let overview = store.overview()?;
             let toon = render_overview(&overview);
-            print_tracked_output_estimate(
+            print_tracked_directory_output_estimate(
                 cli.format,
                 &store,
                 &cli.session,
@@ -625,7 +626,7 @@ fn run() -> Result<(), CliError> {
             let selected = store.load_ranked_nodes(query, NodeKind::Folder, None, *limit, 0)?;
             let toon = render_nodes("folders", &selected);
             let payload = render_node_rows("folders", &selected);
-            print_tracked_output_estimate(
+            print_tracked_directory_output_estimate(
                 cli.format,
                 &store,
                 &cli.session,
@@ -982,7 +983,7 @@ fn run() -> Result<(), CliError> {
             let store = open_atlas_store(&cli.db)?;
             let findings = store.unresolved_health_findings(&store.resolved_health_ids()?)?;
             let toon = render_health(&findings);
-            print_tracked_output_estimate(
+            print_tracked_directory_output_estimate(
                 cli.format,
                 &store,
                 &cli.session,
@@ -1317,6 +1318,31 @@ fn serialized_output<T: serde::Serialize>(
 }
 
 /// Record estimated-token telemetry for the exact emitted CLI payload.
+fn print_tracked_directory_output_estimate<T: serde::Serialize>(
+    format: OutputFormat,
+    store: &AtlasStore,
+    session: &str,
+    command: &str,
+    path: Option<String>,
+    query: Option<String>,
+    estimated_without_projectatlas: usize,
+    toon: &str,
+    payload: &T,
+) -> Result<(), CliError> {
+    let output = serialized_output(format, toon, payload)?;
+    record_directory_walk_usage_estimate(
+        store,
+        session,
+        command,
+        path,
+        query,
+        estimated_without_projectatlas,
+        &output,
+    )?;
+    write_stdout(&output)
+}
+
+/// Record candidate-set telemetry for the exact emitted CLI payload.
 fn print_tracked_output_estimate<T: serde::Serialize>(
     format: OutputFormat,
     store: &AtlasStore,
@@ -1517,6 +1543,7 @@ fn render_token_dashboard(overview: &TokenOverview, session: Option<&str>) -> St
     let without_bar = token_dashboard_bar(without, max_tokens);
     let with_bar = token_dashboard_bar(with, max_tokens);
     let saved_bar = token_dashboard_bar(saved, max_tokens);
+    let bucket_lines = token_dashboard_bucket_lines(overview);
     format!(
         "\
 +----------------------------------------------------------------+\n\
@@ -1531,6 +1558,7 @@ fn render_token_dashboard(overview: &TokenOverview, session: Option<&str>) -> St
 | With PA        [{with_bar}] {with_label:>14} tokens\n\
 | Saved          [{saved_bar}] {saved_label:>14} tokens\n\
 +----------------------------------------------------------------+\n\
+{bucket_lines}\
 | Funnel         overview > folders > files > summary > slice\n\
 | Avoided        wrong folders, wrong files, unnecessary full reads\n\
 +----------------------------------------------------------------+\n",
@@ -1538,6 +1566,41 @@ fn render_token_dashboard(overview: &TokenOverview, session: Option<&str>) -> St
         without_label = grouped_count(without),
         with_label = grouped_count(with),
     )
+}
+
+/// Render compact token bucket rows for the human dashboard.
+fn token_dashboard_bucket_lines(overview: &TokenOverview) -> String {
+    if overview.buckets.is_empty() {
+        return String::new();
+    }
+    let mut lines = String::from("| Buckets        kind / accuracy / confidence / saved tokens\n");
+    for bucket in &overview.buckets {
+        lines.push_str("| - ");
+        lines.push_str(&dashboard_fit(&format!(
+            "{} / {} / {} / {}",
+            bucket.token_savings_bucket,
+            bucket.accuracy,
+            bucket.confidence,
+            signed_count(bucket.estimated_saved)
+        )));
+        lines.push('\n');
+    }
+    lines.push_str("+----------------------------------------------------------------+\n");
+    lines
+}
+
+/// Fit one dashboard row to the fixed-width ASCII frame.
+fn dashboard_fit(value: &str) -> String {
+    const WIDTH: usize = 60;
+    if value.chars().count() <= WIDTH {
+        return value.to_string();
+    }
+    let mut fitted = value
+        .chars()
+        .take(WIDTH.saturating_sub(3))
+        .collect::<String>();
+    fitted.push_str("...");
+    fitted
 }
 
 /// Render one fixed-width token comparison bar.
@@ -2270,16 +2333,7 @@ mod tests {
     #[test]
     fn token_dashboard_is_human_readable_and_ascii() {
         let dashboard = render_token_dashboard(
-            &TokenOverview {
-                estimate_kind: "heuristic".to_string(),
-                estimator: "chars_or_bytes_div_ceil_4".to_string(),
-                estimate_scope: "workflow_payload_estimate_not_model_billing_tokens".to_string(),
-                calls: 3,
-                estimated_without_projectatlas: 12_000,
-                estimated_with_projectatlas: 3_000,
-                estimated_saved: 9_000,
-                savings_rate: Some(0.75),
-            },
+            &TokenOverview::from_estimated_totals(3, 12_000, 3_000),
             Some("session-a"),
         );
 
@@ -2291,6 +2345,8 @@ mod tests {
         assert!(dashboard.contains("| Without PA     [####################################]"));
         assert!(dashboard.contains("| With PA        [#########...........................]"));
         assert!(dashboard.contains("| Saved          [###########################.........]"));
+        assert!(dashboard.contains("| Buckets        kind / accuracy / confidence / saved tokens"));
+        assert!(dashboard.contains("navigation_avoidance / heuristic_estimate / inferred"));
         assert!(dashboard.contains("wrong folders, wrong files"));
         assert!(dashboard.contains("overview > folders > files > summary > slice"));
         assert!(dashboard.is_ascii());
@@ -2449,6 +2505,12 @@ mod tests {
         if !summary_text.contains("file_purpose_status: suggested") {
             return Err("atlas_file_summary result did not expose purpose status".into());
         }
+        if !summary_text.contains("parser_kind: \"tree-sitter-symbol-graph\"") {
+            return Err("atlas_file_summary result did not expose parser kind".into());
+        }
+        if !summary_text.contains("summary_status: ok") {
+            return Err("atlas_file_summary result did not expose summary status".into());
+        }
         if !summary_text.contains("helper") {
             return Err("atlas_file_summary result did not contain helper symbol".into());
         }
@@ -2492,8 +2554,15 @@ mod tests {
             if !token_text.contains("calls: 0") {
                 return Err("atlas_token_report recorded MCP usage in no-telemetry mode".into());
             }
-        } else if !token_text.contains("calls: 2") {
-            return Err("atlas_token_report did not count MCP usage events".into());
+        } else {
+            if !token_text.contains("calls: 2") {
+                return Err("atlas_token_report did not count MCP usage events".into());
+            }
+            if !token_text.contains("buckets[") || !token_text.contains("heuristic_estimate") {
+                return Err(
+                    "atlas_token_report result did not contain bucket accuracy labels".into(),
+                );
+            }
         }
 
         let parity_report = client

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -5,8 +5,9 @@ use crate::runtime::{
     build_symbols_for_index, byte_count_to_tokens, canonical_project_root,
     default_mcp_project_root, estimated_source_tokens_for_indexed_files,
     estimated_source_tokens_for_paths, file_summary_usage_baseline, normalized_folder_filter,
-    open_atlas_store, ranked_file_nodes, read_indexed_file_content, record_usage_estimate,
-    record_usage_text, reset_index_files, run_scan_pipeline, run_watch_loop, strip_legacy_purpose,
+    open_atlas_store, ranked_file_nodes, read_indexed_file_content,
+    record_directory_walk_usage_estimate, record_usage_estimate, record_usage_text,
+    reset_index_files, run_scan_pipeline, run_watch_loop, strip_legacy_purpose,
     validated_indexed_file_key, watcher_status_report,
 };
 use crate::{
@@ -511,7 +512,7 @@ impl ProjectAtlasMcpServer {
             let store = self.open_store()?;
             let overview = store.overview()?;
             let toon = render_overview(&overview);
-            record_usage_estimate(
+            record_directory_walk_usage_estimate(
                 &store,
                 &self.session,
                 "mcp.atlas_overview",
@@ -541,7 +542,7 @@ impl ProjectAtlasMcpServer {
                 0,
             )?;
             let toon = render_nodes("folders", &selected);
-            record_usage_estimate(
+            record_directory_walk_usage_estimate(
                 &store,
                 &self.session,
                 "mcp.atlas_folders",
@@ -827,7 +828,7 @@ impl ProjectAtlasMcpServer {
             let page =
                 store.unresolved_health_findings_page(&store.resolved_health_ids()?, &query)?;
             let toon = render_health_page(&page, &query);
-            record_usage_estimate(
+            record_directory_walk_usage_estimate(
                 &store,
                 &self.session,
                 "mcp.atlas_health",

--- a/crates/projectatlas-cli/src/runtime.rs
+++ b/crates/projectatlas-cli/src/runtime.rs
@@ -10,9 +10,14 @@ use crate::{
     CliError, OutputFormat, WATCH_MODE_NOTIFY, WATCH_MODE_ONCE, WATCH_MODE_POLLING, truthy_env,
 };
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use projectatlas_core::language::{LanguageParserSupport, language_spec};
 use projectatlas_core::outline::estimate_tokens;
 use projectatlas_core::symbols::{RelationKind, SymbolGraph, SymbolKind};
-use projectatlas_core::telemetry::{usage_from_estimates, usage_from_text};
+use projectatlas_core::telemetry::{
+    TOKEN_BASELINE_DIRECTORY_WALK, TOKEN_BASELINE_SELECTED_CANDIDATES,
+    TOKEN_BUCKET_NAVIGATION_AVOIDANCE, TOKEN_CONFIDENCE_INFERRED, TOKEN_CONFIDENCE_POLICY_ESTIMATE,
+    usage_from_estimates_with_context, usage_from_text,
+};
 use projectatlas_core::{
     Node, NodeKind, Overview, PurposeSource, PurposeStatus, normalize_native_path_display,
     normalize_native_path_display_str, normalize_repo_path, repo_path_to_native,
@@ -287,18 +292,73 @@ pub(crate) fn record_usage_estimate(
     estimated_without_projectatlas: usize,
     projectatlas_text: &str,
 ) -> Result<(), CliError> {
+    record_usage_estimate_with_context(
+        store,
+        session,
+        command,
+        path,
+        query,
+        estimated_without_projectatlas,
+        projectatlas_text,
+        TOKEN_BUCKET_NAVIGATION_AVOIDANCE,
+        TOKEN_BASELINE_SELECTED_CANDIDATES,
+        TOKEN_CONFIDENCE_INFERRED,
+    )
+}
+
+/// Record a usage event from a fast baseline estimate and explicit baseline semantics.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn record_usage_estimate_with_context(
+    store: &AtlasStore,
+    session: &str,
+    command: &str,
+    path: Option<String>,
+    query: Option<String>,
+    estimated_without_projectatlas: usize,
+    projectatlas_text: &str,
+    token_savings_bucket: &str,
+    baseline_kind: &str,
+    confidence: &str,
+) -> Result<(), CliError> {
     if telemetry_disabled() {
         return Ok(());
     }
-    store.record_usage(&usage_from_estimates(
+    store.record_usage(&usage_from_estimates_with_context(
         session,
         command,
         path,
         query,
         estimated_without_projectatlas,
         estimate_tokens(projectatlas_text),
+        token_savings_bucket,
+        baseline_kind,
+        confidence,
     ))?;
     Ok(())
+}
+
+/// Record a broad directory-walk avoidance estimate.
+pub(crate) fn record_directory_walk_usage_estimate(
+    store: &AtlasStore,
+    session: &str,
+    command: &str,
+    path: Option<String>,
+    query: Option<String>,
+    estimated_without_projectatlas: usize,
+    projectatlas_text: &str,
+) -> Result<(), CliError> {
+    record_usage_estimate_with_context(
+        store,
+        session,
+        command,
+        path,
+        query,
+        estimated_without_projectatlas,
+        projectatlas_text,
+        TOKEN_BUCKET_NAVIGATION_AVOIDANCE,
+        TOKEN_BASELINE_DIRECTORY_WALK,
+        TOKEN_CONFIDENCE_POLICY_ESTIMATE,
+    )
 }
 
 /// Record a usage event from baseline and emitted text unless telemetry is disabled.
@@ -1115,13 +1175,15 @@ pub(crate) fn build_symbols_for_paths(
             continue;
         }
         let symbol_count = store.symbol_count_for_path(&node.node.path)?;
-        if symbol_count > 0
-            && node.node.content_hash.as_ref().is_some_and(|hash| {
-                previous_hashes.and_then(|hashes| hashes.get(&node.node.path)) == Some(hash)
-            })
-        {
-            report.unchanged += 1;
-            continue;
+        if node.node.content_hash.as_ref().is_some_and(|hash| {
+            previous_hashes.and_then(|hashes| hashes.get(&node.node.path)) == Some(hash)
+        }) {
+            let has_source_index =
+                symbol_count > 0 || store.load_source_parse_metadata(&node.node.path)?.is_some();
+            if has_source_index {
+                report.unchanged += 1;
+                continue;
+            }
         }
         jobs.push(SymbolParseJob {
             path: node.node.path.clone(),
@@ -1482,19 +1544,13 @@ pub(crate) fn is_symbol_candidate(path: &str, language: Option<&str>) -> bool {
     {
         return true;
     }
+    if matches!(language, Some("vue")) {
+        return true;
+    }
     language.is_some_and(|language| {
         !matches!(
-            language,
-            "text"
-                | "json"
-                | "yaml"
-                | "xml"
-                | "config"
-                | "markdown"
-                | "css"
-                | "html"
-                | "toml"
-                | "toon"
+            language_spec(language).map(|spec| spec.parser_support),
+            Some(LanguageParserSupport::Structural)
         )
     })
 }

--- a/crates/projectatlas-cli/src/structural.rs
+++ b/crates/projectatlas-cli/src/structural.rs
@@ -30,6 +30,7 @@ pub(crate) fn structural_summary_for_path(
         "json" => json_summary(path, content),
         "yaml" => yaml_summary(path, content),
         "toml" | "cargo-manifest" => toml_summary(path, content),
+        "xml" => xml_summary(content),
         "css" => css_summary(content),
         "html" => html_summary(content),
         "config" | "text" => config_text_summary(path, content),
@@ -47,6 +48,7 @@ pub(crate) fn is_structural_summary_candidate(path: &str, language: Option<&str>
             | "yaml"
             | "toml"
             | "cargo-manifest"
+            | "xml"
             | "css"
             | "html"
             | "config"
@@ -665,6 +667,52 @@ fn toon_section_names(content: &str) -> Vec<&str> {
         .collect()
 }
 
+/// Summarize XML-like documents from their declared element names.
+fn xml_summary(content: &str) -> Option<String> {
+    let elements = content
+        .lines()
+        .flat_map(xml_element_names)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if elements.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "xml document with elements {}.",
+            join_limited(elements.iter().map(String::as_str).collect())
+        ))
+    }
+}
+
+/// Extract XML element names from one line with conservative string scanning.
+fn xml_element_names(line: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut rest = line;
+    while let Some((_, after_open)) = rest.split_once('<') {
+        let trimmed = after_open.trim_start();
+        if trimmed.starts_with(['/', '!', '?']) {
+            rest = trimmed.get(1..).unwrap_or_default();
+            continue;
+        }
+        let name = trimmed
+            .split(|character: char| character.is_whitespace() || matches!(character, '/' | '>'))
+            .next()
+            .unwrap_or_default();
+        if !name.is_empty()
+            && name.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | ':' | '.')
+            })
+        {
+            names.push(name.to_string());
+        }
+        rest = trimmed
+            .split_once('>')
+            .map_or("", |(_element, remaining)| remaining);
+    }
+    names
+}
+
 /// Summarize simple config or text files from key-like lines.
 fn config_text_summary(path: &str, content: &str) -> Option<String> {
     let keys = content
@@ -844,6 +892,24 @@ mod tests {
         assert_eq!(
             summary.as_deref(),
             Some("ProjectAtlas config with tables project, scan and 2 scan excludes.")
+        );
+    }
+
+    #[test]
+    fn summarizes_xml_elements() {
+        let summary = structural_summary_for_path(
+            "config/routes.xml",
+            Some("xml"),
+            r#"<?xml version="1.0"?>
+<routes>
+  <route id="home" />
+  <route id="about"></route>
+</routes>
+"#,
+        );
+        assert_eq!(
+            summary.as_deref(),
+            Some("xml document with elements route, routes.")
         );
     }
 

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -783,6 +783,33 @@ fn scan_overview_and_token_flow() -> Result<(), Box<dyn Error>> {
     require_json_usize_greater_than(&token_json, &["estimated_without_projectatlas"], 0)?;
     require_json_usize_greater_than(&token_json, &["estimated_with_projectatlas"], 0)?;
     require_json_i64_greater_than(&token_json, &["estimated_saved"], 0)?;
+    let buckets = token_json["buckets"]
+        .as_array()
+        .ok_or_else(|| io::Error::other("token buckets missing from json report"))?;
+    if !buckets.iter().any(|bucket| {
+        bucket["token_savings_bucket"] == "full_file_compression"
+            && bucket["accuracy"] == "heuristic_estimate"
+            && bucket["baseline_kind"] == "full_file"
+            && bucket["confidence"] == "observed"
+    }) {
+        return Err(io::Error::other("full-file compression token bucket missing").into());
+    }
+    if !buckets.iter().any(|bucket| {
+        bucket["token_savings_bucket"] == "navigation_avoidance"
+            && bucket["accuracy"] == "heuristic_estimate"
+            && bucket["baseline_kind"] == "directory_walk"
+            && bucket["confidence"] == "policy_estimate"
+    }) {
+        return Err(io::Error::other("directory-walk navigation token bucket missing").into());
+    }
+    if !buckets.iter().any(|bucket| {
+        bucket["token_savings_bucket"] == "navigation_avoidance"
+            && bucket["accuracy"] == "heuristic_estimate"
+            && bucket["baseline_kind"] == "selected_candidates"
+            && bucket["confidence"] == "inferred"
+    }) {
+        return Err(io::Error::other("selected-candidates navigation token bucket missing").into());
+    }
     let calls_before = token_json["calls"]
         .as_u64()
         .ok_or_else(|| io::Error::other("token calls missing before no-telemetry check"))?;
@@ -827,6 +854,8 @@ fn scan_overview_and_token_flow() -> Result<(), Box<dyn Error>> {
         .stdout(predicate::str::contains("Without PA"))
         .stdout(predicate::str::contains("With PA"))
         .stdout(predicate::str::contains("Saved"))
+        .stdout(predicate::str::contains("Buckets"))
+        .stdout(predicate::str::contains("heuristic_estimate"))
         .stdout(predicate::str::contains("wrong folders, wrong files"))
         .stdout(predicate::str::contains("unnecessary full reads"));
     Ok(())
@@ -2524,7 +2553,7 @@ fn structural_summaries_cover_declarative_files_and_projectatlas_inputs()
         &["content_summary"],
         "rust source file with no declarations found.",
     )?;
-    require_json_string(&rust_summary, &["parser_kind"], "symbol-graph")?;
+    require_json_string(&rust_summary, &["parser_kind"], "tree-sitter-symbol-graph")?;
     require_json_string(&rust_summary, &["summary_status"], "ok")?;
 
     Ok(())
@@ -2640,6 +2669,12 @@ fn scan_indexes_every_supported_language_extension() -> Result<(), Box<dyn Error
             ))
             .into());
         }
+        if is_scanner_byte_summary(content_summary) {
+            return Err(io::Error::other(format!(
+                "byte-count scanner fallback summary for language fixture {relative_path}: {content_summary}"
+            ))
+            .into());
+        }
         let parser_kind = json_at(&summary, &["parser_kind"])?
             .as_str()
             .ok_or_else(|| {
@@ -2665,6 +2700,10 @@ fn scan_indexes_every_supported_language_extension() -> Result<(), Box<dyn Error
                 "missing summary status for language fixture {relative_path}"
             ))
             .into());
+        }
+        if expected_language == "ruby" {
+            require_json_string(&summary, &["parser_kind"], "fallback-symbol-graph")?;
+            require_json_string(&summary, &["summary_status"], "fallback")?;
         }
     }
 
@@ -3138,6 +3177,49 @@ fn watch_once_preserves_unchanged_deep_summary_and_text_index() -> Result<(), Bo
     let search_json: Value = serde_json::from_slice(&search.stdout)?;
     require_json_string(&search_json, &["source"], "sqlite-file-text")?;
     require_json_usize_at_least(&search_json, &["returned"], 1)?;
+    Ok(())
+}
+
+#[test]
+fn watch_once_skips_unchanged_empty_native_parse() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("repo");
+    fs::create_dir(&repo)?;
+    fs::create_dir(repo.join("src"))?;
+    fs::write(repo.join("src").join("empty.rs"), "// comment only\n")?;
+    let db = temp.path().join("projectatlas.db");
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args(["scan", "."])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("parsed: 1"));
+
+    let before = json_summary_command(&repo, &db, "src/empty.rs")?;
+    require_json_string(&before, &["parser_kind"], "tree-sitter-symbol-graph")?;
+    require_json_string(&before, &["summary_status"], "ok")?;
+    require_json_string(
+        &before,
+        &["content_summary"],
+        "rust source file with no declarations found.",
+    )?;
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args(["watch", ".", "--once"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("parsed: 0"))
+        .stdout(predicate::str::contains("unchanged: 1"));
+
+    let after = json_summary_command(&repo, &db, "src/empty.rs")?;
+    require_json_string(&after, &["parser_kind"], "tree-sitter-symbol-graph")?;
+    require_json_string(&after, &["summary_status"], "ok")?;
     Ok(())
 }
 
@@ -4178,6 +4260,18 @@ fn fixture_content_for_extension(extension: &str) -> &'static str {
         | ".cql" | ".cypher" | ".sparql" | ".gql" | ".liquibase" | ".flyway" => "SELECT 1;\n",
         _ => "fixture\n",
     }
+}
+
+/// Return whether a summary is only the scanner byte-count fallback.
+fn is_scanner_byte_summary(summary: &str) -> bool {
+    let trimmed = summary.trim_end_matches('.');
+    let Some((_, tail)) = trimmed.rsplit_once(", ") else {
+        return false;
+    };
+    let Some(number) = tail.strip_suffix(" bytes") else {
+        return false;
+    };
+    !number.is_empty() && number.chars().all(|character| character.is_ascii_digit())
 }
 
 /// Return the generated Python baseline source used only inside temporary repos.

--- a/crates/projectatlas-core/src/language.rs
+++ b/crates/projectatlas-core/src/language.rs
@@ -127,6 +127,290 @@ pub const BROAD_SOURCE_EXTENSIONS: &[&str] = &[
     ".flyway",
 ];
 
+/// Parser coverage level available for a detected language family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LanguageParserSupport {
+    /// A native Tree-sitter adapter backs symbol extraction.
+    Native,
+    /// A manifest-specific parser backs package/dependency extraction.
+    Manifest,
+    /// A deterministic structural summarizer backs agent-facing summaries.
+    Structural,
+    /// A conservative fallback parser is the current coverage boundary.
+    Fallback,
+}
+
+/// Static parser coverage metadata for one detected language family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LanguageSpec {
+    /// Detected language or file-family identifier.
+    pub language: &'static str,
+    /// Parser coverage level.
+    pub parser_support: LanguageParserSupport,
+}
+
+/// Supported detected language families and their parser coverage level.
+pub const LANGUAGE_SPECS: &[LanguageSpec] = &[
+    LanguageSpec {
+        language: "rust",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "rust-build-script",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "python",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "javascript",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "typescript",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "tsx",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "java",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "kotlin",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "csharp",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "go",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "objective-c",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "zig",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "c",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "cpp",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "h",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "hpp",
+        parser_support: LanguageParserSupport::Native,
+    },
+    LanguageSpec {
+        language: "cargo-manifest",
+        parser_support: LanguageParserSupport::Manifest,
+    },
+    LanguageSpec {
+        language: "cargo-lock",
+        parser_support: LanguageParserSupport::Manifest,
+    },
+    LanguageSpec {
+        language: "vue",
+        parser_support: LanguageParserSupport::Structural,
+    },
+    LanguageSpec {
+        language: "markdown",
+        parser_support: LanguageParserSupport::Structural,
+    },
+    LanguageSpec {
+        language: "json",
+        parser_support: LanguageParserSupport::Structural,
+    },
+    LanguageSpec {
+        language: "yaml",
+        parser_support: LanguageParserSupport::Structural,
+    },
+    LanguageSpec {
+        language: "css",
+        parser_support: LanguageParserSupport::Structural,
+    },
+    LanguageSpec {
+        language: "html",
+        parser_support: LanguageParserSupport::Structural,
+    },
+    LanguageSpec {
+        language: "toon",
+        parser_support: LanguageParserSupport::Structural,
+    },
+    LanguageSpec {
+        language: "dockerfile",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "makefile",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "text",
+        parser_support: LanguageParserSupport::Structural,
+    },
+    LanguageSpec {
+        language: "toml",
+        parser_support: LanguageParserSupport::Structural,
+    },
+    LanguageSpec {
+        language: "xml",
+        parser_support: LanguageParserSupport::Structural,
+    },
+    LanguageSpec {
+        language: "svelte",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "astro",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "jsp",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "jsp-tag",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "gsp",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "groovy",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "protobuf",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "handlebars",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "ejs",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "pug",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "freemarker",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "mustache",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "liquid",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "erb",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "sql",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "graphql",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "config",
+        parser_support: LanguageParserSupport::Structural,
+    },
+    LanguageSpec {
+        language: "ruby",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "php",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "swift",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "scala",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "shell",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "powershell",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "batch",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "r",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "perl",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "lua",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "dart",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "haskell",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "ocaml",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "fsharp",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "clojure",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+    LanguageSpec {
+        language: "vim",
+        parser_support: LanguageParserSupport::Fallback,
+    },
+];
+
+/// Return parser coverage metadata for a detected language family.
+#[must_use]
+pub fn language_spec(language: &str) -> Option<&'static LanguageSpec> {
+    LANGUAGE_SPECS.iter().find(|spec| spec.language == language)
+}
+
 /// Detect a language or file family from an extension.
 #[must_use]
 pub fn detect_language(extension: Option<&str>) -> Option<String> {
@@ -218,7 +502,13 @@ pub fn detect_language_for_path(path: &str, extension: Option<&str>) -> Option<S
 
 #[cfg(test)]
 mod tests {
-    use super::{BROAD_SOURCE_EXTENSIONS, detect_language, detect_language_for_path};
+    use super::{
+        BROAD_SOURCE_EXTENSIONS, LanguageParserSupport, detect_language, detect_language_for_path,
+        language_spec,
+    };
+    use std::collections::HashSet;
+    use std::error::Error;
+    use std::io;
 
     #[test]
     fn detects_every_broad_source_extension() {
@@ -259,6 +549,78 @@ mod tests {
         assert_eq!(
             detect_language_for_path("crates/demo/build.rs", Some(".rs")).as_deref(),
             Some("rust-build-script")
+        );
+    }
+
+    #[test]
+    fn every_detected_language_has_parser_coverage_metadata() -> Result<(), Box<dyn Error>> {
+        let mut languages = HashSet::new();
+        for extension in BROAD_SOURCE_EXTENSIONS {
+            let Some(language) = detect_language(Some(extension)) else {
+                return Err(
+                    io::Error::other(format!("missing detected language for {extension}")).into(),
+                );
+            };
+            languages.insert(language);
+        }
+        for (path, extension) in [
+            ("Cargo.toml", Some(".toml")),
+            ("Cargo.lock", None),
+            ("build.rs", Some(".rs")),
+            ("Dockerfile", None),
+            ("Makefile", None),
+        ] {
+            let Some(language) = detect_language_for_path(path, extension) else {
+                return Err(
+                    io::Error::other(format!("missing detected language for {path}")).into(),
+                );
+            };
+            languages.insert(language);
+        }
+        for language in languages {
+            if language_spec(&language).is_none() {
+                return Err(io::Error::other(format!(
+                    "missing parser coverage metadata for {language}"
+                ))
+                .into());
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn representative_parser_coverage_is_explicit() {
+        assert_eq!(
+            language_spec("rust").map(|spec| spec.parser_support),
+            Some(LanguageParserSupport::Native)
+        );
+        assert_eq!(
+            language_spec("cargo-manifest").map(|spec| spec.parser_support),
+            Some(LanguageParserSupport::Manifest)
+        );
+        assert_eq!(
+            language_spec("vue").map(|spec| spec.parser_support),
+            Some(LanguageParserSupport::Structural)
+        );
+        assert_eq!(
+            language_spec("toml").map(|spec| spec.parser_support),
+            Some(LanguageParserSupport::Structural)
+        );
+        assert_eq!(
+            language_spec("config").map(|spec| spec.parser_support),
+            Some(LanguageParserSupport::Structural)
+        );
+        assert_eq!(
+            language_spec("text").map(|spec| spec.parser_support),
+            Some(LanguageParserSupport::Structural)
+        );
+        assert_eq!(
+            language_spec("xml").map(|spec| spec.parser_support),
+            Some(LanguageParserSupport::Structural)
+        );
+        assert_eq!(
+            language_spec("ruby").map(|spec| spec.parser_support),
+            Some(LanguageParserSupport::Fallback)
         );
     }
 }

--- a/crates/projectatlas-core/src/symbols.rs
+++ b/crates/projectatlas-core/src/symbols.rs
@@ -224,3 +224,32 @@ pub struct SymbolGraph {
     /// Extracted import, dependency, containment, and call relations.
     pub relations: Vec<SymbolRelation>,
 }
+
+/// File-level parser metadata persisted even when a graph has no symbols.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SourceParseMetadata {
+    /// Repository-relative file path.
+    pub path: String,
+    /// Detected language or file family.
+    pub language: Option<String>,
+    /// Primary parser strategy used for the file.
+    pub parser: ParserKind,
+    /// Number of declaration or manifest symbols emitted for this file.
+    pub symbol_count: usize,
+    /// Number of relations emitted for this file.
+    pub relation_count: usize,
+}
+
+impl SourceParseMetadata {
+    /// Build persisted parser metadata from a graph.
+    #[must_use]
+    pub fn from_graph(graph: &SymbolGraph) -> Self {
+        Self {
+            path: graph.path.clone(),
+            language: graph.language.clone(),
+            parser: graph.parser,
+            symbol_count: graph.symbols.len(),
+            relation_count: graph.relations.len(),
+        }
+    }
+}

--- a/crates/projectatlas-core/src/telemetry.rs
+++ b/crates/projectatlas-core/src/telemetry.rs
@@ -2,6 +2,7 @@
 
 use crate::outline::estimate_tokens;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Token overview counting mode.
 pub const TOKEN_ESTIMATE_KIND: &str = "heuristic";
@@ -9,6 +10,32 @@ pub const TOKEN_ESTIMATE_KIND: &str = "heuristic";
 pub const TOKEN_ESTIMATOR: &str = "chars_or_bytes_div_ceil_4";
 /// Token overview scope label.
 pub const TOKEN_ESTIMATE_SCOPE: &str = "workflow_payload_estimate_not_model_billing_tokens";
+/// Default token-count provider label for offline estimates.
+pub const TOKEN_PROVIDER_HEURISTIC: &str = "heuristic";
+/// Default model label when no model-specific counter is used.
+pub const TOKEN_MODEL_UNKNOWN: &str = "unknown";
+/// Default token-count backend for offline estimates.
+pub const TOKENIZER_BACKEND_HEURISTIC: &str = "chars_div_4";
+/// Accuracy label for the default offline estimator.
+pub const TOKEN_ACCURACY_HEURISTIC: &str = "heuristic_estimate";
+/// Bucket for source compression through summaries, outlines, search, or slices.
+pub const TOKEN_BUCKET_FULL_FILE_COMPRESSION: &str = "full_file_compression";
+/// Bucket for navigation that avoids broad folder/file exploration.
+pub const TOKEN_BUCKET_NAVIGATION_AVOIDANCE: &str = "navigation_avoidance";
+/// Baseline kind for a concrete full-file comparison.
+pub const TOKEN_BASELINE_FULL_FILE: &str = "full_file";
+/// Baseline kind for inferred candidate-set navigation savings.
+pub const TOKEN_BASELINE_SELECTED_CANDIDATES: &str = "selected_candidates";
+/// Baseline kind for broad directory-walk navigation savings.
+pub const TOKEN_BASELINE_DIRECTORY_WALK: &str = "directory_walk";
+/// Confidence label for observed source-compression comparisons.
+pub const TOKEN_CONFIDENCE_OBSERVED: &str = "observed";
+/// Confidence label for inferred navigation comparisons.
+pub const TOKEN_CONFIDENCE_INFERRED: &str = "inferred";
+/// Confidence label for policy-modeled navigation comparisons.
+pub const TOKEN_CONFIDENCE_POLICY_ESTIMATE: &str = "policy_estimate";
+/// Trace label for the default heuristic calculation.
+pub const TOKEN_TRACE_HEURISTIC: &str = "heuristic=ceil(chars_or_bytes/4)";
 
 /// Token savings event for a funnel command.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -27,6 +54,59 @@ pub struct UsageEvent {
     pub estimated_tokens_with_projectatlas: Option<usize>,
     /// Estimated token delta.
     pub estimated_tokens_saved: Option<isize>,
+    /// Savings bucket used for reporting hard evidence separately from modeled savings.
+    #[serde(default = "default_token_savings_bucket")]
+    pub token_savings_bucket: String,
+    /// Provider used for token counting.
+    #[serde(default = "default_token_provider")]
+    pub provider: String,
+    /// Model used for token counting.
+    #[serde(default = "default_token_model")]
+    pub model: String,
+    /// Tokenizer or API backend used for token counting.
+    #[serde(default = "default_tokenizer_backend")]
+    pub tokenizer_backend: String,
+    /// Accuracy level for the token count.
+    #[serde(default = "default_token_accuracy")]
+    pub accuracy: String,
+    /// Baseline scenario used for the without-ProjectAtlas estimate.
+    #[serde(default = "default_token_baseline_kind")]
+    pub baseline_kind: String,
+    /// Confidence level for the baseline scenario.
+    #[serde(default = "default_token_confidence")]
+    pub confidence: String,
+    /// Compact calculation trace.
+    #[serde(default = "default_token_trace")]
+    pub calculation_trace: String,
+}
+
+/// Aggregated token savings for one bucket and counting mode.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct TokenBucketOverview {
+    /// Savings bucket.
+    pub token_savings_bucket: String,
+    /// Provider used for token counting.
+    pub provider: String,
+    /// Model used for token counting.
+    pub model: String,
+    /// Tokenizer or API backend used for token counting.
+    pub tokenizer_backend: String,
+    /// Accuracy level for the token count.
+    pub accuracy: String,
+    /// Baseline scenario used for the without-ProjectAtlas estimate.
+    pub baseline_kind: String,
+    /// Confidence level for the baseline scenario.
+    pub confidence: String,
+    /// Number of tracked calls in this bucket.
+    pub calls: usize,
+    /// Total baseline estimate.
+    pub estimated_without_projectatlas: usize,
+    /// Total `ProjectAtlas` estimate.
+    pub estimated_with_projectatlas: usize,
+    /// Total saved tokens.
+    pub estimated_saved: isize,
+    /// Signed savings ratio, or `None` when the baseline estimate is zero.
+    pub savings_rate: Option<f64>,
 }
 
 /// Token savings overview.
@@ -48,15 +128,15 @@ pub struct TokenOverview {
     pub estimated_saved: isize,
     /// Signed savings ratio, or `None` when the baseline estimate is zero.
     pub savings_rate: Option<f64>,
+    /// Bucketed token savings grouped by baseline and accuracy semantics.
+    pub buckets: Vec<TokenBucketOverview>,
 }
 
 impl TokenOverview {
     /// Build an overview from usage events.
     #[must_use]
     pub fn from_events(events: &[UsageEvent]) -> Self {
-        let mut without = 0u128;
-        let mut with = 0u128;
-        let mut calls = 0u128;
+        let mut totals = BTreeMap::<TokenBucketKey, (u128, u128, u128)>::new();
         for event in events {
             let (Some(event_without), Some(event_with)) = (
                 event.estimated_tokens_without_projectatlas,
@@ -64,16 +144,47 @@ impl TokenOverview {
             ) else {
                 continue;
             };
-            calls = calls.saturating_add(1);
-            without = without.saturating_add(event_without as u128);
-            with = with.saturating_add(event_with as u128);
+            let entry = totals.entry(TokenBucketKey::from(event)).or_default();
+            entry.0 = entry.0.saturating_add(1);
+            entry.1 = entry.1.saturating_add(event_without as u128);
+            entry.2 = entry.2.saturating_add(event_with as u128);
         }
-        Self::from_estimated_totals(calls, without, with)
+        let buckets = totals
+            .into_iter()
+            .map(|(key, (calls, without, with))| key.into_overview(calls, without, with))
+            .collect();
+        Self::from_buckets(buckets)
     }
 
     /// Build an overview from aggregate heuristic token totals.
     #[must_use]
     pub fn from_estimated_totals(calls: u128, without: u128, with: u128) -> Self {
+        Self::from_buckets(vec![TokenBucketOverview::from_totals(
+            default_token_savings_bucket(),
+            default_token_provider(),
+            default_token_model(),
+            default_tokenizer_backend(),
+            default_token_accuracy(),
+            default_token_baseline_kind(),
+            default_token_confidence(),
+            calls,
+            without,
+            with,
+        )])
+    }
+
+    /// Build an overview from pre-aggregated buckets.
+    #[must_use]
+    pub fn from_buckets(buckets: Vec<TokenBucketOverview>) -> Self {
+        let calls = buckets.iter().fold(0u128, |acc, bucket| {
+            acc.saturating_add(bucket.calls as u128)
+        });
+        let without = buckets.iter().fold(0u128, |acc, bucket| {
+            acc.saturating_add(bucket.estimated_without_projectatlas as u128)
+        });
+        let with = buckets.iter().fold(0u128, |acc, bucket| {
+            acc.saturating_add(bucket.estimated_with_projectatlas as u128)
+        });
         let saved = aggregate_token_delta(without, with);
         let savings_rate = if without == 0 {
             None
@@ -89,7 +200,97 @@ impl TokenOverview {
             estimated_with_projectatlas: saturating_u128_to_usize(with),
             estimated_saved: saved,
             savings_rate,
+            buckets,
         }
+    }
+}
+
+impl TokenBucketOverview {
+    /// Build a bucket overview from aggregate heuristic token totals.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_totals(
+        token_savings_bucket: String,
+        provider: String,
+        model: String,
+        tokenizer_backend: String,
+        accuracy: String,
+        baseline_kind: String,
+        confidence: String,
+        calls: u128,
+        without: u128,
+        with: u128,
+    ) -> Self {
+        let estimated_saved = aggregate_token_delta(without, with);
+        let savings_rate = if without == 0 {
+            None
+        } else {
+            Some((without as f64 - with as f64) / without as f64)
+        };
+        Self {
+            token_savings_bucket,
+            provider,
+            model,
+            tokenizer_backend,
+            accuracy,
+            baseline_kind,
+            confidence,
+            calls: saturating_u128_to_usize(calls),
+            estimated_without_projectatlas: saturating_u128_to_usize(without),
+            estimated_with_projectatlas: saturating_u128_to_usize(with),
+            estimated_saved,
+            savings_rate,
+        }
+    }
+}
+
+/// Grouping key for token bucket aggregation.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct TokenBucketKey {
+    /// Savings bucket.
+    token_savings_bucket: String,
+    /// Provider used for token counting.
+    provider: String,
+    /// Model used for token counting.
+    model: String,
+    /// Tokenizer or API backend used for token counting.
+    tokenizer_backend: String,
+    /// Accuracy level for the token count.
+    accuracy: String,
+    /// Baseline scenario used for the without-ProjectAtlas estimate.
+    baseline_kind: String,
+    /// Confidence level for the baseline scenario.
+    confidence: String,
+}
+
+impl TokenBucketKey {
+    /// Build a grouping key from one usage event.
+    fn from(event: &UsageEvent) -> Self {
+        Self {
+            token_savings_bucket: event.token_savings_bucket.clone(),
+            provider: event.provider.clone(),
+            model: event.model.clone(),
+            tokenizer_backend: event.tokenizer_backend.clone(),
+            accuracy: event.accuracy.clone(),
+            baseline_kind: event.baseline_kind.clone(),
+            confidence: event.confidence.clone(),
+        }
+    }
+
+    /// Convert an aggregate bucket into a report row.
+    fn into_overview(self, calls: u128, without: u128, with: u128) -> TokenBucketOverview {
+        TokenBucketOverview::from_totals(
+            self.token_savings_bucket,
+            self.provider,
+            self.model,
+            self.tokenizer_backend,
+            self.accuracy,
+            self.baseline_kind,
+            self.confidence,
+            calls,
+            without,
+            with,
+        )
     }
 }
 
@@ -105,7 +306,17 @@ pub fn usage_from_text(
 ) -> UsageEvent {
     let without = estimate_tokens(baseline_text);
     let with = estimate_tokens(projectatlas_text);
-    usage_from_estimates(session_id, command, path, query, without, with)
+    usage_from_estimates_with_context(
+        session_id,
+        command,
+        path,
+        query,
+        without,
+        with,
+        TOKEN_BUCKET_FULL_FILE_COMPRESSION,
+        TOKEN_BASELINE_FULL_FILE,
+        TOKEN_CONFIDENCE_OBSERVED,
+    )
 }
 
 /// Create a usage event from already-computed token estimates.
@@ -118,6 +329,33 @@ pub fn usage_from_estimates(
     estimated_without_projectatlas: usize,
     estimated_with_projectatlas: usize,
 ) -> UsageEvent {
+    usage_from_estimates_with_context(
+        session_id,
+        command,
+        path,
+        query,
+        estimated_without_projectatlas,
+        estimated_with_projectatlas,
+        TOKEN_BUCKET_NAVIGATION_AVOIDANCE,
+        TOKEN_BASELINE_SELECTED_CANDIDATES,
+        TOKEN_CONFIDENCE_INFERRED,
+    )
+}
+
+/// Create a usage event from token estimates and explicit baseline semantics.
+#[must_use]
+#[allow(clippy::too_many_arguments)]
+pub fn usage_from_estimates_with_context(
+    session_id: &str,
+    command: &str,
+    path: Option<String>,
+    query: Option<String>,
+    estimated_without_projectatlas: usize,
+    estimated_with_projectatlas: usize,
+    token_savings_bucket: &str,
+    baseline_kind: &str,
+    confidence: &str,
+) -> UsageEvent {
     UsageEvent {
         session_id: session_id.to_string(),
         command: command.to_string(),
@@ -129,7 +367,63 @@ pub fn usage_from_estimates(
             estimated_without_projectatlas,
             estimated_with_projectatlas,
         )),
+        token_savings_bucket: token_savings_bucket.to_string(),
+        provider: default_token_provider(),
+        model: default_token_model(),
+        tokenizer_backend: default_tokenizer_backend(),
+        accuracy: default_token_accuracy(),
+        baseline_kind: baseline_kind.to_string(),
+        confidence: confidence.to_string(),
+        calculation_trace: default_token_trace(),
     }
+}
+
+/// Default token savings bucket for legacy usage events.
+#[must_use]
+pub fn default_token_savings_bucket() -> String {
+    TOKEN_BUCKET_NAVIGATION_AVOIDANCE.to_string()
+}
+
+/// Default token provider for legacy usage events.
+#[must_use]
+pub fn default_token_provider() -> String {
+    TOKEN_PROVIDER_HEURISTIC.to_string()
+}
+
+/// Default token model for legacy usage events.
+#[must_use]
+pub fn default_token_model() -> String {
+    TOKEN_MODEL_UNKNOWN.to_string()
+}
+
+/// Default tokenizer backend for legacy usage events.
+#[must_use]
+pub fn default_tokenizer_backend() -> String {
+    TOKENIZER_BACKEND_HEURISTIC.to_string()
+}
+
+/// Default accuracy label for legacy usage events.
+#[must_use]
+pub fn default_token_accuracy() -> String {
+    TOKEN_ACCURACY_HEURISTIC.to_string()
+}
+
+/// Default baseline kind for legacy usage events.
+#[must_use]
+pub fn default_token_baseline_kind() -> String {
+    TOKEN_BASELINE_SELECTED_CANDIDATES.to_string()
+}
+
+/// Default confidence label for legacy usage events.
+#[must_use]
+pub fn default_token_confidence() -> String {
+    TOKEN_CONFIDENCE_INFERRED.to_string()
+}
+
+/// Default calculation trace for legacy usage events.
+#[must_use]
+pub fn default_token_trace() -> String {
+    TOKEN_TRACE_HEURISTIC.to_string()
 }
 
 /// Return a saturating signed token delta.
@@ -170,8 +464,9 @@ fn saturating_u128_to_usize(value: u128) -> usize {
 #[cfg(test)]
 mod tests {
     use super::{
-        TOKEN_ESTIMATE_KIND, TOKEN_ESTIMATE_SCOPE, TOKEN_ESTIMATOR, TokenOverview, UsageEvent,
-        usage_from_estimates, usage_from_text,
+        TOKEN_BUCKET_FULL_FILE_COMPRESSION, TOKEN_BUCKET_NAVIGATION_AVOIDANCE, TOKEN_ESTIMATE_KIND,
+        TOKEN_ESTIMATE_SCOPE, TOKEN_ESTIMATOR, TokenOverview, usage_from_estimates,
+        usage_from_text,
     };
 
     #[test]
@@ -193,26 +488,11 @@ mod tests {
 
     #[test]
     fn overview_recomputes_saved_from_aggregate_without_and_with() {
-        let overview = TokenOverview::from_events(&[
-            UsageEvent {
-                session_id: "s".to_string(),
-                command: "a".to_string(),
-                path: None,
-                query: None,
-                estimated_tokens_without_projectatlas: Some(20),
-                estimated_tokens_with_projectatlas: Some(50),
-                estimated_tokens_saved: Some(999),
-            },
-            UsageEvent {
-                session_id: "s".to_string(),
-                command: "b".to_string(),
-                path: None,
-                query: None,
-                estimated_tokens_without_projectatlas: Some(0),
-                estimated_tokens_with_projectatlas: Some(10),
-                estimated_tokens_saved: Some(999),
-            },
-        ]);
+        let mut first = usage_from_estimates("s", "a", None, None, 20, 50);
+        first.estimated_tokens_saved = Some(999);
+        let mut second = usage_from_estimates("s", "b", None, None, 0, 10);
+        second.estimated_tokens_saved = Some(999);
+        let overview = TokenOverview::from_events(&[first, second]);
 
         assert_eq!(overview.estimate_kind, TOKEN_ESTIMATE_KIND);
         assert_eq!(overview.estimator, TOKEN_ESTIMATOR);
@@ -222,5 +502,24 @@ mod tests {
         assert_eq!(overview.estimated_with_projectatlas, 60);
         assert_eq!(overview.estimated_saved, -40);
         assert_eq!(overview.savings_rate, Some(-2.0));
+    }
+
+    #[test]
+    fn overview_keeps_source_compression_and_navigation_buckets_separate() {
+        let overview = TokenOverview::from_events(&[
+            usage_from_text("s", "summary", None, None, "abcdefghijkl", "abcd"),
+            usage_from_estimates("s", "folders", None, None, 100, 20),
+        ]);
+
+        assert_eq!(overview.calls, 2);
+        assert_eq!(overview.buckets.len(), 2);
+        assert_eq!(
+            overview.buckets[0].token_savings_bucket,
+            TOKEN_BUCKET_FULL_FILE_COMPRESSION
+        );
+        assert_eq!(
+            overview.buckets[1].token_savings_bucket,
+            TOKEN_BUCKET_NAVIGATION_AVOIDANCE
+        );
     }
 }

--- a/crates/projectatlas-core/src/toon.rs
+++ b/crates/projectatlas-core/src/toon.rs
@@ -86,9 +86,27 @@ pub fn render_health(findings: &[HealthFinding]) -> String {
 /// Render token savings overview as standard TOON.
 #[must_use]
 pub fn render_token_overview(overview: &TokenOverview) -> String {
-    let savings_rate = overview
-        .savings_rate
-        .map(|rate| format!("{:.1}%", rate * 100.0));
+    let savings_rate = percentage_label(overview.savings_rate);
+    let buckets = overview
+        .buckets
+        .iter()
+        .map(|bucket| {
+            json!({
+                "token_savings_bucket": bucket.token_savings_bucket,
+                "provider": bucket.provider,
+                "model": bucket.model,
+                "tokenizer_backend": bucket.tokenizer_backend,
+                "accuracy": bucket.accuracy,
+                "baseline_kind": bucket.baseline_kind,
+                "confidence": bucket.confidence,
+                "calls": bucket.calls,
+                "baseline_tokens": bucket.estimated_without_projectatlas,
+                "emitted_tokens": bucket.estimated_with_projectatlas,
+                "saved_tokens": bucket.estimated_saved,
+                "savings_rate": percentage_label(bucket.savings_rate),
+            })
+        })
+        .collect::<Vec<_>>();
     encode_agent_payload(&json!({
         "token_savings": {
             "estimate_kind": overview.estimate_kind,
@@ -98,7 +116,14 @@ pub fn render_token_overview(overview: &TokenOverview) -> String {
             "estimated_without_projectatlas": overview.estimated_without_projectatlas,
             "estimated_with_projectatlas": overview.estimated_with_projectatlas,
             "estimated_saved": overview.estimated_saved,
-            "savings_rate": savings_rate.as_deref().unwrap_or("unknown"),
+            "savings_rate": savings_rate,
+            "totals": {
+                "baseline_tokens": overview.estimated_without_projectatlas,
+                "emitted_tokens": overview.estimated_with_projectatlas,
+                "saved_tokens": overview.estimated_saved,
+                "savings_rate": savings_rate,
+            },
+            "buckets": buckets,
         }
     }))
 }
@@ -179,6 +204,14 @@ fn render_severity(severity: Severity) -> &'static str {
         Severity::Warning => "warning",
         Severity::Error => "error",
     }
+}
+
+/// Format an optional savings rate as a stable display label.
+fn percentage_label(rate: Option<f64>) -> String {
+    rate.map_or_else(
+        || "unknown".to_string(),
+        |value| format!("{:.1}%", value * 100.0),
+    )
 }
 
 /// Return a conservative quoted fallback for rare encoder failures.

--- a/crates/projectatlas-db/src/lib.rs
+++ b/crates/projectatlas-db/src/lib.rs
@@ -2,9 +2,10 @@
 
 use projectatlas_core::health::{HealthFinding, Severity, finding_id};
 use projectatlas_core::symbols::{
-    CodeSymbol, ParserKind, RelationKind, SymbolGraph, SymbolKind, SymbolRelation,
+    CodeSymbol, ParserKind, RelationKind, SourceParseMetadata, SymbolGraph, SymbolKind,
+    SymbolRelation,
 };
-use projectatlas_core::telemetry::{TokenOverview, UsageEvent};
+use projectatlas_core::telemetry::{TokenBucketOverview, TokenOverview, UsageEvent};
 use projectatlas_core::{
     IndexedNode, Node, NodeKind, Overview, Purpose, PurposeSource, PurposeStatus,
     normalize_native_path_display, normalize_repo_path_prefix,
@@ -18,7 +19,7 @@ use std::path::Path;
 use thiserror::Error;
 
 /// Current `SQLite` schema version supported by this crate.
-const SCHEMA_VERSION: i64 = 6;
+const SCHEMA_VERSION: i64 = 8;
 
 /// Database-layer error type.
 #[derive(Debug, Error)]
@@ -251,6 +252,14 @@ impl AtlasStore {
                 estimated_tokens_without_projectatlas INTEGER,
                 estimated_tokens_with_projectatlas INTEGER,
                 estimated_tokens_saved INTEGER,
+                token_savings_bucket TEXT NOT NULL DEFAULT 'navigation_avoidance',
+                provider TEXT NOT NULL DEFAULT 'heuristic',
+                model TEXT NOT NULL DEFAULT 'unknown',
+                tokenizer_backend TEXT NOT NULL DEFAULT 'chars_div_4',
+                accuracy TEXT NOT NULL DEFAULT 'heuristic_estimate',
+                baseline_kind TEXT NOT NULL DEFAULT 'selected_candidates',
+                confidence TEXT NOT NULL DEFAULT 'inferred',
+                calculation_trace TEXT NOT NULL DEFAULT 'heuristic=ceil(chars_or_bytes/4)',
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
 
@@ -269,6 +278,15 @@ impl AtlasStore {
                 parser TEXT NOT NULL,
                 detail TEXT,
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE TABLE IF NOT EXISTS source_parse_metadata (
+                path TEXT PRIMARY KEY,
+                language TEXT,
+                parser TEXT NOT NULL,
+                symbol_count INTEGER NOT NULL,
+                relation_count INTEGER NOT NULL,
                 updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
 
@@ -312,6 +330,7 @@ impl AtlasStore {
             CREATE INDEX IF NOT EXISTS idx_symbols_path ON symbols(path);
             CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
             CREATE INDEX IF NOT EXISTS idx_symbols_kind ON symbols(kind);
+            CREATE INDEX IF NOT EXISTS idx_source_parse_metadata_parser ON source_parse_metadata(parser);
             CREATE INDEX IF NOT EXISTS idx_symbol_relations_path ON symbol_relations(path);
             CREATE INDEX IF NOT EXISTS idx_symbol_relations_target ON symbol_relations(target_name);
             CREATE INDEX IF NOT EXISTS idx_health_resolutions_category ON health_resolutions(category);
@@ -319,6 +338,7 @@ impl AtlasStore {
             ",
         )?;
         self.ensure_symbol_metadata_columns()?;
+        self.ensure_usage_event_metadata_columns()?;
         let stored = self
             .connection
             .query_row(
@@ -349,6 +369,62 @@ impl AtlasStore {
                 )?;
             }
         }
+        Ok(())
+    }
+
+    /// Add usage telemetry metadata columns to older databases.
+    fn ensure_usage_event_metadata_columns(&self) -> DbResult<()> {
+        let mut statement = self.connection.prepare("PRAGMA table_info(usage_events)")?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(1))?;
+        let mut columns = Vec::new();
+        for row in rows {
+            columns.push(row?);
+        }
+        self.ensure_usage_event_column(
+            &columns,
+            "token_savings_bucket",
+            "TEXT NOT NULL DEFAULT 'navigation_avoidance'",
+        )?;
+        self.ensure_usage_event_column(&columns, "provider", "TEXT NOT NULL DEFAULT 'heuristic'")?;
+        self.ensure_usage_event_column(&columns, "model", "TEXT NOT NULL DEFAULT 'unknown'")?;
+        self.ensure_usage_event_column(
+            &columns,
+            "tokenizer_backend",
+            "TEXT NOT NULL DEFAULT 'chars_div_4'",
+        )?;
+        self.ensure_usage_event_column(
+            &columns,
+            "accuracy",
+            "TEXT NOT NULL DEFAULT 'heuristic_estimate'",
+        )?;
+        self.ensure_usage_event_column(
+            &columns,
+            "baseline_kind",
+            "TEXT NOT NULL DEFAULT 'selected_candidates'",
+        )?;
+        self.ensure_usage_event_column(&columns, "confidence", "TEXT NOT NULL DEFAULT 'inferred'")?;
+        self.ensure_usage_event_column(
+            &columns,
+            "calculation_trace",
+            "TEXT NOT NULL DEFAULT 'heuristic=ceil(chars_or_bytes/4)'",
+        )?;
+        Ok(())
+    }
+
+    /// Add one usage event metadata column when it is absent.
+    fn ensure_usage_event_column(
+        &self,
+        columns: &[String],
+        name: &str,
+        definition: &str,
+    ) -> DbResult<()> {
+        if columns.iter().any(|column| column == name) {
+            return Ok(());
+        }
+        self.connection.execute(
+            &format!("ALTER TABLE usage_events ADD COLUMN {name} {definition}"),
+            [],
+        )?;
         Ok(())
     }
 
@@ -422,6 +498,10 @@ impl AtlasStore {
             [],
         )?;
         transaction.execute(
+            "DELETE FROM source_parse_metadata WHERE path IN (SELECT path FROM nodes WHERE exists_now = 0)",
+            [],
+        )?;
+        transaction.execute(
             "DELETE FROM file_texts WHERE path IN (SELECT path FROM nodes WHERE exists_now = 0)",
             [],
         )?;
@@ -465,6 +545,10 @@ impl AtlasStore {
             )?;
             transaction.execute(
                 "DELETE FROM symbols WHERE path = ?1 OR path LIKE ?2 ESCAPE '\\'",
+                params![path, descendant_pattern],
+            )?;
+            transaction.execute(
+                "DELETE FROM source_parse_metadata WHERE path = ?1 OR path LIKE ?2 ESCAPE '\\'",
                 params![path, descendant_pattern],
             )?;
             transaction.execute(
@@ -679,11 +763,38 @@ impl AtlasStore {
     ///
     /// Returns an error if persistence fails.
     pub fn replace_symbol_graph(&mut self, graph: &SymbolGraph) -> DbResult<()> {
+        let metadata = SourceParseMetadata::from_graph(graph);
         let transaction = self.connection.transaction()?;
         transaction.execute("DELETE FROM symbols WHERE path = ?1", [&graph.path])?;
         transaction.execute(
             "DELETE FROM symbol_relations WHERE path = ?1",
             [&graph.path],
+        )?;
+        transaction.execute(
+            "
+            INSERT INTO source_parse_metadata(
+                path,
+                language,
+                parser,
+                symbol_count,
+                relation_count,
+                updated_at
+            )
+            VALUES(?1, ?2, ?3, ?4, ?5, CURRENT_TIMESTAMP)
+            ON CONFLICT(path) DO UPDATE SET
+                language = excluded.language,
+                parser = excluded.parser,
+                symbol_count = excluded.symbol_count,
+                relation_count = excluded.relation_count,
+                updated_at = CURRENT_TIMESTAMP
+            ",
+            params![
+                metadata.path,
+                metadata.language.as_deref(),
+                metadata.parser.to_string(),
+                usize_to_i64(metadata.symbol_count),
+                usize_to_i64(metadata.relation_count),
+            ],
         )?;
         for symbol in &graph.symbols {
             transaction.execute(
@@ -763,6 +874,8 @@ impl AtlasStore {
             .execute("DELETE FROM symbols WHERE path = ?1", [path])?;
         self.connection
             .execute("DELETE FROM symbol_relations WHERE path = ?1", [path])?;
+        self.connection
+            .execute("DELETE FROM source_parse_metadata WHERE path = ?1", [path])?;
         self.connection.execute(
             "
             DELETE FROM summaries
@@ -785,6 +898,8 @@ impl AtlasStore {
             .execute("DELETE FROM symbols WHERE path = ?1", [path])?;
         self.connection
             .execute("DELETE FROM symbol_relations WHERE path = ?1", [path])?;
+        self.connection
+            .execute("DELETE FROM source_parse_metadata WHERE path = ?1", [path])?;
         Ok(())
     }
 
@@ -1478,6 +1593,36 @@ impl AtlasStore {
             parsers.push(row?);
         }
         Ok(parsers)
+    }
+
+    /// Load file-level parser metadata for one path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading fails or stored counts are invalid.
+    pub fn load_source_parse_metadata(&self, path: &str) -> DbResult<Option<SourceParseMetadata>> {
+        self.connection
+            .query_row(
+                "
+                SELECT path, language, parser, symbol_count, relation_count
+                FROM source_parse_metadata
+                WHERE path = ?1
+                ",
+                [path],
+                |row| {
+                    let symbol_count = row.get::<_, i64>(3)?;
+                    let relation_count = row.get::<_, i64>(4)?;
+                    Ok(SourceParseMetadata {
+                        path: row.get(0)?,
+                        language: row.get(1)?,
+                        parser: ParserKind::from_db(&row.get::<_, String>(2)?),
+                        symbol_count: i64_to_usize(symbol_count),
+                        relation_count: i64_to_usize(relation_count),
+                    })
+                },
+            )
+            .optional()
+            .map_err(Into::into)
     }
 
     /// Load the maximum indexed symbol end line for one file path.
@@ -2621,9 +2766,17 @@ impl AtlasStore {
                 query,
                 estimated_tokens_without_projectatlas,
                 estimated_tokens_with_projectatlas,
-                estimated_tokens_saved
+                estimated_tokens_saved,
+                token_savings_bucket,
+                provider,
+                model,
+                tokenizer_backend,
+                accuracy,
+                baseline_kind,
+                confidence,
+                calculation_trace
             )
-            VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
             ",
             params![
                 event.session_id,
@@ -2632,7 +2785,15 @@ impl AtlasStore {
                 event.query,
                 event.estimated_tokens_without_projectatlas,
                 event.estimated_tokens_with_projectatlas,
-                event.estimated_tokens_saved
+                event.estimated_tokens_saved,
+                event.token_savings_bucket,
+                event.provider,
+                event.model,
+                event.tokenizer_backend,
+                event.accuracy,
+                event.baseline_kind,
+                event.confidence,
+                event.calculation_trace
             ],
         )?;
         Ok(())
@@ -2647,7 +2808,9 @@ impl AtlasStore {
         let sql = if session_id.is_some() {
             "
             SELECT session_id, command, path, query, estimated_tokens_without_projectatlas,
-                   estimated_tokens_with_projectatlas, estimated_tokens_saved
+                   estimated_tokens_with_projectatlas, estimated_tokens_saved,
+                   token_savings_bucket, provider, model, tokenizer_backend,
+                   accuracy, baseline_kind, confidence, calculation_trace
             FROM usage_events
             WHERE session_id = ?1
             ORDER BY id
@@ -2655,7 +2818,9 @@ impl AtlasStore {
         } else {
             "
             SELECT session_id, command, path, query, estimated_tokens_without_projectatlas,
-                   estimated_tokens_with_projectatlas, estimated_tokens_saved
+                   estimated_tokens_with_projectatlas, estimated_tokens_saved,
+                   token_savings_bucket, provider, model, tokenizer_backend,
+                   accuracy, baseline_kind, confidence, calculation_trace
             FROM usage_events
             ORDER BY id
             "
@@ -2670,6 +2835,14 @@ impl AtlasStore {
                 estimated_tokens_without_projectatlas: row.get(4)?,
                 estimated_tokens_with_projectatlas: row.get(5)?,
                 estimated_tokens_saved: row.get(6)?,
+                token_savings_bucket: row.get(7)?,
+                provider: row.get(8)?,
+                model: row.get(9)?,
+                tokenizer_backend: row.get(10)?,
+                accuracy: row.get(11)?,
+                baseline_kind: row.get(12)?,
+                confidence: row.get(13)?,
+                calculation_trace: row.get(14)?,
             })
         };
         let rows = if let Some(session) = session_id {
@@ -2693,6 +2866,13 @@ impl AtlasStore {
         let sql = if session_id.is_some() {
             "
             SELECT
+                token_savings_bucket,
+                provider,
+                model,
+                tokenizer_backend,
+                accuracy,
+                baseline_kind,
+                confidence,
                 COUNT(*),
                 TOTAL(estimated_tokens_without_projectatlas),
                 TOTAL(estimated_tokens_with_projectatlas)
@@ -2700,32 +2880,57 @@ impl AtlasStore {
             WHERE session_id = ?1
               AND estimated_tokens_without_projectatlas IS NOT NULL
               AND estimated_tokens_with_projectatlas IS NOT NULL
+            GROUP BY token_savings_bucket, provider, model, tokenizer_backend,
+                     accuracy, baseline_kind, confidence
+            ORDER BY token_savings_bucket, accuracy, baseline_kind, confidence
             "
         } else {
             "
             SELECT
+                token_savings_bucket,
+                provider,
+                model,
+                tokenizer_backend,
+                accuracy,
+                baseline_kind,
+                confidence,
                 COUNT(*),
                 TOTAL(estimated_tokens_without_projectatlas),
                 TOTAL(estimated_tokens_with_projectatlas)
             FROM usage_events
             WHERE estimated_tokens_without_projectatlas IS NOT NULL
               AND estimated_tokens_with_projectatlas IS NOT NULL
+            GROUP BY token_savings_bucket, provider, model, tokenizer_backend,
+                     accuracy, baseline_kind, confidence
+            ORDER BY token_savings_bucket, accuracy, baseline_kind, confidence
             "
         };
         let mapper = |row: &rusqlite::Row<'_>| {
-            Ok((
-                row.get::<_, i64>(0)?,
-                token_total_from_sql("estimated_tokens_without_projectatlas", row.get(1)?),
-                token_total_from_sql("estimated_tokens_with_projectatlas", row.get(2)?),
+            let calls = row.get::<_, i64>(7)? as u128;
+            Ok(TokenBucketOverview::from_totals(
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+                calls,
+                token_total_from_sql("estimated_tokens_without_projectatlas", row.get(8)?),
+                token_total_from_sql("estimated_tokens_with_projectatlas", row.get(9)?),
             ))
         };
-        let (calls, without, with) = if let Some(session) = session_id {
-            self.connection.query_row(sql, [session], mapper)?
+        let mut statement = self.connection.prepare(sql)?;
+        let rows = if let Some(session) = session_id {
+            statement.query_map([session], mapper)?
         } else {
-            self.connection.query_row(sql, [], mapper)?
+            statement.query_map([], mapper)?
         };
-        let calls = row_token_count("token_overview_calls", calls)?;
-        Ok(token_overview_from_totals(calls, without, with))
+        let mut buckets = Vec::new();
+        for row in rows {
+            buckets.push(row?);
+        }
+        Ok(token_overview_from_buckets(buckets))
     }
 
     /// Mark a deterministic health finding as agent-resolved.
@@ -3069,15 +3274,6 @@ fn count_to_usize(field: &'static str, value: i64) -> DbResult<usize> {
     })
 }
 
-/// Convert one telemetry row count into a non-negative wide integer.
-fn row_token_count(field: &'static str, value: i64) -> DbResult<u128> {
-    u128::try_from(value).map_err(|source| DbError::InvalidCount {
-        field,
-        value,
-        source,
-    })
-}
-
 /// Convert a `SQLite` REAL aggregate token total to a saturating wide integer.
 fn token_total_from_sql(_field: &'static str, value: f64) -> u128 {
     if !value.is_finite() || value <= 0.0 {
@@ -3089,9 +3285,9 @@ fn token_total_from_sql(_field: &'static str, value: f64) -> u128 {
     }
 }
 
-/// Build a token overview from Rust-side aggregate totals.
-fn token_overview_from_totals(calls: u128, without: u128, with: u128) -> TokenOverview {
-    TokenOverview::from_estimated_totals(calls, without, with)
+/// Build a token overview from Rust-side aggregate buckets.
+fn token_overview_from_buckets(buckets: Vec<TokenBucketOverview>) -> TokenOverview {
+    TokenOverview::from_buckets(buckets)
 }
 
 /// Convert a usize to i64 with saturation for database storage.
@@ -3287,6 +3483,10 @@ fn resolved_ids_for_category(resolved_ids: &[String], category: &str) -> Vec<Str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use projectatlas_core::telemetry::{
+        TOKEN_ACCURACY_HEURISTIC, TOKEN_BUCKET_FULL_FILE_COMPRESSION,
+        TOKEN_BUCKET_NAVIGATION_AVOIDANCE, usage_from_estimates, usage_from_text,
+    };
     use projectatlas_core::{NodeKind, normalized_parent};
     use std::error::Error;
     use std::fmt::Debug;
@@ -3339,36 +3539,38 @@ mod tests {
     #[test]
     fn records_token_overview() -> Result<(), Box<dyn Error>> {
         let store = AtlasStore::in_memory()?;
-        store.record_usage(&UsageEvent {
-            session_id: "session".to_string(),
-            command: "outline".to_string(),
-            path: Some("src/main.rs".to_string()),
-            query: None,
-            estimated_tokens_without_projectatlas: Some(100),
-            estimated_tokens_with_projectatlas: Some(20),
-            estimated_tokens_saved: Some(1),
-        })?;
-        store.record_usage(&UsageEvent {
-            session_id: "session".to_string(),
-            command: "unknown".to_string(),
-            path: None,
-            query: None,
-            estimated_tokens_without_projectatlas: None,
-            estimated_tokens_with_projectatlas: None,
-            estimated_tokens_saved: None,
-        })?;
-        store.record_usage(&UsageEvent {
-            session_id: "other-session".to_string(),
-            command: "outline".to_string(),
-            path: Some("src/lib.rs".to_string()),
-            query: None,
-            estimated_tokens_without_projectatlas: Some(200),
-            estimated_tokens_with_projectatlas: Some(50),
-            estimated_tokens_saved: Some(150),
-        })?;
+        let mut session_event = usage_from_estimates(
+            "session",
+            "outline",
+            Some("src/main.rs".to_string()),
+            None,
+            100,
+            20,
+        );
+        session_event.estimated_tokens_saved = Some(1);
+        store.record_usage(&session_event)?;
+        let mut unknown_event = usage_from_estimates("session", "unknown", None, None, 0, 0);
+        unknown_event.estimated_tokens_without_projectatlas = None;
+        unknown_event.estimated_tokens_with_projectatlas = None;
+        unknown_event.estimated_tokens_saved = None;
+        store.record_usage(&unknown_event)?;
+        store.record_usage(&usage_from_estimates(
+            "other-session",
+            "outline",
+            Some("src/lib.rs".to_string()),
+            None,
+            200,
+            50,
+        ))?;
         let overview = store.token_overview(Some("session"))?;
         require_eq(&overview.calls, &1, "usage call count")?;
         require_eq(&overview.estimated_saved, &80, "saved token count")?;
+        require_eq(&overview.buckets.len(), &1, "usage bucket count")?;
+        require_eq(
+            &overview.buckets[0].accuracy,
+            &TOKEN_ACCURACY_HEURISTIC.to_string(),
+            "usage bucket accuracy",
+        )?;
         let all_sessions = store.token_overview(None)?;
         require_eq(&all_sessions.calls, &2, "all-session usage call count")?;
         require_eq(
@@ -3387,15 +3589,33 @@ mod tests {
             "all-session saved tokens",
         )?;
 
-        store.record_usage(&UsageEvent {
-            session_id: "negative".to_string(),
-            command: "outline".to_string(),
-            path: None,
-            query: None,
-            estimated_tokens_without_projectatlas: Some(20),
-            estimated_tokens_with_projectatlas: Some(50),
-            estimated_tokens_saved: Some(999),
-        })?;
+        store.record_usage(&usage_from_text(
+            "bucketed",
+            "summary",
+            Some("src/main.rs".to_string()),
+            None,
+            "abcdefghijkl",
+            "abcd",
+        ))?;
+        store.record_usage(&usage_from_estimates(
+            "bucketed", "folders", None, None, 100, 20,
+        ))?;
+        let bucketed = store.token_overview(Some("bucketed"))?;
+        require_eq(&bucketed.buckets.len(), &2, "bucketed overview count")?;
+        require_eq(
+            &bucketed.buckets[0].token_savings_bucket,
+            &TOKEN_BUCKET_FULL_FILE_COMPRESSION.to_string(),
+            "source compression bucket",
+        )?;
+        require_eq(
+            &bucketed.buckets[1].token_savings_bucket,
+            &TOKEN_BUCKET_NAVIGATION_AVOIDANCE.to_string(),
+            "navigation bucket",
+        )?;
+
+        let mut negative_event = usage_from_estimates("negative", "outline", None, None, 20, 50);
+        negative_event.estimated_tokens_saved = Some(999);
+        store.record_usage(&negative_event)?;
         let negative = store.token_overview(Some("negative"))?;
         require_eq(&negative.calls, &1, "negative session call count")?;
         require_eq(
@@ -3409,15 +3629,9 @@ mod tests {
             "negative session savings rate",
         )?;
 
-        store.record_usage(&UsageEvent {
-            session_id: "zero-baseline".to_string(),
-            command: "outline".to_string(),
-            path: None,
-            query: None,
-            estimated_tokens_without_projectatlas: Some(0),
-            estimated_tokens_with_projectatlas: Some(12),
-            estimated_tokens_saved: Some(999),
-        })?;
+        let mut zero_event = usage_from_estimates("zero-baseline", "outline", None, None, 0, 12);
+        zero_event.estimated_tokens_saved = Some(999);
+        store.record_usage(&zero_event)?;
         let zero_baseline = store.token_overview(Some("zero-baseline"))?;
         require_eq(&zero_baseline.calls, &1, "zero baseline call count")?;
         require_eq(
@@ -4002,13 +4216,45 @@ mod tests {
         store.replace_symbol_graph(&graph)?;
         let symbols = store.load_symbols(Some("src/main.rs"), Some("main"), 10)?;
         let relations = store.load_symbol_relations(Some("src/main.rs"), Some("println"), 10)?;
+        let metadata = store
+            .load_source_parse_metadata("src/main.rs")?
+            .ok_or_else(|| io::Error::other("missing source parse metadata"))?;
         require_eq(&symbols.len(), &1, "symbol count after replace")?;
         require_eq(&relations.len(), &1, "relation count after replace")?;
+        require_eq(&metadata.parser, &ParserKind::TreeSitter, "metadata parser")?;
+        require_eq(&metadata.symbol_count, &1, "metadata symbol count")?;
+        require_eq(&metadata.relation_count, &1, "metadata relation count")?;
         require_eq(&symbols[0].exported, &true, "exported metadata")?;
         require_eq(
             &symbols[0].documentation,
             &Some("Run the application.".to_string()),
             "documentation metadata",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn full_scan_removal_clears_source_parse_metadata() -> Result<(), Box<dyn Error>> {
+        let mut store = AtlasStore::in_memory()?;
+        store.replace_scan(&[test_file_node("src/a.rs", "hash-a")])?;
+        store.replace_symbol_graph(&SymbolGraph {
+            path: "src/a.rs".to_string(),
+            language: Some("rust".to_string()),
+            parser: ParserKind::TreeSitter,
+            symbols: Vec::new(),
+            relations: Vec::new(),
+        })?;
+        require_eq(
+            &store.load_source_parse_metadata("src/a.rs")?.is_some(),
+            &true,
+            "metadata exists before removal",
+        )?;
+
+        store.replace_scan(&[test_file_node("src/b.rs", "hash-b")])?;
+        require_eq(
+            &store.load_source_parse_metadata("src/a.rs")?,
+            &None,
+            "metadata cleared after full scan removal",
         )?;
         Ok(())
     }

--- a/crates/projectatlas-service/src/lib.rs
+++ b/crates/projectatlas-service/src/lib.rs
@@ -6,7 +6,7 @@ use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use import_aliases::{ImportAliasMap, load_import_alias_map};
 use projectatlas_core::outline::estimate_tokens;
 use projectatlas_core::symbols::{
-    CodeSymbol, ParserKind, RelationKind, SymbolKind, SymbolRelation,
+    CodeSymbol, ParserKind, RelationKind, SourceParseMetadata, SymbolKind, SymbolRelation,
 };
 use projectatlas_core::{IndexedNode, NodeKind, repo_path_to_native, validated_repo_file_key};
 use projectatlas_db::{AtlasStore, DbError, IndexedFileText};
@@ -339,6 +339,7 @@ pub fn build_file_summary(
     let total_exports = store.exported_symbol_count_for_path(&file_key)?;
     let symbol_count = store.symbol_count_for_path(&file_key)?;
     let symbol_parser_kinds = store.symbol_parser_kinds_for_path(&file_key)?;
+    let parse_metadata = store.load_source_parse_metadata(&file_key)?;
     let truncated = [
         total_functions,
         total_methods,
@@ -353,10 +354,20 @@ pub fn build_file_summary(
     .any(|total| *total > effective_limit);
 
     let content_summary = indexed.summary.unwrap_or_default();
-    let parser_kind =
-        summary_parser_kind(&content_summary, symbol_count, &symbol_parser_kinds).to_string();
-    let summary_status =
-        summary_status(&content_summary, symbol_count, &symbol_parser_kinds).to_string();
+    let parser_kind = summary_parser_kind(
+        &content_summary,
+        symbol_count,
+        &symbol_parser_kinds,
+        parse_metadata.as_ref(),
+    )
+    .to_string();
+    let summary_status = summary_status(
+        &content_summary,
+        symbol_count,
+        &symbol_parser_kinds,
+        parse_metadata.as_ref(),
+    )
+    .to_string();
 
     Ok(FileSummaryReport {
         file_path: file_key,
@@ -412,7 +423,11 @@ fn summary_parser_kind(
     summary: &str,
     symbol_count: usize,
     parser_kinds: &[ParserKind],
+    parse_metadata: Option<&SourceParseMetadata>,
 ) -> &'static str {
+    if let Some(metadata) = parse_metadata {
+        return parser_kind_label(metadata.parser);
+    }
     if symbol_count > 0 {
         return symbol_parser_kind(parser_kinds);
     }
@@ -428,15 +443,31 @@ fn summary_parser_kind(
 }
 
 /// Return a summary quality status for agent consumers.
-fn summary_status(summary: &str, symbol_count: usize, parser_kinds: &[ParserKind]) -> &'static str {
+fn summary_status(
+    summary: &str,
+    symbol_count: usize,
+    parser_kinds: &[ParserKind],
+    parse_metadata: Option<&SourceParseMetadata>,
+) -> &'static str {
     if summary.is_empty() {
         "missing"
     } else if is_scanner_fallback_summary(summary)
+        || parse_metadata.is_some_and(|metadata| metadata.parser == ParserKind::Fallback)
         || fallback_only_symbols(symbol_count, parser_kinds)
     {
         "fallback"
     } else {
         "ok"
+    }
+}
+
+/// Return the public parser label for one file-level parser strategy.
+fn parser_kind_label(parser: ParserKind) -> &'static str {
+    match parser {
+        ParserKind::TreeSitter => "tree-sitter-symbol-graph",
+        ParserKind::Manifest => "manifest-symbol-graph",
+        ParserKind::Structural => "structural-symbol-graph",
+        ParserKind::Fallback => "fallback-symbol-graph",
     }
 }
 
@@ -1512,6 +1543,40 @@ mod tests {
             &report.summary_status,
             &"fallback".to_string(),
             "fallback summary status",
+        )
+    }
+
+    #[test]
+    fn file_summary_marks_empty_fallback_graph_as_fallback() -> Result<(), Box<dyn Error>> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path();
+        fs::create_dir(root.join("scripts"))?;
+        fs::write(root.join("scripts").join("config.ps1"), "# comment only\n")?;
+        let mut store = AtlasStore::in_memory()?;
+        store.set_project_root(root)?;
+        store.replace_scan(&[test_node("scripts/config.ps1", "hash-ps1")])?;
+        store.set_node_summary(
+            "scripts/config.ps1",
+            "powershell source file with no declarations found.",
+        )?;
+        store.replace_symbol_graph(&SymbolGraph {
+            path: "scripts/config.ps1".to_string(),
+            language: Some("powershell".to_string()),
+            parser: ParserKind::Fallback,
+            symbols: Vec::new(),
+            relations: Vec::new(),
+        })?;
+
+        let report = build_file_summary(&store, Path::new("scripts/config.ps1"), 10)?;
+        require_eq(
+            &report.parser_kind,
+            &"fallback-symbol-graph".to_string(),
+            "empty fallback parser kind",
+        )?;
+        require_eq(
+            &report.summary_status,
+            &"fallback".to_string(),
+            "empty fallback summary status",
         )
     }
 

--- a/crates/projectatlas-symbols/src/lib.rs
+++ b/crates/projectatlas-symbols/src/lib.rs
@@ -31,6 +31,13 @@ pub fn extract_symbol_graph(path: &str, language: Option<&str>, content: &str) -
         return extract_vue_sfc_graph(path, language, parse_content.as_ref());
     }
     if let Some(graph) = extract_tree_sitter_graph(path, language, parse_content.as_ref()) {
+        if !graph.symbols.is_empty() || !graph.relations.is_empty() {
+            return graph;
+        }
+        let fallback = extract_fallback_graph(path, language, parse_content.as_ref());
+        if !fallback.symbols.is_empty() || !fallback.relations.is_empty() {
+            return fallback;
+        }
         return graph;
     }
     extract_fallback_graph(path, language, parse_content.as_ref())
@@ -473,11 +480,7 @@ fn extract_tree_sitter_graph(
     let mut graph = empty_graph(path, language, ParserKind::TreeSitter);
     visit_node(tree.root_node(), content, &mut graph);
     languages::augment_language_graph(&mut graph, content);
-    if graph.symbols.is_empty() && graph.relations.is_empty() {
-        None
-    } else {
-        Some(graph)
-    }
+    Some(graph)
 }
 
 /// Return a tree-sitter language for supported source families.
@@ -1690,6 +1693,29 @@ fn helper() {}
         }));
         assert!(graph.relations.iter().any(|relation| {
             relation.kind == RelationKind::Calls && relation.target_name.contains("helper")
+        }));
+    }
+
+    #[test]
+    fn native_parser_graph_survives_when_empty() {
+        let graph = extract_symbol_graph("src/empty.rs", Some("rust"), "// comment only\n");
+        assert_eq!(graph.parser, ParserKind::TreeSitter);
+        assert!(graph.symbols.is_empty());
+        assert!(graph.relations.is_empty());
+    }
+
+    #[test]
+    fn native_empty_graph_keeps_fallback_rescue() {
+        let graph = extract_symbol_graph(
+            "src/misdetected.rs",
+            Some("rust"),
+            "def rescued():\n    return 1\n",
+        );
+        assert_eq!(graph.parser, ParserKind::Fallback);
+        assert!(graph.symbols.iter().any(|symbol| {
+            symbol.name == "rescued"
+                && symbol.kind == SymbolKind::Function
+                && symbol.detail.as_deref() == Some("fallback-python-function")
         }));
     }
 

--- a/crates/projectatlas-symbols/src/lib.rs
+++ b/crates/projectatlas-symbols/src/lib.rs
@@ -30,15 +30,17 @@ pub fn extract_symbol_graph(path: &str, language: Option<&str>, content: &str) -
     if is_vue_sfc(path, language) {
         return extract_vue_sfc_graph(path, language, parse_content.as_ref());
     }
-    if let Some(graph) = extract_tree_sitter_graph(path, language, parse_content.as_ref()) {
-        if !graph.symbols.is_empty() || !graph.relations.is_empty() {
-            return graph;
+    if let Some(parsed) = extract_tree_sitter_graph(path, language, parse_content.as_ref()) {
+        if !parsed.graph.symbols.is_empty() || !parsed.graph.relations.is_empty() {
+            return parsed.graph;
         }
-        let fallback = extract_fallback_graph(path, language, parse_content.as_ref());
-        if !fallback.symbols.is_empty() || !fallback.relations.is_empty() {
-            return fallback;
+        if parsed.had_errors {
+            let fallback = extract_fallback_graph(path, language, parse_content.as_ref());
+            if !fallback.symbols.is_empty() || !fallback.relations.is_empty() {
+                return fallback;
+            }
         }
-        return graph;
+        return parsed.graph;
     }
     extract_fallback_graph(path, language, parse_content.as_ref())
 }
@@ -464,12 +466,20 @@ fn normalize_toml_section(section: &str) -> String {
     parts.join(".")
 }
 
+/// Tree-sitter extraction result with parse health metadata.
+struct TreeSitterParse {
+    /// Extracted symbol graph.
+    graph: SymbolGraph,
+    /// Whether tree-sitter found syntax errors while parsing.
+    had_errors: bool,
+}
+
 /// Extract a graph through tree-sitter when the language has a grammar.
 fn extract_tree_sitter_graph(
     path: &str,
     language: Option<&str>,
     content: &str,
-) -> Option<SymbolGraph> {
+) -> Option<TreeSitterParse> {
     let language_name = language?;
     let parser_language = tree_sitter_language(language_name)?;
     let mut parser = Parser::new();
@@ -478,9 +488,11 @@ fn extract_tree_sitter_graph(
     }
     let tree = parser.parse(content, None)?;
     let mut graph = empty_graph(path, language, ParserKind::TreeSitter);
-    visit_node(tree.root_node(), content, &mut graph);
+    let root = tree.root_node();
+    let had_errors = root.has_error();
+    visit_node(root, content, &mut graph);
     languages::augment_language_graph(&mut graph, content);
-    Some(graph)
+    Some(TreeSitterParse { graph, had_errors })
 }
 
 /// Return a tree-sitter language for supported source families.
@@ -1699,6 +1711,27 @@ fn helper() {}
     #[test]
     fn native_parser_graph_survives_when_empty() {
         let graph = extract_symbol_graph("src/empty.rs", Some("rust"), "// comment only\n");
+        assert_eq!(graph.parser, ParserKind::TreeSitter);
+        assert!(graph.symbols.is_empty());
+        assert!(graph.relations.is_empty());
+    }
+
+    #[test]
+    fn native_parser_ignores_fallback_patterns_inside_comments() {
+        let graph = extract_symbol_graph(
+            "src/commented.rs",
+            Some("rust"),
+            "/*\ndef leaked():\n    pass\nfunction leaked() {}\nimport x\n*/\n",
+        );
+        assert_eq!(graph.parser, ParserKind::TreeSitter);
+        assert!(graph.symbols.is_empty());
+        assert!(graph.relations.is_empty());
+
+        let graph = extract_symbol_graph(
+            "src/commented.ts",
+            Some("typescript"),
+            "/*\ndef leaked():\n    pass\nfunction leaked() {}\nimport x\n*/\n",
+        );
         assert_eq!(graph.parser, ParserKind::TreeSitter);
         assert!(graph.symbols.is_empty());
         assert!(graph.relations.is_empty());

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -84,7 +84,7 @@ fails closed instead of starting an older MCP server:
   "mcpServers": {
     "projectatlas": {
       "command": "projectatlas",
-      "args": ["--require-version", "0.3.5", "--db", ".projectatlas/projectatlas.db", "mcp"]
+      "args": ["--require-version", "0.3.6", "--db", ".projectatlas/projectatlas.db", "mcp"]
     }
   }
 }
@@ -205,6 +205,12 @@ Token savings estimate context that ProjectAtlas prevented the agent from wastin
 wrong-file opens, and unnecessary full-code reads avoided by the overview -> folders -> files -> summary/outline
 -> exact-slice funnel. Agent and MCP surfaces stay structured TOON; terminal decoration belongs only to the
 explicit `projectatlas token --view tui` view.
+
+The default token report is a fast offline heuristic, not provider billing telemetry. It estimates emitted
+ProjectAtlas payload text with `ceil(chars / 4)` and file-size baselines with `ceil(bytes / 4)`. Reports expose
+bucket, baseline kind, confidence, provider, model, tokenizer backend, and accuracy labels so agents can separate
+observed full-file compression from modeled navigation savings. Provider/model-aware counting belongs behind an
+explicit calibration command or config; normal orientation and `atlas_token_report` must stay local and fast.
 
 For freshness, treat `projectatlas watch` as the steady-state updater for local editing sessions. Line slices
 validate against SQLite and then read the current file from disk. Symbol slices also read current disk content,

--- a/docs/assets/agent-harness-funnel.svg
+++ b/docs/assets/agent-harness-funnel.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 960 360">
+  <title id="title">ProjectAtlas agent harness funnel</title>
+  <desc id="desc">Workflow diagram showing an agent moving from folder purpose overview, to file purpose and content summary, to detailed summary and symbols, to exact source slices, with watch keeping the atlas current.</desc>
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #24292f; }
+    .title { font-size: 24px; font-weight: 700; }
+    .subtitle { font-size: 15px; fill: #57606a; }
+    .step { font-size: 16px; font-weight: 700; }
+    .small { font-size: 13px; fill: #57606a; }
+    .tiny { font-size: 12px; fill: #57606a; }
+    .box { fill: #ffffff; stroke-width: 2; rx: 8; }
+    .blue { stroke: #0969da; }
+    .green { stroke: #1a7f37; }
+    .amber { stroke: #9a6700; }
+    .red { stroke: #cf222e; }
+    .gray { stroke: #57606a; }
+    .arrow { stroke: #57606a; stroke-width: 2.2; fill: none; marker-end: url(#arrowhead); }
+    .loop { stroke: #0969da; stroke-width: 2; fill: none; stroke-dasharray: 7 5; marker-end: url(#arrowheadBlue); }
+  </style>
+  <defs>
+    <marker id="arrowhead" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#57606a" />
+    </marker>
+    <marker id="arrowheadBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#0969da" />
+    </marker>
+  </defs>
+
+  <text x="36" y="36" class="title">Agent harness flow: high-level navigation to exact source</text>
+  <text x="36" y="60" class="subtitle">ProjectAtlas keeps the expensive code read as the last step, not the first guess.</text>
+
+  <rect x="36" y="96" width="168" height="130" class="box blue" />
+  <text x="56" y="124" class="step">1. Folder map</text>
+  <text x="56" y="151" class="small">Which area matters?</text>
+  <text x="56" y="176" class="tiny">overview</text>
+  <text x="56" y="195" class="tiny">folders query</text>
+  <text x="56" y="214" class="tiny">folder_purpose</text>
+
+  <path d="M 214 161 H 258" class="arrow" />
+
+  <rect x="270" y="96" width="168" height="130" class="box green" />
+  <text x="290" y="124" class="step">2. File vicinity</text>
+  <text x="290" y="151" class="small">Which file is close?</text>
+  <text x="290" y="176" class="tiny">files query</text>
+  <text x="290" y="195" class="tiny">file_purpose</text>
+  <text x="290" y="214" class="tiny">content_summary</text>
+
+  <path d="M 448 161 H 492" class="arrow" />
+
+  <rect x="504" y="96" width="168" height="130" class="box amber" />
+  <text x="524" y="124" class="step">3. Detail plan</text>
+  <text x="524" y="151" class="small">What exactly matters?</text>
+  <text x="524" y="176" class="tiny">summary / outline</text>
+  <text x="524" y="195" class="tiny">symbols / relations</text>
+  <text x="524" y="214" class="tiny">bounded search</text>
+
+  <path d="M 682 161 H 726" class="arrow" />
+
+  <rect x="738" y="96" width="168" height="130" class="box red" />
+  <text x="758" y="124" class="step">4. Exact slice</text>
+  <text x="758" y="151" class="small">Read only target code.</text>
+  <text x="758" y="176" class="tiny">slice lines</text>
+  <text x="758" y="195" class="tiny">symbol slice</text>
+  <text x="758" y="214" class="tiny">then edit/test</text>
+
+  <rect x="266" y="270" width="426" height="54" class="box gray" />
+  <text x="286" y="300" class="step">watch keeps the atlas current while files change</text>
+  <text x="286" y="318" class="small">watch / watch --once refreshes text, summaries, symbols, purposes, and health signals.</text>
+
+  <path d="M 822 236 C 822 306 724 330 694 302" class="loop" />
+  <path d="M 264 302 C 146 302 104 258 104 232" class="loop" />
+</svg>

--- a/docs/assets/token-savings-bar.svg
+++ b/docs/assets/token-savings-bar.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 860 230">
+  <title id="title">ProjectAtlas token savings benchmark bar chart</title>
+  <desc id="desc">Bar chart for 142 benchmark calls: without ProjectAtlas 221.1 million estimated tokens, with ProjectAtlas 0.4 million estimated tokens, estimated saved 220.7 million tokens.</desc>
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #24292f; }
+    .muted { fill: #57606a; font-size: 15px; }
+    .label { font-size: 18px; font-weight: 600; }
+    .value { font-size: 17px; font-weight: 600; }
+    .track { fill: #d0d7de; }
+    .without { fill: #cf222e; }
+    .with { fill: #1a7f37; }
+    .saved { fill: #0969da; }
+  </style>
+  <text x="24" y="34" class="label">Benchmark token path, 142 agent calls</text>
+  <text x="24" y="58" class="muted">Linear scale. The ProjectAtlas payload is the thin green bar because it is 0.19% of the baseline.</text>
+
+  <text x="24" y="102" class="label">Without ProjectAtlas</text>
+  <rect x="220" y="82" width="600" height="28" rx="4" class="track" />
+  <rect x="220" y="82" width="600" height="28" rx="4" class="without" />
+  <text x="220" y="132" class="value">221.1M estimated tokens</text>
+
+  <text x="24" y="172" class="label">With ProjectAtlas</text>
+  <rect x="220" y="152" width="600" height="28" rx="4" class="track" />
+  <rect x="220" y="152" width="2" height="28" rx="1" class="with" />
+  <text x="220" y="202" class="value">0.4M estimated tokens</text>
+  <text x="430" y="202" class="muted">Estimated saved: 220.7M tokens, 99.8% for this workload</text>
+</svg>

--- a/docs/benchmarks/large-application-token-savings.md
+++ b/docs/benchmarks/large-application-token-savings.md
@@ -2,7 +2,7 @@
 
 A large application audit that motivated the ProjectAtlas 3 hardening pass showed the intended effect of the atlas-first workflow: the agent used folder and file orientation, then selected exact summaries and slices instead of rereading broad source trees.
 
-The positive finding recorded in issue #153 was a 99.8% token-savings observation on a representative application corpus. The exact percentage is workload-specific, but it validates the product target:
+The positive finding recorded in issue #153 was a 99.8% token-savings observation on a representative application corpus. The exact percentage is workload-specific. It depends on repository size, how many times the agent asks for orientation, and how much broad source reading ProjectAtlas avoids.
 
 - Start with repository overview and folder purpose.
 - Narrow to likely files with file purpose and content summary.
@@ -21,18 +21,33 @@ The positive finding recorded in issue #153 was a 99.8% token-savings observatio
 
 ## Token Telemetry
 
+- Estimator: `ceil(chars_or_bytes / 4)`.
+- Scope: workflow estimate, not provider billing tokens.
+- Average baseline avoided per call: 1,557,144 tokens.
+- Average ProjectAtlas payload per call: 2,997 tokens.
 - Estimated without ProjectAtlas: 221,114,448 tokens.
 - Estimated with ProjectAtlas: 425,622 tokens.
 - Estimated saved: 220,688,826 tokens.
 - Savings rate: 99.8%.
 
+Formula:
+
+```text
+without ProjectAtlas = avoided candidate files, directory walks, and full-file reads
+with ProjectAtlas    = compact TOON payloads returned by atlas commands
+saved                = without ProjectAtlas - with ProjectAtlas
+savings rate         = saved / without ProjectAtlas
+```
+
 ## Responsiveness Sample
 
-Representative warm CLI reads from the same audit stayed around 160-166 ms:
+Representative warm CLI reads from the same audit stayed around 160-166 ms after the repository was indexed. Initial scan/watch refresh is separate; it hashes files, updates SQLite, refreshes text, and parses symbol candidates.
 
 - `projectatlas summary <large-source-file> --limit 25`: approximately 165 ms.
 - `projectatlas files workflow --folder .github/workflows --limit 20`: approximately 164 ms.
 - `projectatlas token`: approximately 161 ms.
 - `projectatlas overview`: approximately 166 ms.
+
+For a comparable large application, warm orientation commands are expected to stay comfortably sub-second. If `overview`, `folders`, `files`, `summary`, or `token` drift into multi-second reads on a warmed index, treat that as a performance issue and inspect database query plans, text-index size, symbol candidate counts, and telemetry aggregation.
 
 ProjectAtlas token telemetry reports this through `projectatlas token` and `projectatlas token --view tui`. The telemetry is estimate-based; the default estimator is the offline `chars/bytes / 4` workflow heuristic, not provider or model billing-token accounting. It is designed for trend and workflow validation rather than billing reconciliation.

--- a/docs/projectatlas-3-architecture.md
+++ b/docs/projectatlas-3-architecture.md
@@ -441,6 +441,12 @@ arrive incrementally, but ProjectAtlas 3.0 stable requires all specialized and
 fallback families in this section to be implemented and tested through the
 ProjectAtlas-native parser registry.
 
+The parser registry records the current coverage level for each detected
+language family: native Tree-sitter, manifest, deterministic structural, or
+fallback. The SQLite index also persists file-level parser metadata even when a
+parse emits zero symbols, so `summary` can distinguish an empty native parse from
+an empty fallback parse instead of inferring quality from the summary sentence.
+
 The v0.3.2 hardening boundary keeps the public `projectatlas-symbols` API
 stable while splitting language-specific augmentation behind private strategy
 modules. The first split moves Kotlin, Objective-C, Zig, and the C-family
@@ -620,7 +626,9 @@ Token accounting model:
   telemetry must measure TOON output for TOON commands and JSON output for
   `--format json`; MCP telemetry measures TOON tool text inside the JSON-RPC
   envelope.
-- Save the raw estimates and per-event delta in `usage_events`.
+- Save the raw estimates, per-event delta, bucket, provider, model, tokenizer
+  backend, accuracy, baseline kind, confidence, and calculation trace in
+  `usage_events`.
 - Compute aggregate `saved = estimated_tokens_without_projectatlas -
   estimated_tokens_with_projectatlas` from the stored raw estimates instead of
   trusting historical per-row saved values.
@@ -639,6 +647,30 @@ Token accounting model:
   model-aware calibration should be opt-in, label the provider/model/tokenizer,
   cache the calibration source, and never require network access for ordinary
   `projectatlas token` reports.
+- Report buckets separately:
+  - `full_file_compression`: observed comparison between selected full-file
+    text and emitted summary/outline/slice/search context.
+  - `navigation_avoidance`: inferred or policy-modeled comparison between
+    candidate source content and emitted overview/folder/file/symbol/search
+    context.
+  - `wrong_path_prevention` and `cache_reuse`: reserved until the runtime has a
+    concrete rejected path or reused-read event to count.
+- Report confidence separately from accuracy. `observed` means both sides of the
+  comparison are concrete local text/payloads; `inferred` means a selected
+  candidate set was used; `policy_estimate` means a broad directory-walk
+  baseline was modeled.
+
+Provider calibration design:
+
+- Normal `projectatlas token` and `atlas_token_report` never call provider APIs.
+- A future explicit calibration command may sample representative ProjectAtlas
+  payloads against provider count-token endpoints, for example OpenAI's
+  Responses input-token count API for OpenAI models or Anthropic's count-token
+  API for Claude models.
+- Any provider-backed result must label `provider`, `model`,
+  `tokenizer_backend`, and `accuracy` as `exact_provider` or
+  `calibrated_estimate`; local tokenizer adapters must use
+  `local_model_tokenizer` unless calibrated against provider output.
 
 Canonical commands:
 
@@ -677,6 +709,9 @@ token_savings:
   estimated_with_projectatlas: 9200
   estimated_saved: 108800
   savings_rate: 92.2%
+  buckets[2]{token_savings_bucket,accuracy,baseline_kind,confidence,saved_tokens}:
+    full_file_compression,heuristic_estimate,full_file,observed,42000
+    navigation_avoidance,heuristic_estimate,directory_walk,policy_estimate,66800
 ```
 
 Every funnel command should record telemetry when it can estimate a baseline.

--- a/docs/structural-summaries.md
+++ b/docs/structural-summaries.md
@@ -26,9 +26,11 @@ The adapters are intentionally bounded and deterministic. They do not approve pu
 `projectatlas summary <file>` exposes:
 
 - `parser_kind`: `tree-sitter-symbol-graph`, `manifest-symbol-graph`,
-  `structural-symbol-graph`, `fallback-symbol-graph`, `mixed-symbol-graph`, `symbol-graph`,
+  `structural-symbol-graph`, `fallback-symbol-graph`, `mixed-symbol-graph`,
   `structural`, `scanner-metadata`, or `missing`.
 - `summary_status`: `ok`, `fallback`, or `missing`.
+
+ProjectAtlas persists file-level parser metadata separately from emitted symbols, so an empty native parse still reports its native parser and an empty fallback parse still reports `fallback-symbol-graph`.
 
 Agent integrations should treat `summary_status: fallback` as a reason to escalate into deeper inspection or parser improvement. Normal supported files should not rely on summaries like `<language> file, N bytes`.
 

--- a/fixtures/languages/baselines.toon
+++ b/fixtures/languages/baselines.toon
@@ -24,5 +24,5 @@ summaries[26]{path,language,parser_kind,status,min_symbols,summary}:
   yaml/workflow.yml,yaml,structural,ok,0,"yaml workflow CI triggered by pull_request, push with jobs test."
   css/tokens.css,css,structural,ok,0,"css stylesheet with selectors .card, .panel, :root, custom properties --brand, 1 media queries, and 0 supports queries."
   html/index.html,html,structural,ok,0,"html document with title Home, meta description Welcome page, headings Hello, structured data."
-  rust/empty.rs,rust,symbol-graph,ok,0,rust source file with no declarations found.
+  rust/empty.rs,rust,tree-sitter-symbol-graph,ok,0,rust source file with no declarations found.
   toon/projectatlas-nonsource-files.toon,toon,structural,ok,0,TOON document with sections nonsource_files.

--- a/plugins/projectatlas/.claude-plugin/plugin.json
+++ b/plugins/projectatlas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for Claude Code.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/.codex-plugin/plugin.json
+++ b/plugins/projectatlas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for coding agents.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/.mcp.json
+++ b/plugins/projectatlas/.mcp.json
@@ -4,7 +4,7 @@
       "command": "projectatlas",
       "args": [
         "--require-version",
-        "0.3.5",
+        "0.3.6",
         "--db",
         ".projectatlas/projectatlas.db",
         "mcp"

--- a/plugins/projectatlas/opencode/opencode.json
+++ b/plugins/projectatlas/opencode/opencode.json
@@ -6,7 +6,7 @@
       "command": [
         "projectatlas",
         "--require-version",
-        "0.3.5",
+        "0.3.6",
         "--db",
         ".projectatlas/projectatlas.db",
         "mcp"

--- a/plugins/projectatlas/skills/projectatlas/SKILL.md
+++ b/plugins/projectatlas/skills/projectatlas/SKILL.md
@@ -202,6 +202,8 @@ If MCP tools are unavailable, use the equivalent CLI sequence:
 
 Token savings estimate avoided wrong-folder exploration, wrong-file opens, and unnecessary full-code reads caused by the atlas-first workflow. Agent and MCP surfaces should remain structured TOON by default; the TUI view is explicit terminal UI with "Without PA", "With PA", and "Saved" comparison bars.
 
+Token reports are offline by default. The current heuristic is `ceil(chars / 4)` for emitted ProjectAtlas text and `ceil(bytes / 4)` for file-size baselines, labeled as `heuristic_estimate`, not model billing tokens. Inspect bucket metadata before making claims: `full_file_compression` with `observed` confidence is stronger than modeled `navigation_avoidance` with `inferred` or `policy_estimate` confidence. Provider/model-aware counting must be explicit calibration work; normal `projectatlas token` and `atlas_token_report` must not call network APIs.
+
 ## Local Gates
 
 For ProjectAtlas itself, run:
@@ -229,7 +231,7 @@ cargo run -p projectatlas-cli -- lint --strict-folders --report-untracked
 - `slice` returns exact source ranges after a file is selected.
 - `health-check` flags missing purposes, duplicate purposes, repeated temp/generated folders, and cleanup signals.
 - `settings` and `watch-status` report local index/config state.
-- `token` reports estimated ProjectAtlas token savings. The default report is a fast offline `chars/bytes / 4` workflow heuristic, not provider/model billing-token accounting.
+- `token` reports estimated ProjectAtlas token savings. The default report is a fast offline `chars/bytes / 4` workflow heuristic, not provider/model billing-token accounting. Token output includes bucket, baseline, confidence, provider/model/backend, and accuracy labels.
 - `mcp` starts the native MCP server. MCP tool text content is TOON.
 
 ## References

--- a/skills/claude/ProjectAtlas.md
+++ b/skills/claude/ProjectAtlas.md
@@ -16,7 +16,7 @@ repository overview to folder, file, compressed outline, and exact source only w
 ## First-Time Setup
 
 1. Establish the project root first. ProjectAtlas stores one project-local index at `.projectatlas/projectatlas.db`.
-2. Install the Rust binary if missing: `cargo install --path crates/projectatlas-cli --locked`.
+2. Install the ProjectAtlas plugin or run the plugin runtime installer from the target project root. Use `cargo install --path crates/projectatlas-cli --locked` only when developing ProjectAtlas from this source checkout.
 3. Initialize: `projectatlas init --seed-purpose`.
 4. Run `projectatlas scan`.
 5. Add or import purpose records for important folders and files.

--- a/skills/claude/ProjectAtlas.md
+++ b/skills/claude/ProjectAtlas.md
@@ -41,6 +41,8 @@ repository overview to folder, file, compressed outline, and exact source only w
 
 Token savings estimate avoided wrong-folder exploration, wrong-file opens, and unnecessary full-code reads caused by the atlas-first workflow. Agent and MCP surfaces should stay structured by default; the TUI dashboard is explicit terminal UI with "Without PA", "With PA", and "Saved" comparison bars.
 
+Token reports are offline by default. The heuristic is `ceil(chars / 4)` for emitted ProjectAtlas text and `ceil(bytes / 4)` for file-size baselines, labeled as `heuristic_estimate`, not model billing tokens. Check bucket metadata before making claims: `full_file_compression` with `observed` confidence is stronger than modeled `navigation_avoidance` with `inferred` or `policy_estimate` confidence.
+
 ## MCP Config
 
 Prefer installer-generated project-local config:

--- a/skills/codex/ProjectAtlas.md
+++ b/skills/codex/ProjectAtlas.md
@@ -17,7 +17,7 @@ the folder, choose the file, inspect compressed context, and only then open exac
 ## First-Time Setup
 
 1. Establish the project root first. ProjectAtlas stores one project-local index at `.projectatlas/projectatlas.db`.
-2. Install the Rust binary if missing: `cargo install --path crates/projectatlas-cli --locked`.
+2. Install the ProjectAtlas plugin or run the plugin runtime installer from the target project root. Use `cargo install --path crates/projectatlas-cli --locked` only when developing ProjectAtlas from this source checkout.
 3. Initialize: `projectatlas init --seed-purpose`.
 4. Run `projectatlas scan`.
 5. Add or import purpose records for important folders and files.

--- a/skills/codex/ProjectAtlas.md
+++ b/skills/codex/ProjectAtlas.md
@@ -42,6 +42,8 @@ the folder, choose the file, inspect compressed context, and only then open exac
 
 Token savings estimate avoided wrong-folder exploration, wrong-file opens, and unnecessary full-code reads caused by the atlas-first workflow. Agent and MCP surfaces should stay structured by default; the TUI dashboard is explicit terminal UI with "Without PA", "With PA", and "Saved" comparison bars.
 
+Token reports are offline by default. The heuristic is `ceil(chars / 4)` for emitted ProjectAtlas text and `ceil(bytes / 4)` for file-size baselines, labeled as `heuristic_estimate`, not model billing tokens. Check bucket metadata before making claims: `full_file_compression` with `observed` confidence is stronger than modeled `navigation_avoidance` with `inferred` or `policy_estimate` confidence.
+
 ## MCP Config
 
 Prefer installer-generated project-local config:


### PR DESCRIPTION
## Summary

This is the v0.3.6 issue-completion release candidate.

- Closes #160 by adding a ProjectAtlas language coverage registry, file-level parser provenance, explicit parser/status reporting for zero-symbol parses, XML structural summaries, and an E2E gate that rejects byte-count scanner fallback as normal advertised-source coverage.
- Hardens #160 further by allowing fallback rescue only when an empty tree-sitter parse reports syntax errors, preventing comments or strings in valid native files from becoming false fallback symbols.
- Closes #164 by making token telemetry bucketed and auditable: provider/model/tokenizer/accuracy/baseline/confidence/trace metadata, CLI/MCP baseline parity, JSON bucket reports, and the requested `Without PA` / `With PA` / `Saved` terminal bar view.
- Clarifies README token-savings claims with the estimate formula, workload dependency, benchmark scale, average per-call numbers, warm indexed latency expectations, and a rendered benchmark bar chart.
- Closes #166 by keeping public repo/docs/fixtures neutral, adding CONTRIBUTING guidance for anonymized public examples, and preserving language fixture coverage after the public metadata sweep.
- Adds public GitHub issue forms for bug reports and improvement requests; #177 remains open as next-week token-session trend work.
- Bumps workspace/plugin/docs release pins to `0.3.6` for Codex, Claude Code, and OpenCode install paths.
- Keeps normal token reporting local/offline/fast; provider-exact counting remains an explicit future mode, not a hidden network dependency.

## Local Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `cargo test --doc --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked`
- `cargo deny check` (passes with existing duplicate dependency warnings)
- `git diff --check`
- SVG XML parse smoke for `docs/assets/agent-harness-funnel.svg` and `docs/assets/token-savings-bar.svg`
- `projectatlas scan . --text-index-max-bytes 2000000`
- `projectatlas health-check`
- `projectatlas lint --strict-folders --report-untracked`
- `projectatlas parity report --profile repository-intelligence`
- `projectatlas map --force` followed by strict lint
- `plugins/projectatlas/scripts/install-runtime.ps1 -ProjectRoot . -RuntimePath target/debug/projectatlas.exe`
- Parsed generated Codex, Claude Code, and OpenCode project-local MCP configs as JSON.

## Cross-Platform Notes

Local Windows installer smoke passed with the v0.3.6 debug runtime. The previous PR run passed Linux, Windows, macOS x64, macOS arm64 E2E smokes and install-smoke. The final commit is waiting on the same GitHub Actions matrix again before merge. WSL has no installed distro on this machine, so Linux/macOS/POSIX installer execution is verified by GitHub Actions and the release workflow before publishing.
