### PR TITLE
feat(projectatlas): release v0.3.7 issue sweep (#177)

### DIFF
--- a/.projectatlas/config.toml
+++ b/.projectatlas/config.toml
@@ -21,6 +21,7 @@ default_style = "javadoc"
 line_comment_prefixes = ["//", "#", "--", ";"]
 
 [purpose.styles_by_extension]
+".md" = "line-comment"
 ".rs" = "line-comment"
 
 [summary_rules]

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,6 +1,6 @@
 version: 1
-generated_at: unix:1782678970
-file_hash: "f745e5399abeb204de4845a5cf03c50715920e70234938ecc3585285b82c5b3b"
+generated_at: unix:1782711088
+file_hash: "e09dd4ce7388ddf15e41afb30f15f6a4a9dd57ee257fe3aab31dda7dc6160d22"
 folder_hash: "f5ec84a38eaa8b9ee18c1d22563973db7217f346e2815ff1fa6abb9273e95036"
 root: .
 overview: tracked_source_files=96 tracked_nonsource_files=37 tracked_files_total=133 tracked_folders=58 source_extensions=122 exclude_dir_names=9 exclude_path_prefixes=0
@@ -222,8 +222,8 @@ files[104]{path,summary,source}:
   crates/projectatlas-cli/Cargo.toml,CLI Rust crate manifest for ProjectAtlas 3,database
   crates/projectatlas-cli/src/atlas_map.rs,Generate and lint `ProjectAtlas` structure maps from Rust.,database
   crates/projectatlas-cli/src/main.rs,Provide the `ProjectAtlas` 3 command-line adapter.,database
-  crates/projectatlas-cli/src/mcp.rs,Provide the native MCP adapter that exposes ProjectAtlas atlas tools to agent harnesses.,database
-  crates/projectatlas-cli/src/runtime.rs,"Provide shared CLI and MCP runtime orchestration for scan policy, indexing, watching, settings, cleanup, and telemetry.",database
+  crates/projectatlas-cli/src/mcp.rs,Serve `ProjectAtlas` repository intelligence over MCP.,database
+  crates/projectatlas-cli/src/runtime.rs,Coordinate shared `ProjectAtlas` CLI and MCP runtime workflows.,database
   crates/projectatlas-cli/src/structural.rs,Create deterministic structural summaries for declaration light files,database
   crates/projectatlas-cli/tests/e2e.rs,Validate `ProjectAtlas` 3 CLI end-to-end behavior.,database
   crates/projectatlas-cli/tests/lint_diagnostics.rs,Validate lint diagnostics for source extension purpose styles.,database
@@ -251,7 +251,7 @@ files[104]{path,summary,source}:
   crates/projectatlas-symbols/src/lib.rs,Extract tree-sitter-backed `ProjectAtlas` symbol graphs.,database
   deny.toml,Cargo dependency and license policy for ProjectAtlas,database
   docs/adoption.md,Adoption checklist for ProjectAtlas,database
-  docs/agent-integration.md,Agent integration instructions for ProjectAtlas,database
+  docs/agent-integration.md,Document agent startup and MCP integration workflows for ProjectAtlas.,database
   docs/assets/agent-harness-funnel.svg,README diagram explaining the ProjectAtlas agent harness workflow from folder purpose to exact source slice,nonsource
   docs/assets/projectatlas-mascot.png,ProjectAtlas README mascot image,nonsource
   docs/assets/token-savings-bar.svg,README bar chart visualizing ProjectAtlas token savings benchmark results,nonsource
@@ -296,8 +296,8 @@ files[104]{path,summary,source}:
   plugins/projectatlas/.codex-plugin/plugin.json,ProjectAtlas Codex plugin manifest,database
   plugins/projectatlas/.mcp.json,Fallback MCP server configuration for the ProjectAtlas Codex plugin.,database
   plugins/projectatlas/opencode/opencode.json,OpenCode config template registering ProjectAtlas as a local MCP server.,database
-  plugins/projectatlas/scripts/install-runtime.ps1,Install and verify the ProjectAtlas native runtime on Windows.,database
-  plugins/projectatlas/scripts/install-runtime.sh,POSIX installer for the native ProjectAtlas runtime.,database
+  plugins/projectatlas/scripts/install-runtime.ps1,Install or update the ProjectAtlas plugin runtime and Windows MCP configs.,database
+  plugins/projectatlas/scripts/install-runtime.sh,Install or update the ProjectAtlas plugin runtime and POSIX MCP configs.,database
   plugins/projectatlas/skills/projectatlas/SKILL.md,ProjectAtlas installable Codex skill,database
   skills/claude/ProjectAtlas.md,Claude skill guidance for using ProjectAtlas as an atlas-first repository workflow.,database
   skills/codex/ProjectAtlas.md,Codex skill guidance for using ProjectAtlas as an atlas-first repository workflow.,database

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-cli"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-core"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "regex",
  "serde",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-db"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "projectatlas-core",
  "rusqlite",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-fs"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "blake3",
  "ignore",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-service"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "globset",
  "projectatlas-core",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-symbols"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "projectatlas-core",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/styler-ai/ProjectAtlas"
@@ -68,11 +68,11 @@ must_use_candidate = "allow"
 missing_inline_in_public_items = "allow"
 
 [workspace.dependencies]
-projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.6" }
-projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.6" }
-projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.6" }
-projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.6" }
-projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.6" }
+projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.7" }
+projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.7" }
+projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.7" }
+projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.7" }
+projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.7" }
 blake3 = "1.5"
 clap = { version = "4.5", features = ["derive"] }
 cssparser = "0.37"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.3.6"><img alt="release" src="https://img.shields.io/badge/release-v0.3.6-blue"></a>
+  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.3.7"><img alt="release" src="https://img.shields.io/badge/release-v0.3.7-blue"></a>
   <img alt="rust" src="https://img.shields.io/badge/Rust-2024-orange">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-green">
 </p>
@@ -25,7 +25,7 @@ No required `.purpose` files. No source-header tax. No hosted index. The project
 ## Quickstart
 
 ```bash
-codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.6
+codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.7
 codex plugin add projectatlas --marketplace projectatlas
 ```
 
@@ -158,7 +158,7 @@ Most users can stop at the plugin install. The CLI is here for local debugging, 
 Only need the CLI yourself? Install it from the released tag:
 
 ```bash
-cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.3.6 --package projectatlas-cli --locked
+cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.3.7 --package projectatlas-cli --locked
 ```
 
 From this checkout:
@@ -248,7 +248,7 @@ ProjectAtlas scans with `.gitignore` awareness, hashes files with BLAKE3, stores
 
 ## Release Quality
 
-`v0.3.6` ships through the full release matrix:
+`v0.3.7` ships through the full release matrix:
 
 - Rust format, check, clippy, dependency policy, tests, doctests, and rustdoc.
 - ProjectAtlas scan, parity, lint, and map drift checks.

--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -12,10 +12,13 @@ use atlas_map::{
 };
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use projectatlas_core::outline::build_outline;
-use projectatlas_core::telemetry::TokenOverview;
+use projectatlas_core::telemetry::{
+    TokenOverview, TokenTrendReport, TokenTrendWindow as CoreTokenTrendWindow,
+};
 use projectatlas_core::toon::{
     encode_agent_payload, render_health, render_node_rows, render_nodes, render_outline,
     render_overview, render_symbol_relations, render_symbols, render_token_overview,
+    render_token_trends,
 };
 use projectatlas_core::{NodeKind, PurposeSource, normalize_native_path_display};
 use projectatlas_db::{AtlasStore, DbError, HealthResolution};
@@ -26,7 +29,7 @@ use projectatlas_service::{
 use runtime::{
     MAX_SYMBOL_FILE_BYTES, ScanRuntimePlan, SettingsReport, SymbolBuildOptions, WatchStatusReport,
     absolute_path, build_settings_report, build_symbols_for_index, byte_count_to_tokens,
-    default_mcp_project_root, defaultable_cli_project_root,
+    canonical_project_root, default_mcp_project_root, defaultable_cli_project_root,
     estimated_source_tokens_for_indexed_files, estimated_source_tokens_for_paths,
     file_summary_usage_baseline, lint_database_if_present, normalized_folder_filter,
     open_atlas_store, ranked_file_nodes, read_indexed_file_content,
@@ -37,6 +40,7 @@ use runtime::{
 use serde::Serialize;
 use serde_json::json;
 use std::collections::BTreeMap;
+use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -112,6 +116,30 @@ enum TokenView {
     Agent,
     /// Human terminal dashboard with a compact savings diagram.
     Tui,
+}
+
+/// Token trend grouping window.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum TokenTrendWindow {
+    /// Group token telemetry by day.
+    Day,
+    /// Group token telemetry by week.
+    Week,
+    /// Group token telemetry by month.
+    Month,
+    /// Group token telemetry by year.
+    Year,
+}
+
+impl From<TokenTrendWindow> for CoreTokenTrendWindow {
+    fn from(window: TokenTrendWindow) -> Self {
+        match window {
+            TokenTrendWindow::Day => Self::Day,
+            TokenTrendWindow::Week => Self::Week,
+            TokenTrendWindow::Month => Self::Month,
+            TokenTrendWindow::Year => Self::Year,
+        }
+    }
 }
 
 /// Manual `ProjectAtlas` ignore entry kind for CLI input.
@@ -299,6 +327,12 @@ enum Command {
     },
     /// Print local `ProjectAtlas` settings and cache/index locations.
     Settings,
+    /// Show, verify, or bind the project-local root.
+    Root {
+        /// Root subcommand to run.
+        #[command(subcommand)]
+        command: Option<RootCommand>,
+    },
     /// Print the effective `ProjectAtlas` configuration.
     Config {
         /// Print the normalized configuration used by scan, map, lint, and watch.
@@ -365,6 +399,9 @@ enum Command {
         /// Presentation mode for the token report.
         #[arg(long, value_enum, default_value_t = TokenView::Agent)]
         view: TokenView,
+        /// Optional trend grouping window.
+        #[arg(long, value_enum)]
+        trend: Option<TokenTrendWindow>,
     },
     /// Check repository-intelligence parity readiness.
     Parity {
@@ -421,6 +458,20 @@ enum Command {
         #[command(subcommand)]
         command: PurposeCommand,
     },
+}
+
+/// Project root diagnostics and binding subcommands.
+#[derive(Debug, Subcommand)]
+enum RootCommand {
+    /// Bind a repository root and regenerate project-local MCP configs.
+    Set {
+        /// Repository root to bind.
+        path: PathBuf,
+    },
+    /// Show the root, DB, config, and runtime identity `ProjectAtlas` will use.
+    Show,
+    /// Verify DB/config/root identity agree.
+    Verify,
 }
 
 /// Manual ignore management subcommands.
@@ -890,6 +941,25 @@ fn run() -> Result<(), CliError> {
             let toon = render_settings_report(&report);
             print_output(cli.format, &toon, &report)?;
         }
+        Command::Root { command } => match command {
+            Some(RootCommand::Set { path }) => {
+                let root = canonical_project_root(path)?;
+                let report = bind_project_root(&root)?;
+                print_output(cli.format, &render_root_report(&report), &report)?;
+            }
+            None | Some(RootCommand::Show) => {
+                let report = build_root_report(&cli.db, cli.config.as_deref())?;
+                print_output(cli.format, &render_root_report(&report), &report)?;
+            }
+            Some(RootCommand::Verify) => {
+                let report = build_root_report(&cli.db, cli.config.as_deref())?;
+                let verified = report.verified;
+                print_output(cli.format, &render_root_report(&report), &report)?;
+                if !verified {
+                    std::process::exit(1);
+                }
+            }
+        },
         Command::Config { print: _ } => {
             let config = load_atlas_config(cli.config.as_deref())?;
             let report = effective_config_report(&config);
@@ -1046,15 +1116,31 @@ fn run() -> Result<(), CliError> {
                 std::process::exit(exit_code);
             }
         }
-        Command::Token { session, view } => {
+        Command::Token {
+            session,
+            view,
+            trend,
+        } => {
             let store = open_atlas_store(&cli.db)?;
-            let overview = store.token_overview(session.as_deref())?;
-            match view {
-                TokenView::Agent => {
-                    print_output(cli.format, &render_token_overview(&overview), &overview)?;
+            if let Some(window) = trend {
+                let report = store.token_trends(session.as_deref(), (*window).into())?;
+                match view {
+                    TokenView::Agent => {
+                        print_output(cli.format, &render_token_trends(&report), &report)?;
+                    }
+                    TokenView::Tui => {
+                        write_stdout(&render_token_trend_dashboard(&report))?;
+                    }
                 }
-                TokenView::Tui => {
-                    write_stdout(&render_token_dashboard(&overview, session.as_deref()))?;
+            } else {
+                let overview = store.token_overview(session.as_deref())?;
+                match view {
+                    TokenView::Agent => {
+                        print_output(cli.format, &render_token_overview(&overview), &overview)?;
+                    }
+                    TokenView::Tui => {
+                        write_stdout(&render_token_dashboard(&overview, session.as_deref()))?;
+                    }
                 }
             }
         }
@@ -1261,6 +1347,9 @@ fn build_runtime_info() -> RuntimeInfoReport {
         project: "ProjectAtlas".to_string(),
         major_version: PROJECTATLAS_MAJOR_VERSION,
         version: env!("CARGO_PKG_VERSION").to_string(),
+        executable: std::env::current_exe()
+            .ok()
+            .map(|path| normalize_native_path_display(&path)),
         repository: env!("CARGO_PKG_REPOSITORY").to_string(),
         capabilities: vec![
             "cli".to_string(),
@@ -1284,6 +1373,94 @@ fn build_runtime_info() -> RuntimeInfoReport {
 /// Render runtime information as compact TOON.
 fn render_runtime_info(report: &RuntimeInfoReport) -> String {
     encode_agent_payload(&json!({ "runtime": report }))
+}
+
+/// Bind a project root without creating any machine-global root state.
+fn bind_project_root(root: &Path) -> Result<RootReport, CliError> {
+    if !root.is_dir() {
+        return Err(CliError::InvalidInput(format!(
+            "project root {} is not a directory",
+            root.display()
+        )));
+    }
+    init_project(root, false)?;
+    let atlas_dir = root.join(".projectatlas");
+    let db_path = atlas_dir.join("projectatlas.db");
+    let config_path = atlas_dir.join("config.toml");
+    {
+        let store = open_atlas_store(&db_path)?;
+        store.set_project_root(root)?;
+    }
+    write_mcp_config_file(
+        &atlas_dir.join("projectatlas.mcp.json"),
+        HarnessConfig::McpJson,
+        &db_path,
+        &config_path,
+    )?;
+    write_mcp_config_file(
+        &atlas_dir.join("projectatlas.claude.mcp.json"),
+        HarnessConfig::ClaudeCode,
+        &db_path,
+        &config_path,
+    )?;
+    write_mcp_config_file(
+        &atlas_dir.join("projectatlas.opencode.json"),
+        HarnessConfig::OpenCode,
+        &db_path,
+        &config_path,
+    )?;
+    build_root_report(&db_path, Some(&config_path))
+}
+
+/// Write one generated MCP config document as pretty JSON.
+fn write_mcp_config_file(
+    path: &Path,
+    harness: HarnessConfig,
+    db_path: &Path,
+    config_path: &Path,
+) -> Result<(), CliError> {
+    let value =
+        build_harness_mcp_config_report(harness, "projectatlas", db_path, Some(config_path))?;
+    let text = format!("{}\n", serde_json::to_string_pretty(&value)?);
+    fs::write(path, text).map_err(|source| CliError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+/// Build a project-local root identity report.
+fn build_root_report(db: &Path, config_path: Option<&Path>) -> Result<RootReport, CliError> {
+    let settings = build_settings_report(db, config_path, OutputFormat::Toon)?;
+    let db_project_root = settings
+        .index
+        .as_ref()
+        .and_then(|index| index.project_root.clone());
+    let atlas_dir = Path::new(&settings.db.path)
+        .parent()
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+    let runtime = build_runtime_info();
+    Ok(RootReport {
+        root: settings.repo_root.clone(),
+        detection_source: settings.root_detection_source.clone(),
+        db_path: settings.db.path.clone(),
+        config_path: settings.config_path.clone(),
+        config_project_root: settings
+            .config_path
+            .as_ref()
+            .map(|_| settings.repo_root.clone()),
+        db_project_root,
+        mcp_config_path: settings.mcp_config.path.clone(),
+        claude_mcp_config_path: normalize_native_path_display(
+            atlas_dir.join("projectatlas.claude.mcp.json"),
+        ),
+        opencode_config_path: normalize_native_path_display(
+            atlas_dir.join("projectatlas.opencode.json"),
+        ),
+        runtime_executable: runtime.executable,
+        runtime_version: runtime.version,
+        verified: settings.root_verified,
+        mismatches: settings.root_mismatches,
+    })
 }
 
 /// Return whether an environment variable is set to a truthy value.
@@ -1491,6 +1668,8 @@ struct RuntimeInfoReport {
     major_version: u8,
     /// Cargo package version.
     version: String,
+    /// Exact executable path for this runtime process, when available.
+    executable: Option<String>,
     /// Repository URL embedded at build time.
     repository: String,
     /// Runtime capabilities available in this binary.
@@ -1501,6 +1680,37 @@ struct RuntimeInfoReport {
     output_formats: Vec<String>,
     /// Required MCP tool names compiled into the runtime.
     mcp_tools: Vec<String>,
+}
+
+/// Project-local root identity report.
+#[derive(Debug, Serialize)]
+struct RootReport {
+    /// Canonical project root `ProjectAtlas` will use.
+    root: String,
+    /// Detection source for the selected root.
+    detection_source: String,
+    /// Durable `SQLite` database path.
+    db_path: String,
+    /// Config path used for project policy.
+    config_path: Option<String>,
+    /// Root stored in config, when config exists.
+    config_project_root: Option<String>,
+    /// Root stored in the DB metadata, when the DB exists.
+    db_project_root: Option<String>,
+    /// Generated generic MCP config path.
+    mcp_config_path: String,
+    /// Generated Claude Code MCP config path.
+    claude_mcp_config_path: String,
+    /// Generated `OpenCode` MCP config path.
+    opencode_config_path: String,
+    /// Current runtime executable path, when available.
+    runtime_executable: Option<String>,
+    /// Current runtime version.
+    runtime_version: String,
+    /// Whether config and DB roots agree with the selected root.
+    verified: bool,
+    /// Root mismatches that must be fixed before trusting the binding.
+    mismatches: Vec<String>,
 }
 
 /// Render a search report as compact TOON.
@@ -1523,101 +1733,219 @@ fn render_settings_report(report: &SettingsReport) -> String {
     encode_agent_payload(&json!({ "settings": report }))
 }
 
+/// Render root diagnostics as compact TOON.
+fn render_root_report(report: &RootReport) -> String {
+    encode_agent_payload(&json!({ "root": report }))
+}
+
 /// Render watcher status as compact TOON.
 fn render_watch_status(report: &WatchStatusReport) -> String {
     encode_agent_payload(&json!({ "watch_status": report }))
 }
 
 /// Render a human-facing token savings dashboard for terminal use.
-fn render_token_dashboard(overview: &TokenOverview, session: Option<&str>) -> String {
+pub(crate) fn render_token_dashboard(overview: &TokenOverview, session: Option<&str>) -> String {
+    render_token_dashboard_with_width(overview, session, dashboard_width())
+}
+
+/// Render a human-facing token savings dashboard at a selected width.
+fn render_token_dashboard_with_width(
+    overview: &TokenOverview,
+    session: Option<&str>,
+    width: usize,
+) -> String {
     let session_label = session.unwrap_or("all sessions");
     let rate_label = overview.savings_rate.map_or_else(
         || "unknown".to_string(),
         |value| format!("{:.1}%", value * 100.0),
     );
+    let width = width.clamp(72, 140);
+    let rule = "-".repeat(width.saturating_sub(2));
+    let bar_width = width.saturating_sub(44).clamp(12, 64);
     let saved_label = signed_count(overview.estimated_saved);
     let without = overview.estimated_without_projectatlas;
     let with = overview.estimated_with_projectatlas;
     let saved = overview.estimated_saved.max(0).unsigned_abs();
     let max_tokens = without.max(with).max(saved).max(1);
-    let without_bar = token_dashboard_bar(without, max_tokens);
-    let with_bar = token_dashboard_bar(with, max_tokens);
-    let saved_bar = token_dashboard_bar(saved, max_tokens);
-    let bucket_lines = token_dashboard_bucket_lines(overview);
-    format!(
-        "\
-+----------------------------------------------------------------+\n\
-| ProjectAtlas Token Delta                                       |\n\
-+----------------------------------------------------------------+\n\
-| Session        {session_label}\n\
-| Calls          {calls}\n\
-| Estimate       heuristic chars/bytes / 4, not model billing tokens\n\
-| Saved          {saved_label} tokens ({rate_label})\n\
-+----------------------------------------------------------------+\n\
-| Without PA     [{without_bar}] {without_label:>14} tokens\n\
-| With PA        [{with_bar}] {with_label:>14} tokens\n\
-| Saved          [{saved_bar}] {saved_label:>14} tokens\n\
-+----------------------------------------------------------------+\n\
-{bucket_lines}\
-| Funnel         overview > folders > files > summary > slice\n\
-| Avoided        wrong folders, wrong files, unnecessary full reads\n\
-+----------------------------------------------------------------+\n",
-        calls = overview.calls,
-        without_label = grouped_count(without),
-        with_label = grouped_count(with),
-    )
+    let mut output = String::new();
+    push_dashboard_fmt(&mut output, format_args!("+{rule}+\n"));
+    output.push_str("| ProjectAtlas Token Savings\n");
+    push_dashboard_fmt(&mut output, format_args!("+{rule}+\n"));
+    push_dashboard_fmt(&mut output, format_args!("| Session   {session_label}\n"));
+    push_dashboard_fmt(
+        &mut output,
+        format_args!("| Calls     {}\n", overview.calls),
+    );
+    output.push_str("| Estimate  heuristic chars/bytes / 4, not model billing tokens\n");
+    push_dashboard_fmt(
+        &mut output,
+        format_args!("| Saved     {saved_label} tokens ({rate_label})\n"),
+    );
+    push_dashboard_fmt(&mut output, format_args!("+{rule}+\n"));
+    output.push_str(&token_dashboard_metric_line(
+        "Without PA",
+        without,
+        max_tokens,
+        bar_width,
+    ));
+    output.push_str(&token_dashboard_metric_line(
+        "With PA", with, max_tokens, bar_width,
+    ));
+    output.push_str(&token_dashboard_metric_line(
+        "Saved", saved, max_tokens, bar_width,
+    ));
+    push_dashboard_fmt(&mut output, format_args!("+{rule}+\n"));
+    output.push_str(&token_dashboard_bucket_lines(overview, width));
+    output.push_str("| Funnel    overview > folders > files > summary > slice\n");
+    output.push_str("| Avoided   wrong folders, wrong files, unnecessary full reads\n");
+    push_dashboard_fmt(&mut output, format_args!("+{rule}+\n"));
+    output
+}
+
+/// Render a human-facing trend dashboard for terminal or MCP use.
+pub(crate) fn render_token_trend_dashboard(report: &TokenTrendReport) -> String {
+    let width = dashboard_width().clamp(72, 140);
+    let rule = "-".repeat(width.saturating_sub(2));
+    let bar_width = width.saturating_sub(48).clamp(12, 64);
+    let max_saved = report
+        .periods
+        .iter()
+        .map(|period| period.estimated_saved.max(0).unsigned_abs())
+        .max()
+        .unwrap_or(1)
+        .max(1);
+    let mut output = String::new();
+    push_dashboard_fmt(&mut output, format_args!("+{rule}+\n"));
+    output.push_str("| ProjectAtlas Token Trends\n");
+    push_dashboard_fmt(&mut output, format_args!("+{rule}+\n"));
+    push_dashboard_fmt(
+        &mut output,
+        format_args!(
+            "| Session   {}\n",
+            report.session.as_deref().unwrap_or("all sessions")
+        ),
+    );
+    push_dashboard_fmt(&mut output, format_args!("| Window    {}\n", report.window));
+    output.push_str("| Estimate  heuristic chars/bytes / 4, not model billing tokens\n");
+    push_dashboard_fmt(&mut output, format_args!("+{rule}+\n"));
+    if report.periods.is_empty() {
+        output.push_str("| No token telemetry rows for this filter\n");
+    }
+    for period in &report.periods {
+        let saved = period.estimated_saved.max(0).unsigned_abs();
+        let bar = token_dashboard_bar(saved, max_saved, bar_width);
+        let rate = period.savings_rate.map_or_else(
+            || "unknown".to_string(),
+            |value| format!("{:.1}%", value * 100.0),
+        );
+        push_dashboard_fmt(
+            &mut output,
+            format_args!(
+                "| {period:<10} [{bar}] {saved_tokens:>12} saved ({rate}), {calls} calls\n",
+                period = period.period.as_str(),
+                saved_tokens = signed_count(period.estimated_saved),
+                calls = period.calls,
+            ),
+        );
+    }
+    push_dashboard_fmt(&mut output, format_args!("+{rule}+\n"));
+    output
+}
+
+/// Append formatted dashboard text to a `String`.
+fn push_dashboard_fmt(output: &mut String, args: std::fmt::Arguments<'_>) {
+    if std::fmt::write(output, args).is_err() {
+        unreachable!("writing to a String cannot fail");
+    }
 }
 
 /// Render compact token bucket rows for the human dashboard.
-fn token_dashboard_bucket_lines(overview: &TokenOverview) -> String {
+fn token_dashboard_bucket_lines(overview: &TokenOverview, width: usize) -> String {
     if overview.buckets.is_empty() {
         return String::new();
     }
     let mut lines = String::from("| Buckets        kind / accuracy / confidence / saved tokens\n");
     for bucket in &overview.buckets {
-        lines.push_str("| - ");
-        lines.push_str(&dashboard_fit(&format!(
-            "{} / {} / {} / {}",
+        let row = format!(
+            "{} / {} / {} / {} saved tokens / {} calls",
             bucket.token_savings_bucket,
             bucket.accuracy,
             bucket.confidence,
-            signed_count(bucket.estimated_saved)
-        )));
-        lines.push('\n');
+            signed_count(bucket.estimated_saved),
+            bucket.calls
+        );
+        push_wrapped_dashboard_line(&mut lines, "| - ", "|   ", &row, width);
     }
-    lines.push_str("+----------------------------------------------------------------+\n");
     lines
 }
 
-/// Fit one dashboard row to the fixed-width ASCII frame.
-fn dashboard_fit(value: &str) -> String {
-    const WIDTH: usize = 60;
-    if value.chars().count() <= WIDTH {
-        return value.to_string();
-    }
-    let mut fitted = value
-        .chars()
-        .take(WIDTH.saturating_sub(3))
-        .collect::<String>();
-    fitted.push_str("...");
-    fitted
+/// Render one token comparison row.
+fn token_dashboard_metric_line(
+    label: &str,
+    value: usize,
+    max_tokens: usize,
+    bar_width: usize,
+) -> String {
+    format!(
+        "| {label:<10} [{bar}] {tokens:>14} tokens\n",
+        bar = token_dashboard_bar(value, max_tokens, bar_width),
+        tokens = grouped_count(value),
+    )
 }
 
-/// Render one fixed-width token comparison bar.
-fn token_dashboard_bar(value: usize, max_tokens: usize) -> String {
-    const BAR_WIDTH: usize = 36;
+/// Render one token comparison bar.
+fn token_dashboard_bar(value: usize, max_tokens: usize, bar_width: usize) -> String {
     let filled = if value == 0 {
         0
     } else {
-        ((value as f64 / max_tokens as f64) * BAR_WIDTH as f64)
+        ((value as f64 / max_tokens as f64) * bar_width as f64)
             .round()
-            .clamp(1.0, BAR_WIDTH as f64) as usize
+            .clamp(1.0, bar_width as f64) as usize
     };
     format!(
         "{}{}",
         "#".repeat(filled),
-        ".".repeat(BAR_WIDTH.saturating_sub(filled))
+        ".".repeat(bar_width.saturating_sub(filled))
     )
+}
+
+/// Append a wrapped dashboard row without clipping values.
+fn push_wrapped_dashboard_line(
+    output: &mut String,
+    first_prefix: &str,
+    continuation_prefix: &str,
+    text: &str,
+    width: usize,
+) {
+    let limit = width.saturating_sub(first_prefix.len()).max(24);
+    let mut prefix = first_prefix;
+    let mut line = String::new();
+    for word in text.split_whitespace() {
+        if !line.is_empty() && line.len() + 1 + word.len() > limit {
+            output.push_str(prefix);
+            output.push_str(&line);
+            output.push('\n');
+            prefix = continuation_prefix;
+            line.clear();
+        }
+        if !line.is_empty() {
+            line.push(' ');
+        }
+        line.push_str(word);
+    }
+    if !line.is_empty() {
+        output.push_str(prefix);
+        output.push_str(&line);
+        output.push('\n');
+    }
+}
+
+/// Return the best available terminal width.
+fn dashboard_width() -> usize {
+    std::env::var("COLUMNS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(100)
 }
 
 /// Format an unsigned count with thousands separators.
@@ -2337,16 +2665,17 @@ mod tests {
             Some("session-a"),
         );
 
-        assert!(dashboard.contains("ProjectAtlas Token Delta"));
-        assert!(dashboard.contains("| Session        session-a"));
+        assert!(dashboard.contains("ProjectAtlas Token Savings"));
+        assert!(dashboard.contains("| Session   session-a"));
         assert!(dashboard.contains("heuristic chars/bytes / 4"));
         assert!(dashboard.contains("not model billing tokens"));
-        assert!(dashboard.contains("| Saved          9,000 tokens (75.0%)"));
-        assert!(dashboard.contains("| Without PA     [####################################]"));
-        assert!(dashboard.contains("| With PA        [#########...........................]"));
-        assert!(dashboard.contains("| Saved          [###########################.........]"));
+        assert!(dashboard.contains("| Saved     9,000 tokens (75.0%)"));
+        assert!(dashboard.contains("| Without PA ["));
+        assert!(dashboard.contains("| With PA    ["));
+        assert!(dashboard.contains("| Saved      ["));
         assert!(dashboard.contains("| Buckets        kind / accuracy / confidence / saved tokens"));
         assert!(dashboard.contains("navigation_avoidance / heuristic_estimate / inferred"));
+        assert!(dashboard.contains("saved tokens / 3 calls"));
         assert!(dashboard.contains("wrong folders, wrong files"));
         assert!(dashboard.contains("overview > folders > files > summary > slice"));
         assert!(dashboard.is_ascii());

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -1,3 +1,4 @@
+//! Purpose: Serve `ProjectAtlas` repository intelligence over MCP.
 //! Native MCP adapter for `ProjectAtlas` agent integrations.
 
 use crate::runtime::{
@@ -13,13 +14,14 @@ use crate::runtime::{
 use crate::{
     CliError, DEFAULT_FILE_SUMMARY_LIMIT, OutputFormat, build_parity_report, render_code_slice,
     render_file_summary, render_parity_report, render_search_report, render_settings_report,
-    render_watch_status,
+    render_token_dashboard, render_token_trend_dashboard, render_watch_status,
 };
 use projectatlas_core::health::Severity;
 use projectatlas_core::outline::build_outline;
+use projectatlas_core::telemetry::TokenTrendWindow;
 use projectatlas_core::toon::{
     encode_agent_payload, render_nodes, render_outline, render_overview, render_symbol_relations,
-    render_symbols, render_token_overview,
+    render_symbols, render_token_overview, render_token_trends,
 };
 use projectatlas_core::{
     NodeKind, PurposeSource, normalize_repo_path_prefix, validated_repo_node_key,
@@ -30,7 +32,7 @@ use projectatlas_service::{
     search_indexed_files,
 };
 use rmcp::handler::server::{router::tool::ToolRouter, wrapper::Parameters};
-use rmcp::model::{ServerCapabilities, ServerInfo};
+use rmcp::model::{Implementation, ServerCapabilities, ServerInfo};
 use rmcp::schemars;
 use rmcp::{ServerHandler, ServiceExt, tool, tool_handler, tool_router};
 use serde::Deserialize;
@@ -216,6 +218,10 @@ struct AtlasSymbolsParams {
 struct AtlasTokenParams {
     /// Optional session id filter.
     session: Option<String>,
+    /// Include a readable ASCII chart in the MCP result.
+    include_chart: Option<bool>,
+    /// Optional trend grouping window: day, week, month, or year.
+    trend_window: Option<String>,
 }
 
 /// MCP parameter payload for bounded health finding lookup.
@@ -874,9 +880,32 @@ impl ProjectAtlasMcpServer {
     fn atlas_token_report(&self, Parameters(params): Parameters<AtlasTokenParams>) -> String {
         Self::as_mcp_text((|| {
             let store = self.open_store()?;
-            Ok(render_token_overview(
-                &store.token_overview(params.session.as_deref())?,
-            ))
+            let include_chart = params.include_chart.unwrap_or(false);
+            if let Some(window) = params.trend_window.as_deref() {
+                let window = TokenTrendWindow::parse(window).ok_or_else(|| {
+                    CliError::InvalidInput(format!(
+                        "unsupported token trend window {window:?}; expected day, week, month, or year"
+                    ))
+                })?;
+                let report = store.token_trends(params.session.as_deref(), window)?;
+                if include_chart {
+                    let chart = render_token_trend_dashboard(&report);
+                    return Ok(encode_agent_payload(&json!({
+                        "token_trends": &report,
+                        "chart": chart,
+                    })));
+                }
+                return Ok(render_token_trends(&report));
+            }
+            let overview = store.token_overview(params.session.as_deref())?;
+            if include_chart {
+                let chart = render_token_dashboard(&overview, params.session.as_deref());
+                return Ok(encode_agent_payload(&json!({
+                    "token_savings": &overview,
+                    "chart": chart,
+                })));
+            }
+            Ok(render_token_overview(&overview))
         })())
     }
 
@@ -1026,8 +1055,10 @@ impl ProjectAtlasMcpServer {
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for ProjectAtlasMcpServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
-            "ProjectAtlas provides TOON-first repository orientation, folder/file ranking, structured file summaries, symbol graph lookup, exact slices, health checks, and token telemetry for coding agents.",
-        )
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("ProjectAtlas", env!("CARGO_PKG_VERSION")))
+            .with_instructions(
+                "ProjectAtlas provides TOON-first repository orientation, folder/file ranking, structured file summaries, symbol graph lookup, exact slices, health checks, and token telemetry for coding agents.",
+            )
     }
 }

--- a/crates/projectatlas-cli/src/runtime.rs
+++ b/crates/projectatlas-cli/src/runtime.rs
@@ -1,3 +1,4 @@
+//! Purpose: Coordinate shared `ProjectAtlas` CLI and MCP runtime workflows.
 //! Shared runtime orchestration for the `ProjectAtlas` CLI and MCP adapters.
 
 use crate::atlas_map::{
@@ -674,6 +675,12 @@ pub(crate) struct SettingsReport {
     pub(crate) config_path: Option<String>,
     /// Repository root used by map/lint config.
     pub(crate) repo_root: String,
+    /// Source that selected the repository root.
+    pub(crate) root_detection_source: String,
+    /// Whether config and DB root metadata agree.
+    pub(crate) root_verified: bool,
+    /// Root mismatches that should be fixed before trusting the binding.
+    pub(crate) root_mismatches: Vec<String>,
     /// Generated map path.
     pub(crate) map_path: String,
     /// Non-source summary path.
@@ -783,6 +790,27 @@ pub(crate) fn build_settings_report(
     } else {
         None
     };
+    let repo_root = normalize_display_path(&config.root);
+    let db_project_root = index
+        .as_ref()
+        .and_then(|stats| stats.project_root.as_ref())
+        .cloned();
+    let mut root_mismatches = Vec::new();
+    if let Some(db_root) = db_project_root.as_ref()
+        && db_root != &repo_root
+    {
+        root_mismatches.push(format!(
+            "db root {db_root:?} does not match config root {repo_root:?}"
+        ));
+    }
+    let root_detection_source = if resolved_config.is_some() {
+        "config"
+    } else if db_project_root.is_some() {
+        "db"
+    } else {
+        "db-path-or-cwd"
+    }
+    .to_string();
     Ok(SettingsReport {
         cache_dir: path_status(&cache_dir)?,
         db: path_status(&absolute_db)?,
@@ -791,7 +819,10 @@ pub(crate) fn build_settings_report(
         db_journal: path_status(&db_sidecar_path(&absolute_db, "journal"))?,
         mcp_config: path_status(&mcp_config_path_for_db(&absolute_db))?,
         config_path: resolved_config.map(|path| normalize_display_path(&path)),
-        repo_root: normalize_display_path(&config.root),
+        repo_root,
+        root_detection_source,
+        root_verified: root_mismatches.is_empty(),
+        root_mismatches,
         map_path: normalize_display_path(&config.map_path),
         nonsource_files_path: normalize_display_path(&config.nonsource_files_path),
         default_format: format!("{format:?}").to_ascii_lowercase(),

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -2,7 +2,10 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use projectatlas_core::PurposeSource;
 use projectatlas_core::language::{BROAD_SOURCE_EXTENSIONS, detect_language_for_path};
+use projectatlas_core::telemetry::usage_from_estimates;
+use projectatlas_db::{AtlasStore, HealthResolution};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::error::Error;
@@ -34,6 +37,9 @@ fn runtime_info_does_not_create_projectatlas_directory() -> Result<(), Box<dyn E
     let runtime_json: Value = serde_json::from_slice(&output.stdout)?;
     require_json_string(&runtime_json, &["project"], "ProjectAtlas")?;
     require_json_usize(&runtime_json, &["major_version"], 3)?;
+    if runtime_json["executable"].as_str().is_none() {
+        return Err(io::Error::other("runtime-info executable path missing").into());
+    }
     if atlas_dir.exists() {
         return Err(io::Error::other("runtime-info created .projectatlas").into());
     }
@@ -200,47 +206,7 @@ fn plugin_installer_writes_real_harness_configs() -> Result<(), Box<dyn Error>> 
     )?;
     let workspace_root = workspace_root()?;
     let runtime = assert_cmd::cargo::cargo_bin("projectatlas");
-    let output = if cfg!(windows) {
-        StdCommand::new("powershell")
-            .arg("-NoProfile")
-            .arg("-ExecutionPolicy")
-            .arg("Bypass")
-            .arg("-File")
-            .arg(
-                workspace_root
-                    .join("plugins")
-                    .join("projectatlas")
-                    .join("scripts")
-                    .join("install-runtime.ps1"),
-            )
-            .arg("-ProjectRoot")
-            .arg(&repo)
-            .arg("-RuntimePath")
-            .arg(&runtime)
-            .env("PROJECTATLAS_VERSION", env!("CARGO_PKG_VERSION"))
-            .output()?
-    } else {
-        StdCommand::new("bash")
-            .arg(
-                workspace_root
-                    .join("plugins")
-                    .join("projectatlas")
-                    .join("scripts")
-                    .join("install-runtime.sh"),
-            )
-            .arg(&repo)
-            .env("PROJECTATLAS_VERSION", env!("CARGO_PKG_VERSION"))
-            .env("PROJECTATLAS_RUNTIME_PATH", &runtime)
-            .output()?
-    };
-    if !output.status.success() {
-        return Err(io::Error::other(format!(
-            "plugin installer failed\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        ))
-        .into());
-    }
+    run_projectatlas_plugin_installer(&workspace_root, &repo, &runtime)?;
 
     let atlas_dir = repo.join(".projectatlas");
     let codex_config = read_json_file(&atlas_dir.join("projectatlas.mcp.json"))?;
@@ -304,6 +270,232 @@ fn plugin_installer_writes_real_harness_configs() -> Result<(), Box<dyn Error>> 
         &repo,
         "opencode cwd",
     )?;
+
+    Ok(())
+}
+
+#[test]
+fn plugin_update_replaces_stale_runtime_configs_and_launches_new_mcp() -> Result<(), Box<dyn Error>>
+{
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("repo");
+    fs::create_dir(&repo)?;
+    let atlas_dir = repo.join(".projectatlas");
+    fs::create_dir_all(&atlas_dir)?;
+    fs::create_dir(repo.join("src"))?;
+    fs::write(repo.join("src").join("a.rs"), "pub fn a() {}\n")?;
+    fs::write(repo.join("src").join("b.rs"), "pub fn b() {}\n")?;
+    fs::write(
+        atlas_dir.join("config.toml"),
+        "[project]\nroot = \".\"\n\n[scan]\nexclude_dir_names = [\".git\", \".projectatlas\", \"target\"]\n",
+    )?;
+    fs::write(
+        atlas_dir.join("projectatlas-nonsource-files.toon"),
+        "nonsource_files[]:\n  # path,summary\n",
+    )?;
+    fs::write(
+        atlas_dir.join("kept-state.txt"),
+        "existing project-local state must survive plugin updates\n",
+    )?;
+    let db = atlas_dir.join("projectatlas.db");
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .arg("--config")
+        .arg(atlas_dir.join("config.toml"))
+        .args(["scan", "."])
+        .assert()
+        .success();
+    let preserved_health_id = {
+        let store = AtlasStore::open(&db)?;
+        store.set_purpose(
+            "src/a.rs",
+            "Shared plugin update state",
+            PurposeSource::Agent,
+        )?;
+        store.set_purpose(
+            "src/b.rs",
+            "Shared plugin update state",
+            PurposeSource::Agent,
+        )?;
+        store.record_usage(&usage_from_estimates(
+            "plugin-update",
+            "summary",
+            Some("src/a.rs".to_string()),
+            None,
+            200,
+            50,
+        ))?;
+        let duplicate = store
+            .unresolved_health_findings(&[])?
+            .into_iter()
+            .find(|finding| finding.category == "duplicate-purpose")
+            .ok_or_else(|| io::Error::other("duplicate-purpose finding missing"))?;
+        let id = duplicate.id.clone();
+        store.resolve_health_finding(&HealthResolution {
+            finding_id: id.clone(),
+            category: duplicate.category,
+            path: duplicate.path,
+            related_path: duplicate.related_path,
+            rationale: "Plugin update preservation fixture.".to_string(),
+        })?;
+        id
+    };
+    let token_calls_before = AtlasStore::open(&db)?.token_overview(None)?.calls;
+    let stale_runtime_dir = temp.path().join("old-plugin");
+    let stale_runtime = stale_runtime_dir.join(if cfg!(windows) {
+        "projectatlas.cmd"
+    } else {
+        "projectatlas"
+    });
+    let stale_runtime_text = stale_runtime.to_string_lossy();
+    fs::create_dir_all(&stale_runtime_dir)?;
+    let stale_runtime_script = if cfg!(windows) {
+        "@echo off\r\necho {\"project\":\"ProjectAtlas\",\"major_version\":3,\"version\":\"0.0.1\",\"capabilities\":[\"mcp\"],\"text_format\":\"TOON\"}\r\n"
+    } else {
+        "#!/usr/bin/env sh\nprintf '%s\\n' '{\"project\":\"ProjectAtlas\",\"major_version\":3,\"version\":\"0.0.1\",\"capabilities\":[\"mcp\"],\"text_format\":\"TOON\"}'\n"
+    };
+    fs::write(&stale_runtime, stale_runtime_script)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(&stale_runtime)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&stale_runtime, permissions)?;
+    }
+    fs::write(
+        atlas_dir.join("projectatlas.mcp.json"),
+        format!(
+            r#"{{"mcpServers":{{"projectatlas":{{"command":{},"args":["--require-version","0.0.1","mcp"],"cwd":{}}}}}}}"#,
+            serde_json::to_string(&stale_runtime_text)?,
+            serde_json::to_string(&repo.to_string_lossy())?
+        ),
+    )?;
+    fs::write(
+        atlas_dir.join("projectatlas.claude.mcp.json"),
+        format!(
+            r#"{{"mcpServers":{{"projectatlas":{{"command":{},"args":["--require-version","0.0.1","mcp"]}}}}}}"#,
+            serde_json::to_string(&stale_runtime_text)?
+        ),
+    )?;
+    fs::write(
+        atlas_dir.join("projectatlas.opencode.json"),
+        format!(
+            r#"{{"$schema":"https://opencode.ai/config.json","mcp":{{"projectatlas":{{"type":"local","enabled":true,"command":[{},"--require-version","0.0.1","mcp"],"cwd":{}}}}}}}"#,
+            serde_json::to_string(&stale_runtime_text)?,
+            serde_json::to_string(&repo.to_string_lossy())?
+        ),
+    )?;
+
+    let workspace_root = workspace_root()?;
+    let runtime = assert_cmd::cargo::cargo_bin("projectatlas");
+    let installer_output = run_projectatlas_plugin_installer_with_path_shadow(
+        &workspace_root,
+        &repo,
+        &runtime,
+        &stale_runtime_dir,
+    )?;
+    let installer_output_text = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&installer_output.stdout),
+        String::from_utf8_lossy(&installer_output.stderr)
+    );
+    if !installer_output_text.contains("Obsolete ProjectAtlas runtime")
+        && !installer_output_text.contains("obsolete ProjectAtlas runtime")
+    {
+        return Err(io::Error::other(format!(
+            "plugin update did not report shadowed stale runtime:\n{installer_output_text}"
+        ))
+        .into());
+    }
+
+    let codex_config = read_json_file(&atlas_dir.join("projectatlas.mcp.json"))?;
+    let claude_config = read_json_file(&atlas_dir.join("projectatlas.claude.mcp.json"))?;
+    let opencode_config = read_json_file(&atlas_dir.join("projectatlas.opencode.json"))?;
+
+    require_same_executable(
+        json_string_at(&codex_config, &["mcpServers", "projectatlas", "command"])?,
+        &runtime,
+        "updated codex",
+    )?;
+    require_json_string(
+        &codex_config,
+        &["mcpServers", "projectatlas", "args", "1"],
+        env!("CARGO_PKG_VERSION"),
+    )?;
+    require_same_executable(
+        json_string_at(&claude_config, &["mcpServers", "projectatlas", "command"])?,
+        &runtime,
+        "updated claude",
+    )?;
+    require_json_string(
+        &claude_config,
+        &["mcpServers", "projectatlas", "args", "1"],
+        env!("CARGO_PKG_VERSION"),
+    )?;
+    require_same_executable(
+        json_string_at(&opencode_config, &["mcp", "projectatlas", "command", "0"])?,
+        &runtime,
+        "updated opencode",
+    )?;
+    require_json_string(
+        &opencode_config,
+        &["mcp", "projectatlas", "command", "2"],
+        env!("CARGO_PKG_VERSION"),
+    )?;
+    let codex_text = fs::read_to_string(atlas_dir.join("projectatlas.mcp.json"))?;
+    if codex_text.contains("0.0.1") || codex_text.contains(stale_runtime_text.as_ref()) {
+        return Err(
+            io::Error::other("updated plugin config still contains stale runtime data").into(),
+        );
+    }
+    if !atlas_dir.join("kept-state.txt").exists() {
+        return Err(io::Error::other("plugin update removed existing project-local state").into());
+    }
+    if fs::read_to_string(atlas_dir.join("projectatlas-nonsource-files.toon"))?
+        != "nonsource_files[]:\n  # path,summary\n"
+    {
+        return Err(io::Error::other("plugin update rewrote nonsource metadata").into());
+    }
+    let preserved_store = AtlasStore::open(&db)?;
+    let token_calls_after = preserved_store.token_overview(None)?.calls;
+    if token_calls_after < token_calls_before {
+        return Err(io::Error::other(format!(
+            "plugin update lost token telemetry: before {token_calls_before}, after {token_calls_after}"
+        ))
+        .into());
+    }
+    let nodes = preserved_store.load_nodes()?;
+    if !nodes.iter().any(|node| {
+        node.node.path == "src/a.rs"
+            && node.purpose.purpose.as_deref() == Some("Shared plugin update state")
+    }) {
+        return Err(io::Error::other("plugin update lost approved purpose metadata").into());
+    }
+    if !preserved_store
+        .resolved_health_ids()?
+        .contains(&preserved_health_id)
+    {
+        return Err(io::Error::other("plugin update lost health resolution metadata").into());
+    }
+
+    let (mcp_command, mcp_args) = mcp_command_and_args(&codex_config)?;
+    let messages = [
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"projectatlas-plugin-update-e2e","version":"0.1.0"}}}"#,
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#,
+    ];
+    let mcp_stdout = run_mcp_stdio(&mcp_command, &repo, &mcp_args, &messages)?;
+    let expected_server_info = format!(
+        r#""serverInfo":{{"name":"ProjectAtlas","version":"{}"}}"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    if !mcp_stdout.contains(&expected_server_info) {
+        return Err(io::Error::other(format!(
+            "updated plugin MCP config did not launch current runtime: {mcp_stdout}"
+        ))
+        .into());
+    }
 
     Ok(())
 }
@@ -842,13 +1034,41 @@ fn scan_overview_and_token_flow() -> Result<(), Box<dyn Error>> {
         .into());
     }
 
+    let raw_trends = Command::cargo_bin("projectatlas")?
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&db)
+        .args(["token", "--trend", "month"])
+        .output()?;
+    if !raw_trends.status.success() {
+        return Err(io::Error::other("json token trend command failed").into());
+    }
+    let trends_json: Value = serde_json::from_slice(&raw_trends.stdout)?;
+    require_json_string(&trends_json, &["window"], "month")?;
+    let periods = trends_json["periods"]
+        .as_array()
+        .ok_or_else(|| io::Error::other("trend periods missing"))?;
+    if periods.is_empty() {
+        return Err(io::Error::other("trend periods were empty").into());
+    }
+    if periods.iter().all(|period| {
+        period
+            .get("buckets")
+            .and_then(Value::as_array)
+            .is_none_or(Vec::is_empty)
+    }) {
+        return Err(io::Error::other("trend periods did not expose token buckets").into());
+    }
+
     Command::cargo_bin("projectatlas")?
+        .env("COLUMNS", "80")
         .arg("--db")
         .arg(&db)
         .args(["token", "--view", "tui"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("ProjectAtlas Token Delta"))
+        .stdout(predicate::str::contains("ProjectAtlas Token Savings"))
         .stdout(predicate::str::contains("heuristic chars/bytes / 4"))
         .stdout(predicate::str::contains("not model billing tokens"))
         .stdout(predicate::str::contains("Without PA"))
@@ -856,8 +1076,125 @@ fn scan_overview_and_token_flow() -> Result<(), Box<dyn Error>> {
         .stdout(predicate::str::contains("Saved"))
         .stdout(predicate::str::contains("Buckets"))
         .stdout(predicate::str::contains("heuristic_estimate"))
+        .stdout(predicate::str::contains("saved tokens"))
         .stdout(predicate::str::contains("wrong folders, wrong files"))
         .stdout(predicate::str::contains("unnecessary full reads"));
+    Command::cargo_bin("projectatlas")?
+        .arg("--db")
+        .arg(&db)
+        .args(["token", "--view", "tui", "--trend", "month"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ProjectAtlas Token Trends"))
+        .stdout(predicate::str::contains("Window    month"))
+        .stdout(predicate::str::contains("saved"));
+    Ok(())
+}
+
+#[test]
+fn root_and_metadata_validation_flow() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("repo");
+    fs::create_dir(&repo)?;
+    fs::create_dir(repo.join("src"))?;
+    fs::write(repo.join("src").join("a.rs"), "pub fn a() {}\n")?;
+    fs::write(repo.join("src").join("b.rs"), "pub fn b() {}\n")?;
+
+    Command::cargo_bin("projectatlas")?
+        .arg("--format")
+        .arg("json")
+        .args(["root", "set"])
+        .arg(&repo)
+        .assert()
+        .success();
+
+    let db = repo.join(".projectatlas").join("projectatlas.db");
+    let config = repo.join(".projectatlas").join("config.toml");
+    let root_show = Command::cargo_bin("projectatlas")?
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&db)
+        .arg("--config")
+        .arg(&config)
+        .args(["root", "show"])
+        .output()?;
+    if !root_show.status.success() {
+        return Err(io::Error::other("root show failed").into());
+    }
+    let root_json: Value = serde_json::from_slice(&root_show.stdout)?;
+    require_json_bool(&root_json, &["verified"], true)?;
+    require_json_string(&root_json, &["detection_source"], "config")?;
+    Command::cargo_bin("projectatlas")?
+        .arg("--db")
+        .arg(&db)
+        .arg("--config")
+        .arg(&config)
+        .arg("root")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("root:"))
+        .stdout(predicate::str::contains("detection_source: config"));
+
+    Command::cargo_bin("projectatlas")?
+        .arg("--db")
+        .arg(&db)
+        .arg("--config")
+        .arg(&config)
+        .args(["scan"])
+        .assert()
+        .success();
+
+    Command::cargo_bin("projectatlas")?
+        .arg("--db")
+        .arg(&db)
+        .args(["purpose", "set", "no/such/file.rs", "Missing file"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not indexed"))
+        .stderr(predicate::str::contains("sqlite error").not());
+
+    for file in ["src/a.rs", "src/b.rs"] {
+        Command::cargo_bin("projectatlas")?
+            .arg("--db")
+            .arg(&db)
+            .args(["purpose", "set", file, "Shared purpose"])
+            .assert()
+            .success();
+    }
+    Command::cargo_bin("projectatlas")?
+        .arg("--db")
+        .arg(&db)
+        .args([
+            "health",
+            "resolve",
+            "missing-id",
+            "duplicate-purpose",
+            "no/such/file.rs",
+            "--rationale",
+            "typo",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not active"));
+
+    let other_repo = temp.path().join("other-repo");
+    fs::create_dir(&other_repo)?;
+    Command::cargo_bin("projectatlas")?
+        .args(["root", "set"])
+        .arg(&other_repo)
+        .assert()
+        .success();
+    Command::cargo_bin("projectatlas")?
+        .arg("--db")
+        .arg(other_repo.join(".projectatlas").join("projectatlas.db"))
+        .arg("--config")
+        .arg(&config)
+        .args(["root", "verify"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("mismatches"));
+
     Ok(())
 }
 
@@ -1556,6 +1893,7 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"atlas_overview","arguments":{}}}"#,
         r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"atlas_files","arguments":{"file_pattern":"*.rs","limit":1}}}"#,
         r#"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"atlas_health","arguments":{"category":"missing-purpose","path_prefix":".","limit":1}}}"#,
+        r#"{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"atlas_token_report","arguments":{"include_chart":true}}}"#,
     ];
     let executable = assert_cmd::cargo::cargo_bin("projectatlas");
     let stdout = run_mcp_stdio(
@@ -1569,12 +1907,14 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         &messages,
     )?;
     if !stdout.contains(r#""id":1"#)
+        || !stdout.contains(r#""serverInfo":{"name":"ProjectAtlas","version":"#)
         || !stdout.contains(r#""name":"atlas_files""#)
         || !stdout.contains("overview:")
         || !stdout.contains("files[1]")
         || !stdout.contains("health:")
         || !stdout.contains("health_findings[1]")
         || !stdout.contains("next_start_index: 1")
+        || !stdout.contains("ProjectAtlas Token Savings")
         || !stdout.contains("src/lib.rs")
     {
         return Err(io::Error::other(format!(
@@ -4430,6 +4770,91 @@ fn workspace_root() -> Result<std::path::PathBuf, Box<dyn Error>> {
         .nth(2)
         .map(Path::to_path_buf)
         .ok_or_else(|| io::Error::other("workspace root not found").into())
+}
+
+/// Run the bundled plugin installer with an explicit runtime path.
+fn run_projectatlas_plugin_installer(
+    workspace_root: &Path,
+    repo: &Path,
+    runtime: &Path,
+) -> Result<std::process::Output, Box<dyn Error>> {
+    run_projectatlas_plugin_installer_with_optional_path(workspace_root, repo, runtime, None)
+}
+
+/// Run the bundled plugin installer while shadowing PATH with a stale runtime.
+fn run_projectatlas_plugin_installer_with_path_shadow(
+    workspace_root: &Path,
+    repo: &Path,
+    runtime: &Path,
+    path_shadow: &Path,
+) -> Result<std::process::Output, Box<dyn Error>> {
+    run_projectatlas_plugin_installer_with_optional_path(
+        workspace_root,
+        repo,
+        runtime,
+        Some(path_shadow),
+    )
+}
+
+/// Run the bundled plugin installer and return its process output.
+fn run_projectatlas_plugin_installer_with_optional_path(
+    workspace_root: &Path,
+    repo: &Path,
+    runtime: &Path,
+    path_shadow: Option<&Path>,
+) -> Result<std::process::Output, Box<dyn Error>> {
+    let mut command = if cfg!(windows) {
+        let mut command = StdCommand::new("powershell");
+        command
+            .arg("-NoProfile")
+            .arg("-ExecutionPolicy")
+            .arg("Bypass")
+            .arg("-File")
+            .arg(
+                workspace_root
+                    .join("plugins")
+                    .join("projectatlas")
+                    .join("scripts")
+                    .join("install-runtime.ps1"),
+            )
+            .arg("-ProjectRoot")
+            .arg(repo)
+            .arg("-RuntimePath")
+            .arg(runtime);
+        command
+    } else {
+        let mut command = StdCommand::new("bash");
+        command
+            .arg(
+                workspace_root
+                    .join("plugins")
+                    .join("projectatlas")
+                    .join("scripts")
+                    .join("install-runtime.sh"),
+            )
+            .arg(repo);
+        command
+    };
+    command
+        .env("PROJECTATLAS_VERSION", env!("CARGO_PKG_VERSION"))
+        .env("PROJECTATLAS_RUNTIME_PATH", runtime);
+    if let Some(path_shadow) = path_shadow {
+        let current_path = std::env::var_os("PATH").unwrap_or_default();
+        let shadowed_path = std::env::join_paths(
+            std::iter::once(path_shadow.to_path_buf()).chain(std::env::split_paths(&current_path)),
+        )?;
+        command.env("PATH", shadowed_path);
+    }
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "plugin installer failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ))
+        .into());
+    }
+    Ok(output)
 }
 
 /// Generate one harness-specific MCP config document.

--- a/crates/projectatlas-core/src/telemetry.rs
+++ b/crates/projectatlas-core/src/telemetry.rs
@@ -132,6 +132,87 @@ pub struct TokenOverview {
     pub buckets: Vec<TokenBucketOverview>,
 }
 
+/// Token trend grouping window.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TokenTrendWindow {
+    /// Group token telemetry by day.
+    Day,
+    /// Group token telemetry by week.
+    Week,
+    /// Group token telemetry by month.
+    Month,
+    /// Group token telemetry by year.
+    Year,
+}
+
+impl TokenTrendWindow {
+    /// Parse a stable window label.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "day" => Some(Self::Day),
+            "week" => Some(Self::Week),
+            "month" => Some(Self::Month),
+            "year" => Some(Self::Year),
+            _ => None,
+        }
+    }
+
+    /// Return the stable CLI/MCP label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Day => "day",
+            Self::Week => "week",
+            Self::Month => "month",
+            Self::Year => "year",
+        }
+    }
+}
+
+impl std::fmt::Display for TokenTrendWindow {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Token trend aggregate for one period.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct TokenTrendPeriod {
+    /// Period label such as `2026-06-29`, `2026-W26`, `2026-06`, or `2026`.
+    pub period: String,
+    /// Number of tracked calls in the period.
+    pub calls: usize,
+    /// Total baseline estimate.
+    pub estimated_without_projectatlas: usize,
+    /// Total `ProjectAtlas` estimate.
+    pub estimated_with_projectatlas: usize,
+    /// Total saved tokens.
+    pub estimated_saved: isize,
+    /// Signed savings ratio, or `None` when the baseline estimate is zero.
+    pub savings_rate: Option<f64>,
+    /// Bucketed token savings grouped by baseline and accuracy semantics.
+    pub buckets: Vec<TokenBucketOverview>,
+}
+
+/// Token savings trend report.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct TokenTrendReport {
+    /// Counting mode for the reported numbers.
+    pub estimate_kind: String,
+    /// Estimator used to produce the reported numbers.
+    pub estimator: String,
+    /// Scope and accuracy boundary for the reported numbers.
+    pub estimate_scope: String,
+    /// Optional session filter.
+    pub session: Option<String>,
+    /// Grouping window.
+    pub window: TokenTrendWindow,
+    /// Period aggregates ordered oldest to newest.
+    pub periods: Vec<TokenTrendPeriod>,
+}
+
 impl TokenOverview {
     /// Build an overview from usage events.
     #[must_use]
@@ -240,6 +321,74 @@ impl TokenBucketOverview {
             estimated_with_projectatlas: saturating_u128_to_usize(with),
             estimated_saved,
             savings_rate,
+        }
+    }
+}
+
+impl TokenTrendPeriod {
+    /// Build a period aggregate from token totals.
+    #[must_use]
+    pub fn from_totals(period: String, calls: u128, without: u128, with: u128) -> Self {
+        let bucket = TokenBucketOverview::from_totals(
+            default_token_savings_bucket(),
+            default_token_provider(),
+            default_token_model(),
+            default_tokenizer_backend(),
+            default_token_accuracy(),
+            default_token_baseline_kind(),
+            default_token_confidence(),
+            calls,
+            without,
+            with,
+        );
+        Self::from_buckets(period, vec![bucket])
+    }
+
+    /// Build a period aggregate from pre-aggregated buckets.
+    #[must_use]
+    pub fn from_buckets(period: String, buckets: Vec<TokenBucketOverview>) -> Self {
+        let calls = buckets.iter().fold(0u128, |acc, bucket| {
+            acc.saturating_add(bucket.calls as u128)
+        });
+        let without = buckets.iter().fold(0u128, |acc, bucket| {
+            acc.saturating_add(bucket.estimated_without_projectatlas as u128)
+        });
+        let with = buckets.iter().fold(0u128, |acc, bucket| {
+            acc.saturating_add(bucket.estimated_with_projectatlas as u128)
+        });
+        let saved = aggregate_token_delta(without, with);
+        let savings_rate = if without == 0 {
+            None
+        } else {
+            Some((without as f64 - with as f64) / without as f64)
+        };
+        Self {
+            period,
+            calls: saturating_u128_to_usize(calls),
+            estimated_without_projectatlas: saturating_u128_to_usize(without),
+            estimated_with_projectatlas: saturating_u128_to_usize(with),
+            estimated_saved: saved,
+            savings_rate,
+            buckets,
+        }
+    }
+}
+
+impl TokenTrendReport {
+    /// Build a trend report from period aggregates.
+    #[must_use]
+    pub fn new(
+        session: Option<String>,
+        window: TokenTrendWindow,
+        periods: Vec<TokenTrendPeriod>,
+    ) -> Self {
+        Self {
+            estimate_kind: TOKEN_ESTIMATE_KIND.to_string(),
+            estimator: TOKEN_ESTIMATOR.to_string(),
+            estimate_scope: TOKEN_ESTIMATE_SCOPE.to_string(),
+            session,
+            window,
+            periods,
         }
     }
 }

--- a/crates/projectatlas-core/src/toon.rs
+++ b/crates/projectatlas-core/src/toon.rs
@@ -3,7 +3,7 @@
 use crate::health::{HealthFinding, Severity};
 use crate::outline::FileOutline;
 use crate::symbols::{CodeSymbol, SymbolRelation};
-use crate::telemetry::TokenOverview;
+use crate::telemetry::{TokenOverview, TokenTrendReport};
 use crate::{IndexedNode, Overview};
 use serde::Serialize;
 use serde_json::json;
@@ -124,6 +124,56 @@ pub fn render_token_overview(overview: &TokenOverview) -> String {
                 "savings_rate": savings_rate,
             },
             "buckets": buckets,
+        }
+    }))
+}
+
+/// Render token savings trends as standard TOON.
+#[must_use]
+pub fn render_token_trends(report: &TokenTrendReport) -> String {
+    let periods = report
+        .periods
+        .iter()
+        .map(|period| {
+            let buckets = period
+                .buckets
+                .iter()
+                .map(|bucket| {
+                    json!({
+                        "token_savings_bucket": bucket.token_savings_bucket,
+                        "provider": bucket.provider,
+                        "model": bucket.model,
+                        "tokenizer_backend": bucket.tokenizer_backend,
+                        "accuracy": bucket.accuracy,
+                        "baseline_kind": bucket.baseline_kind,
+                        "confidence": bucket.confidence,
+                        "calls": bucket.calls,
+                        "baseline_tokens": bucket.estimated_without_projectatlas,
+                        "emitted_tokens": bucket.estimated_with_projectatlas,
+                        "saved_tokens": bucket.estimated_saved,
+                        "savings_rate": percentage_label(bucket.savings_rate),
+                    })
+                })
+                .collect::<Vec<_>>();
+            json!({
+                "period": period.period,
+                "calls": period.calls,
+                "baseline_tokens": period.estimated_without_projectatlas,
+                "emitted_tokens": period.estimated_with_projectatlas,
+                "saved_tokens": period.estimated_saved,
+                "savings_rate": percentage_label(period.savings_rate),
+                "buckets": buckets,
+            })
+        })
+        .collect::<Vec<_>>();
+    encode_agent_payload(&json!({
+        "token_trends": {
+            "estimate_kind": report.estimate_kind,
+            "estimator": report.estimator,
+            "estimate_scope": report.estimate_scope,
+            "session": report.session.as_deref().unwrap_or("all sessions"),
+            "window": report.window,
+            "periods": periods,
         }
     }))
 }

--- a/crates/projectatlas-db/src/lib.rs
+++ b/crates/projectatlas-db/src/lib.rs
@@ -5,7 +5,10 @@ use projectatlas_core::symbols::{
     CodeSymbol, ParserKind, RelationKind, SourceParseMetadata, SymbolGraph, SymbolKind,
     SymbolRelation,
 };
-use projectatlas_core::telemetry::{TokenBucketOverview, TokenOverview, UsageEvent};
+use projectatlas_core::telemetry::{
+    TokenBucketOverview, TokenOverview, TokenTrendPeriod, TokenTrendReport, TokenTrendWindow,
+    UsageEvent,
+};
 use projectatlas_core::{
     IndexedNode, Node, NodeKind, Overview, Purpose, PurposeSource, PurposeStatus,
     normalize_native_path_display, normalize_repo_path_prefix,
@@ -13,7 +16,7 @@ use projectatlas_core::{
 use rusqlite::types::Value;
 use rusqlite::{Connection, OptionalExtension, Transaction, params, params_from_iter};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::TryFromIntError;
 use std::path::Path;
 use thiserror::Error;
@@ -52,6 +55,24 @@ pub enum DbError {
         value: i64,
         /// Source conversion error.
         source: TryFromIntError,
+    },
+    /// A caller supplied a path that is not in the current index.
+    #[error("path {path:?} is not indexed; run scan, fix the path, or choose an indexed path")]
+    PathNotIndexed {
+        /// Repository-relative path.
+        path: String,
+    },
+    /// A caller attempted to resolve a health finding that is not currently active.
+    #[error(
+        "health finding {finding_id:?} with category {category:?} and path {path:?} is not active; run health-check and use an exact finding id/path/category"
+    )]
+    HealthFindingNotActive {
+        /// Requested finding id.
+        finding_id: String,
+        /// Requested category.
+        category: String,
+        /// Requested primary path.
+        path: String,
     },
 }
 
@@ -339,6 +360,12 @@ impl AtlasStore {
         )?;
         self.ensure_symbol_metadata_columns()?;
         self.ensure_usage_event_metadata_columns()?;
+        self.connection.execute_batch(
+            "
+            CREATE INDEX IF NOT EXISTS idx_usage_created_at ON usage_events(created_at);
+            CREATE INDEX IF NOT EXISTS idx_usage_session_created_at ON usage_events(session_id, created_at);
+            ",
+        )?;
         let stored = self
             .connection
             .query_row(
@@ -407,6 +434,11 @@ impl AtlasStore {
             &columns,
             "calculation_trace",
             "TEXT NOT NULL DEFAULT 'heuristic=ceil(chars_or_bytes/4)'",
+        )?;
+        self.ensure_usage_event_column(&columns, "created_at", "TEXT")?;
+        self.connection.execute(
+            "UPDATE usage_events SET created_at = CURRENT_TIMESTAMP WHERE created_at IS NULL OR created_at = ''",
+            [],
         )?;
         Ok(())
     }
@@ -1748,12 +1780,16 @@ impl AtlasStore {
 
     /// Load a node id for a repository path.
     fn node_id_for_path(&self, path: &str) -> DbResult<i64> {
-        let node_id =
-            self.connection
-                .query_row("SELECT id FROM nodes WHERE path = ?1", [path], |row| {
-                    row.get::<_, i64>(0)
-                })?;
-        Ok(node_id)
+        self.connection
+            .query_row(
+                "SELECT id FROM nodes WHERE path = ?1 AND exists_now = 1",
+                [path],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()?
+            .ok_or_else(|| DbError::PathNotIndexed {
+                path: path.to_string(),
+            })
     }
 
     /// Load existing nodes with purpose state.
@@ -2774,9 +2810,10 @@ impl AtlasStore {
                 accuracy,
                 baseline_kind,
                 confidence,
-                calculation_trace
+                calculation_trace,
+                created_at
             )
-            VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+            VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, CURRENT_TIMESTAMP)
             ",
             params![
                 event.session_id,
@@ -2933,12 +2970,127 @@ impl AtlasStore {
         Ok(token_overview_from_buckets(buckets))
     }
 
+    /// Build token trend aggregates grouped by day, week, month, or year.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the window is unsupported or loading events fails.
+    pub fn token_trends(
+        &self,
+        session_id: Option<&str>,
+        window: TokenTrendWindow,
+    ) -> DbResult<TokenTrendReport> {
+        let period_expr = token_trend_period_expression(window);
+        let sql = if session_id.is_some() {
+            format!(
+                "
+            SELECT
+                {period_expr} AS period,
+                token_savings_bucket,
+                provider,
+                model,
+                tokenizer_backend,
+                accuracy,
+                baseline_kind,
+                confidence,
+                COUNT(*),
+                TOTAL(estimated_tokens_without_projectatlas),
+                TOTAL(estimated_tokens_with_projectatlas)
+            FROM usage_events
+            WHERE session_id = ?1
+              AND estimated_tokens_without_projectatlas IS NOT NULL
+              AND estimated_tokens_with_projectatlas IS NOT NULL
+            GROUP BY period, token_savings_bucket, provider, model, tokenizer_backend,
+                     accuracy, baseline_kind, confidence
+            ORDER BY period, token_savings_bucket, accuracy, baseline_kind, confidence
+            "
+            )
+        } else {
+            format!(
+                "
+            SELECT
+                {period_expr} AS period,
+                token_savings_bucket,
+                provider,
+                model,
+                tokenizer_backend,
+                accuracy,
+                baseline_kind,
+                confidence,
+                COUNT(*),
+                TOTAL(estimated_tokens_without_projectatlas),
+                TOTAL(estimated_tokens_with_projectatlas)
+            FROM usage_events
+            WHERE estimated_tokens_without_projectatlas IS NOT NULL
+              AND estimated_tokens_with_projectatlas IS NOT NULL
+            GROUP BY period, token_savings_bucket, provider, model, tokenizer_backend,
+                     accuracy, baseline_kind, confidence
+            ORDER BY period, token_savings_bucket, accuracy, baseline_kind, confidence
+            "
+            )
+        };
+        let mapper = |row: &rusqlite::Row<'_>| {
+            let period = row.get::<_, String>(0)?;
+            let calls = row.get::<_, i64>(8)?.max(0) as u128;
+            let bucket = TokenBucketOverview::from_totals(
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+                row.get(7)?,
+                calls,
+                token_total_from_sql("estimated_tokens_without_projectatlas", row.get(9)?),
+                token_total_from_sql("estimated_tokens_with_projectatlas", row.get(10)?),
+            );
+            Ok((period, bucket))
+        };
+        let mut statement = self.connection.prepare(&sql)?;
+        let rows = if let Some(session) = session_id {
+            statement.query_map([session], mapper)?
+        } else {
+            statement.query_map([], mapper)?
+        };
+        let mut buckets_by_period = BTreeMap::<String, Vec<TokenBucketOverview>>::new();
+        for row in rows {
+            let (period, bucket) = row?;
+            buckets_by_period.entry(period).or_default().push(bucket);
+        }
+        let periods = buckets_by_period
+            .into_iter()
+            .map(|(period, buckets)| TokenTrendPeriod::from_buckets(period, buckets))
+            .collect();
+        Ok(TokenTrendReport::new(
+            session_id.map(ToString::to_string),
+            window,
+            periods,
+        ))
+    }
+
     /// Mark a deterministic health finding as agent-resolved.
     ///
     /// # Errors
     ///
-    /// Returns an error if persistence fails.
+    /// Returns an error if the finding is not active or persistence fails.
     pub fn resolve_health_finding(&self, resolution: &HealthResolution) -> DbResult<()> {
+        let resolved_ids = self.resolved_health_ids()?;
+        let active = self
+            .unresolved_health_findings(&resolved_ids)?
+            .into_iter()
+            .any(|finding| {
+                finding.id == resolution.finding_id
+                    && finding.category == resolution.category
+                    && finding.path == resolution.path
+                    && finding.related_path == resolution.related_path
+            });
+        if !active {
+            return Err(DbError::HealthFindingNotActive {
+                finding_id: resolution.finding_id.clone(),
+                category: resolution.category.clone(),
+                path: resolution.path.clone(),
+            });
+        }
         self.connection.execute(
             "
             INSERT INTO health_resolutions(
@@ -3282,6 +3434,16 @@ fn token_total_from_sql(_field: &'static str, value: f64) -> u128 {
         u128::MAX
     } else {
         value.round() as u128
+    }
+}
+
+/// Return the `SQLite` period expression for one token trend window.
+fn token_trend_period_expression(window: TokenTrendWindow) -> &'static str {
+    match window {
+        TokenTrendWindow::Day => "substr(COALESCE(created_at, CURRENT_TIMESTAMP), 1, 10)",
+        TokenTrendWindow::Week => "strftime('%Y-W%W', COALESCE(created_at, CURRENT_TIMESTAMP))",
+        TokenTrendWindow::Month => "substr(COALESCE(created_at, CURRENT_TIMESTAMP), 1, 7)",
+        TokenTrendWindow::Year => "substr(COALESCE(created_at, CURRENT_TIMESTAMP), 1, 4)",
     }
 }
 
@@ -3667,6 +3829,186 @@ mod tests {
             &large.estimated_saved,
             &isize::MAX,
             "large aggregate saturates without sqlite SUM overflow",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn token_trends_group_usage_by_period_and_bucket() -> Result<(), Box<dyn Error>> {
+        let store = AtlasStore::in_memory()?;
+        for (session, created_at, bucket, baseline_kind, confidence, without, with) in [
+            (
+                "session",
+                "2026-06-01 00:00:00",
+                TOKEN_BUCKET_NAVIGATION_AVOIDANCE,
+                "selected_candidates",
+                "inferred",
+                100_i64,
+                25_i64,
+            ),
+            (
+                "session",
+                "2026-06-10 00:00:00",
+                TOKEN_BUCKET_FULL_FILE_COMPRESSION,
+                "full_file",
+                "observed",
+                50_i64,
+                10_i64,
+            ),
+            (
+                "session",
+                "2026-07-01 00:00:00",
+                TOKEN_BUCKET_NAVIGATION_AVOIDANCE,
+                "selected_candidates",
+                "inferred",
+                80_i64,
+                20_i64,
+            ),
+            (
+                "other",
+                "2026-06-03 00:00:00",
+                TOKEN_BUCKET_NAVIGATION_AVOIDANCE,
+                "selected_candidates",
+                "inferred",
+                999_i64,
+                1_i64,
+            ),
+        ] {
+            store.connection.execute(
+                "
+                INSERT INTO usage_events(
+                    session_id,
+                    command,
+                    estimated_tokens_without_projectatlas,
+                    estimated_tokens_with_projectatlas,
+                    estimated_tokens_saved,
+                    token_savings_bucket,
+                    baseline_kind,
+                    confidence,
+                    created_at
+                )
+                VALUES(?1, 'trend', ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                ",
+                params![
+                    session,
+                    without,
+                    with,
+                    without - with,
+                    bucket,
+                    baseline_kind,
+                    confidence,
+                    created_at
+                ],
+            )?;
+        }
+
+        let trends = store.token_trends(Some("session"), TokenTrendWindow::Month)?;
+        require_eq(&trends.periods.len(), &2, "monthly periods")?;
+        require_eq(
+            &trends.periods[0].period,
+            &"2026-06".to_string(),
+            "first month",
+        )?;
+        require_eq(&trends.periods[0].calls, &2, "june call count")?;
+        require_eq(
+            &trends.periods[0].estimated_saved,
+            &115,
+            "june saved tokens",
+        )?;
+        require_eq(
+            &trends.periods[0].buckets.len(),
+            &2,
+            "june preserves evidence buckets",
+        )?;
+        require_eq(
+            &trends.periods[0].buckets[0].token_savings_bucket,
+            &TOKEN_BUCKET_FULL_FILE_COMPRESSION.to_string(),
+            "full-file bucket remains visible",
+        )?;
+        require_eq(
+            &trends.periods[0].buckets[0].confidence,
+            &"observed".to_string(),
+            "bucket confidence remains visible",
+        )?;
+        require_eq(
+            &trends.periods[1].period,
+            &"2026-07".to_string(),
+            "second month",
+        )?;
+        require_eq(&trends.periods[1].calls, &1, "july call count")?;
+        Ok(())
+    }
+
+    #[test]
+    fn token_trends_backfill_created_at_for_upgraded_databases() -> Result<(), Box<dyn Error>> {
+        let temp = tempfile::tempdir()?;
+        let db_path = temp.path().join("legacy.db");
+        {
+            let connection = Connection::open(&db_path)?;
+            connection.execute_batch(
+                "
+                CREATE TABLE metadata(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                INSERT INTO metadata(key, value) VALUES('schema_version', '7');
+                CREATE TABLE usage_events (
+                    id INTEGER PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    command TEXT NOT NULL,
+                    path TEXT,
+                    query TEXT,
+                    estimated_tokens_without_projectatlas INTEGER,
+                    estimated_tokens_with_projectatlas INTEGER,
+                    estimated_tokens_saved INTEGER,
+                    token_savings_bucket TEXT NOT NULL DEFAULT 'navigation_avoidance',
+                    provider TEXT NOT NULL DEFAULT 'heuristic',
+                    model TEXT NOT NULL DEFAULT 'unknown',
+                    tokenizer_backend TEXT NOT NULL DEFAULT 'chars_div_4',
+                    accuracy TEXT NOT NULL DEFAULT 'heuristic_estimate',
+                    baseline_kind TEXT NOT NULL DEFAULT 'selected_candidates',
+                    confidence TEXT NOT NULL DEFAULT 'inferred',
+                    calculation_trace TEXT NOT NULL DEFAULT 'heuristic=ceil(chars_or_bytes/4)'
+                );
+                INSERT INTO usage_events(
+                    session_id,
+                    command,
+                    estimated_tokens_without_projectatlas,
+                    estimated_tokens_with_projectatlas,
+                    estimated_tokens_saved
+                )
+                VALUES('legacy-session', 'legacy', 100, 20, 80);
+                ",
+            )?;
+        }
+
+        let store = AtlasStore::open(&db_path)?;
+        let null_created_at = store.connection.query_row(
+            "SELECT COUNT(*) FROM usage_events WHERE created_at IS NULL OR created_at = ''",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?;
+        require_eq(&null_created_at, &0, "legacy created_at values backfilled")?;
+        store.record_usage(&usage_from_estimates(
+            "legacy-session",
+            "new-call",
+            None,
+            None,
+            50,
+            10,
+        ))?;
+        let null_created_at = store.connection.query_row(
+            "SELECT COUNT(*) FROM usage_events WHERE created_at IS NULL OR created_at = ''",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?;
+        require_eq(&null_created_at, &0, "new created_at values populated")?;
+        let trends = store.token_trends(Some("legacy-session"), TokenTrendWindow::Month)?;
+        require_eq(&trends.periods.is_empty(), &false, "trend periods exist")?;
+        require_eq(
+            &trends
+                .periods
+                .iter()
+                .any(|period| period.period.starts_with("1970")),
+            &false,
+            "upgraded telemetry does not aggregate under 1970",
         )?;
         Ok(())
     }
@@ -4308,19 +4650,85 @@ mod tests {
 
     #[test]
     fn stores_health_resolution_ids() -> Result<(), Box<dyn Error>> {
-        let store = AtlasStore::in_memory()?;
+        let mut store = AtlasStore::in_memory()?;
+        store.replace_scan(&[
+            test_file_node("src/a.rs", "hash-a"),
+            test_file_node("src/b.rs", "hash-b"),
+        ])?;
+        store.set_purpose("src/a.rs", "Shared purpose", PurposeSource::Agent)?;
+        store.set_purpose("src/b.rs", "Shared purpose", PurposeSource::Agent)?;
+        let duplicate = store
+            .unresolved_health_findings(&[])?
+            .into_iter()
+            .find(|finding| finding.category == "duplicate-purpose")
+            .ok_or_else(|| io::Error::other("duplicate-purpose finding missing"))?;
+        let duplicate_id = duplicate.id.clone();
         store.resolve_health_finding(&HealthResolution {
-            finding_id: "duplicate-purpose:a:b".to_string(),
-            category: "duplicate-purpose".to_string(),
-            path: "a".to_string(),
-            related_path: Some("b".to_string()),
+            finding_id: duplicate_id.clone(),
+            category: duplicate.category,
+            path: duplicate.path,
+            related_path: duplicate.related_path,
             rationale: "Paths intentionally mirror agent skill variants.".to_string(),
         })?;
         let ids = store.resolved_health_ids()?;
+        require_eq(&ids, &vec![duplicate_id], "resolved ids")?;
+        Ok(())
+    }
+
+    #[test]
+    fn purpose_set_reports_unindexed_path_without_sqlite_leak() -> Result<(), Box<dyn Error>> {
+        let mut store = AtlasStore::in_memory()?;
+        store.replace_scan(&[test_file_node("src/main.rs", "hash")])?;
+        let error = match store.set_purpose("no/such/file.rs", "Missing file", PurposeSource::Agent)
+        {
+            Ok(()) => return Err(io::Error::other("missing path should fail").into()),
+            Err(error) => error,
+        };
+
         require_eq(
-            &ids,
-            &vec!["duplicate-purpose:a:b".to_string()],
-            "resolved ids",
+            &error.to_string().contains("no/such/file.rs"),
+            &true,
+            "path named in error",
+        )?;
+        require_eq(
+            &error.to_string().contains("sqlite error"),
+            &false,
+            "raw sqlite error hidden",
+        )?;
+        store.replace_scan(&[])?;
+        let error = match store.set_purpose("src/main.rs", "Removed file", PurposeSource::Agent) {
+            Ok(()) => return Err(io::Error::other("stale indexed path should fail").into()),
+            Err(error) => error,
+        };
+        require_eq(
+            &error.to_string().contains("src/main.rs"),
+            &true,
+            "stale path named in error",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn health_resolution_requires_active_finding_tuple() -> Result<(), Box<dyn Error>> {
+        let mut store = AtlasStore::in_memory()?;
+        store.replace_scan(&[test_file_node("src/main.rs", "hash")])?;
+        let error = match store.resolve_health_finding(&HealthResolution {
+            finding_id: "missing-id".to_string(),
+            category: "duplicate-purpose".to_string(),
+            path: "no/such/file.rs".to_string(),
+            related_path: None,
+            rationale: "typo".to_string(),
+        }) {
+            Ok(()) => {
+                return Err(io::Error::other("nonexistent health finding should fail").into());
+            }
+            Err(error) => error,
+        };
+
+        require_eq(
+            &error.to_string().contains("not active"),
+            &true,
+            "inactive finding rejected",
         )?;
         Ok(())
     }

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -1,3 +1,5 @@
+# Purpose: Document agent startup and MCP integration workflows for ProjectAtlas.
+
 # Agent Integration
 
 ProjectAtlas is designed to be read at agent startup so you can:
@@ -84,7 +86,7 @@ fails closed instead of starting an older MCP server:
   "mcpServers": {
     "projectatlas": {
       "command": "projectatlas",
-      "args": ["--require-version", "0.3.6", "--db", ".projectatlas/projectatlas.db", "mcp"]
+      "args": ["--require-version", "0.3.7", "--db", ".projectatlas/projectatlas.db", "mcp"]
     }
   }
 }
@@ -112,6 +114,18 @@ on PowerShell or `PROJECTATLAS_RUNTIME_PATH=<path-to-projectatlas>` with the
 POSIX installer. The supplied binary is still verified through
 `projectatlas --format json runtime-info`, including version pinning when
 `PROJECTATLAS_VERSION` is set.
+
+Installer updates preserve project-local atlas state by default. They rewrite
+generated MCP configs and managed runtime binaries, but they do not delete
+`.projectatlas/projectatlas.db`, SQLite sidecars, token telemetry, approved
+purposes, health resolutions, project config, or nonsource metadata. Use
+`projectatlas reset-index --apply` only when you explicitly want local atlas
+state removed.
+
+Installers also report obsolete `projectatlas` binaries or shims that remain on
+PATH. Generated MCP configs use absolute, version-guarded runtime paths, but a
+stale Python, npm, or Cargo shim can still affect bare `projectatlas` commands
+in another shell until PATH order is fixed or the obsolete shim is removed.
 
 Harness-specific config can also be generated directly:
 

--- a/plugins/projectatlas/.claude-plugin/plugin.json
+++ b/plugins/projectatlas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for Claude Code.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/.codex-plugin/plugin.json
+++ b/plugins/projectatlas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for coding agents.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/.mcp.json
+++ b/plugins/projectatlas/.mcp.json
@@ -4,7 +4,7 @@
       "command": "projectatlas",
       "args": [
         "--require-version",
-        "0.3.6",
+        "0.3.7",
         "--db",
         ".projectatlas/projectatlas.db",
         "mcp"

--- a/plugins/projectatlas/opencode/opencode.json
+++ b/plugins/projectatlas/opencode/opencode.json
@@ -6,7 +6,7 @@
       "command": [
         "projectatlas",
         "--require-version",
-        "0.3.6",
+        "0.3.7",
         "--db",
         ".projectatlas/projectatlas.db",
         "mcp"

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -1,3 +1,5 @@
+# Purpose: Install or update the ProjectAtlas plugin runtime and Windows MCP configs.
+
 param(
     [string]$ProjectRoot,
     [string]$Repository = "https://github.com/styler-ai/ProjectAtlas",
@@ -92,6 +94,27 @@ function Test-ProjectAtlasRuntime {
     }
 }
 
+function Get-ProjectAtlasRuntimeVersion {
+    param(
+        [string]$FilePath
+    )
+    if (-not $FilePath -or -not (Test-Path -LiteralPath $FilePath)) {
+        return $null
+    }
+    try {
+        $runtimeJson = & $FilePath --format json runtime-info 2>$null | Out-String
+        if ($LASTEXITCODE -ne 0) {
+            return $null
+        }
+        $payload = $runtimeJson | ConvertFrom-Json
+        $runtime = if ($payload.runtime) { $payload.runtime } else { $payload }
+        return $runtime.version
+    }
+    catch {
+        return $null
+    }
+}
+
 function Split-PathList {
     param(
         [string]$Value
@@ -179,6 +202,37 @@ function Find-ProjectAtlas {
         return $projectAtlasCommand.Source
     }
     return $null
+}
+
+function Write-ProjectAtlasPathShadowReport {
+    param(
+        [string]$VerifiedPath,
+        [string]$ExpectedVersion
+    )
+    if (-not $VerifiedPath) {
+        return
+    }
+    $verified = Get-NormalizedPathEntry $VerifiedPath
+    $candidates = @(where.exe projectatlas 2>$null | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($candidates.Count -eq 0) {
+        Write-Warning "Bare 'projectatlas' is not on PATH. Generated MCP configs use the verified absolute runtime: $VerifiedPath"
+        return
+    }
+    $first = Get-NormalizedPathEntry $candidates[0]
+    if ($first -ne $verified) {
+        $firstVersion = Get-ProjectAtlasRuntimeVersion $candidates[0]
+        Write-Warning "Bare 'projectatlas' resolves to $($candidates[0]) version '$firstVersion', not the verified runtime $VerifiedPath. Start a new shell, put $(Split-Path -Parent $VerifiedPath) first on PATH, or remove the obsolete shim."
+    }
+    foreach ($candidate in $candidates) {
+        $normalized = Get-NormalizedPathEntry $candidate
+        if ($normalized -eq $verified) {
+            continue
+        }
+        if (-not (Test-ProjectAtlasRuntime $candidate $ExpectedVersion)) {
+            $version = Get-ProjectAtlasRuntimeVersion $candidate
+            Write-Warning "Obsolete ProjectAtlas runtime or shim still exists on PATH: $candidate version '$version'. It was not removed automatically."
+        }
+    }
 }
 
 function Invoke-Checked {
@@ -300,6 +354,7 @@ else {
     Set-ProjectAtlasPathPrecedence $projectAtlas
 }
 Invoke-Checked $projectAtlas @("--format", "json", "runtime-info") | Out-Null
+Write-ProjectAtlasPathShadowReport $projectAtlas $ProjectAtlasVersion
 
 $atlasDir = Join-Path $ProjectRoot ".projectatlas"
 New-Item -ItemType Directory -Force -Path $atlasDir | Out-Null
@@ -340,6 +395,7 @@ Write-ProjectAtlasMcpConfig $claudeMcpConfigPath "claude-code"
 Write-ProjectAtlasMcpConfig $opencodeConfigPath "opencode"
 
 Write-Output "ProjectAtlas runtime installed and verified: $projectAtlas"
+Write-Output "ProjectAtlas update preserved project state under $atlasDir; use reset-index --apply for explicit state cleanup."
 Write-Output "Project-local MCP config written: $mcpConfigPath"
 Write-Output "Project-local Claude Code MCP config written: $claudeMcpConfigPath"
 Write-Output "Project-local OpenCode MCP config written: $opencodeConfigPath"

--- a/plugins/projectatlas/scripts/install-runtime.sh
+++ b/plugins/projectatlas/scripts/install-runtime.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+# Purpose: Install or update the ProjectAtlas plugin runtime and POSIX MCP configs.
 set -eu
 
 repository=${PROJECTATLAS_REPOSITORY:-https://github.com/styler-ai/ProjectAtlas}
@@ -76,6 +77,46 @@ is_projectatlas_runtime() {
       return 1
       ;;
   esac
+}
+
+runtime_version() {
+  candidate=$1
+  runtime_info=$("$candidate" --format json runtime-info 2>/dev/null || true)
+  printf '%s\n' "$runtime_info" | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1
+}
+
+canonical_file() {
+  file=$1
+  dir=$(CDPATH= cd -- "$(dirname -- "$file")" 2>/dev/null && pwd -P) || {
+    printf '%s\n' "$file"
+    return 0
+  }
+  printf '%s/%s\n' "$dir" "$(basename -- "$file")"
+}
+
+warn_path_shadow() {
+  verified=$1
+  verified_canonical=$(canonical_file "$verified")
+  first=$(command -v projectatlas 2>/dev/null || true)
+  if [ -z "$first" ]; then
+    printf '%s\n' "warning: bare 'projectatlas' is not on PATH. Generated MCP configs use the verified absolute runtime: $verified" >&2
+  elif [ "$(canonical_file "$first")" != "$verified_canonical" ]; then
+    first_version=$(runtime_version "$first")
+    printf '%s\n' "warning: bare 'projectatlas' resolves to $first version '$first_version', not the verified runtime $verified. Put $(dirname -- "$verified") first on PATH or remove the obsolete shim." >&2
+  fi
+  old_ifs=$IFS
+  IFS=:
+  for entry in $PATH; do
+    candidate=$entry/projectatlas
+    if [ ! -x "$candidate" ] || [ "$(canonical_file "$candidate")" = "$verified_canonical" ]; then
+      continue
+    fi
+    if ! is_projectatlas_runtime "$candidate"; then
+      version=$(runtime_version "$candidate")
+      printf '%s\n' "warning: obsolete ProjectAtlas runtime or shim still exists on PATH: $candidate version '$version'. It was not removed automatically." >&2
+    fi
+  done
+  IFS=$old_ifs
 }
 
 install_release_binary() {
@@ -171,6 +212,7 @@ else
 fi
 
 "$projectatlas_bin" --format json runtime-info >/dev/null
+warn_path_shadow "$projectatlas_bin"
 
 atlas_dir="$project_root/.projectatlas"
 mkdir -p "$atlas_dir"
@@ -201,6 +243,7 @@ write_mcp_config "$claude_mcp_config_path" claude-code
 write_mcp_config "$opencode_config_path" opencode
 
 printf 'ProjectAtlas runtime installed and verified: %s\n' "$projectatlas_bin"
+printf 'ProjectAtlas update preserved project state under %s; use reset-index --apply for explicit state cleanup.\n' "$atlas_dir"
 printf 'Project-local MCP config written: %s\n' "$mcp_config_path"
 printf 'Project-local Claude Code MCP config written: %s\n' "$claude_mcp_config_path"
 printf 'Project-local OpenCode MCP config written: %s\n' "$opencode_config_path"


### PR DESCRIPTION
## Summary

- Fixes #177, #180, #181, #182, #183, #184, #185, #186, #187, #188.
- Bumps ProjectAtlas/plugin/runtime pins to v0.3.7.
- Adds root diagnostics, MCP server identity, runtime executable diagnostics, PATH-shadow installer warnings, stricter metadata validation, token trend buckets, and holistic plugin update coverage.

## Verification

- `cargo fmt --check --all`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo deny check`
- `cargo test --workspace --all-features --locked`
- `cargo test --doc --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked`
- `cargo run --locked -p projectatlas-cli -- --format json scan .`
- `cargo run --locked -p projectatlas-cli -- parity report --profile repository-intelligence`
- `cargo run --locked -p projectatlas-cli -- lint --strict-folders --report-untracked`
- `cargo run --locked -p projectatlas-cli -- map --force`
- `git diff --check`
- `git diff --exit-code -- .projectatlas/projectatlas.toon .projectatlas/projectatlas-nonsource-files.toon`

## Release

Pushing this version bump to `main` should dispatch `release.yml` for `v0.3.7` via `03-Auto-Release`.
