### PR TITLE
ci(release): automate Codex-style release notes (#190)

### DIFF
--- a/.github/scripts/release-notes.py
+++ b/.github/scripts/release-notes.py
@@ -1,0 +1,188 @@
+"""Purpose: Generate ProjectAtlas release notes from merged PRs and linked issues."""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+def run(args, check=True):
+    process = subprocess.run(args, capture_output=True, text=True)
+    if check and process.returncode:
+        raise SystemExit(
+            f"command failed: {' '.join(args)}\n{process.stderr.strip()}"
+        )
+    return process
+
+
+def clean(text):
+    return " ".join((text or "").replace("\r", "").split())
+
+
+def note_title(text):
+    title = re.sub(r"^(bug|feat|fix|docs|chore):\s*", "", clean(text), flags=re.I)
+    return title[:1].upper() + title[1:]
+
+
+SECTIONS = ("New Features", "Bug Fixes", "Chores")
+
+
+def pr_summary(body, fallback):
+    lines = (body or "").splitlines()
+    in_summary = False
+    summary = []
+    for raw in lines:
+        line = raw.strip()
+        if line.startswith("## "):
+            if in_summary:
+                break
+            in_summary = line.lstrip("#").strip().lower() == "summary"
+            continue
+        if in_summary and line:
+            if line.startswith(("- ", "* ")):
+                line = line[2:].strip()
+            summary.append(clean(line))
+    if summary:
+        return summary[:3]
+    for raw in lines:
+        line = raw.strip()
+        if line and not line.startswith("#"):
+            return [clean(line[2:] if line.startswith(("- ", "* ")) else line)]
+    return [fallback]
+
+
+def issue_numbers(body):
+    seen = set()
+    numbers = []
+    for match in re.finditer(r"#([0-9]+)", body or ""):
+        number = int(match.group(1))
+        if number not in seen:
+            seen.add(number)
+            numbers.append(number)
+    return numbers
+
+
+def section_for(title="", labels=()):
+    names = {label.get("name", "") for label in labels}
+    lowered = title.lower()
+    if "type:bug" in names or lowered.startswith(("fix", "bug")):
+        return "Bug Fixes"
+    if "type:feature" in names or lowered.startswith(("feat", "feature")):
+        return "New Features"
+    return "Chores"
+
+
+def gh_json(endpoint):
+    return json.loads(
+        run(
+            [
+                "gh",
+                "api",
+                endpoint,
+                "-H",
+                "Accept: application/vnd.github+json",
+            ]
+        ).stdout
+    )
+
+
+def previous_tag(version):
+    process = run(["git", "describe", "--tags", "--abbrev=0", f"{version}^"], False)
+    return process.stdout.strip() if process.returncode == 0 else ""
+
+
+def merged_prs(repo, start_tag):
+    range_spec = f"{start_tag}..HEAD" if start_tag else "HEAD"
+    shas = run(["git", "rev-list", "--reverse", range_spec]).stdout.splitlines()
+    prs = []
+    seen = set()
+    for sha in shas:
+        for pr in gh_json(f"/repos/{repo}/commits/{sha}/pulls"):
+            number = pr.get("number")
+            if pr.get("merged_at") and number not in seen:
+                seen.add(number)
+                prs.append(pr)
+    return prs
+
+
+def issue(repo, number):
+    try:
+        item = gh_json(f"/repos/{repo}/issues/{number}")
+    except SystemExit:
+        return None
+    if "pull_request" in item:
+        return None
+    return item
+
+
+def write_notes(repo, version):
+    start_tag = previous_tag(version)
+    prs = merged_prs(repo, start_tag)
+    sections = {name: [] for name in SECTIONS}
+    changelog = []
+
+    for pr in prs:
+        author = pr.get("user", {}).get("login", "unknown")
+        changelog.append(f"- #{pr['number']} {clean(pr['title'])} @{author}")
+        fixed = [item for item in (issue(repo, number) for number in issue_numbers(pr.get("body"))) if item]
+        if fixed:
+            for item in fixed:
+                section = section_for(item.get("title", ""), item.get("labels", []))
+                sections[section].append(
+                    f"- {note_title(item['title'])}. ([#{item['number']}]({item['html_url']}), [#{pr['number']}]({pr['html_url']}))"
+                )
+        else:
+            section = section_for(pr.get("title", ""))
+            for line in pr_summary(pr.get("body"), pr["title"]):
+                sections[section].append(f"- {line} ([#{pr['number']}]({pr['html_url']}))")
+
+    wrote_section = False
+    for name in SECTIONS:
+        items = sections[name]
+        if not items:
+            continue
+        wrote_section = True
+        print(f"## {name}")
+        print()
+        print("\n".join(items))
+        print()
+    if not wrote_section:
+        print("## Chores")
+        print()
+        print("- No user-facing changes were identified for this release.")
+        print()
+
+    print("## Changelog")
+    print()
+    if start_tag:
+        print(f"Full Changelog: https://github.com/{repo}/compare/{start_tag}...{version}")
+    else:
+        print(f"Full Changelog: https://github.com/{repo}/commits/{version}")
+    print()
+    print("\n".join(changelog))
+
+
+def self_test():
+    body = """## Summary
+
+- First fix.
+- Second fix.
+
+## Verification
+
+- cargo test
+"""
+    assert pr_summary(body, "fallback") == ["First fix.", "Second fix."]
+    assert issue_numbers("Fixes #177, #180 and resolves #188.") == [177, 180, 188]
+    assert note_title("bug: stale runtime remains") == "Stale runtime remains"
+    assert section_for("fix(db): reject stale paths") == "Bug Fixes"
+    assert section_for("feat(cli): add root diagnostics") == "New Features"
+    print("release notes self-test passed")
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        self_test()
+    else:
+        write_notes(os.environ["GITHUB_REPOSITORY"], os.environ["RELEASE_VERSION"])

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
 
 permissions:
   contents: write
+  issues: read
+  pull-requests: read
 
 env:
   RELEASE_VERSION: ${{ inputs.version }}
@@ -56,6 +58,9 @@ jobs:
 
       - name: Rustdoc
         run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked
+
+      - name: Release notes generator self-test
+        run: python3 .github/scripts/release-notes.py --self-test
 
       - name: Verify version
         run: |
@@ -355,6 +360,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Download artifacts
         uses: actions/download-artifact@v8
@@ -378,9 +385,10 @@ jobs:
 
       - name: Create GitHub release
         run: |
+          python3 .github/scripts/release-notes.py > release-notes.md
           gh release create "$RELEASE_VERSION" release-assets/* \
             --title "$RELEASE_VERSION" \
-            --generate-notes
+            --notes-file release-notes.md
 
   installer-smoke-unix:
     name: installer smoke ${{ matrix.label }}

--- a/.projectatlas/config.toml
+++ b/.projectatlas/config.toml
@@ -23,6 +23,8 @@ line_comment_prefixes = ["//", "#", "--", ";"]
 [purpose.styles_by_extension]
 ".md" = "line-comment"
 ".rs" = "line-comment"
+".yaml" = "line-comment"
+".yml" = "line-comment"
 
 [summary_rules]
 ascii_only = true

--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,9 +1,9 @@
 version: 1
-generated_at: unix:1782711088
-file_hash: "e09dd4ce7388ddf15e41afb30f15f6a4a9dd57ee257fe3aab31dda7dc6160d22"
-folder_hash: "f5ec84a38eaa8b9ee18c1d22563973db7217f346e2815ff1fa6abb9273e95036"
+generated_at: unix:1782715134
+file_hash: "b4e4a9aad88bce6245b10e432cb5a9ed202fffe36def1959593e9f5ddab63260"
+folder_hash: "b88b72a9bca4a994c317ad6861ab4182cebbd93179a6a18c5ce6d184a8264407"
 root: .
-overview: tracked_source_files=96 tracked_nonsource_files=37 tracked_files_total=133 tracked_folders=58 source_extensions=122 exclude_dir_names=9 exclude_path_prefixes=0
+overview: tracked_source_files=97 tracked_nonsource_files=37 tracked_files_total=134 tracked_folders=59 source_extensions=122 exclude_dir_names=9 exclude_path_prefixes=0
 source_extensions[]:
   - .astro
   - .bash
@@ -138,13 +138,14 @@ exclude_dir_names[]:
   - node_modules
   - target
 exclude_path_prefixes[]:
-folders[58]{path,summary,source}:
+folders[59]{path,summary,source}:
   .,ProjectAtlas repository root.,database
   .agents,Agent marketplace metadata for ProjectAtlas.,database
   .agents/plugins,Codex plugin marketplace catalog for ProjectAtlas.,database
   .githooks,Git hook scripts for ProjectAtlas commits.,database
   .github,ProjectAtlas GitHub metadata and workflows.,database
   .github/ISSUE_TEMPLATE,GitHub issue forms for public bug reports and improvement requests.,database
+  .github/scripts,ProjectAtlas GitHub automation helper scripts.,database
   .github/workflows,ProjectAtlas CI and release workflows.,database
   crates,Rust workspace crates for ProjectAtlas 3.,database
   crates/projectatlas-cli,Command-line adapter for ProjectAtlas 3.,database
@@ -197,7 +198,7 @@ folders[58]{path,summary,source}:
   skills/claude,Claude guidance for ProjectAtlas usage.,database
   skills/codex,Codex guidance for ProjectAtlas usage.,database
   templates,Reusable agent templates and snippets.,database
-files[104]{path,summary,source}:
+files[105]{path,summary,source}:
   .agents/plugins/marketplace.json,Codex plugin marketplace catalog for ProjectAtlas,database
   .gitattributes,Line-ending policy for ProjectAtlas repository fixtures,nonsource
   .githooks/commit-msg,Git hook to enforce issue references in commits,nonsource
@@ -206,6 +207,7 @@ files[104]{path,summary,source}:
   .github/ISSUE_TEMPLATE/config.yml,GitHub issue template chooser configuration for ProjectAtlas.,database
   .github/ISSUE_TEMPLATE/improvement_request.yml,GitHub issue form for public ProjectAtlas improvement requests.,database
   .github/pull_request_template.md,Pull request checklist for ProjectAtlas,database
+  .github/scripts/release-notes.py,Generate ProjectAtlas release notes from merged PRs and linked issues.,database
   .github/workflows/03-auto-release.yml,ProjectAtlas auto release workflow,database
   .github/workflows/04-docs.yml,ProjectAtlas docs site workflow,database
   .github/workflows/ci.yml,ProjectAtlas CI workflow,database
@@ -311,6 +313,7 @@ folder_tree[]:
   - .githooks/ - Git hook scripts for ProjectAtlas commits.
   - .github/ - ProjectAtlas GitHub metadata and workflows.
   - "  ISSUE_TEMPLATE/ - GitHub issue forms for public bug reports and improvement requests."
+  - "  scripts/ - ProjectAtlas GitHub automation helper scripts."
   - "  workflows/ - ProjectAtlas CI and release workflows."
   - crates/ - Rust workspace crates for ProjectAtlas 3.
   - "  projectatlas-cli/ - Command-line adapter for ProjectAtlas 3."


### PR DESCRIPTION
## Summary

- Fixes #190.
- Replaces GitHub default generated release notes with a Codex-style release notes generator run by `02-Release`.
- Emits `New Features`, `Bug Fixes`, `Chores`, and `Changelog` sections from merged PRs and linked issues in the release range.

## Verification

- `python .github/scripts/release-notes.py --self-test`
- `GITHUB_REPOSITORY=styler-ai/ProjectAtlas RELEASE_VERSION=v0.3.7 python .github/scripts/release-notes.py`
- `projectatlas --require-version 0.3.7 scan .`
- `projectatlas --require-version 0.3.7 map --force`
- `projectatlas --require-version 0.3.7 lint --strict-folders --report-untracked`
- `git diff --check`