### PR TITLE
feat(purpose): improve curation and Gradle DSL signals

### DIFF
--- a/.projectatlas/projectatlas.toon
+++ b/.projectatlas/projectatlas.toon
@@ -1,9 +1,9 @@
 version: 1
-generated_at: unix:1782718500
-file_hash: "19adf1e8f7533ff5e0a386adc36ea57fb35a95afa88a3cd81e43b1b99e68fda3"
-folder_hash: "b88b72a9bca4a994c317ad6861ab4182cebbd93179a6a18c5ce6d184a8264407"
+generated_at: unix:1782725765
+file_hash: "ac8644ce79a4cc96e9ac498ed995ee8ff698ea0cc82ae2d381f03d5a5b42e7c0"
+folder_hash: "33ae57e42f0cff932b5a373f7f64f7cf2bfd56e13da3c7223d7ee1e03be536b3"
 root: .
-overview: tracked_source_files=96 tracked_nonsource_files=37 tracked_files_total=133 tracked_folders=59 source_extensions=122 exclude_dir_names=9 exclude_path_prefixes=0
+overview: tracked_source_files=99 tracked_nonsource_files=37 tracked_files_total=136 tracked_folders=60 source_extensions=122 exclude_dir_names=9 exclude_path_prefixes=0
 source_extensions[]:
   - .astro
   - .bash
@@ -138,7 +138,7 @@ exclude_dir_names[]:
   - node_modules
   - target
 exclude_path_prefixes[]:
-folders[59]{path,summary,source}:
+folders[60]{path,summary,source}:
   .,ProjectAtlas repository root.,database
   .agents,Agent marketplace metadata for ProjectAtlas.,database
   .agents/plugins,Codex plugin marketplace catalog for ProjectAtlas.,database
@@ -172,6 +172,7 @@ folders[59]{path,summary,source}:
   fixtures/languages/csharp,C# fixture folder for parser and summary baseline coverage.,database
   fixtures/languages/css,Store CSS structural summary fixtures,database
   fixtures/languages/go,Go fixture folder for parser and summary baseline coverage.,database
+  fixtures/languages/groovy,Provide Gradle Groovy DSL fixtures for language extraction tests.,database
   fixtures/languages/html,Store HTML structural summary fixtures,database
   fixtures/languages/java,Java fixture folder for parser and summary baseline coverage.,database
   fixtures/languages/javascript,JavaScript fixture folder for parser and summary baseline coverage.,database
@@ -198,7 +199,7 @@ folders[59]{path,summary,source}:
   skills/claude,Claude guidance for ProjectAtlas usage.,database
   skills/codex,Codex guidance for ProjectAtlas usage.,database
   templates,Reusable agent templates and snippets.,database
-files[104]{path,summary,source}:
+files[107]{path,summary,source}:
   .agents/plugins/marketplace.json,Codex plugin marketplace catalog for ProjectAtlas,database
   .gitattributes,Line-ending policy for ProjectAtlas repository fixtures,nonsource
   .githooks/commit-msg,Git hook to enforce issue references in commits,nonsource
@@ -246,6 +247,7 @@ files[104]{path,summary,source}:
   crates/projectatlas-service/src/lib.rs,Provide shared `ProjectAtlas` query services for CLI and MCP adapters.,database
   crates/projectatlas-symbols/Cargo.toml,Symbol extraction crate manifest and tree-sitter dependencies,database
   crates/projectatlas-symbols/src/languages/c_family.rs,Reserves the C and C++ language augmentation boundary for parser-specific corrections.,database
+  crates/projectatlas-symbols/src/languages/gradle.rs,Extract Gradle Kotlin and Groovy DSL task registrations as symbols.,database
   crates/projectatlas-symbols/src/languages/kotlin.rs,"Adds Kotlin package, type, and method facts that the generic tree-sitter pass does not emit reliably.",database
   crates/projectatlas-symbols/src/languages/mod.rs,Dispatches language-specific symbol graph augmentation and shared helper behavior for augmentation modules.,database
   crates/projectatlas-symbols/src/languages/objective_c.rs,Adds Objective-C class ownership and de-duplicates interface versus implementation symbols for summaries.,database
@@ -276,11 +278,13 @@ files[104]{path,summary,source}:
   fixtures/languages/csharp/Runner.cs,Exercise C# type and method summary extraction.,database
   fixtures/languages/css/tokens.css,Exercise CSS selector and token summaries,database
   fixtures/languages/go/service.go,"Exercise Go type, method, function, and import summary extraction.",database
+  fixtures/languages/groovy/build.gradle,Exercise Gradle Groovy DSL task extraction fixtures.,database
   fixtures/languages/html/index.html,Exercise HTML metadata and heading summaries,database
   fixtures/languages/java/AtlasService.java,Exercise Java class and method summary extraction.,database
   fixtures/languages/javascript/service.js,Exercise JavaScript exported and local function summary extraction.,database
   fixtures/languages/json/package.json,Exercise package manifest summary extraction,database
   fixtures/languages/kotlin/Runner.kt,Exercise Kotlin class and function summary extraction.,database
+  fixtures/languages/kotlin/build.gradle.kts,Exercise Gradle Kotlin DSL task extraction fixtures.,database
   fixtures/languages/markdown/readme.md,Exercise Markdown heading summary extraction,database
   fixtures/languages/objective-c/UserManager.m,Exercise Objective-C type and method summary extraction.,database
   fixtures/languages/rust/build.rs,Exercise Rust build-script language detection and summary extraction.,database
@@ -339,6 +343,7 @@ folder_tree[]:
   - "    csharp/ - C# fixture folder for parser and summary baseline coverage."
   - "    css/ - Store CSS structural summary fixtures"
   - "    go/ - Go fixture folder for parser and summary baseline coverage."
+  - "    groovy/ - Provide Gradle Groovy DSL fixtures for language extraction tests."
   - "    html/ - Store HTML structural summary fixtures"
   - "    java/ - Java fixture folder for parser and summary baseline coverage."
   - "    javascript/ - JavaScript fixture folder for parser and summary baseline coverage."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "regex",
  "serde",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-db"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "projectatlas-core",
  "rusqlite",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-fs"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "blake3",
  "ignore",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-service"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "globset",
  "projectatlas-core",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-symbols"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "projectatlas-core",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/styler-ai/ProjectAtlas"
@@ -68,11 +68,11 @@ must_use_candidate = "allow"
 missing_inline_in_public_items = "allow"
 
 [workspace.dependencies]
-projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.8" }
-projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.8" }
-projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.8" }
-projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.8" }
-projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.8" }
+projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.9" }
+projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.9" }
+projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.9" }
+projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.9" }
+projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.9" }
 blake3 = "1.5"
 clap = { version = "4.5", features = ["derive"] }
 cssparser = "0.37"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.3.8"><img alt="release" src="https://img.shields.io/badge/release-v0.3.8-blue"></a>
+  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.3.9"><img alt="release" src="https://img.shields.io/badge/release-v0.3.9-blue"></a>
   <img alt="rust" src="https://img.shields.io/badge/Rust-2024-orange">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-green">
 </p>
@@ -25,7 +25,7 @@ No required `.purpose` files. No source-header tax. No hosted index. The project
 ## Quickstart
 
 ```bash
-codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.8
+codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.9
 codex plugin add projectatlas --marketplace projectatlas
 ```
 
@@ -158,7 +158,7 @@ Most users can stop at the plugin install. The CLI is here for local debugging, 
 Only need the CLI yourself? Install it from the released tag:
 
 ```bash
-cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.3.8 --package projectatlas-cli --locked
+cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.3.9 projectatlas-cli --locked
 ```
 
 From this checkout:
@@ -237,7 +237,8 @@ ProjectAtlas exposes the same workflow through CLI and MCP:
 | See symbols | `projectatlas symbols list --file <file>` | `atlas_symbols` |
 | Search narrowly | `projectatlas search <pattern> --file-pattern <glob>` | `atlas_search` |
 | Read exact code | `projectatlas slice <file> --start-line <n> --end-line <m>` | `atlas_slice` |
-| Find cleanup work | `projectatlas health-check` | `atlas_health` |
+| Find cleanup work | `projectatlas health-check --source-only --limit <n>` | `atlas_health` |
+| Curate purposes | `projectatlas purpose queue --limit <n>` / `projectatlas purpose set <path> "<purpose>"` | `atlas_purpose_queue` / `atlas_purpose_set` |
 | Report savings | `projectatlas token` | `atlas_token_report` |
 
 ## Why Rust
@@ -248,7 +249,7 @@ ProjectAtlas scans with `.gitignore` awareness, hashes files with BLAKE3, stores
 
 ## Release Quality
 
-`v0.3.8` ships through the full release matrix:
+`v0.3.9` ships through the full release matrix:
 
 - Rust format, check, clippy, dependency policy, tests, doctests, and rustdoc.
 - ProjectAtlas scan, parity, lint, and map drift checks.

--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -10,31 +10,35 @@ use atlas_map::{
     init_project, lint_map, list_ignore_entries, load_atlas_config, remove_ignore_entry, write_map,
 };
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use projectatlas_core::health::Severity;
 use projectatlas_core::outline::build_outline;
 use projectatlas_core::telemetry::{
     TokenOverview, TokenTrendReport, TokenTrendWindow as CoreTokenTrendWindow,
 };
 use projectatlas_core::toon::{
-    encode_agent_payload, render_health, render_node_rows, render_nodes, render_outline,
-    render_overview, render_symbol_relations, render_symbols, render_token_overview,
-    render_token_trends,
+    encode_agent_payload, render_node_rows, render_nodes, render_outline, render_overview,
+    render_symbol_relations, render_symbols, render_token_overview, render_token_trends,
 };
-use projectatlas_core::{NodeKind, PurposeSource, normalize_native_path_display};
-use projectatlas_db::{AtlasStore, DbError, HealthResolution};
+use projectatlas_core::{
+    NodeKind, PurposeSource, normalize_native_path_display, normalize_repo_path_prefix,
+};
+use projectatlas_db::{AtlasStore, DbError, HealthQuery, HealthResolution};
 use projectatlas_service::{
     CodeSlice, FileSummaryReport, SearchReport, SymbolSliceSelector, build_file_summary,
     read_indexed_code_slice, read_symbol_slice, search_indexed_files,
 };
 use runtime::{
-    MAX_SYMBOL_FILE_BYTES, ScanRuntimePlan, SettingsReport, SymbolBuildOptions, WatchStatusReport,
-    absolute_path, build_settings_report, build_symbols_for_index, byte_count_to_tokens,
-    canonical_project_root, default_mcp_project_root, defaultable_cli_project_root,
+    DEFAULT_HEALTH_LIMIT, MAX_HEALTH_LIMIT, MAX_SYMBOL_FILE_BYTES, ScanRuntimePlan, SettingsReport,
+    SymbolBuildOptions, WatchStatusReport, absolute_path, build_settings_report,
+    build_symbols_for_index, byte_count_to_tokens, canonical_project_root,
+    default_mcp_project_root, defaultable_cli_project_root,
     estimated_source_tokens_for_indexed_files, estimated_source_tokens_for_paths,
     file_summary_usage_baseline, lint_database_if_present, normalized_folder_filter,
-    open_atlas_store, ranked_file_nodes, read_indexed_file_content,
+    open_atlas_store, purpose_curation_page, ranked_file_nodes, read_indexed_file_content,
     record_directory_walk_usage_estimate, record_usage_estimate, record_usage_text,
-    reset_index_files, resolved_mcp_config_path, run_scan_pipeline, run_watch_loop,
-    strip_legacy_purpose, validated_indexed_file_key, watcher_status_report,
+    render_health_page, render_purpose_curation_page, reset_index_files, resolved_mcp_config_path,
+    run_scan_pipeline, run_watch_loop, strip_legacy_purpose, validated_indexed_file_key,
+    watcher_status_report,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -141,6 +145,27 @@ impl From<TokenTrendWindow> for CoreTokenTrendWindow {
     }
 }
 
+/// Health severity filter accepted by CLI commands.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum HealthSeverityArg {
+    /// Informational finding.
+    Info,
+    /// Warning finding.
+    Warning,
+    /// Error finding.
+    Error,
+}
+
+impl From<HealthSeverityArg> for Severity {
+    fn from(value: HealthSeverityArg) -> Self {
+        match value {
+            HealthSeverityArg::Info => Self::Info,
+            HealthSeverityArg::Warning => Self::Warning,
+            HealthSeverityArg::Error => Self::Error,
+        }
+    }
+}
+
 /// Manual `ProjectAtlas` ignore entry kind for CLI input.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum IgnoreKind {
@@ -243,6 +268,9 @@ enum Command {
         /// Optional repository-relative glob filter.
         #[arg(long)]
         file_pattern: Option<String>,
+        /// Include indexed file text as a bounded fallback ranking signal.
+        #[arg(long, default_value_t = false)]
+        include_content: bool,
         /// Maximum number of files to return.
         #[arg(long, default_value_t = 10)]
         limit: usize,
@@ -365,7 +393,29 @@ enum Command {
         text_index_max_bytes: Option<u64>,
     },
     /// Report structural health findings.
-    HealthCheck,
+    HealthCheck {
+        /// Pagination start index after filters are applied.
+        #[arg(long, default_value_t = 0)]
+        start_index: usize,
+        /// Maximum findings to return.
+        #[arg(long, default_value_t = DEFAULT_HEALTH_LIMIT)]
+        limit: usize,
+        /// Optional finding category filter.
+        #[arg(long)]
+        category: Option<String>,
+        /// Optional severity filter.
+        #[arg(long, value_enum)]
+        severity: Option<HealthSeverityArg>,
+        /// Optional repository-relative primary or related path prefix.
+        #[arg(long)]
+        path_prefix: Option<String>,
+        /// Return counts and paging metadata without finding rows.
+        #[arg(long)]
+        summary_only: bool,
+        /// Restrict findings to source files and folders that contain source files.
+        #[arg(long)]
+        source_only: bool,
+    },
     /// Resolve a deterministic health finding with agent rationale.
     Health {
         /// Health subcommand to run.
@@ -501,6 +551,30 @@ enum PurposeCommand {
         path: String,
         /// Agent-approved purpose one-liner.
         purpose: String,
+    },
+    /// Return a bounded queue of paths that need purpose curation.
+    Queue {
+        /// Pagination start index after filters are applied.
+        #[arg(long, default_value_t = 0)]
+        start_index: usize,
+        /// Maximum findings to return.
+        #[arg(long, default_value_t = DEFAULT_HEALTH_LIMIT)]
+        limit: usize,
+        /// Optional finding category filter.
+        #[arg(long)]
+        category: Option<String>,
+        /// Optional severity filter.
+        #[arg(long, value_enum)]
+        severity: Option<HealthSeverityArg>,
+        /// Optional repository-relative primary or related path prefix.
+        #[arg(long)]
+        path_prefix: Option<String>,
+        /// Return counts and paging metadata without queue rows.
+        #[arg(long)]
+        summary_only: bool,
+        /// Include non-source files and asset-only folders in the queue.
+        #[arg(long)]
+        include_assets: bool,
     },
 }
 
@@ -681,6 +755,7 @@ fn run() -> Result<(), CliError> {
             query,
             folder,
             file_pattern,
+            include_content,
             limit,
         } => {
             let store = open_atlas_store(&cli.db)?;
@@ -695,6 +770,7 @@ fn run() -> Result<(), CliError> {
                 folder_filter.as_deref(),
                 file_pattern.as_deref(),
                 *limit,
+                *include_content,
             )?;
             let baseline_tokens = estimated_source_tokens_for_indexed_files(
                 &store,
@@ -1037,10 +1113,28 @@ fn run() -> Result<(), CliError> {
                 &report,
             )?;
         }
-        Command::HealthCheck => {
+        Command::HealthCheck {
+            start_index,
+            limit,
+            category,
+            severity,
+            path_prefix,
+            summary_only,
+            source_only,
+        } => {
             let store = open_atlas_store(&cli.db)?;
-            let findings = store.unresolved_health_findings(&store.resolved_health_ids()?)?;
-            let toon = render_health(&findings);
+            let query = health_query_from_cli(
+                *start_index,
+                *limit,
+                category.as_deref(),
+                *severity,
+                path_prefix.as_deref(),
+                *summary_only,
+                *source_only,
+            );
+            let page =
+                store.unresolved_health_findings_page(&store.resolved_health_ids()?, &query)?;
+            let toon = render_health_page(&page, &query);
             print_tracked_directory_output_estimate(
                 cli.format,
                 &store,
@@ -1050,7 +1144,7 @@ fn run() -> Result<(), CliError> {
                 None,
                 estimated_source_tokens_for_indexed_files(&store, None, None)?,
                 &toon,
-                &findings,
+                &page,
             )?;
         }
         Command::Health { command } => match command {
@@ -1201,6 +1295,28 @@ fn run() -> Result<(), CliError> {
                 let store = open_atlas_store(&cli.db)?;
                 store.set_purpose(path, purpose, PurposeSource::Agent)?;
                 write_stdout(&format!("purpose set: {path}\n"))?;
+            }
+            PurposeCommand::Queue {
+                start_index,
+                limit,
+                category,
+                severity,
+                path_prefix,
+                summary_only,
+                include_assets,
+            } => {
+                let store = open_atlas_store(&cli.db)?;
+                let query = health_query_from_cli(
+                    *start_index,
+                    *limit,
+                    category.as_deref(),
+                    *severity,
+                    path_prefix.as_deref(),
+                    *summary_only,
+                    !*include_assets,
+                );
+                let page = purpose_curation_page(&store, &query)?;
+                print_output(cli.format, &render_purpose_curation_page(&page), &page)?;
             }
         },
     }
@@ -1480,6 +1596,36 @@ fn serialized_output<T: serde::Serialize>(
         OutputFormat::Toon => Ok(toon.to_string()),
         OutputFormat::Json => Ok(format!("{}\n", serde_json::to_string_pretty(payload)?)),
     }
+}
+
+/// Build a bounded DB health query from CLI filter arguments.
+fn health_query_from_cli(
+    start_index: usize,
+    limit: usize,
+    category: Option<&str>,
+    severity: Option<HealthSeverityArg>,
+    path_prefix: Option<&str>,
+    summary_only: bool,
+    source_only: bool,
+) -> HealthQuery {
+    HealthQuery {
+        start_index,
+        limit: limit.clamp(1, MAX_HEALTH_LIMIT),
+        category: trimmed_cli_filter(category),
+        severity: severity.map(Severity::from),
+        path_prefix: trimmed_cli_filter(path_prefix)
+            .map(|value| normalize_repo_path_prefix(&value)),
+        summary_only,
+        source_only,
+    }
+}
+
+/// Return a trimmed non-empty CLI string filter.
+fn trimmed_cli_filter(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 /// Record estimated-token telemetry for the exact emitted CLI payload.
@@ -2238,7 +2384,28 @@ mod tests {
                 "src/empty.rs",
                 "rust source file with no declarations found."
             ),
-            "Implement empty."
+            "Implement the empty source."
+        );
+        assert_eq!(
+            suggest_file_purpose(
+                "src/customers/service.rs",
+                "rust source defining type and function CustomerService, boot."
+            ),
+            "Implement the customers service source around CustomerService and boot."
+        );
+        assert_eq!(
+            suggest_file_purpose(
+                "build.gradle.kts",
+                "kotlin source defining functions bootRunE2E, copyE2EReports, verifyAtlas."
+            ),
+            "Define Gradle build tasks around bootRunE2E, copyE2EReports, and verifyAtlas."
+        );
+        assert_eq!(
+            suggest_file_purpose(
+                "src/auth/session.test.ts",
+                "typescript source defining functions createsSession, rejectsExpiredSession."
+            ),
+            "Implement the auth session test source around createsSession and rejectsExpiredSession."
         );
     }
 
@@ -2915,6 +3082,7 @@ mod tests {
             || !health_text.contains("returned: 1")
             || !health_text.contains("limit: 1")
             || !health_text.contains("next_start_index: null")
+            || !health_text.contains("source_only: false")
             || !health_text.contains("path_prefix: src")
             || !health_text.contains("health_findings[1]")
             || health_text.contains("suggested-purpose-review")
@@ -2949,6 +3117,27 @@ mod tests {
         {
             return Err(format!(
                 "atlas_health summary_only result lost paging metadata: {summary_health_text}"
+            )
+            .into());
+        }
+
+        let purpose_queue = client
+            .peer()
+            .call_tool(CallToolRequestParams::new("atlas_purpose_queue").with_arguments(Map::new()))
+            .await?;
+        let purpose_queue_text = purpose_queue
+            .content
+            .first()
+            .and_then(|content| content.raw.as_text())
+            .map(|text| text.text.as_str())
+            .ok_or_else(|| std::io::Error::other("purpose queue result did not contain text"))?;
+        if !purpose_queue_text.contains("purpose_curation:")
+            || !purpose_queue_text.contains("source_only: true")
+            || !purpose_queue_text.contains("purpose_curation_items[")
+            || !purpose_queue_text.contains("suggested-purpose-review:src/main.rs:")
+        {
+            return Err(format!(
+                "atlas_purpose_queue result did not contain source-focused curation payload: {purpose_queue_text}"
             )
             .into());
         }

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -2,14 +2,14 @@
 //! Native MCP adapter for `ProjectAtlas` agent integrations.
 
 use crate::runtime::{
-    MAX_SYMBOL_FILE_BYTES, ScanRuntimePlan, SymbolBuildOptions, build_settings_report,
-    build_symbols_for_index, byte_count_to_tokens, canonical_project_root,
-    default_mcp_project_root, estimated_source_tokens_for_indexed_files,
+    DEFAULT_HEALTH_LIMIT, MAX_HEALTH_LIMIT, MAX_SYMBOL_FILE_BYTES, ScanRuntimePlan,
+    SymbolBuildOptions, build_settings_report, build_symbols_for_index, byte_count_to_tokens,
+    canonical_project_root, default_mcp_project_root, estimated_source_tokens_for_indexed_files,
     estimated_source_tokens_for_paths, file_summary_usage_baseline, normalized_folder_filter,
-    open_atlas_store, ranked_file_nodes, read_indexed_file_content,
+    open_atlas_store, purpose_curation_page, ranked_file_nodes, read_indexed_file_content,
     record_directory_walk_usage_estimate, record_usage_estimate, record_usage_text,
-    reset_index_files, run_scan_pipeline, run_watch_loop, strip_legacy_purpose,
-    validated_indexed_file_key, watcher_status_report,
+    render_health_page, render_purpose_curation_page, reset_index_files, run_scan_pipeline,
+    run_watch_loop, strip_legacy_purpose, validated_indexed_file_key, watcher_status_report,
 };
 use crate::{
     CliError, DEFAULT_FILE_SUMMARY_LIMIT, OutputFormat, build_parity_report, render_code_slice,
@@ -26,7 +26,7 @@ use projectatlas_core::toon::{
 use projectatlas_core::{
     NodeKind, PurposeSource, normalize_repo_path_prefix, validated_repo_node_key,
 };
-use projectatlas_db::{AtlasStore, HealthFindingsPage, HealthQuery, HealthResolution};
+use projectatlas_db::{AtlasStore, HealthQuery, HealthResolution};
 use projectatlas_service::{
     SymbolSliceSelector, build_file_summary, read_indexed_code_slice, read_symbol_slice,
     search_indexed_files,
@@ -38,11 +38,6 @@ use rmcp::{ServerHandler, ServiceExt, tool, tool_handler, tool_router};
 use serde::Deserialize;
 use serde_json::json;
 use std::path::PathBuf;
-
-/// Default MCP health rows returned when the caller does not request a page size.
-const DEFAULT_HEALTH_LIMIT: usize = 50;
-/// Maximum MCP health rows returned in one payload.
-const MAX_HEALTH_LIMIT: usize = 200;
 
 /// MCP tools required for the agent-first repository-intelligence surface.
 pub(crate) const REQUIRED_MCP_TOOL_NAMES: &[&str] = &[
@@ -66,6 +61,7 @@ pub(crate) const REQUIRED_MCP_TOOL_NAMES: &[&str] = &[
     "atlas_watch_once",
     "atlas_strip_legacy_purpose",
     "atlas_reset_index",
+    "atlas_purpose_queue",
     "atlas_purpose_set",
 ];
 
@@ -140,6 +136,8 @@ struct AtlasQueryParams {
     folder: Option<String>,
     /// Optional repository-relative glob filter.
     file_pattern: Option<String>,
+    /// Include indexed file text as a bounded fallback ranking signal.
+    include_content: Option<bool>,
     /// Maximum number of rows to return.
     limit: Option<usize>,
 }
@@ -239,6 +237,8 @@ struct AtlasHealthParams {
     path_prefix: Option<String>,
     /// Return counts and paging metadata without finding rows.
     summary_only: Option<bool>,
+    /// Restrict findings to source files and folders that contain source files.
+    source_only: Option<bool>,
 }
 
 /// MCP parameter payload for parity reports.
@@ -405,50 +405,8 @@ fn health_query_from_params(params: &AtlasHealthParams) -> Result<HealthQuery, C
         path_prefix: trimmed_filter(params.path_prefix.as_deref())
             .map(|value| normalize_repo_path_prefix(&value)),
         summary_only: params.summary_only.unwrap_or(false),
+        source_only: params.source_only.unwrap_or(false),
     })
-}
-
-/// Return a compact health report page for MCP agents.
-fn render_health_page(page: &HealthFindingsPage, query: &HealthQuery) -> String {
-    let rows = page
-        .findings
-        .iter()
-        .map(|finding| {
-            json!({
-                "severity": severity_name(finding.severity),
-                "id": finding.id,
-                "category": finding.category,
-                "path": finding.path,
-                "related_path": finding.related_path.as_deref().unwrap_or(""),
-                "message": finding.message,
-                "recommendation": finding.recommendation,
-            })
-        })
-        .collect::<Vec<_>>();
-    let page_width = page.limit.min(page.total.saturating_sub(page.start_index));
-    let page_end = page.start_index.saturating_add(page_width);
-    let next_start_index = if page_width == 0 || page_end >= page.total {
-        None
-    } else {
-        Some(page_end)
-    };
-    encode_agent_payload(&json!({
-        "health": {
-            "total": page.total,
-            "unfiltered_total": page.unfiltered_total,
-            "returned": page.returned,
-            "start_index": page.start_index,
-            "limit": page.limit,
-            "max_limit": MAX_HEALTH_LIMIT,
-            "next_start_index": next_start_index,
-            "truncated": next_start_index.is_some(),
-            "summary_only": query.summary_only,
-            "category": query.category.as_deref().unwrap_or(""),
-            "severity": query.severity.map_or("", severity_name),
-            "path_prefix": query.path_prefix.as_deref().unwrap_or(""),
-        },
-        "health_findings": rows,
-    }))
 }
 
 /// Return a trimmed non-empty string parameter.
@@ -457,15 +415,6 @@ fn trimmed_filter(value: Option<&str>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
-}
-
-/// Return a stable lowercase severity name.
-fn severity_name(severity: Severity) -> &'static str {
-    match severity {
-        Severity::Info => "info",
-        Severity::Warning => "warning",
-        Severity::Error => "error",
-    }
 }
 
 /// Parse an MCP health severity filter.
@@ -564,7 +513,7 @@ impl ProjectAtlasMcpServer {
     /// Rank files after an agent has chosen a folder or query.
     #[tool(
         name = "atlas_files",
-        description = "Rank repository files by query, purpose, and optional folder before an agent opens source."
+        description = "Rank repository files by query, purpose, optional folder, and optional indexed text fallback before an agent opens source."
     )]
     fn atlas_files(&self, Parameters(params): Parameters<AtlasQueryParams>) -> String {
         Self::as_mcp_text((|| {
@@ -581,6 +530,7 @@ impl ProjectAtlasMcpServer {
                 folder_filter.as_deref(),
                 params.file_pattern.as_deref(),
                 params.limit.unwrap_or(10),
+                params.include_content.unwrap_or(false),
             )?;
             let baseline_tokens = estimated_source_tokens_for_indexed_files(
                 &store,
@@ -1029,6 +979,33 @@ impl ProjectAtlasMcpServer {
                 params.include_mcp_config.unwrap_or(false),
             )?;
             Ok(encode_agent_payload(&json!({ "reset_index": report })))
+        })())
+    }
+
+    /// Return a bounded purpose curation queue.
+    #[tool(
+        name = "atlas_purpose_queue",
+        description = "Return a bounded source-focused queue of ProjectAtlas paths that need agent purpose curation."
+    )]
+    fn atlas_purpose_queue(&self, Parameters(mut params): Parameters<AtlasHealthParams>) -> String {
+        Self::as_mcp_text((|| {
+            if params.source_only.is_none() {
+                params.source_only = Some(true);
+            }
+            let store = self.open_store()?;
+            let query = health_query_from_params(&params)?;
+            let page = purpose_curation_page(&store, &query)?;
+            let toon = render_purpose_curation_page(&page);
+            record_directory_walk_usage_estimate(
+                &store,
+                &self.session,
+                "mcp.atlas_purpose_queue",
+                None,
+                None,
+                estimated_source_tokens_for_indexed_files(&store, None, None)?,
+                &toon,
+            )?;
+            Ok(toon)
         })())
     }
 

--- a/crates/projectatlas-cli/src/runtime.rs
+++ b/crates/projectatlas-cli/src/runtime.rs
@@ -11,6 +11,7 @@ use crate::{
     CliError, OutputFormat, WATCH_MODE_NOTIFY, WATCH_MODE_ONCE, WATCH_MODE_POLLING, truthy_env,
 };
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use projectatlas_core::health::Severity;
 use projectatlas_core::language::{LanguageParserSupport, language_spec};
 use projectatlas_core::outline::estimate_tokens;
 use projectatlas_core::symbols::{RelationKind, SymbolGraph, SymbolKind};
@@ -19,12 +20,13 @@ use projectatlas_core::telemetry::{
     TOKEN_BUCKET_NAVIGATION_AVOIDANCE, TOKEN_CONFIDENCE_INFERRED, TOKEN_CONFIDENCE_POLICY_ESTIMATE,
     usage_from_estimates_with_context, usage_from_text,
 };
+use projectatlas_core::toon::encode_agent_payload;
 use projectatlas_core::{
     Node, NodeKind, Overview, PurposeSource, PurposeStatus, normalize_native_path_display,
     normalize_native_path_display_str, normalize_repo_path, repo_path_to_native,
     validated_repo_file_key,
 };
-use projectatlas_db::{AtlasStore, IndexedFileText};
+use projectatlas_db::{AtlasStore, HealthFindingsPage, HealthQuery, IndexedFileText};
 use projectatlas_fs::{ScanOptions, gitignore_excludes_path, scan_path, scan_repo};
 use projectatlas_service::{
     FilePathMatcher, FileSummaryReport, file_summary_baseline_text, load_ranked_file_nodes,
@@ -33,6 +35,7 @@ use projectatlas_symbols::extract_symbol_graph;
 use rayon::ThreadPoolBuilder;
 use rayon::prelude::*;
 use serde::Serialize;
+use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 use std::fs;
@@ -44,6 +47,10 @@ use std::time::{Duration, Instant};
 
 /// Maximum file size parsed for symbols by default.
 pub(crate) const MAX_SYMBOL_FILE_BYTES: u64 = 2_000_000;
+/// Default health rows returned when the caller does not request a page size.
+pub(crate) const DEFAULT_HEALTH_LIMIT: usize = 50;
+/// Maximum health rows returned in one payload.
+pub(crate) const MAX_HEALTH_LIMIT: usize = 200;
 
 /// Built-in purposes for reserved project-local `ProjectAtlas` metadata inputs.
 const BUILTIN_PROJECTATLAS_PURPOSES: &[(&str, &str)] = &[
@@ -440,6 +447,7 @@ pub(crate) fn ranked_file_nodes(
     folder: Option<&str>,
     file_pattern: Option<&str>,
     limit: usize,
+    include_content: bool,
 ) -> Result<Vec<projectatlas_core::IndexedNode>, CliError> {
     Ok(load_ranked_file_nodes(
         store,
@@ -447,7 +455,216 @@ pub(crate) fn ranked_file_nodes(
         folder,
         file_pattern,
         limit,
+        include_content,
     )?)
+}
+
+/// Agent-facing purpose curation queue with bounded health metadata.
+#[derive(Debug, Serialize)]
+pub(crate) struct PurposeCurationPage {
+    /// Findings after filters are applied.
+    pub(crate) total: usize,
+    /// Findings before filters are applied, after resolved findings are removed.
+    pub(crate) unfiltered_total: usize,
+    /// Findings returned in this page.
+    pub(crate) returned: usize,
+    /// Pagination start index used for this page.
+    pub(crate) start_index: usize,
+    /// Maximum findings requested for this page.
+    pub(crate) limit: usize,
+    /// Maximum allowed page size.
+    pub(crate) max_limit: usize,
+    /// Next start index when more rows are available.
+    pub(crate) next_start_index: Option<usize>,
+    /// Whether more rows are available.
+    pub(crate) truncated: bool,
+    /// Whether the queue is restricted to source-relevant paths.
+    pub(crate) source_only: bool,
+    /// Applied category filter.
+    pub(crate) category: String,
+    /// Applied severity filter.
+    pub(crate) severity: String,
+    /// Applied path-prefix filter.
+    pub(crate) path_prefix: String,
+    /// Whether rows were intentionally omitted.
+    pub(crate) summary_only: bool,
+    /// Queue items that need agent inspection or approval.
+    pub(crate) items: Vec<PurposeCurationItem>,
+}
+
+/// One path that needs purpose curation.
+#[derive(Debug, Serialize)]
+pub(crate) struct PurposeCurationItem {
+    /// Finding severity.
+    pub(crate) severity: String,
+    /// Stable health finding id.
+    pub(crate) id: String,
+    /// Health finding category.
+    pub(crate) category: String,
+    /// Indexed repository-relative path.
+    pub(crate) path: String,
+    /// Related path for structural findings.
+    pub(crate) related_path: String,
+    /// Node kind when the path is still indexed.
+    pub(crate) kind: String,
+    /// Detected language for source files.
+    pub(crate) language: String,
+    /// Current approved or suggested purpose text.
+    pub(crate) purpose: String,
+    /// Purpose lifecycle status.
+    pub(crate) purpose_status: String,
+    /// Purpose source.
+    pub(crate) purpose_source: String,
+    /// Current deterministic content summary.
+    pub(crate) content_summary: String,
+    /// Recommended agent action.
+    pub(crate) recommendation: String,
+}
+
+/// Build a purpose curation queue from the bounded health page.
+pub(crate) fn purpose_curation_page(
+    store: &AtlasStore,
+    query: &HealthQuery,
+) -> Result<PurposeCurationPage, CliError> {
+    let page = store.unresolved_health_findings_page(&store.resolved_health_ids()?, query)?;
+    let paths = page
+        .findings
+        .iter()
+        .map(|finding| finding.path.clone())
+        .collect::<Vec<_>>();
+    let nodes = store
+        .load_nodes_by_paths(&paths)?
+        .into_iter()
+        .map(|node| (node.node.path.clone(), node))
+        .collect::<HashMap<_, _>>();
+    let items = page
+        .findings
+        .iter()
+        .map(|finding| {
+            let node = nodes.get(&finding.path);
+            PurposeCurationItem {
+                severity: health_severity_name(finding.severity).to_string(),
+                id: finding.id.clone(),
+                category: finding.category.clone(),
+                path: finding.path.clone(),
+                related_path: finding.related_path.clone().unwrap_or_default(),
+                kind: node
+                    .map(|indexed| indexed.node.kind.to_string())
+                    .unwrap_or_default(),
+                language: node
+                    .and_then(|indexed| indexed.node.language.clone())
+                    .unwrap_or_default(),
+                purpose: node
+                    .and_then(|indexed| indexed.purpose.purpose.clone())
+                    .unwrap_or_default(),
+                purpose_status: node
+                    .map(|indexed| indexed.purpose.status.to_string())
+                    .unwrap_or_default(),
+                purpose_source: node
+                    .map(|indexed| indexed.purpose.source.to_string())
+                    .unwrap_or_default(),
+                content_summary: node
+                    .and_then(|indexed| indexed.summary.clone())
+                    .unwrap_or_default(),
+                recommendation: finding.recommendation.clone(),
+            }
+        })
+        .collect::<Vec<_>>();
+    Ok(PurposeCurationPage {
+        total: page.total,
+        unfiltered_total: page.unfiltered_total,
+        returned: page.returned,
+        start_index: page.start_index,
+        limit: page.limit,
+        max_limit: MAX_HEALTH_LIMIT,
+        next_start_index: health_next_start_index(&page),
+        truncated: health_next_start_index(&page).is_some(),
+        source_only: query.source_only,
+        category: query.category.clone().unwrap_or_default(),
+        severity: query.severity.map_or("", health_severity_name).to_string(),
+        path_prefix: query.path_prefix.clone().unwrap_or_default(),
+        summary_only: query.summary_only,
+        items,
+    })
+}
+
+/// Render a bounded health page as compact TOON.
+pub(crate) fn render_health_page(page: &HealthFindingsPage, query: &HealthQuery) -> String {
+    let rows = page
+        .findings
+        .iter()
+        .map(|finding| {
+            json!({
+                "severity": health_severity_name(finding.severity),
+                "id": finding.id,
+                "category": finding.category,
+                "path": finding.path,
+                "related_path": finding.related_path.as_deref().unwrap_or(""),
+                "message": finding.message,
+                "recommendation": finding.recommendation,
+            })
+        })
+        .collect::<Vec<_>>();
+    encode_agent_payload(&json!({
+        "health": {
+            "total": page.total,
+            "unfiltered_total": page.unfiltered_total,
+            "returned": page.returned,
+            "start_index": page.start_index,
+            "limit": page.limit,
+            "max_limit": MAX_HEALTH_LIMIT,
+            "next_start_index": health_next_start_index(page),
+            "truncated": health_next_start_index(page).is_some(),
+            "summary_only": query.summary_only,
+            "source_only": query.source_only,
+            "category": query.category.as_deref().unwrap_or(""),
+            "severity": query.severity.map_or("", health_severity_name),
+            "path_prefix": query.path_prefix.as_deref().unwrap_or(""),
+        },
+        "health_findings": rows,
+    }))
+}
+
+/// Render a purpose curation queue as compact TOON.
+pub(crate) fn render_purpose_curation_page(page: &PurposeCurationPage) -> String {
+    encode_agent_payload(&json!({
+        "purpose_curation": {
+            "total": page.total,
+            "unfiltered_total": page.unfiltered_total,
+            "returned": page.returned,
+            "start_index": page.start_index,
+            "limit": page.limit,
+            "max_limit": page.max_limit,
+            "next_start_index": page.next_start_index,
+            "truncated": page.truncated,
+            "source_only": page.source_only,
+            "category": page.category,
+            "severity": page.severity,
+            "path_prefix": page.path_prefix,
+            "summary_only": page.summary_only,
+        },
+        "purpose_curation_items": page.items,
+    }))
+}
+
+/// Return a stable lowercase severity name.
+pub(crate) fn health_severity_name(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Info => "info",
+        Severity::Warning => "warning",
+        Severity::Error => "error",
+    }
+}
+
+/// Return the next start index for a bounded health page.
+fn health_next_start_index(page: &HealthFindingsPage) -> Option<usize> {
+    let page_width = page.limit.min(page.total.saturating_sub(page.start_index));
+    let page_end = page.start_index.saturating_add(page_width);
+    if page_width == 0 || page_end >= page.total {
+        None
+    } else {
+        Some(page_end)
+    }
 }
 
 /// Estimate source tokens for repository paths referenced by symbols/relations.
@@ -1105,8 +1322,8 @@ pub(crate) struct SymbolParseJob {
     language: Option<String>,
     /// Existing node summary fallback.
     fallback_summary: Option<String>,
-    /// Whether a generated purpose suggestion should be written.
-    purpose_missing: bool,
+    /// Whether a generated purpose suggestion should be written or refreshed.
+    purpose_needs_suggestion: bool,
 }
 
 /// Successful parser output waiting for sequential DB persistence.
@@ -1221,7 +1438,10 @@ pub(crate) fn build_symbols_for_paths(
             native_path: root.join(repo_path_to_native(&node.node.path)),
             language: node.node.language.clone(),
             fallback_summary: node.summary.clone(),
-            purpose_missing: node.purpose.status == PurposeStatus::Missing,
+            purpose_needs_suggestion: matches!(
+                node.purpose.status,
+                PurposeStatus::Missing | PurposeStatus::Suggested
+            ),
         });
     }
     let started_at = Instant::now();
@@ -1308,7 +1528,7 @@ pub(crate) fn parse_symbol_job(
     let graph = extract_symbol_graph(&job.path, job.language.as_deref(), &content);
     let summary = summarize_symbol_graph(&graph, job.fallback_summary.as_deref());
     let purpose_suggestion = job
-        .purpose_missing
+        .purpose_needs_suggestion
         .then(|| suggest_file_purpose(&job.path, &summary));
     SymbolParseOutcome::Parsed(SymbolParseSuccess {
         path: job.path.clone(),
@@ -1528,13 +1748,7 @@ pub(crate) fn relation_targets(
 
 /// Create a generated file-purpose suggestion from a path and content summary.
 pub(crate) fn suggest_file_purpose(path: &str, summary: &str) -> String {
-    let name = path
-        .rsplit('/')
-        .next()
-        .filter(|value| !value.is_empty())
-        .unwrap_or(path);
-    let stem = name.split_once('.').map_or(name, |(stem, _)| stem);
-    let subject = stem.replace(['-', '_'], " ");
+    let subject = path_context_subject(path);
     if summary.contains("dataset manifest") {
         if let Some(datasets) = summary_between(summary, " including ", " and keys") {
             format!("Define the {subject} dataset manifest for {datasets}.")
@@ -1554,9 +1768,179 @@ pub(crate) fn suggest_file_purpose(path: &str, summary: &str) -> String {
     } else if summary.contains("stylesheet") {
         format!("Style the {subject} stylesheet.")
     } else if summary.contains("config") {
-        format!("Configure {subject}.")
+        format!("Configure the {subject}.")
+    } else if is_gradle_build_script(path) {
+        if let Some(declarations) = summary_primary_declarations(summary) {
+            format!("Define Gradle build tasks around {declarations}.")
+        } else {
+            "Configure the Gradle build.".to_string()
+        }
+    } else if let Some(declarations) = summary_primary_declarations(summary) {
+        format!("Implement the {subject} source around {declarations}.")
+    } else if summary.contains("source") {
+        format!("Implement the {subject} source.")
     } else {
-        format!("Implement {subject}.")
+        format!("Implement the {subject}.")
+    }
+}
+
+/// Return whether a path is a Gradle build script rather than ordinary Kotlin/Groovy source.
+fn is_gradle_build_script(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    normalized.ends_with("build.gradle") || normalized.ends_with("build.gradle.kts")
+}
+
+/// Return a path-aware subject phrase for a generated purpose suggestion.
+fn path_context_subject(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    let mut segments = normalized
+        .split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .collect::<Vec<_>>();
+    let Some(file_name) = segments.pop() else {
+        return "path".to_string();
+    };
+    let stem = file_name
+        .rsplit_once('.')
+        .map_or(file_name, |(stem, _)| stem);
+    let stem_words = path_segment_words(stem);
+    let parent_words = segments
+        .iter()
+        .rev()
+        .find(|segment| !is_generic_context_segment(segment))
+        .map(|segment| path_segment_words(segment));
+    match parent_words {
+        Some(parent) if !parent.is_empty() && parent != stem_words => {
+            format!("{parent} {stem_words}")
+        }
+        _ => stem_words,
+    }
+}
+
+/// Convert one path segment into readable lowercase words.
+fn path_segment_words(segment: &str) -> String {
+    let mut words = String::new();
+    let mut previous_lowercase = false;
+    for character in segment.chars() {
+        if character == '-' || character == '_' || character == '.' {
+            push_word_space(&mut words);
+            previous_lowercase = false;
+            continue;
+        }
+        if character.is_uppercase() && previous_lowercase {
+            push_word_space(&mut words);
+        }
+        words.extend(character.to_lowercase());
+        previous_lowercase = character.is_lowercase() || character.is_ascii_digit();
+    }
+    let words = words.trim();
+    if words.is_empty() {
+        "path".to_string()
+    } else {
+        words.to_string()
+    }
+}
+
+/// Append one word separator when the phrase already has content.
+fn push_word_space(words: &mut String) {
+    if !words.ends_with(' ') && !words.is_empty() {
+        words.push(' ');
+    }
+}
+
+/// Return whether a path segment is too generic to add useful purpose context.
+fn is_generic_context_segment(segment: &str) -> bool {
+    matches!(
+        segment.to_ascii_lowercase().as_str(),
+        "src"
+            | "source"
+            | "sources"
+            | "app"
+            | "apps"
+            | "lib"
+            | "libs"
+            | "crate"
+            | "crates"
+            | "package"
+            | "packages"
+            | "test"
+            | "tests"
+            | "spec"
+            | "specs"
+            | "fixture"
+            | "fixtures"
+            | "example"
+            | "examples"
+            | "script"
+            | "scripts"
+    )
+}
+
+/// Extract primary declaration names from a deterministic content summary.
+fn summary_primary_declarations(summary: &str) -> Option<String> {
+    let after_marker = summary
+        .split_once(" source defining ")
+        .map(|(_, value)| value)
+        .or_else(|| summary.split_once(" declaring ").map(|(_, value)| value))?;
+    let declaration_clause = trim_summary_clause(after_marker);
+    let names = strip_declaration_kind_prefix(declaration_clause)
+        .split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .take(3)
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if names.is_empty() {
+        None
+    } else {
+        Some(join_human_names(&names))
+    }
+}
+
+/// Trim trailing summary details from a declaration clause.
+fn trim_summary_clause(value: &str) -> &str {
+    value
+        .split(" with imports ")
+        .next()
+        .unwrap_or(value)
+        .split(" and depending on ")
+        .next()
+        .unwrap_or(value)
+        .trim_end_matches('.')
+        .trim()
+}
+
+/// Remove the deterministic symbol-kind phrase before the primary names.
+fn strip_declaration_kind_prefix(value: &str) -> &str {
+    const PREFIXES: &[&str] = &[
+        "types and functions ",
+        "type and functions ",
+        "types and function ",
+        "type and function ",
+        "manifest entries ",
+        "functions ",
+        "function ",
+        "types ",
+        "type ",
+        "bindings ",
+        "binding ",
+        "values ",
+        "value ",
+        "symbols ",
+    ];
+    PREFIXES
+        .iter()
+        .find_map(|prefix| value.strip_prefix(prefix))
+        .unwrap_or(value)
+}
+
+/// Join declaration names as a compact human phrase.
+fn join_human_names(names: &[String]) -> String {
+    match names {
+        [] => String::new(),
+        [one] => one.clone(),
+        [first, second] => format!("{first} and {second}"),
+        [first, second, third, ..] => format!("{first}, {second}, and {third}"),
     }
 }
 
@@ -2151,7 +2535,10 @@ pub(crate) fn refresh_structural_summaries_for_nodes(
         };
         store.set_node_summary(&indexed.node.path, &summary)?;
         report.summarized += 1;
-        if indexed.purpose.status == PurposeStatus::Missing {
+        if matches!(
+            indexed.purpose.status,
+            PurposeStatus::Missing | PurposeStatus::Suggested
+        ) {
             store.set_suggested_purpose(
                 &indexed.node.path,
                 &suggest_file_purpose(&indexed.node.path, &summary),

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -95,6 +95,13 @@ fn plugin_installers_require_matching_runtime_version() -> Result<(), Box<dyn Er
             .join(".claude-plugin")
             .join("plugin.json"),
     )?;
+    let codex_manifest = fs::read_to_string(
+        workspace_root
+            .join("plugins")
+            .join("projectatlas")
+            .join(".codex-plugin")
+            .join("plugin.json"),
+    )?;
     let opencode_template = fs::read_to_string(
         workspace_root
             .join("plugins")
@@ -167,6 +174,37 @@ fn plugin_installers_require_matching_runtime_version() -> Result<(), Box<dyn Er
         &["version"],
         env!("CARGO_PKG_VERSION"),
     )?;
+    let codex_manifest_json: Value = serde_json::from_str(&codex_manifest)?;
+    require_json_string(&codex_manifest_json, &["name"], "projectatlas")?;
+    require_json_string(
+        &codex_manifest_json,
+        &["version"],
+        env!("CARGO_PKG_VERSION"),
+    )?;
+    let default_prompts = codex_manifest_json["interface"]["defaultPrompt"]
+        .as_array()
+        .ok_or_else(|| io::Error::other("Codex plugin defaultPrompt must be an array"))?;
+    if default_prompts.len() > 3 {
+        return Err(
+            io::Error::other("Codex plugin defaultPrompt must contain at most 3 prompts").into(),
+        );
+    }
+    for prompt in default_prompts {
+        let prompt = prompt.as_str().ok_or_else(|| {
+            io::Error::other("Codex plugin defaultPrompt entries must be strings")
+        })?;
+        if prompt.trim().is_empty() {
+            return Err(
+                io::Error::other("Codex plugin defaultPrompt entries must not be empty").into(),
+            );
+        }
+        if prompt.chars().count() > 128 {
+            return Err(io::Error::other(format!(
+                "Codex plugin defaultPrompt entry is longer than 128 characters: {prompt}"
+            ))
+            .into());
+        }
+    }
     let opencode_json: Value = serde_json::from_str(&opencode_template)?;
     require_json_string(
         &opencode_json,
@@ -3702,7 +3740,7 @@ fn full_repository_intelligence_flow_indexes_database_and_commands() -> Result<(
     )?;
     fs::write(
         repo.join("src").join("main.rs"),
-        "mod service;\nfn main() {\n    service::run();\n}\n",
+        "mod service;\nconst CONTENT_ONLY_ROUTE: &str = \"contentOnlyRoute\";\nfn main() {\n    service::run();\n}\n",
     )?;
     fs::write(
         repo.join("src").join("service.rs"),
@@ -3749,6 +3787,25 @@ fn full_repository_intelligence_flow_indexes_database_and_commands() -> Result<(
         .assert()
         .success()
         .stdout(predicate::str::contains("src/service.rs"));
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args([
+            "files",
+            "contentOnlyRoute",
+            "--folder",
+            "src",
+            "--file-pattern",
+            "*.rs",
+            "--include-content",
+            "--limit",
+            "5",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("src/main.rs"));
 
     Command::cargo_bin("projectatlas")?
         .current_dir(&repo)
@@ -3890,6 +3947,148 @@ fn full_repository_intelligence_flow_indexes_database_and_commands() -> Result<(
         .failure()
         .stdout(predicate::str::contains("parity:"))
         .stdout(predicate::str::contains("5 suggested"));
+
+    Ok(())
+}
+
+#[test]
+fn gradle_dsl_tasks_are_symbols_and_file_ranking_signals() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("repo");
+    fs::create_dir(&repo)?;
+    fs::write(
+        repo.join("build.gradle.kts"),
+        r#"
+import org.springframework.boot.gradle.tasks.run.BootRun
+
+fun loadDotEnv() = emptyMap<String, String>()
+
+tasks.register<BootRun>("bootRunE2E") {
+    group = "verification"
+}
+
+val verifyAtlas by tasks.registering {
+    group = "verification"
+}
+
+tasks {
+    register<Copy>("copyE2EReports") {
+        group = "verification"
+    }
+}
+"#,
+    )?;
+    fs::write(
+        repo.join("build.gradle"),
+        r"
+plugins { id 'java' }
+
+tasks.register('bootRunSmoke', BootRun) {
+    group = 'verification'
+}
+
+task cleanE2E(type: Delete) {}
+
+tasks {
+    create('copyGroovyReports') {
+        group = 'verification'
+    }
+}
+",
+    )?;
+    let db = temp.path().join("projectatlas.db");
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args(["scan", "."])
+        .assert()
+        .success();
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args([
+            "files",
+            "bootRunE2E",
+            "--file-pattern",
+            "*.kts",
+            "--limit",
+            "5",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("build.gradle.kts"));
+
+    let kotlin_summary = json_summary_command(&repo, &db, "build.gradle.kts")?;
+    require_json_string(
+        &kotlin_summary,
+        &["parser_kind"],
+        "tree-sitter-symbol-graph",
+    )?;
+    require_json_contains(&kotlin_summary, &["content_summary"], "bootRunE2E")?;
+    require_json_contains(&kotlin_summary, &["content_summary"], "copyE2EReports")?;
+    require_json_contains(&kotlin_summary, &["content_summary"], "verifyAtlas")?;
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args([
+            "symbols",
+            "list",
+            "--file",
+            "build.gradle.kts",
+            "--query",
+            "bootRunE2E",
+            "--limit",
+            "20",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("bootRunE2E"));
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args([
+            "files",
+            "bootRunSmoke",
+            "--file-pattern",
+            "*.gradle",
+            "--limit",
+            "5",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("build.gradle"));
+
+    let groovy_summary = json_summary_command(&repo, &db, "build.gradle")?;
+    require_json_string(&groovy_summary, &["parser_kind"], "fallback-symbol-graph")?;
+    require_json_contains(&groovy_summary, &["content_summary"], "bootRunSmoke")?;
+    require_json_contains(&groovy_summary, &["content_summary"], "copyGroovyReports")?;
+    require_json_contains(&groovy_summary, &["content_summary"], "cleanE2E")?;
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args([
+            "symbols",
+            "list",
+            "--file",
+            "build.gradle",
+            "--query",
+            "copyGroovyReports",
+            "--limit",
+            "20",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("copyGroovyReports"));
 
     Ok(())
 }
@@ -4150,7 +4349,11 @@ fn generated_file_purpose_suggestions_require_agent_approval() -> Result<(), Box
         "rust source defining type and function Service, run.",
     )?;
     require_json_string(file_entry, &["status"], "suggested")?;
-    require_json_string(file_entry, &["file_purpose"], "Implement service.")?;
+    require_json_string(
+        file_entry,
+        &["file_purpose"],
+        "Implement the service source around Service and run.",
+    )?;
 
     Command::cargo_bin("projectatlas")?
         .current_dir(&repo)
@@ -4227,6 +4430,23 @@ fn generated_file_purpose_suggestions_require_agent_approval() -> Result<(), Box
         .stdout(predicate::str::contains("missing-purpose:src"))
         .stdout(predicate::str::contains(
             "suggested-purpose-review:src/service.rs:",
+        ));
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args(["purpose", "queue", "--limit", "5"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("purpose_curation:"))
+        .stdout(predicate::str::contains("source_only: true"))
+        .stdout(predicate::str::contains("missing-purpose:."))
+        .stdout(predicate::str::contains(
+            "suggested-purpose-review:src/service.rs:",
+        ))
+        .stdout(predicate::str::contains(
+            "Implement the service source around Service and run.",
         ));
 
     for (path, purpose) in [
@@ -4314,6 +4534,84 @@ fn generated_file_purpose_suggestions_require_agent_approval() -> Result<(), Box
         .assert()
         .success()
         .stdout(predicate::str::contains("health_findings[0]"));
+
+    Ok(())
+}
+
+#[test]
+fn generated_purpose_queue_avoids_generic_and_asset_noise() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("repo");
+    fs::create_dir(&repo)?;
+    fs::create_dir_all(repo.join("src").join("customers"))?;
+    fs::create_dir_all(repo.join("src").join("settings"))?;
+    fs::create_dir(repo.join("assets"))?;
+    fs::write(
+        repo.join("src").join("customers").join("service.rs"),
+        "pub struct CustomerService;\n\nimpl CustomerService {\n    pub fn reconcile(&self) {}\n}\n",
+    )?;
+    fs::write(
+        repo.join("src").join("settings").join("service.rs"),
+        "pub struct SettingsService;\n\nimpl SettingsService {\n    pub fn load(&self) {}\n}\n",
+    )?;
+    fs::write(
+        repo.join("build.gradle.kts"),
+        "tasks.register<BootRun>(\"bootRunE2E\") {\n    group = \"verification\"\n}\n\ntasks {\n    register<Copy>(\"copyE2EReports\") {\n        group = \"verification\"\n    }\n}\n\nval verifyAtlas by tasks.registering {\n    group = \"verification\"\n}\n",
+    )?;
+    fs::write(
+        repo.join("assets").join("logo.svg"),
+        "<svg xmlns=\"http://www.w3.org/2000/svg\"/>",
+    )?;
+    let db = temp.path().join("projectatlas.db");
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args(["scan", "."])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("purpose_suggestions: 3"));
+
+    let output = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args(["purpose", "queue", "--limit", "20"])
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "purpose queue failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+        .into());
+    }
+    let queue = String::from_utf8(output.stdout)?;
+    for expected in [
+        "Implement the customers service source around CustomerService and reconcile.",
+        "Implement the settings service source around SettingsService and load.",
+        "Define Gradle build tasks around bootRunE2E, copyE2EReports, and verifyAtlas.",
+    ] {
+        if !queue.contains(expected) {
+            return Err(io::Error::other(format!(
+                "purpose queue missed useful suggestion `{expected}`:\n{queue}"
+            ))
+            .into());
+        }
+    }
+    for noisy in [
+        "Implement build.",
+        "Implement service.",
+        "Implement the service source",
+        "assets/logo.svg",
+    ] {
+        if queue.contains(noisy) {
+            return Err(io::Error::other(format!(
+                "purpose queue included noisy suggestion/path `{noisy}`:\n{queue}"
+            ))
+            .into());
+        }
+    }
 
     Ok(())
 }

--- a/crates/projectatlas-core/src/health.rs
+++ b/crates/projectatlas-core/src/health.rs
@@ -1,6 +1,6 @@
 //! Purpose: Detect structural health issues in `ProjectAtlas` indexes.
 
-use crate::{IndexedNode, NodeKind, PurposeStatus};
+use crate::{IndexedNode, NodeKind, PurposeStatus, normalized_parent};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -128,7 +128,7 @@ fn stale_purpose_findings(nodes: &[IndexedNode]) -> Vec<HealthFinding> {
 
 /// Find paths that share the same purpose text.
 fn duplicate_purpose_findings(nodes: &[IndexedNode]) -> Vec<HealthFinding> {
-    let mut by_purpose: HashMap<(NodeKind, String), Vec<&IndexedNode>> = HashMap::new();
+    let mut by_purpose: HashMap<(NodeKind, String, String), Vec<&IndexedNode>> = HashMap::new();
     for node in nodes {
         if node.purpose.status != PurposeStatus::Approved {
             continue;
@@ -137,12 +137,16 @@ fn duplicate_purpose_findings(nodes: &[IndexedNode]) -> Vec<HealthFinding> {
             continue;
         };
         by_purpose
-            .entry((node.node.kind, purpose.to_lowercase()))
+            .entry((
+                node.node.kind,
+                purpose.to_lowercase(),
+                duplicate_context_key(node),
+            ))
             .or_default()
             .push(node);
     }
     let mut findings = Vec::new();
-    for ((kind, _), matches) in by_purpose {
+    for ((kind, _, _), matches) in by_purpose {
         if matches.len() < 2 {
             continue;
         }
@@ -166,6 +170,15 @@ fn duplicate_purpose_findings(nodes: &[IndexedNode]) -> Vec<HealthFinding> {
         }
     }
     findings
+}
+
+/// Return the duplicate-purpose comparison context for a node.
+fn duplicate_context_key(node: &IndexedNode) -> String {
+    if node.node.kind == NodeKind::Folder {
+        normalized_parent(&node.node.path).unwrap_or_default()
+    } else {
+        String::new()
+    }
 }
 
 /// Find repeated temporary or generated-output folders.
@@ -267,6 +280,28 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn duplicate_folder_purpose_is_scoped_by_parent_context() -> Result<(), Box<dyn Error>> {
+        let nodes = vec![
+            test_node(
+                "customers/service",
+                NodeKind::Folder,
+                Some("Service layer"),
+                PurposeStatus::Approved,
+            ),
+            test_node(
+                "settings/service",
+                NodeKind::Folder,
+                Some("Service layer"),
+                PurposeStatus::Approved,
+            ),
+        ];
+
+        let findings = health_check(&nodes);
+        reject_category(&findings, "duplicate-purpose")?;
+        Ok(())
+    }
+
     /// Build a health-check test node.
     fn test_node(
         path: &str,
@@ -278,7 +313,7 @@ mod tests {
             node: Node {
                 path: path.to_string(),
                 kind,
-                parent_path: Some("src".to_string()),
+                parent_path: normalized_parent(path),
                 extension: Some(".rs".to_string()),
                 language: Some("rust".to_string()),
                 size_bytes: Some(10),

--- a/crates/projectatlas-db/src/lib.rs
+++ b/crates/projectatlas-db/src/lib.rs
@@ -23,6 +23,8 @@ use thiserror::Error;
 
 /// Current `SQLite` schema version supported by this crate.
 const SCHEMA_VERSION: i64 = 8;
+/// Maximum persisted text for denormalized symbol-name search summaries.
+const MAX_SYMBOL_SEARCH_SUMMARY_CHARS: usize = 16_000;
 
 /// Database-layer error type.
 #[derive(Debug, Error)]
@@ -130,10 +132,12 @@ pub struct HealthQuery {
     pub path_prefix: Option<String>,
     /// Return counts without finding rows.
     pub summary_only: bool,
+    /// Restrict findings to source files and folders that contain source files.
+    pub source_only: bool,
 }
 
 /// Bounded health findings page returned by the database layer.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct HealthFindingsPage {
     /// Findings after filters are applied.
     pub total: usize,
@@ -828,6 +832,13 @@ impl AtlasStore {
                 usize_to_i64(metadata.relation_count),
             ],
         )?;
+        let node_id = transaction
+            .query_row(
+                "SELECT id FROM nodes WHERE path = ?1 AND exists_now = 1",
+                [&graph.path],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()?;
         for symbol in &graph.symbols {
             transaction.execute(
                 "
@@ -888,6 +899,13 @@ impl AtlasStore {
                 ],
             )?;
         }
+        if let Some(node_id) = node_id {
+            replace_symbol_search_summary(
+                &transaction,
+                node_id,
+                symbol_search_summary(graph).as_deref(),
+            )?;
+        }
         transaction.commit()?;
         Ok(())
     }
@@ -912,8 +930,10 @@ impl AtlasStore {
             "
             DELETE FROM summaries
             WHERE node_id = ?1
-              AND summary_level = 'node'
-              AND subject = ''
+              AND (
+                    (summary_level = 'node' AND subject = '')
+                    OR (summary_level = 'search' AND subject = 'symbols')
+                  )
             ",
             [node_id],
         )?;
@@ -926,12 +946,22 @@ impl AtlasStore {
     ///
     /// Returns an error if persistence fails.
     pub fn clear_symbol_graph_for_path(&self, path: &str) -> DbResult<()> {
+        let node_id = self.node_id_for_path(path)?;
         self.connection
             .execute("DELETE FROM symbols WHERE path = ?1", [path])?;
         self.connection
             .execute("DELETE FROM symbol_relations WHERE path = ?1", [path])?;
         self.connection
             .execute("DELETE FROM source_parse_metadata WHERE path = ?1", [path])?;
+        self.connection.execute(
+            "
+            DELETE FROM summaries
+            WHERE node_id = ?1
+              AND summary_level = 'search'
+              AND subject = 'symbols'
+            ",
+            [node_id],
+        )?;
         Ok(())
     }
 
@@ -1933,6 +1963,9 @@ impl AtlasStore {
                 LEFT JOIN summaries s ON s.node_id = n.id
                     AND s.summary_level = 'node'
                     AND s.subject = ''
+                LEFT JOIN summaries symbol_summaries ON symbol_summaries.node_id = n.id
+                    AND symbol_summaries.summary_level = 'search'
+                    AND symbol_summaries.subject = 'symbols'
                 WHERE n.exists_now = 1
                   AND n.kind = ?
             "
@@ -1940,6 +1973,7 @@ impl AtlasStore {
         let mut values = Vec::new();
         for term in &terms {
             let pattern = sqlite_like_pattern(term);
+            values.push(Value::from(pattern.clone()));
             values.push(Value::from(pattern.clone()));
             values.push(Value::from(pattern.clone()));
             values.push(Value::from(pattern));
@@ -2070,7 +2104,8 @@ impl AtlasStore {
         let mut findings = Vec::new();
 
         for spec in PURPOSE_HEALTH_SPECS {
-            unfiltered_total += self.count_purpose_status_findings(spec, None, resolved_ids)?;
+            unfiltered_total +=
+                self.count_purpose_status_findings(spec, None, resolved_ids, false)?;
             if !purpose_health_spec_matches_query(spec, query) {
                 continue;
             }
@@ -2079,6 +2114,7 @@ impl AtlasStore {
                 spec,
                 query.path_prefix.as_deref(),
                 resolved_ids,
+                query.source_only,
             )?;
             if !query.summary_only
                 && findings.len() < query.limit
@@ -2090,6 +2126,7 @@ impl AtlasStore {
                     spec,
                     query.path_prefix.as_deref(),
                     resolved_ids,
+                    query.source_only,
                     local_start,
                     local_limit,
                 )?);
@@ -2099,7 +2136,7 @@ impl AtlasStore {
 
         for category in ["duplicate-purpose", "repeated-temporary-folder"] {
             let unfiltered_count =
-                self.count_structural_health_findings(category, None, resolved_ids)?;
+                self.count_structural_health_findings(category, None, resolved_ids, false)?;
             unfiltered_total += unfiltered_count;
             if !health_category_matches_query(category, Severity::Warning, query) {
                 continue;
@@ -2108,6 +2145,7 @@ impl AtlasStore {
                 category,
                 query.path_prefix.as_deref(),
                 resolved_ids,
+                query.source_only,
             )?;
             if !query.summary_only
                 && findings.len() < query.limit
@@ -2119,6 +2157,7 @@ impl AtlasStore {
                     category,
                     query.path_prefix.as_deref(),
                     resolved_ids,
+                    query.source_only,
                     local_start,
                     local_limit,
                 )?);
@@ -2220,8 +2259,10 @@ impl AtlasStore {
         spec: PurposeHealthSpec,
         path_prefix: Option<&str>,
         resolved_ids: &[String],
+        source_only: bool,
     ) -> DbResult<usize> {
-        let (where_clause, values) = purpose_status_where_clause(spec, path_prefix, resolved_ids);
+        let (where_clause, values) =
+            purpose_status_where_clause(spec, path_prefix, resolved_ids, source_only);
         let sql = format!(
             "
             SELECT COUNT(*)
@@ -2242,6 +2283,7 @@ impl AtlasStore {
         spec: PurposeHealthSpec,
         path_prefix: Option<&str>,
         resolved_ids: &[String],
+        source_only: bool,
         start_index: usize,
         limit: usize,
     ) -> DbResult<Vec<HealthFinding>> {
@@ -2249,7 +2291,7 @@ impl AtlasStore {
             return Ok(Vec::new());
         }
         let (where_clause, mut values) =
-            purpose_status_where_clause(spec, path_prefix, resolved_ids);
+            purpose_status_where_clause(spec, path_prefix, resolved_ids, source_only);
         let limit_placeholder = values.len() + 1;
         let offset_placeholder = values.len() + 2;
         values.push(Value::from(usize_to_i64(limit)));
@@ -2288,11 +2330,14 @@ impl AtlasStore {
         category: &str,
         path_prefix: Option<&str>,
         resolved_ids: &[String],
+        source_only: bool,
     ) -> DbResult<usize> {
         match category {
-            "duplicate-purpose" => self.count_duplicate_purpose_findings(path_prefix, resolved_ids),
+            "duplicate-purpose" => {
+                self.count_duplicate_purpose_findings(path_prefix, resolved_ids, source_only)
+            }
             "repeated-temporary-folder" => {
-                self.count_repeated_temp_folder_findings(path_prefix, resolved_ids)
+                self.count_repeated_temp_folder_findings(path_prefix, resolved_ids, source_only)
             }
             _ => Ok(0),
         }
@@ -2304,6 +2349,7 @@ impl AtlasStore {
         category: &str,
         path_prefix: Option<&str>,
         resolved_ids: &[String],
+        source_only: bool,
         start_index: usize,
         limit: usize,
     ) -> DbResult<Vec<HealthFinding>> {
@@ -2311,12 +2357,14 @@ impl AtlasStore {
             "duplicate-purpose" => self.load_duplicate_purpose_findings_page(
                 path_prefix,
                 resolved_ids,
+                source_only,
                 start_index,
                 limit,
             ),
             "repeated-temporary-folder" => self.load_repeated_temp_folder_findings_page(
                 path_prefix,
                 resolved_ids,
+                source_only,
                 start_index,
                 limit,
             ),
@@ -2329,25 +2377,36 @@ impl AtlasStore {
         &self,
         path_prefix: Option<&str>,
         resolved_ids: &[String],
+        source_only: bool,
     ) -> DbResult<usize> {
-        let (where_clause, values) =
-            structural_finding_where_clause("duplicate-purpose", path_prefix, resolved_ids, 1);
+        let (where_clause, values) = structural_finding_where_clause(
+            "duplicate-purpose",
+            path_prefix,
+            resolved_ids,
+            source_only,
+            1,
+        );
+        let source_relevant = source_relevant_node_expression("n");
+        let duplicate_scope =
+            "CASE WHEN n.kind = 'folder' THEN COALESCE(n.parent_path, '') ELSE '' END";
         let sql = format!(
             "
             WITH duplicate_rows AS (
                 SELECT n.path,
                        n.kind,
+                       n.language,
                        p.purpose,
+                       {source_relevant} AS source_relevant,
                        FIRST_VALUE(n.path) OVER (
-                           PARTITION BY n.kind, lower(p.purpose)
+                           PARTITION BY n.kind, lower(p.purpose), {duplicate_scope}
                            ORDER BY n.path
                        ) AS related_path,
                        ROW_NUMBER() OVER (
-                           PARTITION BY n.kind, lower(p.purpose)
+                           PARTITION BY n.kind, lower(p.purpose), {duplicate_scope}
                            ORDER BY n.path
                        ) AS duplicate_rank,
                        COUNT(*) OVER (
-                           PARTITION BY n.kind, lower(p.purpose)
+                           PARTITION BY n.kind, lower(p.purpose), {duplicate_scope}
                        ) AS duplicate_count
                 FROM nodes n
                 JOIN purposes p ON p.node_id = n.id
@@ -2356,7 +2415,7 @@ impl AtlasStore {
                   AND p.purpose IS NOT NULL
             ),
             findings AS (
-                SELECT path, kind, purpose, related_path
+                SELECT path, kind, language, purpose, related_path, source_relevant
                 FROM duplicate_rows
                 WHERE duplicate_count > 1
                   AND duplicate_rank > 1
@@ -2377,14 +2436,23 @@ impl AtlasStore {
         &self,
         path_prefix: Option<&str>,
         resolved_ids: &[String],
+        source_only: bool,
         start_index: usize,
         limit: usize,
     ) -> DbResult<Vec<HealthFinding>> {
         if limit == 0 {
             return Ok(Vec::new());
         }
-        let (where_clause, mut values) =
-            structural_finding_where_clause("duplicate-purpose", path_prefix, resolved_ids, 1);
+        let (where_clause, mut values) = structural_finding_where_clause(
+            "duplicate-purpose",
+            path_prefix,
+            resolved_ids,
+            source_only,
+            1,
+        );
+        let source_relevant = source_relevant_node_expression("n");
+        let duplicate_scope =
+            "CASE WHEN n.kind = 'folder' THEN COALESCE(n.parent_path, '') ELSE '' END";
         let limit_placeholder = values.len() + 1;
         let offset_placeholder = values.len() + 2;
         values.push(Value::from(usize_to_i64(limit)));
@@ -2394,17 +2462,19 @@ impl AtlasStore {
             WITH duplicate_rows AS (
                 SELECT n.path,
                        n.kind,
+                       n.language,
                        p.purpose,
+                       {source_relevant} AS source_relevant,
                        FIRST_VALUE(n.path) OVER (
-                           PARTITION BY n.kind, lower(p.purpose)
+                           PARTITION BY n.kind, lower(p.purpose), {duplicate_scope}
                            ORDER BY n.path
                        ) AS related_path,
                        ROW_NUMBER() OVER (
-                           PARTITION BY n.kind, lower(p.purpose)
+                           PARTITION BY n.kind, lower(p.purpose), {duplicate_scope}
                            ORDER BY n.path
                        ) AS duplicate_rank,
                        COUNT(*) OVER (
-                           PARTITION BY n.kind, lower(p.purpose)
+                           PARTITION BY n.kind, lower(p.purpose), {duplicate_scope}
                        ) AS duplicate_count
                 FROM nodes n
                 JOIN purposes p ON p.node_id = n.id
@@ -2413,7 +2483,7 @@ impl AtlasStore {
                   AND p.purpose IS NOT NULL
             ),
             findings AS (
-                SELECT path, kind, purpose, related_path
+                SELECT path, kind, language, purpose, related_path, source_relevant
                 FROM duplicate_rows
                 WHERE duplicate_count > 1
                   AND duplicate_rank > 1
@@ -2460,11 +2530,16 @@ impl AtlasStore {
         &self,
         path_prefix: Option<&str>,
         resolved_ids: &[String],
+        source_only: bool,
     ) -> DbResult<usize> {
         let mut total = 0_usize;
         for bucket in TEMP_FOLDER_BUCKETS {
-            total +=
-                self.count_repeated_temp_folder_bucket_findings(bucket, path_prefix, resolved_ids)?;
+            total += self.count_repeated_temp_folder_bucket_findings(
+                bucket,
+                path_prefix,
+                resolved_ids,
+                source_only,
+            )?;
         }
         Ok(total)
     }
@@ -2475,6 +2550,7 @@ impl AtlasStore {
         bucket: &str,
         path_prefix: Option<&str>,
         resolved_ids: &[String],
+        source_only: bool,
     ) -> DbResult<usize> {
         let exact = bucket.to_string();
         let suffix = format!("%/{bucket}");
@@ -2482,24 +2558,29 @@ impl AtlasStore {
             "repeated-temporary-folder",
             path_prefix,
             resolved_ids,
+            source_only,
             3,
         );
         let mut values = vec![Value::from(exact), Value::from(suffix)];
         values.append(&mut filter_values);
+        let source_relevant = source_relevant_node_expression("n");
         let sql = format!(
             "
             WITH bucket_rows AS (
-                SELECT path,
-                       FIRST_VALUE(path) OVER (ORDER BY path) AS related_path,
+                SELECT n.path,
+                       n.kind,
+                       n.language,
+                       {source_relevant} AS source_relevant,
+                       FIRST_VALUE(n.path) OVER (ORDER BY n.path) AS related_path,
                        ROW_NUMBER() OVER (ORDER BY path) AS duplicate_rank,
                        COUNT(*) OVER () AS duplicate_count
-                FROM nodes
-                WHERE exists_now = 1
-                  AND kind = 'folder'
-                  AND (lower(path) = ?1 OR lower(path) LIKE ?2)
+                FROM nodes n
+                WHERE n.exists_now = 1
+                  AND n.kind = 'folder'
+                  AND (lower(n.path) = ?1 OR lower(n.path) LIKE ?2)
             ),
             findings AS (
-                SELECT path, related_path
+                SELECT path, kind, language, related_path, source_relevant
                 FROM bucket_rows
                 WHERE duplicate_count > 1
                   AND duplicate_rank > 1
@@ -2520,6 +2601,7 @@ impl AtlasStore {
         &self,
         path_prefix: Option<&str>,
         resolved_ids: &[String],
+        source_only: bool,
         start_index: usize,
         limit: usize,
     ) -> DbResult<Vec<HealthFinding>> {
@@ -2529,8 +2611,12 @@ impl AtlasStore {
         let mut total = 0_usize;
         let mut findings = Vec::new();
         for bucket in TEMP_FOLDER_BUCKETS {
-            let matching_count =
-                self.count_repeated_temp_folder_bucket_findings(bucket, path_prefix, resolved_ids)?;
+            let matching_count = self.count_repeated_temp_folder_bucket_findings(
+                bucket,
+                path_prefix,
+                resolved_ids,
+                source_only,
+            )?;
             if findings.len() < limit && total + matching_count > start_index {
                 let local_start = start_index.saturating_sub(total);
                 let local_limit = limit - findings.len();
@@ -2538,6 +2624,7 @@ impl AtlasStore {
                     bucket,
                     path_prefix,
                     resolved_ids,
+                    source_only,
                     local_start,
                     local_limit,
                 )?);
@@ -2556,6 +2643,7 @@ impl AtlasStore {
         bucket: &str,
         path_prefix: Option<&str>,
         resolved_ids: &[String],
+        source_only: bool,
         start_index: usize,
         limit: usize,
     ) -> DbResult<Vec<HealthFinding>> {
@@ -2568,10 +2656,12 @@ impl AtlasStore {
             "repeated-temporary-folder",
             path_prefix,
             resolved_ids,
+            source_only,
             3,
         );
         let mut values = vec![Value::from(exact), Value::from(suffix)];
         values.append(&mut filter_values);
+        let source_relevant = source_relevant_node_expression("n");
         let limit_placeholder = values.len() + 1;
         let offset_placeholder = values.len() + 2;
         values.push(Value::from(usize_to_i64(limit)));
@@ -2579,17 +2669,20 @@ impl AtlasStore {
         let sql = format!(
             "
             WITH bucket_rows AS (
-                SELECT path,
-                       FIRST_VALUE(path) OVER (ORDER BY path) AS related_path,
-                       ROW_NUMBER() OVER (ORDER BY path) AS duplicate_rank,
+                SELECT n.path,
+                       n.kind,
+                       n.language,
+                       {source_relevant} AS source_relevant,
+                       FIRST_VALUE(n.path) OVER (ORDER BY n.path) AS related_path,
+                       ROW_NUMBER() OVER (ORDER BY n.path) AS duplicate_rank,
                        COUNT(*) OVER () AS duplicate_count
-                FROM nodes
-                WHERE exists_now = 1
-                  AND kind = 'folder'
-                  AND (lower(path) = ?1 OR lower(path) LIKE ?2)
+                FROM nodes n
+                WHERE n.exists_now = 1
+                  AND n.kind = 'folder'
+                  AND (lower(n.path) = ?1 OR lower(n.path) LIKE ?2)
             ),
             findings AS (
-                SELECT path, related_path
+                SELECT path, kind, language, related_path, source_relevant
                 FROM bucket_rows
                 WHERE duplicate_count > 1
                   AND duplicate_rank > 1
@@ -2632,54 +2725,59 @@ impl AtlasStore {
     where
         F: FnMut(HealthFinding) -> DbResult<bool>,
     {
-        let mut statement = self.connection.prepare(
+        let duplicate_scope =
+            "CASE WHEN n.kind = 'folder' THEN COALESCE(n.parent_path, '') ELSE '' END";
+        let sql = format!(
             "
-            SELECT n.path, n.kind, p.purpose
-            FROM nodes n
-            JOIN purposes p ON p.node_id = n.id
-            WHERE n.exists_now = 1
-              AND p.status = 'approved'
-              AND p.purpose IS NOT NULL
-              AND (n.kind, lower(p.purpose)) IN (
-                  SELECT n2.kind, lower(p2.purpose)
-                  FROM nodes n2
-                  JOIN purposes p2 ON p2.node_id = n2.id
-                  WHERE n2.exists_now = 1
-                    AND p2.status = 'approved'
-                    AND p2.purpose IS NOT NULL
-                  GROUP BY n2.kind, lower(p2.purpose)
-                  HAVING COUNT(*) > 1
-              )
-            ORDER BY n.kind, lower(p.purpose), n.path
-            ",
-        )?;
+            WITH duplicate_rows AS (
+                SELECT n.path,
+                       n.kind,
+                       p.purpose,
+                       FIRST_VALUE(n.path) OVER (
+                           PARTITION BY n.kind, lower(p.purpose), {duplicate_scope}
+                           ORDER BY n.path
+                       ) AS related_path,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY n.kind, lower(p.purpose), {duplicate_scope}
+                           ORDER BY n.path
+                       ) AS duplicate_rank,
+                       COUNT(*) OVER (
+                           PARTITION BY n.kind, lower(p.purpose), {duplicate_scope}
+                       ) AS duplicate_count
+                FROM nodes n
+                JOIN purposes p ON p.node_id = n.id
+                WHERE n.exists_now = 1
+                  AND p.status = 'approved'
+                  AND p.purpose IS NOT NULL
+            )
+            SELECT path, kind, purpose, related_path
+            FROM duplicate_rows
+            WHERE duplicate_count > 1
+              AND duplicate_rank > 1
+            ORDER BY kind, lower(purpose), path
+            "
+        );
+        let mut statement = self.connection.prepare(&sql)?;
         let rows = statement.query_map([], |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
             ))
         })?;
-        let mut current_key: Option<(String, String)> = None;
-        let mut first_path = String::new();
         for row in rows {
-            let (path, kind_value, purpose) = row?;
+            let (path, kind_value, _purpose, related_path) = row?;
             let kind = NodeKind::from_db(&kind_value).ok_or_else(|| DbError::InvalidEnum {
                 field: "kind",
                 value: kind_value.clone(),
             })?;
-            let key = (kind_value, purpose.to_lowercase());
-            if current_key.as_ref() != Some(&key) {
-                current_key = Some(key);
-                first_path = path;
-                continue;
-            }
             let finding = HealthFinding {
-                id: finding_id("duplicate-purpose", &path, Some(&first_path)),
+                id: finding_id("duplicate-purpose", &path, Some(&related_path)),
                 severity: Severity::Warning,
                 category: "duplicate-purpose".to_string(),
                 path,
-                related_path: Some(first_path.clone()),
+                related_path: Some(related_path),
                 message: format!("Multiple {kind} nodes share the same purpose."),
                 recommendation:
                     "Review whether these paths duplicate responsibility or need clearer purposes."
@@ -3374,7 +3472,8 @@ fn ranked_score_expression(term_count: usize) -> String {
         .map(|_| {
             "(CASE WHEN lower(n.path) LIKE ? ESCAPE '\\' THEN 20 ELSE 0 END \
              + CASE WHEN lower(COALESCE(p.purpose, '')) LIKE ? ESCAPE '\\' THEN 30 ELSE 0 END \
-             + CASE WHEN lower(COALESCE(s.summary, '')) LIKE ? ESCAPE '\\' THEN 10 ELSE 0 END)"
+             + CASE WHEN lower(COALESCE(s.summary, '')) LIKE ? ESCAPE '\\' THEN 10 ELSE 0 END \
+             + CASE WHEN lower(COALESCE(symbol_summaries.summary, '')) LIKE ? ESCAPE '\\' THEN 25 ELSE 0 END)"
                 .to_string()
         })
         .collect::<Vec<_>>()
@@ -3397,6 +3496,67 @@ fn sqlite_like_escape(value: &str) -> String {
         .replace('\\', "\\\\")
         .replace('%', "\\%")
         .replace('_', "\\_")
+}
+
+/// Replace the denormalized symbol-name search summary for one file node.
+fn replace_symbol_search_summary(
+    transaction: &Transaction<'_>,
+    node_id: i64,
+    summary: Option<&str>,
+) -> DbResult<()> {
+    if let Some(summary) = summary {
+        transaction.execute(
+            "
+            INSERT INTO summaries(node_id, summary_level, subject, summary, updated_at)
+            VALUES(?1, 'search', 'symbols', ?2, CURRENT_TIMESTAMP)
+            ON CONFLICT(node_id, summary_level, subject) DO UPDATE SET
+                summary = excluded.summary,
+                updated_at = CURRENT_TIMESTAMP
+            ",
+            params![node_id, summary],
+        )?;
+    } else {
+        transaction.execute(
+            "
+            DELETE FROM summaries
+            WHERE node_id = ?1
+              AND summary_level = 'search'
+              AND subject = 'symbols'
+            ",
+            [node_id],
+        )?;
+    }
+    Ok(())
+}
+
+/// Build a bounded search-only summary from symbol names.
+fn symbol_search_summary(graph: &SymbolGraph) -> Option<String> {
+    let mut names = graph
+        .symbols
+        .iter()
+        .filter(|symbol| !matches!(symbol.kind, SymbolKind::Import | SymbolKind::Unknown))
+        .map(|symbol| symbol.name.trim())
+        .filter(|name| !name.is_empty())
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    if names.is_empty() {
+        return None;
+    }
+    let summary = format!("symbols {}", names.join(" "));
+    Some(truncate_summary_chars(
+        &summary,
+        MAX_SYMBOL_SEARCH_SUMMARY_CHARS,
+    ))
+}
+
+/// Truncate a summary at a valid UTF-8 boundary.
+fn truncate_summary_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    value.chars().take(max_chars).collect()
 }
 
 /// Parse a stored purpose source value into the domain enum.
@@ -3543,9 +3703,14 @@ fn purpose_status_where_clause(
     spec: PurposeHealthSpec,
     path_prefix: Option<&str>,
     resolved_ids: &[String],
+    source_only: bool,
 ) -> (String, Vec<Value>) {
     let mut clauses = vec!["n.exists_now = 1".to_string(), "p.status = ?1".to_string()];
     let mut values = vec![Value::from(spec.status.to_string())];
+
+    if source_only {
+        clauses.push(source_relevant_node_expression("n"));
+    }
 
     let normalized_prefix = path_prefix
         .map(normalize_repo_path_prefix)
@@ -3577,11 +3742,16 @@ fn structural_finding_where_clause(
     category: &str,
     path_prefix: Option<&str>,
     resolved_ids: &[String],
+    source_only: bool,
     first_placeholder: usize,
 ) -> (String, Vec<Value>) {
     let mut placeholder = first_placeholder;
     let mut clauses = Vec::new();
     let mut values = Vec::new();
+
+    if source_only {
+        clauses.push("source_relevant = 1".to_string());
+    }
 
     let normalized_prefix = path_prefix
         .map(normalize_repo_path_prefix)
@@ -3616,6 +3786,24 @@ fn structural_finding_where_clause(
     } else {
         (format!("WHERE {}", clauses.join(" AND ")), values)
     }
+}
+
+/// Return a SQL expression that treats source files and folders with source descendants as source-relevant.
+fn source_relevant_node_expression(alias: &str) -> String {
+    format!(
+        "(({alias}.kind = 'file' AND COALESCE({alias}.language, '') <> '') \
+          OR ({alias}.kind = 'folder' AND EXISTS (\
+              SELECT 1 FROM nodes source_child \
+              WHERE source_child.exists_now = 1 \
+                AND source_child.kind = 'file' \
+                AND COALESCE(source_child.language, '') <> '' \
+                AND (\
+                    {alias}.path = '.' \
+                    OR source_child.parent_path = {alias}.path \
+                    OR substr(source_child.parent_path, 1, length({alias}.path) + 1) = {alias}.path || '/'\
+                )\
+          )))"
+    )
 }
 
 /// Extract resolved primary paths for lifecycle categories without related paths.
@@ -4092,11 +4280,15 @@ mod tests {
     #[test]
     fn ranked_nodes_are_loaded_bounded_from_sql() -> Result<(), Box<dyn Error>> {
         let mut store = AtlasStore::in_memory()?;
+        let mut gradle_task_node = test_file_node("build.gradle.kts", "hash-gradle");
+        gradle_task_node.extension = Some(".kts".to_string());
+        gradle_task_node.language = Some("kotlin".to_string());
         store.replace_scan(&[
             test_folder_node("src/auth"),
             test_folder_node("src/ui"),
             test_file_node("src/auth/login.rs", "hash-login"),
             test_file_node("src/ui/button.rs", "hash-button"),
+            gradle_task_node,
         ])?;
         store.set_purpose(
             "src/auth",
@@ -4120,6 +4312,41 @@ mod tests {
             &files[0].node.path,
             &"src/auth/login.rs".to_string(),
             "ranked file path",
+        )?;
+        store.replace_symbol_graph(&SymbolGraph {
+            path: "build.gradle.kts".to_string(),
+            language: Some("kotlin".to_string()),
+            parser: ParserKind::TreeSitter,
+            symbols: vec![CodeSymbol {
+                path: "build.gradle.kts".to_string(),
+                language: Some("kotlin".to_string()),
+                name: "bootRunE2E".to_string(),
+                kind: SymbolKind::Function,
+                signature: "tasks.register<BootRun>(\"bootRunE2E\")".to_string(),
+                exported: false,
+                documentation: None,
+                line_start: 1,
+                line_end: 1,
+                parent: None,
+                parser: ParserKind::TreeSitter,
+                detail: Some("gradle-kotlin-dsl-task".to_string()),
+            }],
+            relations: Vec::new(),
+        })?;
+        let gradle_files = store.load_ranked_nodes("bootRunE2E", NodeKind::File, None, 10, 0)?;
+        require_eq(&gradle_files.len(), &1, "symbol-ranked file count")?;
+        require_eq(
+            &gradle_files[0].node.path,
+            &"build.gradle.kts".to_string(),
+            "symbol-ranked file path",
+        )?;
+        store.clear_symbol_graph_for_path("build.gradle.kts")?;
+        let cleared_gradle_files =
+            store.load_ranked_nodes("bootRunE2E", NodeKind::File, None, 10, 0)?;
+        require_eq(
+            &cleared_gradle_files.len(),
+            &0,
+            "cleared symbol-ranked file count",
         )?;
         Ok(())
     }
@@ -4238,6 +4465,7 @@ mod tests {
             severity: Some(Severity::Warning),
             path_prefix: Some("src".to_string()),
             summary_only: false,
+            source_only: false,
         };
 
         let page = store.unresolved_health_findings_page(&[], &query)?;
@@ -4293,6 +4521,7 @@ mod tests {
                 severity: Some(Severity::Warning),
                 path_prefix: Some("src".to_string()),
                 summary_only: false,
+                source_only: false,
             },
         )?;
 
@@ -4338,6 +4567,7 @@ mod tests {
                 severity: Some(Severity::Warning),
                 path_prefix: Some("src".to_string()),
                 summary_only: false,
+                source_only: false,
             },
         )?;
         require_eq(&duplicate_page.total, &1, "duplicate total")?;
@@ -4357,6 +4587,7 @@ mod tests {
                 severity: Some(Severity::Warning),
                 path_prefix: Some(".".to_string()),
                 summary_only: false,
+                source_only: false,
             },
         )?;
         require_eq(&temp_page.total, &1, "temp total")?;
@@ -4365,6 +4596,160 @@ mod tests {
             &temp_page.findings[0].category,
             &"repeated-temporary-folder".to_string(),
             "temp category",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn unresolved_health_findings_page_source_only_filters_asset_noise()
+    -> Result<(), Box<dyn Error>> {
+        let mut store = AtlasStore::in_memory()?;
+        let asset_file = Node {
+            path: "assets/logo.png".to_string(),
+            kind: NodeKind::File,
+            parent_path: Some("assets".to_string()),
+            extension: Some(".png".to_string()),
+            language: None,
+            size_bytes: Some(42),
+            mtime_ns: Some(10),
+            content_hash: Some("hash-logo".to_string()),
+        };
+        store.replace_scan(&[
+            test_folder_node("."),
+            test_folder_node("src"),
+            test_file_node("src/main.rs", "hash-main"),
+            test_folder_node("assets"),
+            asset_file,
+        ])?;
+
+        let page = store.unresolved_health_findings_page(
+            &[],
+            &HealthQuery {
+                start_index: 0,
+                limit: 10,
+                category: Some("missing-purpose".to_string()),
+                severity: Some(Severity::Warning),
+                path_prefix: Some(".".to_string()),
+                summary_only: false,
+                source_only: true,
+            },
+        )?;
+
+        require_eq(&page.unfiltered_total, &5, "all unresolved rows")?;
+        require_eq(&page.total, &3, "source-only missing total")?;
+        require_eq(
+            &page
+                .findings
+                .iter()
+                .map(|finding| finding.path.as_str())
+                .collect::<Vec<_>>(),
+            &vec![".", "src", "src/main.rs"],
+            "source-only paths",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_purpose_health_is_contextual_for_folders() -> Result<(), Box<dyn Error>> {
+        let mut store = AtlasStore::in_memory()?;
+        store.replace_scan(&[
+            test_folder_node("."),
+            test_folder_node("customers"),
+            test_folder_node("customers/service"),
+            test_folder_node("settings"),
+            test_folder_node("settings/service"),
+        ])?;
+        store.set_purpose("customers/service", "Service layer", PurposeSource::Agent)?;
+        store.set_purpose("settings/service", "Service layer", PurposeSource::Agent)?;
+
+        let page = store.unresolved_health_findings_page(
+            &[],
+            &HealthQuery {
+                start_index: 0,
+                limit: 10,
+                category: Some("duplicate-purpose".to_string()),
+                severity: Some(Severity::Warning),
+                path_prefix: Some(".".to_string()),
+                summary_only: false,
+                source_only: false,
+            },
+        )?;
+
+        require_eq(&page.total, &0, "folder duplicates scoped by parent")?;
+        Ok(())
+    }
+
+    #[test]
+    fn contextual_folder_duplicate_identity_matches_unpaged_health_and_resolution()
+    -> Result<(), Box<dyn Error>> {
+        let mut store = AtlasStore::in_memory()?;
+        store.replace_scan(&[
+            test_folder_node("."),
+            test_folder_node("customers"),
+            test_folder_node("customers/service"),
+            test_folder_node("settings"),
+            test_folder_node("settings/service"),
+            test_folder_node("settings/worker"),
+        ])?;
+        store.set_purpose("customers/service", "Service layer", PurposeSource::Agent)?;
+        store.set_purpose("settings/service", "Service layer", PurposeSource::Agent)?;
+        store.set_purpose("settings/worker", "Service layer", PurposeSource::Agent)?;
+
+        let page = store.unresolved_health_findings_page(
+            &[],
+            &HealthQuery {
+                start_index: 0,
+                limit: 10,
+                category: Some("duplicate-purpose".to_string()),
+                severity: Some(Severity::Warning),
+                path_prefix: Some(".".to_string()),
+                summary_only: false,
+                source_only: false,
+            },
+        )?;
+        require_eq(&page.total, &1, "contextual duplicate total")?;
+        let paged_finding = page
+            .findings
+            .first()
+            .ok_or_else(|| io::Error::other("paged duplicate missing"))?;
+        require_eq(
+            &paged_finding.path,
+            &"settings/worker".to_string(),
+            "paged duplicate path",
+        )?;
+        require_eq(
+            &paged_finding.related_path,
+            &Some("settings/service".to_string()),
+            "paged related path",
+        )?;
+
+        let unpaged_duplicates = store
+            .unresolved_health_findings(&[])?
+            .into_iter()
+            .filter(|finding| finding.category == "duplicate-purpose")
+            .collect::<Vec<_>>();
+        require_eq(
+            &unpaged_duplicates,
+            &page.findings,
+            "unpaged duplicate identity",
+        )?;
+
+        store.resolve_health_finding(&HealthResolution {
+            finding_id: paged_finding.id.clone(),
+            category: paged_finding.category.clone(),
+            path: paged_finding.path.clone(),
+            related_path: paged_finding.related_path.clone(),
+            rationale: "Settings service and worker intentionally share a layer purpose."
+                .to_string(),
+        })?;
+        let has_remaining_duplicate = store
+            .unresolved_health_findings(&store.resolved_health_ids()?)?
+            .into_iter()
+            .any(|finding| finding.category == "duplicate-purpose");
+        require_eq(
+            &has_remaining_duplicate,
+            &false,
+            "resolved contextual duplicate",
         )?;
         Ok(())
     }

--- a/crates/projectatlas-service/src/lib.rs
+++ b/crates/projectatlas-service/src/lib.rs
@@ -639,12 +639,32 @@ pub fn load_ranked_file_nodes(
     folder: Option<&str>,
     file_pattern: Option<&str>,
     limit: usize,
+    include_content: bool,
 ) -> ServiceResult<Vec<IndexedNode>> {
     let matcher = FilePathMatcher::new(file_pattern)?;
-    if !matcher.filters() {
-        return Ok(store.load_ranked_nodes(query, NodeKind::File, folder, limit.max(1), 0)?);
-    }
     let target = limit.max(1);
+    let mut selected = if matcher.filters() {
+        load_ranked_file_nodes_matching_glob(store, query, folder, &matcher, target)?
+    } else {
+        store.load_ranked_nodes(query, NodeKind::File, folder, target, 0)?
+    };
+    if include_content && !query.trim().is_empty() && selected.len() < target {
+        append_content_ranked_file_nodes(store, query, folder, &matcher, target, &mut selected)?;
+    }
+    Ok(selected)
+}
+
+/// Load ranked files while applying a compiled repository-relative glob.
+fn load_ranked_file_nodes_matching_glob(
+    store: &AtlasStore,
+    query: &str,
+    folder: Option<&str>,
+    matcher: &FilePathMatcher,
+    target: usize,
+) -> ServiceResult<Vec<IndexedNode>> {
+    if !matcher.filters() {
+        return Ok(store.load_ranked_nodes(query, NodeKind::File, folder, target, 0)?);
+    }
     let batch_size = target.saturating_mul(20).clamp(50, 500);
     let mut offset = 0usize;
     let mut selected = Vec::new();
@@ -664,6 +684,53 @@ pub fn load_ranked_file_nodes(
         }
     }
     Ok(selected)
+}
+
+/// Append indexed-text hits after ordinary ranked file results.
+fn append_content_ranked_file_nodes(
+    store: &AtlasStore,
+    query: &str,
+    folder: Option<&str>,
+    matcher: &FilePathMatcher,
+    target: usize,
+    selected: &mut Vec<IndexedNode>,
+) -> ServiceResult<()> {
+    let needle = normalized_search_text(query, false);
+    let mut seen = selected
+        .iter()
+        .map(|node| node.node.path.clone())
+        .collect::<HashSet<_>>();
+    store.visit_file_texts_for_search(Some(query), false, |text| {
+        if selected.len() >= target {
+            return Ok(false);
+        }
+        if !seen.contains(&text.path)
+            && path_is_inside_folder(&text.path, folder)
+            && matcher.is_match(&text.path)
+            && normalized_search_text(&text.content, false).contains(&needle)
+            && let Some(node) = store.load_node_by_path(&text.path)?
+        {
+            seen.insert(text.path);
+            selected.push(node);
+        }
+        Ok(selected.len() < target)
+    })?;
+    Ok(())
+}
+
+/// Return whether a file path is inside an optional repository folder filter.
+fn path_is_inside_folder(path: &str, folder: Option<&str>) -> bool {
+    let Some(folder) = folder
+        .map(|folder| folder.trim_matches('/').trim_matches('\\'))
+        .filter(|folder| !folder.is_empty() && *folder != ".")
+    else {
+        return true;
+    };
+    let folder = folder.replace('\\', "/");
+    path == folder
+        || path
+            .strip_prefix(&folder)
+            .is_some_and(|tail| tail.starts_with('/'))
 }
 
 /// Return whether one repository-relative path matches an optional file glob.
@@ -2307,7 +2374,7 @@ mod tests {
             store.set_node_summary(path, "needle indexed summary")?;
         }
 
-        let selected = load_ranked_file_nodes(&store, "needle", None, Some("*.rs"), 10)?;
+        let selected = load_ranked_file_nodes(&store, "needle", None, Some("*.rs"), 10, false)?;
         require_eq(&selected.len(), &2, "ranked rs glob count")?;
         if selected
             .iter()
@@ -2316,12 +2383,52 @@ mod tests {
             return Err(io::Error::other("ranked glob included docs/readme.md").into());
         }
 
-        let nested = load_ranked_file_nodes(&store, "needle", None, Some("src/nested/*.rs"), 10)?;
+        let nested =
+            load_ranked_file_nodes(&store, "needle", None, Some("src/nested/*.rs"), 10, false)?;
         require_eq(&nested.len(), &1, "ranked nested glob count")?;
         require_eq(
             &nested[0].node.path,
             &"src/nested/b.rs".to_string(),
             "ranked nested glob path",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn ranked_file_nodes_can_include_indexed_text_hits() -> Result<(), Box<dyn Error>> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path();
+        fs::create_dir_all(root.join("src"))?;
+        fs::create_dir_all(root.join("docs"))?;
+        fs::write(
+            root.join("src").join("owner.rs"),
+            "const ROUTE = \"hiddenNeedle\";\n",
+        )?;
+        fs::write(root.join("docs").join("owner.md"), "hiddenNeedle docs\n")?;
+        let mut store = AtlasStore::in_memory()?;
+        store.set_project_root(root)?;
+        let nodes = [
+            test_node("src/owner.rs", "hash-src-owner"),
+            test_node("docs/owner.md", "hash-doc-owner"),
+        ];
+        store.replace_scan(&nodes)?;
+        index_test_file_texts(&mut store, root, &nodes)?;
+
+        let default_ranked =
+            load_ranked_file_nodes(&store, "hiddenNeedle", Some("src"), Some("*.rs"), 10, false)?;
+        require_eq(
+            &default_ranked.len(),
+            &0,
+            "default ranking ignores content-only hits",
+        )?;
+
+        let content_ranked =
+            load_ranked_file_nodes(&store, "hiddenNeedle", Some("src"), Some("*.rs"), 10, true)?;
+        require_eq(&content_ranked.len(), &1, "content-aware ranked count")?;
+        require_eq(
+            &content_ranked[0].node.path,
+            &"src/owner.rs".to_string(),
+            "content-aware ranked path",
         )?;
         Ok(())
     }

--- a/crates/projectatlas-symbols/src/languages/gradle.rs
+++ b/crates/projectatlas-symbols/src/languages/gradle.rs
@@ -1,0 +1,199 @@
+//! Gradle DSL symbol graph augmentation.
+
+use projectatlas_core::symbols::{SymbolGraph, SymbolKind};
+use regex::Regex;
+
+use crate::push_symbol;
+
+/// Add Gradle Kotlin DSL task registrations from `.gradle.kts` files.
+pub(super) fn augment_kotlin(graph: &mut SymbolGraph, content: &str) {
+    if !path_has_ascii_suffix(&graph.path, ".gradle.kts") {
+        return;
+    }
+    if let Some(patterns) = GradleTaskPatterns::kotlin() {
+        augment_tasks(graph, content, &patterns, "gradle-kotlin-dsl-task");
+    }
+}
+
+/// Add Gradle Groovy DSL task registrations from `.gradle` files.
+pub(super) fn augment_groovy(graph: &mut SymbolGraph, content: &str) {
+    if !path_has_ascii_suffix(&graph.path, ".gradle") {
+        return;
+    }
+    if let Some(patterns) = GradleTaskPatterns::groovy() {
+        augment_tasks(graph, content, &patterns, "gradle-groovy-dsl-task");
+    }
+}
+
+/// Regexes for one Gradle DSL task declaration style.
+struct GradleTaskPatterns {
+    /// Task declaration calls that are valid outside a `tasks {}` block.
+    top_level_call_regexes: Vec<Regex>,
+    /// `register`, `create`, or `named` call inside `tasks {}`.
+    block_call_regex: Regex,
+    /// Start of a multiline top-level task call.
+    pending_regex: Regex,
+    /// Start of a multiline task call inside `tasks {}`.
+    block_pending_regex: Regex,
+    /// String first argument on the following line of a multiline task call.
+    string_arg_regex: Regex,
+    /// Start of a `tasks {}` block.
+    tasks_block_regex: Regex,
+}
+
+impl GradleTaskPatterns {
+    /// Build regexes for Gradle Kotlin DSL scripts.
+    fn kotlin() -> Option<Self> {
+        Some(Self {
+            top_level_call_regexes: vec![
+                Regex::new(
+                    r#"\btasks\.(?:register|create|named)\s*(?:<[^>]+>)?\s*\(\s*["']([^"']+)["']"#,
+                )
+                .ok()?,
+                Regex::new(r#"\btask\s*(?:<[^>]+>)?\s*\(\s*["']([^"']+)["']"#).ok()?,
+                Regex::new(
+                    r"^\s*(?:val|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s+by\s+tasks\.(?:registering|creating|existing)",
+                )
+                .ok()?,
+            ],
+            block_call_regex: Regex::new(
+                r#"\b(?:register|create|named)\s*(?:<[^>]+>)?\s*\(\s*["']([^"']+)["']"#,
+            )
+            .ok()?,
+            pending_regex: Regex::new(
+                r"\b(?:tasks\.(?:register|create|named)|task)\s*(?:<[^>]+>)?\s*\(\s*$",
+            )
+            .ok()?,
+            block_pending_regex: Regex::new(
+                r"\b(?:register|create|named)\s*(?:<[^>]+>)?\s*\(\s*$",
+            )
+            .ok()?,
+            string_arg_regex: Regex::new(r#"^\s*["']([^"']+)["']"#).ok()?,
+            tasks_block_regex: Regex::new(r"^\s*tasks\s*\{").ok()?,
+        })
+    }
+
+    /// Build regexes for Gradle Groovy DSL scripts.
+    fn groovy() -> Option<Self> {
+        Some(Self {
+            top_level_call_regexes: vec![
+                Regex::new(
+                    r#"\btasks\.(?:register|create|named)\s*\(\s*(?:name\s*:\s*)?["']([^"']+)["']"#,
+                )
+                .ok()?,
+                Regex::new(r#"\btask\s*\(\s*(?:name\s*:\s*)?["']([^"']+)["']"#).ok()?,
+                Regex::new(r"^task\s+([A-Za-z_][A-Za-z0-9_-]*)\b").ok()?,
+            ],
+            block_call_regex: Regex::new(
+                r#"\b(?:register|create|named)\s*\(\s*(?:name\s*:\s*)?["']([^"']+)["']"#,
+            )
+            .ok()?,
+            pending_regex: Regex::new(r"\b(?:tasks\.(?:register|create|named)|task)\s*\(\s*$")
+                .ok()?,
+            block_pending_regex: Regex::new(r"\b(?:register|create|named)\s*\(\s*$").ok()?,
+            string_arg_regex: Regex::new(r#"^\s*(?:name\s*:\s*)?["']([^"']+)["']"#).ok()?,
+            tasks_block_regex: Regex::new(r"^\s*tasks\s*\{").ok()?,
+        })
+    }
+}
+
+/// Add task symbols from one Gradle DSL source.
+fn augment_tasks(
+    graph: &mut SymbolGraph,
+    content: &str,
+    patterns: &GradleTaskPatterns,
+    detail: &str,
+) {
+    let mut in_tasks_block = false;
+    let mut tasks_block_depth = 0_i32;
+    let mut pending_gradle_task_line: Option<usize> = None;
+    for (line_index, line) in content.lines().enumerate() {
+        let line_number = line_index + 1;
+        let trimmed = line.trim();
+        let tasks_block_starts = patterns.tasks_block_regex.is_match(trimmed);
+        let in_tasks_context = in_tasks_block || tasks_block_starts;
+        if let Some(name) = capture_first(trimmed, &patterns.top_level_call_regexes) {
+            push_gradle_task_symbol(graph, name, line_number, line_number, detail, trimmed);
+            pending_gradle_task_line = None;
+        } else if in_tasks_context
+            && let Some(name) = patterns
+                .block_call_regex
+                .captures(trimmed)
+                .and_then(|capture| capture.get(1))
+                .map(|value| value.as_str())
+        {
+            push_gradle_task_symbol(graph, name, line_number, line_number, detail, trimmed);
+            pending_gradle_task_line = None;
+        } else if let Some(start_line) = pending_gradle_task_line {
+            if let Some(capture) = patterns.string_arg_regex.captures(trimmed)
+                && let Some(name) = capture.get(1).map(|value| value.as_str())
+            {
+                push_gradle_task_symbol(graph, name, start_line, line_number, detail, trimmed);
+                pending_gradle_task_line = None;
+            } else if trimmed.contains(')') {
+                pending_gradle_task_line = None;
+            }
+        } else if patterns.pending_regex.is_match(trimmed)
+            || (in_tasks_context && patterns.block_pending_regex.is_match(trimmed))
+        {
+            pending_gradle_task_line = Some(line_number);
+        }
+        if tasks_block_starts && !in_tasks_block {
+            in_tasks_block = true;
+            tasks_block_depth = 0;
+        }
+        if in_tasks_block {
+            tasks_block_depth += trimmed.matches('{').count() as i32;
+            tasks_block_depth -= trimmed.matches('}').count() as i32;
+            if tasks_block_depth <= 0 {
+                in_tasks_block = false;
+                tasks_block_depth = 0;
+            }
+        }
+    }
+}
+
+/// Return the first captured identifier from a set of regexes.
+fn capture_first<'a>(line: &'a str, patterns: &[Regex]) -> Option<&'a str> {
+    patterns.iter().find_map(|regex| {
+        regex
+            .captures(line)
+            .and_then(|capture| capture.get(1))
+            .map(|value| value.as_str())
+    })
+}
+
+/// Emit a Gradle DSL task as a primary symbol for ranking and summaries.
+fn push_gradle_task_symbol(
+    graph: &mut SymbolGraph,
+    name: &str,
+    line_start: usize,
+    line_end: usize,
+    detail: &str,
+    signature: &str,
+) {
+    if graph
+        .symbols
+        .iter()
+        .any(|symbol| symbol.name == name && symbol.detail.as_deref() == Some(detail))
+    {
+        return;
+    }
+    push_symbol(
+        graph,
+        name,
+        SymbolKind::Function,
+        line_start,
+        line_end,
+        None,
+        Some(detail),
+        signature,
+    );
+}
+
+/// Case-insensitive ASCII suffix check for repository paths.
+fn path_has_ascii_suffix(path: &str, suffix: &str) -> bool {
+    let path = path.as_bytes();
+    let suffix = suffix.as_bytes();
+    path.len() >= suffix.len() && path[path.len() - suffix.len()..].eq_ignore_ascii_case(suffix)
+}

--- a/crates/projectatlas-symbols/src/languages/mod.rs
+++ b/crates/projectatlas-symbols/src/languages/mod.rs
@@ -1,6 +1,7 @@
 //! Language-specific symbol graph augmenters.
 
 mod c_family;
+mod gradle;
 mod kotlin;
 mod objective_c;
 mod zig;
@@ -12,10 +13,22 @@ use crate::{push_relation, push_symbol};
 /// Add language-specific facts that are not exposed by the generic node pass.
 pub(crate) fn augment_language_graph(graph: &mut SymbolGraph, content: &str) {
     match graph.language.as_deref() {
-        Some("kotlin") => kotlin::augment(graph, content),
+        Some("kotlin") => {
+            kotlin::augment(graph, content);
+            gradle::augment_kotlin(graph, content);
+        }
         Some("objective-c") => objective_c::augment(graph, content),
         Some("zig") => zig::augment(graph, content),
         Some("c" | "cpp" | "h" | "hpp") => c_family::augment(graph, content),
+        _ => {}
+    }
+}
+
+/// Add language-specific fallback facts for languages without a native parser.
+pub(crate) fn augment_fallback_language_graph(graph: &mut SymbolGraph, content: &str) {
+    match graph.language.as_deref() {
+        Some("kotlin") => gradle::augment_kotlin(graph, content),
+        Some("groovy") => gradle::augment_groovy(graph, content),
         _ => {}
     }
 }

--- a/crates/projectatlas-symbols/src/lib.rs
+++ b/crates/projectatlas-symbols/src/lib.rs
@@ -1437,6 +1437,7 @@ fn extract_fallback_graph(path: &str, language: Option<&str>, content: &str) -> 
             );
         }
     }
+    languages::augment_fallback_language_graph(&mut graph, content);
     graph
 }
 
@@ -1668,7 +1669,9 @@ fn is_snippet_boundary(character: char) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{MAX_SYMBOLS_PER_FILE, extract_symbol_graph, specialized_languages};
+    use super::{
+        MAX_SYMBOLS_PER_FILE, extract_fallback_graph, extract_symbol_graph, specialized_languages,
+    };
     use projectatlas_core::symbols::{ParserKind, RelationKind, SymbolKind};
 
     #[test]
@@ -2423,6 +2426,123 @@ class KotlinRunner { fun run() { helper() } private fun helper() {} }
                 && symbol.name == "run"
                 && symbol.parent.as_deref() == Some("KotlinRunner")
         }));
+
+        for path in ["src/Worker.kt", "scripts/tasks.kts"] {
+            let ordinary_kotlin = extract_symbol_graph(
+                path,
+                Some("kotlin"),
+                r#"
+class Worker {
+    fun queue(tasks: TaskContainer) {
+        tasks.register("notGradleTask")
+    }
+}
+"#,
+            );
+            assert!(
+                !ordinary_kotlin.symbols.iter().any(|symbol| {
+                    symbol.name == "notGradleTask"
+                        || symbol.detail.as_deref() == Some("gradle-kotlin-dsl-task")
+                }),
+                "ordinary Kotlin path {path} should not emit Gradle task symbols: {:?}",
+                ordinary_kotlin.symbols
+            );
+        }
+
+        let gradle_kotlin = extract_symbol_graph(
+            "build.gradle.kts",
+            Some("kotlin"),
+            r#"
+import org.springframework.boot.gradle.tasks.run.BootRun
+
+fun loadDotEnv() = emptyMap<String, String>()
+
+tasks.register<BootRun>("bootRunE2E") {
+    group = "verification"
+}
+
+val verifyAtlas by tasks.registering {
+    group = "verification"
+}
+
+tasks {
+    register<Copy>("copyE2EReports") {
+        group = "verification"
+    }
+}
+
+task("publishKtsE2E") {}
+"#,
+        );
+        assert_eq!(gradle_kotlin.parser, ParserKind::TreeSitter);
+        for task in [
+            "bootRunE2E",
+            "copyE2EReports",
+            "verifyAtlas",
+            "publishKtsE2E",
+        ] {
+            assert!(gradle_kotlin.symbols.iter().any(|symbol| {
+                symbol.kind == SymbolKind::Function
+                    && symbol.name == task
+                    && symbol.detail.as_deref() == Some("gradle-kotlin-dsl-task")
+            }));
+        }
+        let fallback_gradle_kotlin = extract_fallback_graph(
+            "build.gradle.kts",
+            Some("kotlin"),
+            r#"
+tasks.register<BootRun>("bootRunE2E") {
+    group = "verification"
+}
+
+fun broken(
+"#,
+        );
+        assert_eq!(fallback_gradle_kotlin.parser, ParserKind::Fallback);
+        assert!(
+            fallback_gradle_kotlin.symbols.iter().any(|symbol| {
+                symbol.kind == SymbolKind::Function
+                    && symbol.name == "bootRunE2E"
+                    && symbol.detail.as_deref() == Some("gradle-kotlin-dsl-task")
+            }),
+            "fallback Gradle KTS graph should retain task symbols: {:?}",
+            fallback_gradle_kotlin.symbols
+        );
+
+        let gradle_groovy = extract_symbol_graph(
+            "build.gradle",
+            Some("groovy"),
+            r"
+plugins { id 'java' }
+
+tasks.register('bootRunSmoke', BootRun) {
+    group = 'verification'
+}
+
+task cleanE2E(type: Delete) {}
+
+tasks {
+    create('copyGroovyReports') {
+        group = 'verification'
+    }
+}
+
+task('publishE2E') {}
+",
+        );
+        assert_eq!(gradle_groovy.parser, ParserKind::Fallback);
+        for task in [
+            "bootRunSmoke",
+            "cleanE2E",
+            "copyGroovyReports",
+            "publishE2E",
+        ] {
+            assert!(gradle_groovy.symbols.iter().any(|symbol| {
+                symbol.kind == SymbolKind::Function
+                    && symbol.name == task
+                    && symbol.detail.as_deref() == Some("gradle-groovy-dsl-task")
+            }));
+        }
 
         let zig = extract_symbol_graph(
             "src/runner.zig",

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -23,12 +23,14 @@ Purpose correctness matters. `folder_purpose` and `file_purpose` explain why a f
 
 Purpose completion loop:
 
-1. Read missing-purpose findings from `atlas_health` or `projectatlas health-check`.
+1. Read the focused curation queue with `atlas_purpose_queue` or `projectatlas purpose queue --limit <n>`.
 2. Use the atlas sequence to inspect the path: folders, files, outline or symbols as needed.
 3. Set the correct purpose with `atlas_purpose_set` or `projectatlas purpose set`.
 4. Refresh with `atlas_watch_once`, `projectatlas watch --once`, or `projectatlas scan`.
 5. Rerun health/lint.
 6. Continue until the database has complete folder/file purposes and the deep index is current.
+
+`atlas_purpose_queue` and `projectatlas purpose queue` default to source-relevant paths: source files and folders that contain source files. Use `projectatlas purpose queue --include-assets`, raw `atlas_health`, or bare `projectatlas health-check` only when intentionally curating assets or generated outputs; non-source files should usually inherit purpose from an approved asset root instead of becoming one-by-one queue noise.
 
 If a duplicate-purpose, repeated temporary folder, or similar deterministic finding is intentional after inspection, resolve that exact finding with `atlas_health_resolve` or `projectatlas health resolve <finding-id> <category> <path> --related-path <path> --rationale "<why>"`. Do not resolve missing-purpose findings; fill the purpose instead.
 
@@ -50,7 +52,7 @@ result text is TOON by default, so agents get compact structured payloads withou
 8. Run `projectatlas symbols list --file <file>` and `projectatlas symbols relations --file <file>` when symbol context is needed.
 9. Run `projectatlas search <pattern> --file-pattern <glob>` for bounded, glob-filtered text search in selected areas; search is intentionally case-insensitive by default for agent discovery, add `--case-sensitive` only when exact casing matters, add `--fuzzy` when the name is approximate, and check returned, searched file, searched byte, and truncated counters before widening the search.
 10. Run `projectatlas slice <file> --start-line <n> --end-line <m>` or `projectatlas symbols slice <file> <symbol> --symbol-parent <parent> --symbol-kind <kind> --symbol-line <line>` for exact source slices; add symbol disambiguators when duplicate names exist.
-11. Run `projectatlas health-check` when planning cleanup or refactors.
+11. Run `projectatlas health-check --source-only --limit 50` when planning cleanup or refactors.
 12. Run `projectatlas lint --strict-folders --report-untracked`.
 13. Run `projectatlas token` when the user asks how many tokens ProjectAtlas saved.
 14. Only then run language-server lookups or broad file reads on the selected files.
@@ -153,14 +155,15 @@ Prefer MCP tools when the harness exposes them:
 8. `atlas_symbol_relations`: inspect imports, calls, dependencies, and containment.
 9. `atlas_search`: search indexed files with filters and pagination.
 10. `atlas_slice`: fetch exact line or symbol source only after selection.
-11. `atlas_health`: find cleanup/refactor/DRY structure issues. Use `limit`, `start_index`, `category`, `severity`, `path_prefix`, or `summary_only` for large health surfaces.
+11. `atlas_health`: find cleanup/refactor/DRY structure issues. Use `limit`, `start_index`, `category`, `severity`, `path_prefix`, `summary_only`, or `source_only` for large health surfaces.
 12. `atlas_watch_once`: bounded refresh after local file changes when no continuous watcher is running.
 13. `atlas_token_report`: report estimated token savings.
 14. `atlas_settings` and `atlas_watch_status`: diagnose runtime/index/cache state.
 15. `atlas_reset_index`: preview or clear local SQLite/cache files when the index is corrupt or intentionally being rebuilt.
 16. `atlas_strip_legacy_purpose`: remove migrated `.purpose` files when explicitly requested.
-17. `atlas_purpose_set`: write agent-approved purpose metadata into SQLite.
-18. `atlas_health_resolve`: mark an intentional deterministic health finding resolved with rationale.
+17. `atlas_purpose_queue`: return the source-focused queue of missing, suggested, stale, and structural purpose work for agent curation.
+18. `atlas_purpose_set`: write agent-approved purpose metadata into SQLite.
+19. `atlas_health_resolve`: mark an intentional deterministic health finding resolved with rationale.
 
 For read-only reviews or diagnostics, set `PROJECTATLAS_NO_TELEMETRY=1` before running CLI commands or the MCP server.
 This preserves normal atlas reads while preventing usage telemetry writes to `.projectatlas/projectatlas.db`.
@@ -182,7 +185,8 @@ This preserves normal atlas reads while preventing usage telemetry writes to `.p
 | Need exact source | `atlas_slice` | `projectatlas slice ...` or `projectatlas symbols slice ... --symbol-parent <parent>` |
 | Files changed locally | `atlas_watch_once` | `projectatlas watch --once` |
 | Long local editing session | `atlas_watch_status` for diagnostics | `projectatlas watch` |
-| Planning cleanup/refactor/DRY work | `atlas_health` with filters/paging when needed | `projectatlas health-check` |
+| Planning cleanup/refactor/DRY work | `atlas_health` with filters/paging when needed | `projectatlas health-check --source-only --limit <n>` |
+| Curating missing or generated purposes | `atlas_purpose_queue`, then `atlas_purpose_set` | `projectatlas purpose queue --limit <n>`, then `projectatlas purpose set ...` |
 | Intentional health conflict | `atlas_health_resolve` | `projectatlas health resolve ... --rationale <why>` |
 | User asks for saved tokens | `atlas_token_report` | `projectatlas token` |
 | Human asks for a terminal token dashboard | `atlas_token_report` first for agent state | `projectatlas token --view tui` |

--- a/docs/projectatlas-3-architecture.md
+++ b/docs/projectatlas-3-architecture.md
@@ -235,7 +235,8 @@ indexing tool. Public and semi-public surfaces use atlas/funnel vocabulary:
   `atlas_symbols_build`, `atlas_symbols`, `atlas_symbol_relations`,
   `atlas_health`, `atlas_health_resolve`, `atlas_token_report`,
   `atlas_settings`, `atlas_watch_status`, `atlas_watch_once`,
-  `atlas_strip_legacy_purpose`, and `atlas_purpose_set`.
+  `atlas_strip_legacy_purpose`, `atlas_purpose_queue`, and
+  `atlas_purpose_set`.
 - Crates/modules: `projectatlas-core`, `projectatlas-db`, `projectatlas-fs`,
   `projectatlas-service`, `projectatlas-symbols`, `projectatlas-query`,
   `projectatlas-mcp`.
@@ -555,6 +556,7 @@ ProjectAtlas-native:
 - `atlas_watch_status`
 - `atlas_watch_once`
 - `atlas_strip_legacy_purpose`
+- `atlas_purpose_queue`
 - `atlas_purpose_set`
 
 The tool descriptions must bias agents toward the funnel:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -99,10 +99,11 @@ The `overview:` line in the atlas now reports `tracked_source_files`,
 Do not add new Purpose headers or `.purpose` files for ProjectAtlas 3. Inspect the folder/file through the atlas funnel and write the correct one-line purpose to SQLite:
 
 ```bash
+projectatlas purpose queue --limit 20
 projectatlas purpose set <path> "<one-line purpose>"
 ```
 
-Generated purpose suggestions remain review-required until an agent approves or corrects them.
+The purpose queue is source-focused by default, so binary assets and asset-only roots do not dominate the next-action list. Pass `--include-assets` only when intentionally curating non-source files. Generated purpose suggestions remain review-required until an agent approves or corrects them.
 
 ### Legacy Purpose headers or .purpose files
 

--- a/fixtures/languages/baselines.toon
+++ b/fixtures/languages/baselines.toon
@@ -1,5 +1,5 @@
 version: 1
-summaries[26]{path,language,parser_kind,status,min_symbols,summary}:
+summaries[28]{path,language,parser_kind,status,min_symbols,summary}:
   rust/lib.rs,rust,tree-sitter-symbol-graph,ok,2,"rust source defining functions helper, run_rust_fixture."
   rust/build.rs,rust-build-script,tree-sitter-symbol-graph,ok,1,rust build script source defining function main.
   python/builder.py,python,tree-sitter-symbol-graph,ok,3,"python source defining type and functions Builder, build, helper."
@@ -9,6 +9,7 @@ summaries[26]{path,language,parser_kind,status,min_symbols,summary}:
   vue/ProductPanel.vue,vue,structural-symbol-graph,ok,3,"vue source defining bindings productTitleId, props, retryCount with imports import { computed, ref } from \"vue\";."
   java/AtlasService.java,java,tree-sitter-symbol-graph,ok,4,"java source defining type and functions AtlasService, helper, run."
   kotlin/Runner.kt,kotlin,tree-sitter-symbol-graph,ok,4,"kotlin source defining type and functions Runner, helper, run."
+  kotlin/build.gradle.kts,kotlin,tree-sitter-symbol-graph,ok,3,"kotlin source defining functions bootRunE2E, copyE2EReports, verifyAtlas."
   csharp/Runner.cs,csharp,tree-sitter-symbol-graph,ok,4,"C# source defining type and functions Helper, Run, Runner."
   go/service.go,go,tree-sitter-symbol-graph,ok,5,"go source defining type and functions Run, Runner, helper with imports import \"fmt\"."
   objective-c/UserManager.m,objective-c,tree-sitter-symbol-graph,ok,2,"Objective-C source defining type and function UserManager, run."
@@ -24,5 +25,6 @@ summaries[26]{path,language,parser_kind,status,min_symbols,summary}:
   yaml/workflow.yml,yaml,structural,ok,0,"yaml workflow CI triggered by pull_request, push with jobs test."
   css/tokens.css,css,structural,ok,0,"css stylesheet with selectors .card, .panel, :root, custom properties --brand, 1 media queries, and 0 supports queries."
   html/index.html,html,structural,ok,0,"html document with title Home, meta description Welcome page, headings Hello, structured data."
+  groovy/build.gradle,groovy,fallback-symbol-graph,fallback,4,"groovy source defining functions bootRunSmoke, cleanE2E, copyGroovyReports, publishE2E."
   rust/empty.rs,rust,tree-sitter-symbol-graph,ok,0,rust source file with no declarations found.
   toon/projectatlas-nonsource-files.toon,toon,structural,ok,0,TOON document with sections nonsource_files.

--- a/fixtures/languages/groovy/build.gradle
+++ b/fixtures/languages/groovy/build.gradle
@@ -1,0 +1,13 @@
+tasks.register('bootRunSmoke', BootRun) {
+    group = 'verification'
+}
+
+task cleanE2E(type: Delete) {}
+
+tasks {
+    create('copyGroovyReports') {
+        group = 'verification'
+    }
+}
+
+task('publishE2E') {}

--- a/fixtures/languages/kotlin/build.gradle.kts
+++ b/fixtures/languages/kotlin/build.gradle.kts
@@ -1,0 +1,13 @@
+tasks.register<BootRun>("bootRunE2E") {
+    group = "verification"
+}
+
+val verifyAtlas by tasks.registering {
+    group = "verification"
+}
+
+tasks {
+    register<Copy>("copyE2EReports") {
+        group = "verification"
+    }
+}

--- a/plugins/projectatlas/.claude-plugin/plugin.json
+++ b/plugins/projectatlas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for Claude Code.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/.codex-plugin/plugin.json
+++ b/plugins/projectatlas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for coding agents.",
   "author": {
     "name": "ProjectAtlas Contributors",
@@ -37,8 +37,7 @@
     "defaultPrompt": [
       "Use ProjectAtlas to map this repo.",
       "Use the ProjectAtlas MCP tools before opening files.",
-      "Adopt ProjectAtlas in this project.",
-      "Fix ProjectAtlas lint failures."
+      "Adopt ProjectAtlas in this project."
     ],
     "brandColor": "#2563EB"
   }

--- a/plugins/projectatlas/opencode/opencode.json
+++ b/plugins/projectatlas/opencode/opencode.json
@@ -6,7 +6,7 @@
       "command": [
         "/absolute/path/to/projectatlas",
         "--require-version",
-        "0.3.8",
+        "0.3.9",
         "--db",
         "/absolute/path/to/project/.projectatlas/projectatlas.db",
         "mcp"

--- a/plugins/projectatlas/skills/projectatlas/SKILL.md
+++ b/plugins/projectatlas/skills/projectatlas/SKILL.md
@@ -35,18 +35,21 @@ Purpose and summary are separate:
 - `stale` applies to approved purpose metadata that needs review after a meaningful change; it does not mean the refreshed `content_summary` is stale.
 - Generated summaries are acceptable as deterministic content metadata.
 - Generated purposes are only suggestions and must not be treated as correct until imported from trusted legacy metadata or approved by the agent after inspection.
-- If lint or health reports missing purposes, the agent must inspect the folder/file enough to write a correct one-line purpose and call `atlas_purpose_set` or `projectatlas purpose set`; do not leave the purpose blank just because no human supplied it.
+- If lint, health, or the curation queue reports missing purposes, the agent must inspect the folder/file enough to write a correct one-line purpose and call `atlas_purpose_set` or `projectatlas purpose set`; do not leave the purpose blank just because no human supplied it.
 
 ## Purpose Completion Loop
 
-When `atlas_health`, `projectatlas health-check`, or `projectatlas lint` reports missing purposes:
+When `atlas_purpose_queue`, `projectatlas purpose queue`, `atlas_health`, `projectatlas health-check`, or `projectatlas lint` reports missing purposes:
 
-1. Use `atlas_folders`/`atlas_files` to locate the missing path.
-2. Inspect only enough context to understand the path's actual role.
-3. Write a precise one-line purpose with `atlas_purpose_set` or `projectatlas purpose set`.
-4. Run `atlas_watch_once`, `projectatlas watch --once`, or `projectatlas scan`.
-5. Rerun health/lint.
-6. Repeat until the ProjectAtlas database has purposes for all indexed folders/files and the deep index is refreshed.
+1. Start with `atlas_purpose_queue` or `projectatlas purpose queue --limit <n>` for a source-focused next-action list.
+2. Use `atlas_folders`/`atlas_files` to locate the missing path.
+3. Inspect only enough context to understand the path's actual role.
+4. Write a precise one-line purpose with `atlas_purpose_set` or `projectatlas purpose set`.
+5. Run `atlas_watch_once`, `projectatlas watch --once`, or `projectatlas scan`.
+6. Rerun health/lint.
+7. Repeat until the ProjectAtlas database has purposes for all indexed folders/files and the deep index is refreshed.
+
+`atlas_purpose_queue` and `projectatlas purpose queue` default to source-relevant paths: source files and folders that contain source files. Use `projectatlas purpose queue --include-assets`, raw `atlas_health`, or bare `projectatlas health-check` only when intentionally curating assets or generated outputs.
 
 This loop is an agent responsibility installed with the plugin. Do not wait for human purpose text during normal agent-harness operation.
 
@@ -115,14 +118,15 @@ Use the MCP tools when the harness exposes them. They are preferred over shell c
 7. `atlas_symbols` and `atlas_symbol_relations` when function/class/import/call context is needed.
 8. `atlas_search` for filtered literal, regex, or fuzzy matches inside indexed files.
 9. `atlas_slice` for exact line or symbol source after folder/file/symbol selection.
-10. `atlas_health` before cleanup, refactor, or DRY decisions. On large repositories, pass `limit`, `start_index`, `category`, `severity`, `path_prefix`, or `summary_only` so health review stays bounded.
+10. `atlas_health` before cleanup, refactor, or DRY decisions. On large repositories, pass `limit`, `start_index`, `category`, `severity`, `path_prefix`, `summary_only`, or `source_only` so health review stays bounded.
 11. `atlas_watch_once` after file changes when a continuous watcher is not running.
 12. `atlas_token_report` when the user asks how many tokens ProjectAtlas saved.
 13. `atlas_settings` and `atlas_watch_status` for diagnostics.
 14. `atlas_reset_index` dry-run first when the local SQLite/cache state is corrupt or intentionally discarded.
 15. `atlas_strip_legacy_purpose` only after migrated `.purpose` metadata is safely stored in SQLite.
-16. `atlas_purpose_set` when an agent-approved purpose should be written to the durable index.
-17. `atlas_health_resolve` when a deterministic conflict is intentionally correct and should not be repeated.
+16. `atlas_purpose_queue` when an agent needs a source-focused purpose curation queue before approving or correcting generated purposes.
+17. `atlas_purpose_set` when an agent-approved purpose should be written to the durable index.
+18. `atlas_health_resolve` when a deterministic conflict is intentionally correct and should not be repeated.
 
 ## Command Decision Rules
 
@@ -138,7 +142,8 @@ Use the MCP tools when the harness exposes them. They are preferred over shell c
 - Need text occurrences: call `atlas_search` with `file_pattern`, `context_lines`, and `limit` rather than broad shell search; search is intentionally case-insensitive by default for agent discovery, set `case_sensitive` only when exact casing matters, set `fuzzy` when the name is approximate, and treat `truncated`, searched file count, and searched byte count as the signal for whether to narrow or widen the glob.
 - After creating, moving, deleting, or editing files: call `atlas_watch_once`, `projectatlas watch --once`, or `atlas_scan` before trusting old results.
 - During a long local editing session: prefer a single continuous `projectatlas watch` process from the project root, then use MCP reads against the refreshed SQLite index. File edits refresh incrementally; directory/root/ignore-rule changes may trigger a full scan for correctness.
-- Planning cleanup/refactor/DRY work: call `atlas_health` after overview/folder/file orientation and before proposing moves/merges; use `summary_only`, `category`, `severity`, `path_prefix`, `limit`, and `start_index` when the health surface is large.
+- Planning cleanup/refactor/DRY work: call `atlas_health` after overview/folder/file orientation and before proposing moves/merges; use `summary_only`, `source_only`, `category`, `severity`, `path_prefix`, `limit`, and `start_index` when the health surface is large.
+- Purpose curation: call `atlas_purpose_queue` before writing purposes; then inspect enough context and call `atlas_purpose_set`.
 - Intentional health conflict after inspection: call `atlas_health_resolve` with a rationale.
 - User asks about saved tokens: call `atlas_token_report`.
 - Runtime looks wrong: call `projectatlas --format json runtime-info`, then `atlas_settings` and `atlas_watch_status`.
@@ -175,7 +180,8 @@ If MCP tools are unavailable, use the equivalent CLI sequence:
 | Exact symbol | `projectatlas symbols slice <file> <symbol> --symbol-parent <parent>` |
 | Refresh after edits | `projectatlas watch --once` |
 | Continuous local refresh | `projectatlas watch` |
-| Cleanup/refactor signals | `projectatlas health-check` |
+| Cleanup/refactor signals | `projectatlas health-check --source-only --limit <n>` |
+| Purpose curation queue | `projectatlas purpose queue --limit <n>` |
 | Token savings | `projectatlas token` |
 | Human token dashboard | `projectatlas token --view tui` |
 | Diagnostics | `projectatlas settings`, `projectatlas config --print`, and `projectatlas watch-status` |
@@ -194,7 +200,7 @@ If MCP tools are unavailable, use the equivalent CLI sequence:
 8. Run `projectatlas symbols list --file <file>` and `projectatlas symbols relations --file <file>` when symbol context is needed.
 9. Run `projectatlas search <pattern> --file-pattern <glob>` for bounded filtered text matches; add `--fuzzy` when the name is approximate, and inspect returned, searched file, searched byte, and truncated counters before widening the search.
 10. Run `projectatlas slice <file> --start-line <n> --end-line <m>` or `projectatlas symbols slice <file> <symbol> --symbol-parent <parent> --symbol-kind <kind> --symbol-line <line>` for exact source; add disambiguators when duplicate names exist.
-11. Run `projectatlas health-check` before cleanup/refactor decisions.
+11. Run `projectatlas health-check --source-only --limit 50` before cleanup/refactor decisions.
 12. Only then use language servers or broad file reads on selected targets.
 13. Run `projectatlas token` when token-savings reporting is requested; use `projectatlas token --view tui` only for a human terminal dashboard.
 14. Run `projectatlas lint --strict-folders --report-untracked` before finishing structural changes.


### PR DESCRIPTION
## Summary
- reduce Codex plugin default prompts and bump ProjectAtlas/plugin manifests to v0.3.9
- add source-focused CLI/MCP purpose curation queue with source-only health filtering, paging, severity/category/path filters, and contextual folder duplicate detection
- improve generated purpose suggestions with path context, symbols, Gradle DSL tasks, multi-dot filenames, and refreshable generated suggestions until agent approval
- extract Gradle Kotlin DSL and Gradle Groovy DSL task registrations as symbols and ranking signals, including fallback KTS coverage
- add content-aware file ranking via indexed text fallback and keep docs/skill/runtime CLI behavior in lockstep
- regenerate the ProjectAtlas compatibility map with approved purposes for new Gradle fixtures/parser files

Fixes #196.
Fixes #197.
Fixes #198.
Fixes #199.
Fixes #200.
Fixes #201.
Fixes #202.
Fixes #203.

## Verification
- `cargo fmt --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `cargo test --doc --workspace --all-features --locked`
- `$env:RUSTDOCFLAGS='-D warnings'; cargo doc --workspace --no-deps --all-features --locked`
- `cargo deny check` (passed with existing duplicate dependency warnings)
- `python .github/scripts/release-notes.py --self-test`
- `git diff --check`
- `cargo run -q -p projectatlas-cli -- map --force`
- `cargo run -q -p projectatlas-cli -- lint --strict-folders --report-untracked`
- `cargo run -q -p projectatlas-cli -- --db .projectatlas/projectatlas.db scan .`
- `cargo run -q -p projectatlas-cli -- --db .projectatlas/projectatlas.db purpose queue --limit 20`
- `cargo run -q -p projectatlas-cli -- --db .projectatlas/projectatlas.db health-check --source-only --limit 20`
- focused e2e: plugin installer version matching, plugin update/reinstall MCP smoke, generated purpose approval, noisy purpose queue regression, Gradle DSL symbols/ranking

## Notes
- README pirate image and repository icon assets were not changed.
- The source-only purpose queue is clean locally: zero missing, stale, or suggested purposes after scan.
