### PR TITLE
Enforce reviewed purpose replay and v0.3.13 release (#217)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,12 @@ jobs:
       - name: Tests
         run: cargo test --workspace --all-features --locked
 
+      - name: ProjectAtlas purpose lint levels
+        run: cargo test --locked -p projectatlas-cli lint_purpose_levels_require_agent_review_at_configured_scope --test e2e
+
+      - name: ProjectAtlas purpose preservation
+        run: cargo test --locked -p projectatlas-cli watch_once_preserves_unchanged_deep_summary_and_text_index --test e2e
+
       - name: Doc tests
         run: cargo test --doc --all-features --locked
 
@@ -78,11 +84,14 @@ jobs:
       - name: ProjectAtlas scan
         run: cargo run --locked -p projectatlas-cli -- --format json scan .
 
+      - name: ProjectAtlas purpose review
+        run: cargo run --locked -p projectatlas-cli -- purpose review --from-file .projectatlas/projectatlas-purpose-review.json --apply
+
       - name: ProjectAtlas parity
         run: cargo run --locked -p projectatlas-cli -- parity report --profile repository-intelligence
 
       - name: ProjectAtlas lint
-        run: cargo run --locked -p projectatlas-cli -- lint --report-untracked
+        run: cargo run --locked -p projectatlas-cli -- lint --report-untracked --purpose-level strict
 
   install-smoke:
     name: install-smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Tests
         run: cargo test --workspace --all-features --locked
 
+      - name: ProjectAtlas purpose lint levels
+        run: cargo test --locked -p projectatlas-cli lint_purpose_levels_require_agent_review_at_configured_scope --test e2e
+
+      - name: ProjectAtlas purpose preservation
+        run: cargo test --locked -p projectatlas-cli watch_once_preserves_unchanged_deep_summary_and_text_index --test e2e
+
       - name: Doc tests
         run: cargo test --doc --workspace --all-features --locked
 
@@ -89,11 +95,14 @@ jobs:
       - name: ProjectAtlas scan
         run: cargo run --locked -p projectatlas-cli -- --format json scan .
 
+      - name: ProjectAtlas purpose review
+        run: cargo run --locked -p projectatlas-cli -- purpose review --from-file .projectatlas/projectatlas-purpose-review.json --apply
+
       - name: ProjectAtlas parity
         run: cargo run --locked -p projectatlas-cli -- parity report --profile repository-intelligence
 
       - name: ProjectAtlas lint
-        run: cargo run --locked -p projectatlas-cli -- lint --report-untracked
+        run: cargo run --locked -p projectatlas-cli -- lint --report-untracked --purpose-level strict
 
   package-unix:
     name: package ${{ matrix.label }}

--- a/.projectatlas/config.toml
+++ b/.projectatlas/config.toml
@@ -5,7 +5,6 @@
 root = "."
 map_path = ".projectatlas/projectatlas.toon"
 nonsource_files_path = ".projectatlas/projectatlas-nonsource-files.toon"
-purpose_filename = ".purpose"
 
 [scan]
 source_extensions = [".py", ".pyw", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".d.ts", ".java", ".c", ".cpp", ".h", ".hpp", ".cxx", ".cc", ".hxx", ".hh", ".cs", ".go", ".m", ".mm", ".rb", ".php", ".swift", ".kt", ".kts", ".rs", ".scala", ".sh", ".bash", ".zsh", ".ps1", ".psm1", ".psd1", ".bat", ".cmd", ".r", ".pl", ".pm", ".lua", ".dart", ".hs", ".ml", ".mli", ".fs", ".fsx", ".clj", ".cljs", ".vim", ".zig", ".zon", ".html", ".htm", ".css", ".scss", ".sass", ".less", ".stylus", ".styl", ".md", ".mdx", ".json", ".jsonc", ".xml", ".yml", ".yaml", ".toml", ".toon", ".txt", ".ini", ".cfg", ".conf", ".vue", ".svelte", ".astro", ".jsp", ".jspx", ".jspf", ".tag", ".tagx", ".gsp", ".properties", ".gradle", ".groovy", ".proto", ".hbs", ".handlebars", ".ejs", ".pug", ".ftl", ".mustache", ".liquid", ".erb", ".sql", ".ddl", ".dml", ".mysql", ".postgresql", ".psql", ".sqlite", ".mssql", ".oracle", ".ora", ".db2", ".proc", ".procedure", ".func", ".function", ".view", ".trigger", ".index", ".migration", ".seed", ".fixture", ".schema", ".cql", ".cypher", ".sparql", ".gql", ".liquibase", ".flyway"]
@@ -32,7 +31,7 @@ no_commas = true
 max_length = 140
 
 [untracked]
-allowed_filenames = [".purpose"]
+allowed_filenames = []
 allowlist_dir_prefixes = [".githooks"]
 allowlist_files = []
 asset_allowed_prefixes = ["docs/assets"]

--- a/.projectatlas/projectatlas-purpose-review.json
+++ b/.projectatlas/projectatlas-purpose-review.json
@@ -1,0 +1,688 @@
+{
+  "items": [
+    {
+      "path": ".",
+      "purpose": "Root workspace for Rust-native ProjectAtlas, including crates, docs, plugin packaging, fixtures, and release automation."
+    },
+    {
+      "path": ".agents",
+      "purpose": "Agent marketplace metadata used to publish ProjectAtlas plugin integrations."
+    },
+    {
+      "path": ".agents/plugins",
+      "purpose": "Marketplace plugin catalog entries that advertise ProjectAtlas to agent hosts."
+    },
+    {
+      "path": ".githooks",
+      "purpose": "Repository Git hooks that enforce local ProjectAtlas development checks."
+    },
+    {
+      "path": ".github",
+      "purpose": "GitHub issue templates, scripts, and workflows for ProjectAtlas development and releases."
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE",
+      "purpose": "GitHub issue forms for structured ProjectAtlas bug reports and improvement requests."
+    },
+    {
+      "path": ".github/scripts",
+      "purpose": "GitHub Actions helper scripts for ProjectAtlas release and automation workflows."
+    },
+    {
+      "path": ".github/workflows",
+      "purpose": "CI, docs, and release workflows for building, testing, packaging, and publishing ProjectAtlas."
+    },
+    {
+      "path": ".projectatlas",
+      "purpose": "Store project-local ProjectAtlas configuration, reviewed-purpose replay input, non-source summaries, and runtime state."
+    },
+    {
+      "path": "crates",
+      "purpose": "Rust workspace crates that implement ProjectAtlas scanning, storage, CLI, MCP, symbols, and services."
+    },
+    {
+      "path": "crates/projectatlas-cli",
+      "purpose": "ProjectAtlas CLI and MCP adapter crate for agent-facing repository intelligence commands."
+    },
+    {
+      "path": "crates/projectatlas-cli/src",
+      "purpose": "CLI, MCP, runtime, and compatibility-map implementation for the ProjectAtlas binary."
+    },
+    {
+      "path": "crates/projectatlas-cli/tests",
+      "purpose": "End-to-end and CLI diagnostic tests for ProjectAtlas workflows, installers, and agent contracts."
+    },
+    {
+      "path": "crates/projectatlas-core",
+      "purpose": "Core ProjectAtlas crate for shared domain models, health findings, summaries, and symbol types."
+    },
+    {
+      "path": "crates/projectatlas-core/src",
+      "purpose": "Shared Rust domain modules used by ProjectAtlas CLI, database, filesystem, and symbol crates."
+    },
+    {
+      "path": "crates/projectatlas-db",
+      "purpose": "SQLite persistence crate for ProjectAtlas indexes, purposes, health findings, text, and telemetry."
+    },
+    {
+      "path": "crates/projectatlas-db/src",
+      "purpose": "Database schema, query, migration, purpose, and health paging implementation for ProjectAtlas."
+    },
+    {
+      "path": "crates/projectatlas-fs",
+      "purpose": "Filesystem scanner crate that discovers repository files and folders with gitignore-aware filtering."
+    },
+    {
+      "path": "crates/projectatlas-fs/src",
+      "purpose": "Rust filesystem walking, ignore handling, and file metadata collection for ProjectAtlas scans."
+    },
+    {
+      "path": "crates/projectatlas-service",
+      "purpose": "Shared query service crate used by CLI and MCP to rank files, summarize slices, and search indexed text."
+    },
+    {
+      "path": "crates/projectatlas-service/src",
+      "purpose": "Service-layer Rust source for ProjectAtlas file, folder, search, summary, and slice queries."
+    },
+    {
+      "path": "crates/projectatlas-symbols",
+      "purpose": "Symbol extraction crate for tree-sitter and language-specific ProjectAtlas code understanding."
+    },
+    {
+      "path": "crates/projectatlas-symbols/src",
+      "purpose": "Tree-sitter-backed symbol graph extraction and summary code for ProjectAtlas."
+    },
+    {
+      "path": "crates/projectatlas-symbols/src/languages",
+      "purpose": "Language-specific symbol augmentation modules for DSLs and constructs beyond generic tree-sitter parsing."
+    },
+    {
+      "path": "docs",
+      "purpose": "ProjectAtlas user, architecture, workflow, configuration, adoption, and release documentation."
+    },
+    {
+      "path": "docs/assets",
+      "purpose": "Images and visual assets referenced by ProjectAtlas README and documentation pages."
+    },
+    {
+      "path": "docs/benchmarks",
+      "purpose": "Measured ProjectAtlas token-savings and repository-orientation benchmark documentation."
+    },
+    {
+      "path": "fixtures",
+      "purpose": "Regression fixtures used to verify ProjectAtlas language parsing, summaries, symbols, and scan behavior."
+    },
+    {
+      "path": "fixtures/languages",
+      "purpose": "Language-specific fixture corpus for ProjectAtlas parser, summary, and symbol regression tests."
+    },
+    {
+      "path": "fixtures/languages/c",
+      "purpose": "C language fixtures for ProjectAtlas parser, summary, and symbol regression coverage."
+    },
+    {
+      "path": "fixtures/languages/cpp",
+      "purpose": "C++ language fixtures for ProjectAtlas parser, summary, and symbol regression coverage."
+    },
+    {
+      "path": "fixtures/languages/csharp",
+      "purpose": "C# language fixtures for ProjectAtlas parser, summary, and symbol regression coverage."
+    },
+    {
+      "path": "fixtures/languages/css",
+      "purpose": "CSS fixtures for ProjectAtlas structural summary and symbol extraction coverage."
+    },
+    {
+      "path": "fixtures/languages/go",
+      "purpose": "Go language fixtures for ProjectAtlas parser, summary, and symbol regression coverage."
+    },
+    {
+      "path": "fixtures/languages/groovy",
+      "purpose": "Gradle Groovy DSL fixtures used to verify build task extraction and summaries."
+    },
+    {
+      "path": "fixtures/languages/html",
+      "purpose": "HTML fixtures for ProjectAtlas structural summary and extraction coverage."
+    },
+    {
+      "path": "fixtures/languages/java",
+      "purpose": "Java language fixtures for ProjectAtlas parser, summary, and symbol regression coverage."
+    },
+    {
+      "path": "fixtures/languages/javascript",
+      "purpose": "JavaScript fixtures for ProjectAtlas parser, summary, and symbol regression coverage."
+    },
+    {
+      "path": "fixtures/languages/json",
+      "purpose": "JSON manifest fixtures for ProjectAtlas package and config summary extraction."
+    },
+    {
+      "path": "fixtures/languages/kotlin",
+      "purpose": "Kotlin and Gradle Kotlin DSL fixtures for ProjectAtlas parser, summary, and task extraction coverage."
+    },
+    {
+      "path": "fixtures/languages/markdown",
+      "purpose": "Markdown fixtures for ProjectAtlas document structure and summary extraction coverage."
+    },
+    {
+      "path": "fixtures/languages/objective-c",
+      "purpose": "Objective-C fixtures for ProjectAtlas parser, summary, and symbol regression coverage."
+    },
+    {
+      "path": "fixtures/languages/rust",
+      "purpose": "Rust language fixtures for ProjectAtlas parser, summary, and symbol regression coverage."
+    },
+    {
+      "path": "fixtures/languages/toml",
+      "purpose": "TOML and Cargo manifest fixtures for ProjectAtlas dependency and config summary coverage."
+    },
+    {
+      "path": "fixtures/languages/toon",
+      "purpose": "TOON fixtures for ProjectAtlas structured-output summary and parsing coverage."
+    },
+    {
+      "path": "fixtures/languages/typescript",
+      "purpose": "TypeScript fixtures for ProjectAtlas parser, summary, and symbol regression coverage."
+    },
+    {
+      "path": "fixtures/languages/vue",
+      "purpose": "Vue fixtures for ProjectAtlas component summary and Composition API extraction coverage."
+    },
+    {
+      "path": "fixtures/languages/yaml",
+      "purpose": "YAML workflow and config fixtures for ProjectAtlas structural summary coverage."
+    },
+    {
+      "path": "fixtures/languages/zig",
+      "purpose": "Zig language fixtures for ProjectAtlas parser, summary, and symbol regression coverage."
+    },
+    {
+      "path": "plugins",
+      "purpose": "Installable ProjectAtlas plugin packages and host integration assets."
+    },
+    {
+      "path": "plugins/projectatlas",
+      "purpose": "ProjectAtlas plugin bundle containing manifests, skills, scripts, and host templates."
+    },
+    {
+      "path": "plugins/projectatlas/.claude-plugin",
+      "purpose": "Claude Code plugin metadata for packaging ProjectAtlas harness integration."
+    },
+    {
+      "path": "plugins/projectatlas/.codex-plugin",
+      "purpose": "Codex plugin manifest metadata for installing ProjectAtlas as a plugin."
+    },
+    {
+      "path": "plugins/projectatlas/opencode",
+      "purpose": "OpenCode templates for registering ProjectAtlas as a local MCP server."
+    },
+    {
+      "path": "plugins/projectatlas/scripts",
+      "purpose": "Cross-platform runtime installer scripts shipped with the ProjectAtlas plugin."
+    },
+    {
+      "path": "plugins/projectatlas/skills",
+      "purpose": "Skill folders included in the installable ProjectAtlas plugin bundle."
+    },
+    {
+      "path": "plugins/projectatlas/skills/projectatlas",
+      "purpose": "ProjectAtlas plugin skill that teaches agents the atlas-first MCP workflow."
+    },
+    {
+      "path": "skills",
+      "purpose": "Standalone agent skill files for using ProjectAtlas from different coding assistants."
+    },
+    {
+      "path": "skills/claude",
+      "purpose": "Claude-oriented ProjectAtlas setup and workflow guidance."
+    },
+    {
+      "path": "skills/codex",
+      "purpose": "Codex-oriented ProjectAtlas setup and workflow guidance."
+    },
+    {
+      "path": "templates",
+      "purpose": "Reusable ProjectAtlas agent instruction templates and startup snippets."
+    },
+    {
+      "path": ".agents/plugins/marketplace.json",
+      "purpose": "Codex plugin marketplace catalog for ProjectAtlas"
+    },
+    {
+      "path": ".gitattributes",
+      "purpose": "Line-ending policy for ProjectAtlas repository fixtures"
+    },
+    {
+      "path": ".githooks/commit-msg",
+      "purpose": "Git hook to enforce issue references in commits"
+    },
+    {
+      "path": ".githooks/pre-push",
+      "purpose": "Git hook to run full local checks before push"
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/bug_report.yml",
+      "purpose": "GitHub issue form for public ProjectAtlas bug reports."
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/config.yml",
+      "purpose": "GitHub issue template chooser configuration for ProjectAtlas."
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/improvement_request.yml",
+      "purpose": "GitHub issue form for public ProjectAtlas improvement requests."
+    },
+    {
+      "path": ".github/pull_request_template.md",
+      "purpose": "Pull request checklist for ProjectAtlas changes, verification gates, issue links, purpose queue review, and release-note hygiene."
+    },
+    {
+      "path": ".github/scripts/release-notes.py",
+      "purpose": "Generate ProjectAtlas release notes from merged PRs and linked issues."
+    },
+    {
+      "path": ".github/workflows/03-auto-release.yml",
+      "purpose": "Workflow that automates ProjectAtlas release publication after validated version changes."
+    },
+    {
+      "path": ".github/workflows/04-docs.yml",
+      "purpose": "Workflow that builds and deploys the ProjectAtlas documentation site."
+    },
+    {
+      "path": ".github/workflows/ci.yml",
+      "purpose": "Workflow that verifies ProjectAtlas Rust gates plus multi-OS installer, update, locked-runtime, and MCP smoke tests."
+    },
+    {
+      "path": ".github/workflows/release.yml",
+      "purpose": "Workflow that packages ProjectAtlas releases, validates cross-platform installers including locked Windows runtime updates, and publishes release artifacts and notes."
+    },
+    {
+      "path": ".gitignore",
+      "purpose": "Ignored files for ProjectAtlas repository"
+    },
+    {
+      "path": ".projectatlas/config.toml",
+      "purpose": "Configure project-local ProjectAtlas scan, lint, purpose, and output policy."
+    },
+    {
+      "path": ".projectatlas/projectatlas-nonsource-files.toon",
+      "purpose": "Declare project-local non-source file purposes for ProjectAtlas map compatibility."
+    },
+    {
+      "path": ".projectatlas/projectatlas-purpose-review.json",
+      "purpose": "Replay agent-reviewed ProjectAtlas purpose records into the local SQLite index."
+    },
+    {
+      "path": "AGENTS.md",
+      "purpose": "Repository-specific Codex startup rules for atlas-first ProjectAtlas development, purpose linting, and release-grade Rust workflow."
+    },
+    {
+      "path": "Cargo.lock",
+      "purpose": "Locked Rust dependency graph for the ProjectAtlas workspace release build."
+    },
+    {
+      "path": "Cargo.toml",
+      "purpose": "Rust workspace manifest for ProjectAtlas crates, shared dependencies, lints, and release version."
+    },
+    {
+      "path": "CODE_OF_CONDUCT.md",
+      "purpose": "Community conduct expectations for ProjectAtlas"
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "purpose": "Contribution policy for ProjectAtlas."
+    },
+    {
+      "path": "crates/projectatlas-cli/Cargo.toml",
+      "purpose": "Cargo manifest for the ProjectAtlas CLI crate and its runtime/test dependencies."
+    },
+    {
+      "path": "crates/projectatlas-cli/src/atlas_map.rs",
+      "purpose": "Generate and lint `ProjectAtlas` structure maps from Rust."
+    },
+    {
+      "path": "crates/projectatlas-cli/src/main.rs",
+      "purpose": "Defines the ProjectAtlas CLI command surface, argument parsing, command dispatch, and parity reporting."
+    },
+    {
+      "path": "crates/projectatlas-cli/src/mcp.rs",
+      "purpose": "Serves ProjectAtlas repository intelligence tools over the Model Context Protocol."
+    },
+    {
+      "path": "crates/projectatlas-cli/src/runtime.rs",
+      "purpose": "Coordinates ProjectAtlas scan, index refresh, purpose import, health, lint, token, watch, and legacy cleanup workflows."
+    },
+    {
+      "path": "crates/projectatlas-cli/src/structural.rs",
+      "purpose": "Create deterministic structural summaries for declaration light files"
+    },
+    {
+      "path": "crates/projectatlas-cli/tests/e2e.rs",
+      "purpose": "End-to-end ProjectAtlas CLI tests for scan, MCP, installer updates, locked-runtime updates, purpose, lint, language, and release workflows."
+    },
+    {
+      "path": "crates/projectatlas-cli/tests/lint_diagnostics.rs",
+      "purpose": "Regression test ensuring ProjectAtlas lint no longer requires legacy source purpose headers."
+    },
+    {
+      "path": "crates/projectatlas-core/Cargo.toml",
+      "purpose": "Cargo manifest for the ProjectAtlas core domain crate."
+    },
+    {
+      "path": "crates/projectatlas-core/src/health.rs",
+      "purpose": "Detect structural health issues in `ProjectAtlas` indexes."
+    },
+    {
+      "path": "crates/projectatlas-core/src/language.rs",
+      "purpose": "Detect file language families from extensions."
+    },
+    {
+      "path": "crates/projectatlas-core/src/lib.rs",
+      "purpose": "Defines core ProjectAtlas domain models, purpose metadata, summaries, and shared helpers."
+    },
+    {
+      "path": "crates/projectatlas-core/src/outline.rs",
+      "purpose": "Build compressed file outlines for agent context."
+    },
+    {
+      "path": "crates/projectatlas-core/src/symbols.rs",
+      "purpose": "Define `ProjectAtlas` symbol graph domain types."
+    },
+    {
+      "path": "crates/projectatlas-core/src/telemetry.rs",
+      "purpose": "Track `ProjectAtlas` token savings telemetry."
+    },
+    {
+      "path": "crates/projectatlas-core/src/toon.rs",
+      "purpose": "Render `ProjectAtlas` responses with the TOON standard encoder."
+    },
+    {
+      "path": "crates/projectatlas-db/Cargo.toml",
+      "purpose": "Cargo manifest for the ProjectAtlas SQLite persistence crate."
+    },
+    {
+      "path": "crates/projectatlas-db/src/lib.rs",
+      "purpose": "Persists ProjectAtlas scan indexes, purpose metadata, health findings, symbols, text, and telemetry in SQLite."
+    },
+    {
+      "path": "crates/projectatlas-fs/Cargo.toml",
+      "purpose": "Cargo manifest for the ProjectAtlas filesystem scanning crate."
+    },
+    {
+      "path": "crates/projectatlas-fs/src/lib.rs",
+      "purpose": "Scans repository files and folders for ProjectAtlas with gitignore-aware filtering."
+    },
+    {
+      "path": "crates/projectatlas-service/Cargo.toml",
+      "purpose": "Cargo manifest for shared ProjectAtlas query services."
+    },
+    {
+      "path": "crates/projectatlas-service/src/import_aliases.rs",
+      "purpose": "Resolves deterministic import-alias caller targets from persisted import and call relations for file summaries."
+    },
+    {
+      "path": "crates/projectatlas-service/src/lib.rs",
+      "purpose": "Provides shared ProjectAtlas query services for file ranking, search, summaries, slices, and outlines."
+    },
+    {
+      "path": "crates/projectatlas-symbols/Cargo.toml",
+      "purpose": "Cargo manifest for ProjectAtlas symbol extraction and tree-sitter dependencies."
+    },
+    {
+      "path": "crates/projectatlas-symbols/src/languages/c_family.rs",
+      "purpose": "Reserves the C and C++ language augmentation boundary for parser-specific corrections."
+    },
+    {
+      "path": "crates/projectatlas-symbols/src/languages/gradle.rs",
+      "purpose": "Extract Gradle Kotlin and Groovy DSL task registrations as symbols."
+    },
+    {
+      "path": "crates/projectatlas-symbols/src/languages/kotlin.rs",
+      "purpose": "Adds Kotlin package, type, and method facts that the generic tree-sitter pass does not emit reliably."
+    },
+    {
+      "path": "crates/projectatlas-symbols/src/languages/mod.rs",
+      "purpose": "Dispatches language-specific symbol augmentation and shared relation helpers."
+    },
+    {
+      "path": "crates/projectatlas-symbols/src/languages/objective_c.rs",
+      "purpose": "Adds Objective-C class ownership and de-duplicates interface versus implementation symbols for summaries."
+    },
+    {
+      "path": "crates/projectatlas-symbols/src/languages/zig.rs",
+      "purpose": "Adds Zig struct binding names and method parents that are missing from generic parser output."
+    },
+    {
+      "path": "crates/projectatlas-symbols/src/lib.rs",
+      "purpose": "Extracts ProjectAtlas symbol graphs and language summaries from source files."
+    },
+    {
+      "path": "deny.toml",
+      "purpose": "Cargo dependency and license policy for ProjectAtlas"
+    },
+    {
+      "path": "docs/adoption.md",
+      "purpose": "Guide teams through adopting ProjectAtlas in an existing repository."
+    },
+    {
+      "path": "docs/agent-integration.md",
+      "purpose": "Document agent startup, purpose curation, lint-level, and MCP integration workflows for ProjectAtlas."
+    },
+    {
+      "path": "docs/assets/agent-harness-funnel.svg",
+      "purpose": "README diagram explaining the ProjectAtlas agent harness workflow from folder purpose to exact source slice"
+    },
+    {
+      "path": "docs/assets/projectatlas-mascot.png",
+      "purpose": "ProjectAtlas README mascot image"
+    },
+    {
+      "path": "docs/assets/token-savings-bar.svg",
+      "purpose": "README bar chart visualizing ProjectAtlas token savings benchmark results"
+    },
+    {
+      "path": "docs/benchmarks/large-application-token-savings.md",
+      "purpose": "Document large-application benchmark evidence for token savings and responsiveness checks."
+    },
+    {
+      "path": "docs/concepts.md",
+      "purpose": "Explain ProjectAtlas purpose metadata source of truth and health concepts."
+    },
+    {
+      "path": "docs/configuration.md",
+      "purpose": "Document ProjectAtlas configuration files scan policy and legacy import settings."
+    },
+    {
+      "path": "docs/format.md",
+      "purpose": "Document ProjectAtlas TOON response and optional compatibility export format."
+    },
+    {
+      "path": "docs/index.md",
+      "purpose": "Documentation landing page that summarizes ProjectAtlas quick start, workflow, and guide links."
+    },
+    {
+      "path": "docs/memory-bank-extension.md",
+      "purpose": "Define ProjectAtlas memory bank integration boundaries"
+    },
+    {
+      "path": "docs/projectatlas-3-architecture.md",
+      "purpose": "Architecture specification for Rust-native, SQLite-first ProjectAtlas 3 and its release gates."
+    },
+    {
+      "path": "docs/projectatlas-3-v0.3.2-hardening-spec.md",
+      "purpose": "Historical v0.3.2 hardening specification covering symbol modules, path normalization, import aliases, and release gates."
+    },
+    {
+      "path": "docs/structural-summaries.md",
+      "purpose": "Document structural summary adapters and quality signals"
+    },
+    {
+      "path": "docs/workflow.md",
+      "purpose": "Document ProjectAtlas local workflow, purpose linting, troubleshooting, release, and verification commands."
+    },
+    {
+      "path": "fixtures/languages/baselines.toon",
+      "purpose": "Record expected structural summary baselines"
+    },
+    {
+      "path": "fixtures/languages/c/header.h",
+      "purpose": "Exercise C header symbol extraction in language fixture tests."
+    },
+    {
+      "path": "fixtures/languages/c/runner.c",
+      "purpose": "Exercise C source symbol and import extraction in language fixture tests."
+    },
+    {
+      "path": "fixtures/languages/cpp/runner.cpp",
+      "purpose": "Exercise C++ source type and function summary extraction."
+    },
+    {
+      "path": "fixtures/languages/cpp/runner.hpp",
+      "purpose": "Exercise C++ header type and method summary extraction."
+    },
+    {
+      "path": "fixtures/languages/csharp/Runner.cs",
+      "purpose": "Exercise C# type and method summary extraction."
+    },
+    {
+      "path": "fixtures/languages/css/tokens.css",
+      "purpose": "Exercise CSS selector and token summaries"
+    },
+    {
+      "path": "fixtures/languages/go/service.go",
+      "purpose": "Exercise Go type, method, function, and import summary extraction."
+    },
+    {
+      "path": "fixtures/languages/groovy/build.gradle",
+      "purpose": "Gradle Groovy DSL fixture that exercises ProjectAtlas build task extraction."
+    },
+    {
+      "path": "fixtures/languages/html/index.html",
+      "purpose": "Exercise HTML metadata and heading summaries"
+    },
+    {
+      "path": "fixtures/languages/java/AtlasService.java",
+      "purpose": "Exercise Java class and method summary extraction."
+    },
+    {
+      "path": "fixtures/languages/javascript/service.js",
+      "purpose": "Exercise JavaScript exported and local function summary extraction."
+    },
+    {
+      "path": "fixtures/languages/json/package.json",
+      "purpose": "Package manifest fixture that exercises ProjectAtlas script and dependency summaries."
+    },
+    {
+      "path": "fixtures/languages/kotlin/build.gradle.kts",
+      "purpose": "Gradle Kotlin DSL fixture that exercises ProjectAtlas task registration extraction."
+    },
+    {
+      "path": "fixtures/languages/kotlin/Runner.kt",
+      "purpose": "Exercise Kotlin class and function summary extraction."
+    },
+    {
+      "path": "fixtures/languages/markdown/readme.md",
+      "purpose": "Exercise Markdown heading summary extraction"
+    },
+    {
+      "path": "fixtures/languages/objective-c/UserManager.m",
+      "purpose": "Exercise Objective-C type and method summary extraction."
+    },
+    {
+      "path": "fixtures/languages/README.md",
+      "purpose": "Describe structural summary fixture coverage"
+    },
+    {
+      "path": "fixtures/languages/rust/build.rs",
+      "purpose": "Exercise Rust build-script language detection and summary extraction."
+    },
+    {
+      "path": "fixtures/languages/rust/empty.rs",
+      "purpose": "Exercise empty Rust source summary behavior"
+    },
+    {
+      "path": "fixtures/languages/rust/lib.rs",
+      "purpose": "Rust fixture that exercises ProjectAtlas function summary and symbol extraction."
+    },
+    {
+      "path": "fixtures/languages/toml/Cargo.lock",
+      "purpose": "Exercise Cargo lockfile package summary extraction."
+    },
+    {
+      "path": "fixtures/languages/toml/Cargo.toml",
+      "purpose": "Cargo manifest fixture that exercises ProjectAtlas dependency summary extraction."
+    },
+    {
+      "path": "fixtures/languages/toon/projectatlas-nonsource-files.toon",
+      "purpose": "Exercise TOON section summary extraction"
+    },
+    {
+      "path": "fixtures/languages/typescript/component.tsx",
+      "purpose": "Exercise TSX component summary extraction."
+    },
+    {
+      "path": "fixtures/languages/typescript/service.ts",
+      "purpose": "Exercise TypeScript class, method, and helper summary extraction."
+    },
+    {
+      "path": "fixtures/languages/vue/ProductPanel.vue",
+      "purpose": "Provide a Vue Composition API fixture for verifying binding and import summaries."
+    },
+    {
+      "path": "fixtures/languages/yaml/workflow.yml",
+      "purpose": "Exercise workflow trigger and job summaries"
+    },
+    {
+      "path": "fixtures/languages/zig/runner.zig",
+      "purpose": "Exercise Zig type and function summary extraction."
+    },
+    {
+      "path": "LICENSE",
+      "purpose": "ProjectAtlas MIT license"
+    },
+    {
+      "path": "plugins/projectatlas/.claude-plugin/plugin.json",
+      "purpose": "Claude Code plugin manifest declaring ProjectAtlas package metadata and version."
+    },
+    {
+      "path": "plugins/projectatlas/.codex-plugin/plugin.json",
+      "purpose": "Codex plugin manifest declaring ProjectAtlas package metadata, interface text, and version."
+    },
+    {
+      "path": "plugins/projectatlas/opencode/opencode.json",
+      "purpose": "OpenCode MCP configuration template pinned to the ProjectAtlas runtime version."
+    },
+    {
+      "path": "plugins/projectatlas/scripts/install-runtime.ps1",
+      "purpose": "Install or update the ProjectAtlas plugin runtime on Windows, including locked-mirror-safe versioned binaries and absolute MCP configs."
+    },
+    {
+      "path": "plugins/projectatlas/scripts/install-runtime.sh",
+      "purpose": "Install or update the ProjectAtlas plugin runtime and POSIX MCP configs."
+    },
+    {
+      "path": "plugins/projectatlas/skills/projectatlas/SKILL.md",
+      "purpose": "Installable ProjectAtlas skill that guides agents through atlas-first orientation, purpose curation, lint levels, and MCP workflows."
+    },
+    {
+      "path": "README.md",
+      "purpose": "ProjectAtlas product overview, plugin-first quickstart, CLI reference, workflow funnel, and release quality notes."
+    },
+    {
+      "path": "SECURITY.md",
+      "purpose": "Security contact information for ProjectAtlas"
+    },
+    {
+      "path": "skills/claude/ProjectAtlas.md",
+      "purpose": "Claude-oriented ProjectAtlas skill instructions for atlas-first repository navigation."
+    },
+    {
+      "path": "skills/codex/ProjectAtlas.md",
+      "purpose": "Codex-oriented ProjectAtlas skill instructions for atlas-first repository navigation."
+    },
+    {
+      "path": "templates/AGENTS.md",
+      "purpose": "Reusable AGENTS.md startup template for repositories adopting ProjectAtlas purpose-aware atlas-first workflow."
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 15. Run `projectatlas runtime-info` when installer/runtime identity is unclear.
 16. Run `projectatlas token` when asked for token savings; use `projectatlas token --view tui` only when a human asks for the terminal dashboard.
 17. Generate harness MCP config with `projectatlas --format json --db .projectatlas/projectatlas.db mcp-config`, adding `--harness claude-code` or `--harness opencode` for those hosts. Prefer installer-generated project-local configs over checked-in fallback templates.
-18. Correct wrong, stale, vague, or generic purposes opportunistically with `atlas_purpose_set` or `projectatlas purpose set` after inspecting enough context. Purpose entries live in SQLite and are preserved across scans; changed approved files become stale instead of losing their curated purpose text.
+18. Correct wrong, stale, vague, or generic purposes opportunistically with `atlas_purpose_set` or `projectatlas purpose set` after inspecting enough context. Use `atlas_purpose_review` or `projectatlas purpose review --from-file <json> --apply` for reviewed batches; never edit SQLite directly. Purpose entries live in SQLite and are preserved across scans; changed approved files become stale instead of losing their curated purpose text.
 
 ## Rust/Dependency Discipline
 - Prefer official or canonical Rust crates and standard implementations for protocols, formats, parsers, storage, watchers, token tooling, and platform integration before writing custom code.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-cli"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-core"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "regex",
  "serde",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-db"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "projectatlas-core",
  "rusqlite",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-fs"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "blake3",
  "ignore",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-service"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "globset",
  "projectatlas-core",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-symbols"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "projectatlas-core",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.12"
+version = "0.3.13"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/styler-ai/ProjectAtlas"
@@ -68,11 +68,11 @@ must_use_candidate = "allow"
 missing_inline_in_public_items = "allow"
 
 [workspace.dependencies]
-projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.12" }
-projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.12" }
-projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.12" }
-projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.12" }
-projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.12" }
+projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.13" }
+projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.13" }
+projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.13" }
+projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.13" }
+projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.13" }
 blake3 = "1.5"
 clap = { version = "4.5", features = ["derive"] }
 cssparser = "0.37"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.3.12"><img alt="release" src="https://img.shields.io/badge/release-v0.3.12-blue"></a>
+  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.3.13"><img alt="release" src="https://img.shields.io/badge/release-v0.3.13-blue"></a>
   <img alt="rust" src="https://img.shields.io/badge/Rust-2024-orange">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-green">
 </p>
@@ -25,7 +25,7 @@ No required `.purpose` files. No source-header tax. No hosted index. The project
 ## Quickstart
 
 ```bash
-codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.12
+codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.13
 codex plugin add projectatlas --marketplace projectatlas
 ```
 
@@ -158,7 +158,7 @@ Most users can stop at the plugin install. The CLI is here for local debugging, 
 Only need the CLI yourself? Install it from the released tag:
 
 ```bash
-cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.3.12 projectatlas-cli --locked
+cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.3.13 projectatlas-cli --locked
 ```
 
 From this checkout:
@@ -201,7 +201,7 @@ projectatlas token --view tui
 
 ## Agent And MCP Setup
 
-ProjectAtlas ships plugin metadata and installer scripts for Codex, Claude Code, and OpenCode.
+ProjectAtlas ships plugin metadata and installer scripts for Codex and Claude Code, plus an OpenCode MCP config template.
 
 Generate project-local MCP configs:
 
@@ -238,7 +238,7 @@ ProjectAtlas exposes the same workflow through CLI and MCP:
 | Search narrowly | `projectatlas search <pattern> --file-pattern <glob>` | `atlas_search` |
 | Read exact code | `projectatlas slice <file> --start-line <n> --end-line <m>` | `atlas_slice` |
 | Find cleanup work | `projectatlas health-check --source-only --limit <n>` | `atlas_health` |
-| Curate purposes | `projectatlas purpose queue --limit <n>` / `projectatlas purpose set <path> "<purpose>"` | `atlas_purpose_queue` / `atlas_purpose_set` |
+| Curate purposes | `projectatlas purpose queue --limit <n>` / `projectatlas purpose set <path> "<purpose>"` / `projectatlas purpose review --from-file <json> --apply` | `atlas_purpose_queue` / `atlas_purpose_set` / `atlas_purpose_review` |
 | Report savings | `projectatlas token` | `atlas_token_report` |
 
 ## Why Rust
@@ -249,7 +249,7 @@ ProjectAtlas scans with `.gitignore` awareness, hashes files with BLAKE3, stores
 
 ## Release Quality
 
-`v0.3.12` ships through the full release matrix:
+`v0.3.13` ships through the full release matrix:
 
 - Rust format, check, clippy, dependency policy, tests, doctests, and rustdoc.
 - ProjectAtlas scan, parity, database-backed purpose lint, and health checks.
@@ -269,7 +269,7 @@ crates/
   projectatlas-service/   summaries, search, slices, health
   projectatlas-symbols/   symbol extraction
 docs/                     architecture, workflow, configuration
-plugins/projectatlas/     Codex, Claude Code, OpenCode plugin assets
+plugins/projectatlas/     Codex and Claude Code plugin metadata, OpenCode MCP config template
 skills/                   standalone agent skill snippets
 ```
 

--- a/crates/projectatlas-cli/src/atlas_map.rs
+++ b/crates/projectatlas-cli/src/atlas_map.rs
@@ -12,8 +12,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 use toml_edit::{Array, DocumentMut, Item, Table, value};
 
-/// Default `ProjectAtlas` purpose filename.
-const DEFAULT_PURPOSE_FILENAME: &str = ".purpose";
+/// Legacy folder-purpose filename accepted only as migration input.
+const DEFAULT_LEGACY_PURPOSE_FILENAME: &str = ".purpose";
 /// Default generated map path.
 const DEFAULT_MAP_PATH: &str = ".projectatlas/projectatlas.toon";
 /// Default non-source summary input path.
@@ -22,6 +22,7 @@ const DEFAULT_NONSOURCE_PATH: &str = ".projectatlas/projectatlas-nonsource-files
 const DURABLE_PROJECTATLAS_INPUT_PATHS: &[&str] = &[
     ".projectatlas/config.toml",
     ".projectatlas/projectatlas-nonsource-files.toon",
+    ".projectatlas/projectatlas-purpose-review.json",
 ];
 /// Default maximum number of lines scanned for purpose headers.
 const DEFAULT_MAX_SCAN_LINES: usize = 80;
@@ -993,7 +994,7 @@ fn normalize_config(
         ),
         purpose_filename: project
             .purpose_filename
-            .unwrap_or_else(|| DEFAULT_PURPOSE_FILENAME.to_string()),
+            .unwrap_or_else(|| DEFAULT_LEGACY_PURPOSE_FILENAME.to_string()),
         source_extensions: normalize_set(scan.source_extensions.unwrap_or_else(|| {
             DEFAULT_SOURCE_EXTENSIONS
                 .iter()
@@ -1004,10 +1005,7 @@ fn normalize_config(
         exclude_dir_suffixes: string_set(scan.exclude_dir_suffixes, &[".egg-info"]),
         exclude_path_prefixes: normalize_prefix_set(scan.exclude_path_prefixes)?,
         non_source_path_prefixes: normalize_prefix_set(scan.non_source_path_prefixes)?,
-        allowed_untracked_filenames: string_set(
-            untracked.allowed_filenames,
-            &[DEFAULT_PURPOSE_FILENAME],
-        ),
+        allowed_untracked_filenames: string_set(untracked.allowed_filenames, &[]),
         untracked_allowlist_dir_prefixes: normalize_prefix_set(untracked.allowlist_dir_prefixes)?,
         untracked_allowlist_files: normalize_prefix_set(untracked.allowlist_files)?,
         asset_allowed_prefixes: normalize_prefix_set(untracked.asset_allowed_prefixes)?,
@@ -2476,7 +2474,6 @@ fn default_config_text() -> String {
         "root = \".\"",
         "map_path = \".projectatlas/projectatlas.toon\"",
         "nonsource_files_path = \".projectatlas/projectatlas-nonsource-files.toon\"",
-        "purpose_filename = \".purpose\"",
         "",
         "[scan]",
         &format!("source_extensions = {source_extensions}"),
@@ -2500,7 +2497,7 @@ fn default_config_text() -> String {
         "max_length = 140",
         "",
         "[untracked]",
-        "allowed_filenames = [\".purpose\"]",
+        "allowed_filenames = []",
         "allowlist_dir_prefixes = [\".githooks\"]",
         "allowlist_files = []",
         "asset_allowed_prefixes = []",

--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -29,16 +29,16 @@ use projectatlas_service::{
 };
 use runtime::{
     DEFAULT_HEALTH_LIMIT, MAX_HEALTH_LIMIT, MAX_SYMBOL_FILE_BYTES, PurposeLintLevel,
-    ScanRuntimePlan, SettingsReport, SymbolBuildOptions, WatchStatusReport, absolute_path,
-    build_settings_report, build_symbols_for_index, byte_count_to_tokens, canonical_project_root,
-    default_mcp_project_root, defaultable_cli_project_root,
+    PurposeReviewRequest, ScanRuntimePlan, SettingsReport, SymbolBuildOptions, WatchStatusReport,
+    absolute_path, build_settings_report, build_symbols_for_index, byte_count_to_tokens,
+    canonical_project_root, default_mcp_project_root, defaultable_cli_project_root,
     estimated_source_tokens_for_indexed_files, estimated_source_tokens_for_paths,
     file_summary_usage_baseline, lint_database_if_present, normalized_folder_filter,
     open_atlas_store, purpose_curation_page, ranked_file_nodes, read_indexed_file_content,
     record_directory_walk_usage_estimate, record_usage_estimate, record_usage_text,
-    render_health_page, render_purpose_curation_page, reset_index_files, resolved_mcp_config_path,
-    run_scan_pipeline, run_watch_loop, strip_legacy_purpose, validated_indexed_file_key,
-    watcher_status_report,
+    render_health_page, render_purpose_curation_page, render_purpose_review_report,
+    reset_index_files, resolved_mcp_config_path, review_purposes, run_scan_pipeline,
+    run_watch_loop, strip_legacy_purpose, validated_indexed_file_key, watcher_status_report,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -575,6 +575,15 @@ enum PurposeCommand {
         path: String,
         /// Agent-approved purpose one-liner.
         purpose: String,
+    },
+    /// Batch review existing purpose records from a JSON file.
+    Review {
+        /// JSON file containing review items or an object with an `items` array.
+        #[arg(long)]
+        from_file: PathBuf,
+        /// Apply reviewed purposes. Without this flag the command previews only.
+        #[arg(long)]
+        apply: bool,
     },
     /// Return a bounded queue of paths that need purpose curation.
     Queue {
@@ -1337,6 +1346,15 @@ fn run() -> Result<(), CliError> {
                 });
                 print_output(cli.format, &encode_agent_payload(&report), &report)?;
             }
+            PurposeCommand::Review { from_file, apply } => {
+                let store = open_atlas_store(&cli.db)?;
+                let requests = load_purpose_review_requests(from_file)?;
+                let report = review_purposes(&store, &requests, *apply)?;
+                print_output(cli.format, &render_purpose_review_report(&report), &report)?;
+                if report.failed > 0 {
+                    std::process::exit(1);
+                }
+            }
             PurposeCommand::Queue {
                 start_index,
                 limit,
@@ -1572,6 +1590,23 @@ fn write_mcp_config_file(
         path: path.to_path_buf(),
         source,
     })
+}
+
+/// Load batch purpose review requests from a JSON file.
+fn load_purpose_review_requests(path: &Path) -> Result<Vec<PurposeReviewRequest>, CliError> {
+    let text = fs::read_to_string(path).map_err(|source| CliError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let value: serde_json::Value = serde_json::from_str(&text)?;
+    let items = value.get("items").cloned().unwrap_or(value);
+    let requests: Vec<PurposeReviewRequest> = serde_json::from_value(items)?;
+    if requests.is_empty() {
+        return Err(CliError::InvalidInput(
+            "purpose review input must contain at least one item".to_string(),
+        ));
+    }
+    Ok(requests)
 }
 
 /// Build a project-local root identity report.

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -2,13 +2,14 @@
 //! Native MCP adapter for `ProjectAtlas` agent integrations.
 
 use crate::runtime::{
-    DEFAULT_HEALTH_LIMIT, MAX_HEALTH_LIMIT, MAX_SYMBOL_FILE_BYTES, ScanRuntimePlan,
-    SymbolBuildOptions, build_settings_report, build_symbols_for_index, byte_count_to_tokens,
-    canonical_project_root, default_mcp_project_root, estimated_source_tokens_for_indexed_files,
-    estimated_source_tokens_for_paths, file_summary_usage_baseline, normalized_folder_filter,
-    open_atlas_store, purpose_curation_page, ranked_file_nodes, read_indexed_file_content,
-    record_directory_walk_usage_estimate, record_usage_estimate, record_usage_text,
-    render_health_page, render_purpose_curation_page, reset_index_files, run_scan_pipeline,
+    DEFAULT_HEALTH_LIMIT, MAX_HEALTH_LIMIT, MAX_SYMBOL_FILE_BYTES, PurposeReviewRequest,
+    ScanRuntimePlan, SymbolBuildOptions, build_settings_report, build_symbols_for_index,
+    byte_count_to_tokens, canonical_project_root, default_mcp_project_root,
+    estimated_source_tokens_for_indexed_files, estimated_source_tokens_for_paths,
+    file_summary_usage_baseline, normalized_folder_filter, open_atlas_store, purpose_curation_page,
+    ranked_file_nodes, read_indexed_file_content, record_directory_walk_usage_estimate,
+    record_usage_estimate, record_usage_text, render_health_page, render_purpose_curation_page,
+    render_purpose_review_report, reset_index_files, review_purposes, run_scan_pipeline,
     run_watch_loop, strip_legacy_purpose, validated_indexed_file_key, watcher_status_report,
 };
 use crate::{
@@ -63,6 +64,7 @@ pub(crate) const REQUIRED_MCP_TOOL_NAMES: &[&str] = &[
     "atlas_reset_index",
     "atlas_purpose_queue",
     "atlas_purpose_set",
+    "atlas_purpose_review",
 ];
 
 /// Run the official RMCP stdio server.
@@ -283,6 +285,26 @@ struct AtlasPurposeSetParams {
     path: String,
     /// Agent-approved purpose one-liner.
     purpose: String,
+}
+
+/// MCP payload for one batch purpose review item.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct AtlasPurposeReviewItem {
+    /// Indexed repository-relative path.
+    path: String,
+    /// Agent-reviewed purpose one-liner. Required for generated suggestions.
+    purpose: Option<String>,
+    /// Confirm the existing non-generated purpose after inspection.
+    confirm_existing: Option<bool>,
+}
+
+/// MCP parameter payload for batch purpose review.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct AtlasPurposeReviewParams {
+    /// Purpose records to agent-review.
+    items: Vec<AtlasPurposeReviewItem>,
+    /// Apply reviewed purposes. Defaults to false for preview.
+    apply: Option<bool>,
 }
 
 /// MCP parameter payload for resolving health findings.
@@ -1049,6 +1071,31 @@ impl ProjectAtlasMcpServer {
                     "agent_reviewed": true
                 }
             })))
+        })())
+    }
+
+    /// Batch-review existing purpose records through the MCP surface.
+    #[tool(
+        name = "atlas_purpose_review",
+        description = "Preview or apply agent-reviewed ProjectAtlas purpose metadata for multiple indexed paths."
+    )]
+    fn atlas_purpose_review(
+        &self,
+        Parameters(params): Parameters<AtlasPurposeReviewParams>,
+    ) -> String {
+        Self::as_mcp_text((|| {
+            let store = self.open_store()?;
+            let requests = params
+                .items
+                .into_iter()
+                .map(|item| PurposeReviewRequest {
+                    path: item.path,
+                    purpose: item.purpose,
+                    confirm_existing: item.confirm_existing.unwrap_or(false),
+                })
+                .collect::<Vec<_>>();
+            let report = review_purposes(&store, &requests, params.apply.unwrap_or(false))?;
+            Ok(render_purpose_review_report(&report))
         })())
     }
 }

--- a/crates/projectatlas-cli/src/runtime.rs
+++ b/crates/projectatlas-cli/src/runtime.rs
@@ -24,7 +24,7 @@ use projectatlas_core::toon::encode_agent_payload;
 use projectatlas_core::{
     Node, NodeKind, Overview, PurposeSource, PurposeStatus, normalize_native_path_display,
     normalize_native_path_display_str, normalize_repo_path, purpose_review_signal,
-    repo_path_to_native, validated_repo_file_key,
+    repo_path_to_native, validated_repo_file_key, validated_repo_node_key,
 };
 use projectatlas_db::{AtlasStore, HealthFindingsPage, HealthQuery, HealthScope, IndexedFileText};
 use projectatlas_fs::{ScanOptions, gitignore_excludes_path, scan_path, scan_repo};
@@ -34,7 +34,7 @@ use projectatlas_service::{
 use projectatlas_symbols::extract_symbol_graph;
 use rayon::ThreadPoolBuilder;
 use rayon::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
@@ -65,6 +65,10 @@ const BUILTIN_PROJECTATLAS_PURPOSES: &[(&str, &str)] = &[
     (
         ".projectatlas/projectatlas-nonsource-files.toon",
         "Declare project-local non-source file purposes for ProjectAtlas map compatibility.",
+    ),
+    (
+        ".projectatlas/projectatlas-purpose-review.json",
+        "Replay agent-reviewed ProjectAtlas purpose records into the local SQLite index.",
     ),
 ];
 
@@ -548,6 +552,159 @@ pub(crate) struct PurposeCurationItem {
     pub(crate) recommendation: String,
 }
 
+/// One agent-reviewed purpose update requested by a batch review.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct PurposeReviewRequest {
+    /// Indexed repository-relative path.
+    pub(crate) path: String,
+    /// Agent-reviewed purpose one-liner. Required for generated suggestions.
+    #[serde(default)]
+    pub(crate) purpose: Option<String>,
+    /// Confirm the currently stored non-generated purpose after inspection.
+    #[serde(default)]
+    pub(crate) confirm_existing: bool,
+}
+
+/// Batch purpose review result.
+#[derive(Debug, Serialize)]
+pub(crate) struct PurposeReviewReport {
+    /// Whether the review changed the database.
+    pub(crate) applied: bool,
+    /// Number of requested review rows.
+    pub(crate) total: usize,
+    /// Number of rows changed when applied or that would change in dry-run.
+    pub(crate) changed: usize,
+    /// Number of rows skipped because they were already agent-reviewed with the same purpose.
+    pub(crate) skipped: usize,
+    /// Number of rows that could not be reviewed.
+    pub(crate) failed: usize,
+    /// Per-path review details.
+    pub(crate) items: Vec<PurposeReviewItem>,
+}
+
+/// Per-path batch review result.
+#[derive(Debug, Serialize)]
+pub(crate) struct PurposeReviewItem {
+    /// Indexed repository-relative path.
+    pub(crate) path: String,
+    /// Action selected for this path.
+    pub(crate) action: String,
+    /// Current purpose lifecycle status.
+    pub(crate) current_status: String,
+    /// Current purpose source.
+    pub(crate) current_source: String,
+    /// Purpose that will be or was written.
+    pub(crate) purpose: String,
+    /// Validation or persistence error.
+    pub(crate) error: String,
+}
+
+/// Validate and optionally apply a batch of agent-reviewed purpose records.
+pub(crate) fn review_purposes(
+    store: &AtlasStore,
+    requests: &[PurposeReviewRequest],
+    apply: bool,
+) -> Result<PurposeReviewReport, CliError> {
+    let mut items = Vec::with_capacity(requests.len());
+    for request in requests {
+        items.push(review_purpose_request(store, request, apply)?);
+    }
+    let changed = items
+        .iter()
+        .filter(|item| item.error.is_empty() && item.action != "skip")
+        .count();
+    let skipped = items.iter().filter(|item| item.action == "skip").count();
+    let failed = items.iter().filter(|item| !item.error.is_empty()).count();
+    Ok(PurposeReviewReport {
+        applied: apply,
+        total: requests.len(),
+        changed,
+        skipped,
+        failed,
+        items,
+    })
+}
+
+/// Validate and optionally apply one agent-reviewed purpose record.
+fn review_purpose_request(
+    store: &AtlasStore,
+    request: &PurposeReviewRequest,
+    apply: bool,
+) -> Result<PurposeReviewItem, CliError> {
+    let path = validated_repo_node_key(Path::new(&request.path)).map_err(|source| {
+        CliError::InvalidInput(format!(
+            "invalid purpose review path {:?}: {source}",
+            request.path
+        ))
+    })?;
+    let Some(indexed) = store.load_node_by_path(&path)? else {
+        return Ok(PurposeReviewItem {
+            path,
+            action: "error".to_string(),
+            current_status: String::new(),
+            current_source: String::new(),
+            purpose: request.purpose.clone().unwrap_or_default(),
+            error: "path is not indexed".to_string(),
+        });
+    };
+    let current_status = indexed.purpose.status.to_string();
+    let current_source = indexed.purpose.source.to_string();
+    let current_purpose = indexed.purpose.purpose.clone().unwrap_or_default();
+    let explicit_purpose = request
+        .purpose
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let Some(reviewed_purpose) = explicit_purpose.or_else(|| {
+        request
+            .confirm_existing
+            .then_some(current_purpose.as_str())
+            .filter(|value| !value.trim().is_empty())
+    }) else {
+        return Ok(PurposeReviewItem {
+            path,
+            action: "error".to_string(),
+            current_status,
+            current_source,
+            purpose: String::new(),
+            error: "provide a reviewed purpose or set confirm_existing=true".to_string(),
+        });
+    };
+
+    if request.confirm_existing
+        && explicit_purpose.is_none()
+        && (indexed.purpose.status == PurposeStatus::Suggested
+            || indexed.purpose.source == PurposeSource::Generated)
+    {
+        return Ok(PurposeReviewItem {
+            path,
+            action: "error".to_string(),
+            current_status,
+            current_source,
+            purpose: current_purpose,
+            error: "generated suggestions require an explicit reviewed purpose".to_string(),
+        });
+    }
+
+    let reviewed_purpose = reviewed_purpose.trim().to_string();
+    let action = if indexed.purpose.agent_reviewed() && current_purpose == reviewed_purpose {
+        "skip"
+    } else if apply {
+        store.set_purpose(&path, &reviewed_purpose, PurposeSource::Agent)?;
+        "review"
+    } else {
+        "would-review"
+    };
+    Ok(PurposeReviewItem {
+        path,
+        action: action.to_string(),
+        current_status,
+        current_source,
+        purpose: reviewed_purpose,
+        error: String::new(),
+    })
+}
+
 /// Build a purpose curation queue from the bounded health page.
 pub(crate) fn purpose_curation_page(
     store: &AtlasStore,
@@ -685,6 +842,20 @@ pub(crate) fn render_purpose_curation_page(page: &PurposeCurationPage) -> String
             "summary_only": page.summary_only,
         },
         "purpose_curation_items": page.items,
+    }))
+}
+
+/// Render a batch purpose review report as compact TOON.
+pub(crate) fn render_purpose_review_report(report: &PurposeReviewReport) -> String {
+    encode_agent_payload(&json!({
+        "purpose_review": {
+            "applied": report.applied,
+            "total": report.total,
+            "changed": report.changed,
+            "skipped": report.skipped,
+            "failed": report.failed,
+        },
+        "purpose_review_items": report.items,
     }))
 }
 

--- a/crates/projectatlas-cli/src/structural.rs
+++ b/crates/projectatlas-cli/src/structural.rs
@@ -33,6 +33,7 @@ pub(crate) fn structural_summary_for_path(
         "xml" => xml_summary(content),
         "css" => css_summary(content),
         "html" => html_summary(content),
+        "powershell" => powershell_summary(content),
         "config" | "text" => config_text_summary(path, content),
         _ if has_extension(path, "toon") => toon_summary(content),
         _ => None,
@@ -51,6 +52,7 @@ pub(crate) fn is_structural_summary_candidate(path: &str, language: Option<&str>
             | "xml"
             | "css"
             | "html"
+            | "powershell"
             | "config"
             | "text"
     ) || has_extension(path, "toon")
@@ -585,6 +587,44 @@ fn html_link_rel_values(document: &Html, limit: usize) -> Vec<String> {
     rels
 }
 
+/// Summarize `PowerShell` scripts from declared function names.
+fn powershell_summary(content: &str) -> Option<String> {
+    let functions = content
+        .lines()
+        .filter_map(powershell_function_name)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if !functions.is_empty() {
+        return Some(format!(
+            "powershell script defining functions {}.",
+            join_limited(functions.iter().map(String::as_str).collect())
+        ));
+    }
+    let lines = content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count();
+    (lines > 0).then(|| format!("powershell script with {lines} non-empty lines."))
+}
+
+/// Extract one `PowerShell` function declaration name.
+fn powershell_function_name(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let mut parts = trimmed.split_whitespace();
+    if !parts.next()?.eq_ignore_ascii_case("function") {
+        return None;
+    }
+    let raw_name = parts.next()?;
+    let name = raw_name.split(['(', '{']).next().unwrap_or_default().trim();
+    let name = name.rsplit_once(':').map_or(name, |(_, scoped)| scoped);
+    let valid = !name.is_empty()
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'));
+    valid.then(|| compact_label(name))
+}
+
 /// Compile an HTML selector.
 fn html_select(_document: &Html, selector: &str) -> Option<Selector> {
     Selector::parse(selector).ok()
@@ -939,6 +979,21 @@ mod tests {
             summary.as_deref(),
             Some(
                 "html document with title Home, meta description Welcome page, headings Hello, link rels alternate, canonical, manifest, structured data."
+            )
+        );
+    }
+
+    #[test]
+    fn summarizes_powershell_functions() {
+        let summary = structural_summary_for_path(
+            "scripts/install-runtime.ps1",
+            Some("powershell"),
+            "function Resolve-DefaultProjectRoot {\n}\nfunction global:Get-ReleaseRuntimeInstallPath($Root) {\n}\nfunction Install-ReleaseBinary {\n}\n",
+        );
+        assert_eq!(
+            summary.as_deref(),
+            Some(
+                "powershell script defining functions Get-ReleaseRuntimeInstallPath, Install-ReleaseBinary, Resolve-DefaultProjectRoot."
             )
         );
     }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -96,6 +96,14 @@ fn plugin_installers_require_matching_runtime_version() -> Result<(), Box<dyn Er
             .join("workflows")
             .join("ci.yml"),
     )?;
+    let readme = fs::read_to_string(workspace_root.join("README.md"))?;
+    let agent_integration =
+        fs::read_to_string(workspace_root.join("docs").join("agent-integration.md"))?;
+    let architecture = fs::read_to_string(
+        workspace_root
+            .join("docs")
+            .join("projectatlas-3-architecture.md"),
+    )?;
     let codex_fallback_mcp = workspace_root
         .join("plugins")
         .join("projectatlas")
@@ -121,6 +129,10 @@ fn plugin_installers_require_matching_runtime_version() -> Result<(), Box<dyn Er
             .join("opencode")
             .join("opencode.json"),
     )?;
+    let opencode_native_plugin_dir = workspace_root
+        .join("plugins")
+        .join("projectatlas")
+        .join(".opencode-plugin");
 
     for required in [
         "Convert-ProjectAtlasVersionTag",
@@ -252,6 +264,33 @@ fn plugin_installers_require_matching_runtime_version() -> Result<(), Box<dyn Er
         )
         .into());
     }
+    if opencode_native_plugin_dir.exists() {
+        return Err(io::Error::other(
+            "ProjectAtlas OpenCode support is an MCP config template, not a native OpenCode plugin directory",
+        )
+        .into());
+    }
+    if !readme.contains("OpenCode MCP config template")
+        || !agent_integration
+            .contains("ProjectAtlas does not ship a native OpenCode JavaScript/TypeScript plugin")
+        || !architecture.contains("not a native OpenCode JavaScript/TypeScript plugin")
+    {
+        return Err(io::Error::other(
+            "docs must distinguish Claude Code plugin packaging from OpenCode MCP config support",
+        )
+        .into());
+    }
+    for forbidden in ["OpenCode plugin assets", "Claude Code / OpenCode plugins"] {
+        if readme.contains(forbidden)
+            || agent_integration.contains(forbidden)
+            || architecture.contains(forbidden)
+        {
+            return Err(io::Error::other(format!(
+                "docs still imply native OpenCode plugin packaging through {forbidden:?}"
+            ))
+            .into());
+        }
+    }
     let windows_release_smoke = workflow_job_block(&release_workflow, "installer-smoke-windows")?;
     for required in [
         "[System.IO.FileShare]::None",
@@ -366,6 +405,43 @@ fn repository_guidance_keeps_legacy_toon_export_optional() -> Result<(), Box<dyn
         if verify.contains("--strict-folders") {
             return Err(io::Error::other(format!(
                 "{workflow_name} verify job must not require legacy folder .purpose linting"
+            ))
+            .into());
+        }
+        if !verify.contains("lint_purpose_levels_require_agent_review_at_configured_scope") {
+            return Err(io::Error::other(format!(
+                "{workflow_name} verify job must run the low/medium/strict purpose lint E2E"
+            ))
+            .into());
+        }
+        if !verify.contains("watch_once_preserves_unchanged_deep_summary_and_text_index") {
+            return Err(io::Error::other(format!(
+                "{workflow_name} verify job must test reviewed purpose preservation across deep refresh"
+            ))
+            .into());
+        }
+        if !verify.contains(
+            "purpose review --from-file .projectatlas/projectatlas-purpose-review.json --apply",
+        ) {
+            return Err(io::Error::other(format!(
+                "{workflow_name} verify job must replay reviewed purposes through ProjectAtlas before strict lint"
+            ))
+            .into());
+        }
+        if !verify.contains("lint --report-untracked --purpose-level strict") {
+            return Err(io::Error::other(format!(
+                "{workflow_name} verify job must enforce strict purpose lint after review replay"
+            ))
+            .into());
+        }
+        let scan_offset = verify.find("ProjectAtlas scan").unwrap_or(usize::MAX);
+        let review_offset = verify
+            .find("ProjectAtlas purpose review")
+            .unwrap_or(usize::MAX);
+        let lint_offset = verify.find("ProjectAtlas lint").unwrap_or(usize::MAX);
+        if !(scan_offset < review_offset && review_offset < lint_offset) {
+            return Err(io::Error::other(format!(
+                "{workflow_name} verify job must run scan, purpose review, then strict lint in order"
             ))
             .into());
         }
@@ -1016,11 +1092,19 @@ fn plugin_update_replaces_stale_runtime_configs_and_launches_new_mcp() -> Result
         .into());
     }
     let nodes = preserved_store.load_nodes()?;
-    if !nodes.iter().any(|node| {
-        node.node.path == "src/a.rs"
-            && node.purpose.purpose.as_deref() == Some("Shared plugin update state")
-    }) {
-        return Err(io::Error::other("plugin update lost approved purpose metadata").into());
+    let preserved_purpose = nodes
+        .iter()
+        .find(|node| node.node.path == "src/a.rs")
+        .ok_or_else(|| io::Error::other("plugin update lost indexed source node"))?;
+    if preserved_purpose.purpose.purpose.as_deref() != Some("Shared plugin update state")
+        || preserved_purpose.purpose.source != PurposeSource::Agent
+        || !preserved_purpose.purpose.agent_reviewed()
+    {
+        return Err(io::Error::other(format!(
+            "plugin update lost approved purpose metadata: {:?}",
+            preserved_purpose.purpose
+        ))
+        .into());
     }
     if !preserved_store
         .resolved_health_ids()?
@@ -2489,6 +2573,14 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         .args(["scan", "."])
         .assert()
         .success();
+    {
+        let store = AtlasStore::open(&db)?;
+        store.set_purpose(
+            "src/lib.rs",
+            "Imported Rust library purpose for MCP review.",
+            PurposeSource::Imported,
+        )?;
+    }
 
     let messages = [
         r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"projectatlas-e2e","version":"0.1.0"}}}"#,
@@ -2498,6 +2590,7 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         r#"{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"atlas_files","arguments":{"file_pattern":"*.rs","limit":1}}}"#,
         r#"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"atlas_health","arguments":{"category":"missing-purpose","path_prefix":".","limit":1}}}"#,
         r#"{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"atlas_token_report","arguments":{"include_chart":true}}}"#,
+        r#"{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"atlas_purpose_review","arguments":{"apply":true,"items":[{"path":"src/lib.rs","confirm_existing":true}]}}}"#,
     ];
     let executable = assert_cmd::cargo::cargo_bin("projectatlas");
     let stdout = run_mcp_stdio(
@@ -2519,6 +2612,8 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         || !stdout.contains("health_findings[1]")
         || !stdout.contains("next_start_index: 1")
         || !stdout.contains("ProjectAtlas Token Savings")
+        || !stdout.contains("purpose_review:")
+        || !stdout.contains("failed: 0")
         || !stdout.contains("src/lib.rs")
     {
         return Err(io::Error::other(format!(
@@ -2526,6 +2621,14 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         ))
         .into());
     }
+    let reviewed_summary = json_summary_command(&repo, &db, "src/lib.rs")?;
+    require_json_string(&reviewed_summary, &["file_purpose_source"], "agent")?;
+    require_json_bool(&reviewed_summary, &["file_purpose_agent_reviewed"], true)?;
+    require_json_string(
+        &reviewed_summary,
+        &["file_purpose"],
+        "Imported Rust library purpose for MCP review.",
+    )?;
     Ok(())
 }
 
@@ -4128,6 +4231,25 @@ fn watch_once_preserves_unchanged_deep_summary_and_text_index() -> Result<(), Bo
         .stdout(predicate::str::contains("text_index:"))
         .stdout(predicate::str::contains("indexed: 1"));
 
+    {
+        let store = AtlasStore::open(&db)?;
+        store.set_purpose(
+            ".",
+            "Reviewed repository root for deep refresh preservation tests.",
+            PurposeSource::Agent,
+        )?;
+        store.set_purpose(
+            "src",
+            "Reviewed source folder for deep refresh preservation tests.",
+            PurposeSource::Agent,
+        )?;
+        store.set_purpose(
+            "src/main.rs",
+            "Reviewed Rust entrypoint for deep refresh preservation tests.",
+            PurposeSource::Agent,
+        )?;
+    }
+
     let before = Command::cargo_bin("projectatlas")?
         .current_dir(&repo)
         .arg("--format")
@@ -4147,6 +4269,13 @@ fn watch_once_preserves_unchanged_deep_summary_and_text_index() -> Result<(), Bo
     if !before_summary.contains("helper") {
         return Err(io::Error::other("summary before watch did not include symbol facts").into());
     }
+    require_json_string(
+        &before_json,
+        &["file_purpose"],
+        "Reviewed Rust entrypoint for deep refresh preservation tests.",
+    )?;
+    require_json_string(&before_json, &["file_purpose_source"], "agent")?;
+    require_json_bool(&before_json, &["file_purpose_agent_reviewed"], true)?;
 
     Command::cargo_bin("projectatlas")?
         .current_dir(&repo)
@@ -4170,6 +4299,13 @@ fn watch_once_preserves_unchanged_deep_summary_and_text_index() -> Result<(), Bo
     }
     let after_json: Value = serde_json::from_slice(&after.stdout)?;
     require_json_string(&after_json, &["content_summary"], &before_summary)?;
+    require_json_string(
+        &after_json,
+        &["file_purpose"],
+        "Reviewed Rust entrypoint for deep refresh preservation tests.",
+    )?;
+    require_json_string(&after_json, &["file_purpose_source"], "agent")?;
+    require_json_bool(&after_json, &["file_purpose_agent_reviewed"], true)?;
 
     let search = Command::cargo_bin("projectatlas")?
         .current_dir(&repo)
@@ -4185,6 +4321,49 @@ fn watch_once_preserves_unchanged_deep_summary_and_text_index() -> Result<(), Bo
     let search_json: Value = serde_json::from_slice(&search.stdout)?;
     require_json_string(&search_json, &["source"], "sqlite-file-text")?;
     require_json_usize_at_least(&search_json, &["returned"], 1)?;
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args(["scan", "."])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("missing_purposes: 0"));
+
+    let final_summary = json_summary_command(&repo, &db, "src/main.rs")?;
+    require_json_string(
+        &final_summary,
+        &["file_purpose"],
+        "Reviewed Rust entrypoint for deep refresh preservation tests.",
+    )?;
+    require_json_string(&final_summary, &["file_purpose_source"], "agent")?;
+    require_json_bool(&final_summary, &["file_purpose_agent_reviewed"], true)?;
+    let final_store = AtlasStore::open(&db)?;
+    for (path, purpose) in [
+        (
+            ".",
+            "Reviewed repository root for deep refresh preservation tests.",
+        ),
+        (
+            "src",
+            "Reviewed source folder for deep refresh preservation tests.",
+        ),
+    ] {
+        let node = final_store
+            .load_node_by_path(path)?
+            .ok_or_else(|| io::Error::other(format!("{path} missing after deep refresh")))?;
+        if node.purpose.source != PurposeSource::Agent
+            || node.purpose.purpose.as_deref() != Some(purpose)
+            || !node.purpose.agent_reviewed()
+        {
+            return Err(io::Error::other(format!(
+                "deep refresh did not preserve reviewed purpose for {path}: {:?}",
+                node.purpose
+            ))
+            .into());
+        }
+    }
     Ok(())
 }
 
@@ -5184,6 +5363,226 @@ fn generated_file_purpose_suggestions_require_agent_approval() -> Result<(), Box
         .success()
         .stdout(predicate::str::contains("health_findings[0]"));
 
+    Ok(())
+}
+
+#[test]
+fn purpose_review_batch_applies_agent_review_without_raw_sql() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("repo");
+    fs::create_dir(&repo)?;
+    fs::create_dir(repo.join("src"))?;
+    fs::write(
+        repo.join("src").join("detail.rs"),
+        "pub fn trusted_detail() {}\n",
+    )?;
+    fs::write(
+        repo.join("src").join("service.rs"),
+        "//! Service module docs.\n/// Service API for tests.\npub struct Service;\n\nimpl Service {\n    /// Run the service.\n    pub fn run(&self) {}\n}\n",
+    )?;
+    let db = temp.path().join("projectatlas.db");
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args(["scan", "."])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("purpose_suggestions: 2"));
+
+    {
+        let store = AtlasStore::open(&db)?;
+        store.set_purpose(
+            "src/detail.rs",
+            "Trusted detail implementation purpose.",
+            PurposeSource::Imported,
+        )?;
+    }
+
+    let bad_review = temp.path().join("bad-review.json");
+    fs::write(
+        &bad_review,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "items": [
+                { "path": "src/service.rs", "confirm_existing": true }
+            ]
+        }))?,
+    )?;
+    let bad_output = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&db)
+        .args(["purpose", "review", "--from-file"])
+        .arg(&bad_review)
+        .output()?;
+    if bad_output.status.success() {
+        return Err(io::Error::other("generated purpose confirm unexpectedly passed").into());
+    }
+    let bad_report: Value = serde_json::from_slice(&bad_output.stdout)?;
+    require_json_usize(&bad_report, &["failed"], 1)?;
+    require_json_string(
+        &bad_report,
+        &["items", "0", "error"],
+        "generated suggestions require an explicit reviewed purpose",
+    )?;
+
+    let review = temp.path().join("review.json");
+    fs::write(
+        &review,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "items": [
+                { "path": "src/detail.rs", "confirm_existing": true },
+                {
+                    "path": "src/service.rs",
+                    "purpose": "Service module defining the test service type and run method."
+                }
+            ]
+        }))?,
+    )?;
+
+    let dry_run_output = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&db)
+        .args(["purpose", "review", "--from-file"])
+        .arg(&review)
+        .output()?;
+    if !dry_run_output.status.success() {
+        return Err(io::Error::other(format!(
+            "purpose review dry-run failed: {}",
+            String::from_utf8_lossy(&dry_run_output.stderr)
+        ))
+        .into());
+    }
+    let dry_run_report: Value = serde_json::from_slice(&dry_run_output.stdout)?;
+    require_json_bool(&dry_run_report, &["applied"], false)?;
+    require_json_usize(&dry_run_report, &["changed"], 2)?;
+    require_json_usize(&dry_run_report, &["failed"], 0)?;
+
+    let service_dry_summary = json_summary_command(&repo, &db, "src/service.rs")?;
+    require_json_string(&service_dry_summary, &["file_purpose_source"], "generated")?;
+    require_json_bool(
+        &service_dry_summary,
+        &["file_purpose_agent_reviewed"],
+        false,
+    )?;
+
+    let apply_output = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&db)
+        .args(["purpose", "review", "--from-file"])
+        .arg(&review)
+        .arg("--apply")
+        .output()?;
+    if !apply_output.status.success() {
+        return Err(io::Error::other(format!(
+            "purpose review apply failed: {}",
+            String::from_utf8_lossy(&apply_output.stderr)
+        ))
+        .into());
+    }
+    let apply_report: Value = serde_json::from_slice(&apply_output.stdout)?;
+    require_json_bool(&apply_report, &["applied"], true)?;
+    require_json_usize(&apply_report, &["changed"], 2)?;
+    require_json_usize(&apply_report, &["failed"], 0)?;
+
+    let detail_summary = json_summary_command(&repo, &db, "src/detail.rs")?;
+    require_json_string(&detail_summary, &["file_purpose_source"], "agent")?;
+    require_json_bool(&detail_summary, &["file_purpose_agent_reviewed"], true)?;
+    require_json_string(
+        &detail_summary,
+        &["file_purpose"],
+        "Trusted detail implementation purpose.",
+    )?;
+    let service_summary = json_summary_command(&repo, &db, "src/service.rs")?;
+    require_json_string(&service_summary, &["file_purpose_source"], "agent")?;
+    require_json_bool(&service_summary, &["file_purpose_agent_reviewed"], true)?;
+    require_json_string(
+        &service_summary,
+        &["file_purpose"],
+        "Service module defining the test service type and run method.",
+    )?;
+
+    let repeat_output = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&db)
+        .args(["purpose", "review", "--from-file"])
+        .arg(&review)
+        .arg("--apply")
+        .output()?;
+    if !repeat_output.status.success() {
+        return Err(io::Error::other("idempotent purpose review apply failed").into());
+    }
+    let repeat_report: Value = serde_json::from_slice(&repeat_output.stdout)?;
+    require_json_usize(&repeat_report, &["changed"], 0)?;
+    require_json_usize(&repeat_report, &["skipped"], 2)?;
+
+    Ok(())
+}
+
+#[test]
+fn powershell_summary_preserves_hyphenated_function_names() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("repo");
+    fs::create_dir(&repo)?;
+    fs::create_dir(repo.join("scripts"))?;
+    fs::write(
+        repo.join("scripts").join("install-runtime.ps1"),
+        "class RuntimeConfig {\n}\n\nfunction Resolve-DefaultProjectRoot {\n}\n\nfunction Get-ReleaseRuntimeInstallPath {\n}\n\nfunction Install-ReleaseBinary {\n}\n",
+    )?;
+    let db = temp.path().join("projectatlas.db");
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args(["scan", "."])
+        .assert()
+        .success();
+
+    let summary = json_summary_command(&repo, &db, "scripts/install-runtime.ps1")?;
+    require_json_string(&summary, &["summary_status"], "ok")?;
+    require_json_usize(&summary, &["total_classes"], 1)?;
+    require_json_string(&summary, &["classes", "0", "name"], "RuntimeConfig")?;
+    require_json_string(&summary, &["classes", "0", "kind"], "class")?;
+    let function_names = summary
+        .get("functions")
+        .and_then(Value::as_array)
+        .ok_or_else(|| io::Error::other("PowerShell summary functions array missing"))?
+        .iter()
+        .filter_map(|entry| entry.get("name").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    for expected in [
+        "Resolve-DefaultProjectRoot",
+        "Get-ReleaseRuntimeInstallPath",
+        "Install-ReleaseBinary",
+    ] {
+        if !function_names.contains(&expected) {
+            return Err(io::Error::other(format!(
+                "PowerShell summary missed full function name {expected}: {function_names:?}"
+            ))
+            .into());
+        }
+    }
+    for truncated in ["Resolve", "Get", "Install"] {
+        if function_names.contains(&truncated) {
+            return Err(io::Error::other(format!(
+                "PowerShell summary included truncated function name {truncated}: {function_names:?}"
+            ))
+            .into());
+        }
+    }
     Ok(())
 }
 
@@ -6634,6 +7033,13 @@ fn init_map_and_lint_flow_uses_rust_implementation() -> Result<(), Box<dyn Error
         .arg("init")
         .assert()
         .success();
+    let generated_config = fs::read_to_string(repo.join(".projectatlas").join("config.toml"))?;
+    if generated_config.contains("purpose_filename") || generated_config.contains(".purpose") {
+        return Err(io::Error::other(format!(
+            "init config advertised legacy purpose files: {generated_config}"
+        ))
+        .into());
+    }
     if repo.join(".purpose").exists() || repo.join("src").join(".purpose").exists() {
         return Err(io::Error::other("init created legacy .purpose files").into());
     }

--- a/crates/projectatlas-cli/tests/lint_diagnostics.rs
+++ b/crates/projectatlas-cli/tests/lint_diagnostics.rs
@@ -17,7 +17,6 @@ fn lint_does_not_require_legacy_source_purpose_headers() -> Result<(), Box<dyn E
 root = "."
 map_path = ".projectatlas/projectatlas.toon"
 nonsource_files_path = ".projectatlas/projectatlas-nonsource-files.toon"
-purpose_filename = ".purpose"
 
 [scan]
 source_extensions = [".foo"]

--- a/crates/projectatlas-fs/src/lib.rs
+++ b/crates/projectatlas-fs/src/lib.rs
@@ -21,6 +21,7 @@ const INDEXED_PROJECTATLAS_INPUT_PATHS: &[&str] = &[
     ".projectatlas",
     ".projectatlas/config.toml",
     ".projectatlas/projectatlas-nonsource-files.toon",
+    ".projectatlas/projectatlas-purpose-review.json",
 ];
 
 /// Filesystem scanner errors.
@@ -610,6 +611,10 @@ mod tests {
             projectatlas.join("projectatlas-nonsource-files.toon"),
             "nonsource_files[]:\n",
         )?;
+        fs::write(
+            projectatlas.join("projectatlas-purpose-review.json"),
+            "{\"items\":[]}\n",
+        )?;
         fs::write(projectatlas.join("projectatlas.db"), b"sqlite bytes")?;
         fs::write(projectatlas.join("projectatlas.toon"), "generated map\n")?;
         fs::write(projectatlas.join("projectatlas.mcp.json"), "{}\n")?;
@@ -618,6 +623,7 @@ mod tests {
         require_path(&nodes, ".projectatlas")?;
         require_path(&nodes, ".projectatlas/config.toml")?;
         require_path(&nodes, ".projectatlas/projectatlas-nonsource-files.toon")?;
+        require_path(&nodes, ".projectatlas/projectatlas-purpose-review.json")?;
         reject_path(&nodes, ".projectatlas/projectatlas.db")?;
         reject_path(&nodes, ".projectatlas/projectatlas.toon")?;
         reject_path(&nodes, ".projectatlas/projectatlas.mcp.json")?;

--- a/crates/projectatlas-symbols/src/lib.rs
+++ b/crates/projectatlas-symbols/src/lib.rs
@@ -30,6 +30,9 @@ pub fn extract_symbol_graph(path: &str, language: Option<&str>, content: &str) -
     if is_vue_sfc(path, language) {
         return extract_vue_sfc_graph(path, language, parse_content.as_ref());
     }
+    if is_powershell_script(path, language) {
+        return extract_powershell_graph(path, language, parse_content.as_ref());
+    }
     if let Some(parsed) = extract_tree_sitter_graph(path, language, parse_content.as_ref()) {
         if !parsed.graph.symbols.is_empty() || !parsed.graph.relations.is_empty() {
             return parsed.graph;
@@ -89,6 +92,17 @@ fn is_vue_sfc(path: &str, language: Option<&str>) -> bool {
             .is_some_and(|extension| extension.eq_ignore_ascii_case("vue"))
 }
 
+/// Return whether this source is a `PowerShell` script or module.
+fn is_powershell_script(path: &str, language: Option<&str>) -> bool {
+    matches!(language, Some("powershell"))
+        || Path::new(path).extension().is_some_and(|extension| {
+            matches!(
+                extension.to_str().map(str::to_ascii_lowercase).as_deref(),
+                Some("ps1" | "psm1" | "psd1")
+            )
+        })
+}
+
 /// Extract Vue SFC Composition API bindings with a deterministic structural adapter.
 fn extract_vue_sfc_graph(path: &str, language: Option<&str>, content: &str) -> SymbolGraph {
     let mut graph = extract_fallback_graph(path, language, content);
@@ -121,6 +135,87 @@ fn extract_vue_sfc_graph(path: &str, language: Option<&str>, content: &str) -> S
     }
     merge_preferred_graph_entries(&mut graph, structural);
     graph
+}
+
+/// Extract `PowerShell` declarations with a deterministic structural adapter.
+fn extract_powershell_graph(path: &str, language: Option<&str>, content: &str) -> SymbolGraph {
+    let mut graph = extract_fallback_graph(path, language, content);
+    graph.parser = ParserKind::Structural;
+    let mut structural = empty_graph(path, language, ParserKind::Structural);
+    for (line_index, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        if let Some(name) = powershell_function_name(trimmed) {
+            push_symbol(
+                &mut structural,
+                &name,
+                SymbolKind::Function,
+                line_index + 1,
+                line_index + 1,
+                None,
+                Some("powershell-function"),
+                trimmed,
+            );
+        }
+        if let Some(name) = powershell_class_name(trimmed) {
+            push_symbol(
+                &mut structural,
+                &name,
+                SymbolKind::Class,
+                line_index + 1,
+                line_index + 1,
+                None,
+                Some("powershell-class"),
+                trimmed,
+            );
+        }
+        if is_fallback_import(trimmed) {
+            push_relation(
+                &mut structural,
+                "<module>",
+                trimmed,
+                RelationKind::Imports,
+                line_index + 1,
+                trimmed,
+            );
+        }
+    }
+    merge_preferred_graph_entries(&mut graph, structural);
+    graph
+}
+
+/// Extract one `PowerShell` function declaration name.
+fn powershell_function_name(line: &str) -> Option<String> {
+    let mut parts = line.split_whitespace();
+    if !parts.next()?.eq_ignore_ascii_case("function") {
+        return None;
+    }
+    let raw_name = parts.next()?;
+    let name = raw_name.split(['(', '{']).next().unwrap_or_default().trim();
+    let name = name.rsplit_once(':').map_or(name, |(_, scoped)| scoped);
+    let valid = !name.is_empty()
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'));
+    valid.then(|| name.to_string())
+}
+
+/// Extract one `PowerShell` class declaration name.
+fn powershell_class_name(line: &str) -> Option<String> {
+    let mut parts = line.split_whitespace();
+    if !parts.next()?.eq_ignore_ascii_case("class") {
+        return None;
+    }
+    let raw_name = parts.next()?;
+    let name = raw_name
+        .split([':', '{', '('])
+        .next()
+        .unwrap_or_default()
+        .trim();
+    let valid = !name.is_empty()
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '_');
+    valid.then(|| name.to_string())
 }
 
 /// Merge preferred graph entries, replacing duplicates and appending within bounds.
@@ -1465,6 +1560,11 @@ fn fallback_patterns() -> Vec<FallbackPattern> {
             "fallback-class",
         ),
         (
+            r"^function\s+([A-Za-z_][A-Za-z0-9_]*(?:-[A-Za-z_][A-Za-z0-9_]*)+)\b",
+            SymbolKind::Function,
+            "fallback-powershell-function",
+        ),
+        (
             r"^(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][A-Za-z0-9_$]*)",
             SymbolKind::Function,
             "fallback-js-function",
@@ -1753,6 +1853,49 @@ fn helper() {}
                 && symbol.kind == SymbolKind::Function
                 && symbol.detail.as_deref() == Some("fallback-python-function")
         }));
+    }
+
+    #[test]
+    fn fallback_preserves_full_powershell_function_names() {
+        let graph = extract_symbol_graph(
+            "scripts/install-runtime.ps1",
+            Some("powershell"),
+            "class RuntimeConfig {\n}\nfunction Resolve-DefaultProjectRoot {\n}\nfunction Get-ReleaseRuntimeInstallPath {\n}\nfunction Install-ReleaseBinary {\n}\n",
+        );
+        assert_eq!(graph.parser, ParserKind::Structural);
+        assert!(
+            graph.symbols.iter().any(|symbol| {
+                symbol.kind == SymbolKind::Class
+                    && symbol.name == "RuntimeConfig"
+                    && symbol.detail.as_deref() == Some("powershell-class")
+            }),
+            "missing PowerShell class symbol: {:?}",
+            graph.symbols
+        );
+
+        for name in [
+            "Resolve-DefaultProjectRoot",
+            "Get-ReleaseRuntimeInstallPath",
+            "Install-ReleaseBinary",
+        ] {
+            assert!(
+                graph.symbols.iter().any(|symbol| {
+                    symbol.kind == SymbolKind::Function
+                        && symbol.name == name
+                        && symbol.detail.as_deref() == Some("powershell-function")
+                }),
+                "missing full PowerShell function name {name}: {:?}",
+                graph.symbols
+            );
+        }
+        assert!(
+            !graph
+                .symbols
+                .iter()
+                .any(|symbol| symbol.name == "Resolve" || symbol.name == "Install"),
+            "PowerShell function names must not be truncated to verbs: {:?}",
+            graph.symbols
+        );
     }
 
     #[test]

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -26,9 +26,11 @@ Purpose completion loop:
 1. Read the focused curation queue with `atlas_purpose_queue` or `projectatlas purpose queue --limit <n>`.
 2. Use the atlas sequence to inspect the path: folders, files, outline or symbols as needed.
 3. Set the correct purpose with `atlas_purpose_set` or `projectatlas purpose set`.
-4. Refresh with `atlas_watch_once`, `projectatlas watch --once`, or `projectatlas scan`.
-5. Rerun health/lint.
-6. Continue until the database has complete reviewed folder purposes, selected high-value file purposes, and the deep index is current.
+4. For a reviewed batch, use `atlas_purpose_review` or `projectatlas purpose review --from-file <json> --apply`
+   instead of raw SQLite edits.
+5. Refresh with `atlas_watch_once`, `projectatlas watch --once`, or `projectatlas scan`.
+6. Rerun health/lint.
+7. Continue until the database has complete reviewed folder purposes, selected high-value file purposes, and the deep index is current.
 
 `atlas_purpose_queue` and `projectatlas purpose queue` default to all folders and high-impact files. Low-priority source files stay out of the default queue so agents are not pushed through every file in a large repository. Pass `projectatlas purpose queue --include-low-priority-files` or MCP `include_low_priority_files: true` only for explicit broad file-purpose cleanup. Use `projectatlas purpose queue --include-assets`, MCP `include_assets: true`, raw `atlas_health`, or bare `projectatlas health-check` only when intentionally curating assets or generated outputs; non-source files should usually inherit purpose from an approved asset root instead of becoming one-by-one queue noise.
 Queue metadata includes `folder_scope` and `file_scope`; agents should use those fields to understand whether files are limited to high-impact entries, all source files, or asset-inclusive mode.
@@ -63,7 +65,8 @@ result text is TOON by default, so agents get compact structured payloads withou
 
 Note: the non-source file list (`.projectatlas/projectatlas-nonsource-files.toon`) is agent-maintained input for
 non-source summaries. Agents should read current repository intelligence from the SQLite-backed CLI/MCP
-surfaces, not from a checked-in static map snapshot.
+surfaces, not from a checked-in static map snapshot. Purpose review batch files are replay inputs for
+`projectatlas purpose review`; SQLite remains authoritative after the ProjectAtlas command applies them.
 ```
 
 ## MCP Server
@@ -172,7 +175,8 @@ Prefer MCP tools when the harness exposes them:
 16. `atlas_strip_legacy_purpose`: remove migrated `.purpose` files when explicitly requested.
 17. `atlas_purpose_queue`: return the folder-first queue of missing, suggested, stale, and structural purpose work for agent curation.
 18. `atlas_purpose_set`: write agent-approved purpose metadata into SQLite.
-19. `atlas_health_resolve`: mark an intentional deterministic health finding resolved with rationale.
+19. `atlas_purpose_review`: preview or apply a reviewed purpose batch into SQLite.
+20. `atlas_health_resolve`: mark an intentional deterministic health finding resolved with rationale.
 
 For read-only reviews or diagnostics, set `PROJECTATLAS_NO_TELEMETRY=1` before running CLI commands or the MCP server.
 This preserves normal atlas reads while preventing usage telemetry writes to `.projectatlas/projectatlas.db`.
@@ -195,7 +199,7 @@ This preserves normal atlas reads while preventing usage telemetry writes to `.p
 | Files changed locally | `atlas_watch_once` | `projectatlas watch --once` |
 | Long local editing session | `atlas_watch_status` for diagnostics | `projectatlas watch` |
 | Planning cleanup/refactor/DRY work | `atlas_health` with filters/paging when needed | `projectatlas health-check --source-only --limit <n>` |
-| Curating missing or generated purposes | `atlas_purpose_queue`, then `atlas_purpose_set` | `projectatlas purpose queue --limit <n>`, then `projectatlas purpose set ...` |
+| Curating missing or generated purposes | `atlas_purpose_queue`, then `atlas_purpose_set` or `atlas_purpose_review` | `projectatlas purpose queue --limit <n>`, then `projectatlas purpose set ...` or `projectatlas purpose review --from-file <json> --apply` |
 | Intentional health conflict | `atlas_health_resolve` | `projectatlas health resolve ... --rationale <why>` |
 | User asks for saved tokens | `atlas_token_report` | `projectatlas token` |
 | Human asks for a terminal token dashboard | `atlas_token_report` first for agent state | `projectatlas token --view tui` |
@@ -238,7 +242,7 @@ but their line ranges come from the deep symbol index and should be kept fresh b
 ProjectAtlas ships public agent guidance through `AGENTS.md`, repository docs, and the packaged plugin skill.
 Personal workspace memory is local state and should stay ignored/untracked through `.gitignore`.
 
-## Claude Code / OpenCode plugins
+## Claude Code Plugin And OpenCode MCP Config
 
 The ProjectAtlas plugin package includes:
 
@@ -249,6 +253,7 @@ The ProjectAtlas plugin package includes:
 
 The generated project-local files are the supported MCP registration path because they contain absolute runtime and project paths.
 Checked-in templates must not be enabled with a bare `projectatlas` command.
+ProjectAtlas does not ship a native OpenCode JavaScript/TypeScript plugin; OpenCode integration is the local MCP server config shape.
 
 ## Lint and CI
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,6 @@ root = "."
 # Optional compatibility export path used only by `projectatlas map`.
 map_path = ".projectatlas/projectatlas.toon"
 nonsource_files_path = ".projectatlas/projectatlas-nonsource-files.toon"
-purpose_filename = ".purpose"
 
 [scan]
 source_extensions = [
@@ -48,7 +47,7 @@ no_commas = true
 max_length = 140
 
 [untracked]
-allowed_filenames = [".purpose"]
+allowed_filenames = []
 allowlist_dir_prefixes = []
 allowlist_files = []
 asset_allowed_prefixes = []
@@ -56,6 +55,11 @@ asset_extensions = [".png", ".jpg", ".jpeg", ".svg", ".gif", ".webp", ".ico", ".
 ```
 
 `projectatlas init` writes the Rust configuration template. Adjust `scan.source_extensions` only when a project needs a narrower or broader compatibility-map surface.
+
+`project.purpose_filename` is intentionally omitted from new configs. ProjectAtlas still accepts the key as a
+legacy migration override and otherwise uses `.purpose` internally only while importing old folder-purpose files
+during `projectatlas scan`; new workflows should write purpose records to SQLite with `projectatlas purpose set`,
+`projectatlas purpose review`, or the matching MCP tools.
 
 ProjectAtlas inherits `.gitignore` dynamically on every scan/watch run through the Rust scanner. Do not copy
 `.gitignore` entries into ProjectAtlas config just to keep them in sync; update `.gitignore` and ProjectAtlas will

--- a/docs/projectatlas-3-architecture.md
+++ b/docs/projectatlas-3-architecture.md
@@ -580,13 +580,13 @@ ProjectAtlas 3 usage. It should not be only an instruction bundle.
 
 Required plugin contents for 3.0:
 
-- ProjectAtlas skill/instructions for Codex, OpenCode, Claude Code, and generic
-  MCP-aware harnesses
+- ProjectAtlas skill/instructions for Codex, Claude Code, OpenCode MCP config
+  users, and generic MCP-aware harnesses
 - installer-generated project-local MCP configs that start the native ProjectAtlas
   MCP server through absolute runtime paths on Windows, Linux, and macOS
 - Claude Code plugin metadata under `.claude-plugin/plugin.json`
 - disabled OpenCode `opencode.json` MCP config template with absolute-path
-  placeholders
+  placeholders, not a native OpenCode JavaScript/TypeScript plugin
 - `projectatlas mcp-config` support for generated per-project MCP configs with
   absolute executable and DB/config paths. Codex/OpenCode outputs include a
   `cwd` project-root hint where supported; Claude Code output avoids relying on
@@ -600,7 +600,7 @@ Required plugin contents for 3.0:
 
 Preferred install behavior:
 
-1. install the plugin from the ProjectAtlas marketplace entry
+1. install the supported plugin or config package for the target harness
 2. make the native `projectatlas` runtime available
 3. register the MCP server for the harness
 4. expose skills/prompts that enforce the context funnel

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -38,7 +38,9 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-features
 cargo test --doc --all-features
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
-cargo run -p projectatlas-cli -- lint --report-untracked
+cargo run -p projectatlas-cli -- --format json scan .
+cargo run -p projectatlas-cli -- purpose review --from-file .projectatlas/projectatlas-purpose-review.json --apply
+cargo run -p projectatlas-cli -- lint --report-untracked --purpose-level strict
 ```
 
 ## Issue hygiene
@@ -71,7 +73,7 @@ cargo run -p projectatlas-cli -- lint --report-untracked
 
 ## CI behavior
 
-- CI refreshes the SQLite index with `projectatlas scan` and validates source metadata with `projectatlas lint`.
+- CI refreshes the SQLite index with `projectatlas scan`, replays the ProjectAtlas repo's reviewed purpose batch with `projectatlas purpose review`, and validates source metadata with strict `projectatlas lint`.
 - `projectatlas lint` checks purpose/header health, non-source declarations, and untracked files; it does not require or validate the optional compatibility TOON export.
 - `projectatlas lint --purpose-level low` is the default first-pass agent gate: stale, duplicate, and repeated temporary-folder findings fail, while missing/suggested/agent-review purpose curation for folders plus high-impact files remains advisory. Use `projectatlas purpose queue` for the actionable curation list, `--purpose-level medium` when all source files must be agent-reviewed, and `--purpose-level strict` only when every indexed file and folder must be agent-reviewed.
 - PRs must reference a GitHub issue and have a milestone.
@@ -101,11 +103,12 @@ Do not add new Purpose headers or `.purpose` files for ProjectAtlas 3. Inspect t
 ```bash
 projectatlas purpose queue --limit 20
 projectatlas purpose set <path> "<one-line purpose>"
+projectatlas purpose review --from-file reviewed-purposes.json --apply
 ```
 
 The purpose queue is source-focused and folder-first by default, so binary assets, asset-only roots, and low-priority source files do not dominate the next-action list. Pass `--include-low-priority-files` only when intentionally doing broad file-purpose cleanup, and pass `--include-assets` only when intentionally curating non-source files. Generated purpose suggestions remain review-required until an agent approves or corrects them.
 
-Purpose entries live in SQLite and are preserved across normal scans and deep index refreshes. Re-scanning keeps existing reviewed purposes for unchanged paths, marks changed approved files stale for review, and deactivates deleted/excluded paths instead of recreating purpose noise. Use the purpose queue or health output to approve only new or stale entries.
+Purpose entries live in SQLite and are preserved across normal scans and deep index refreshes. Re-scanning keeps existing reviewed purposes for unchanged paths, marks changed approved files stale for review, and deactivates deleted/excluded paths instead of recreating purpose noise. Use the purpose queue or health output to approve only new or stale entries. If a repository needs reproducible strict lint from a fresh checkout, keep a reviewed batch input in the repo and replay it with `projectatlas purpose review --apply`; do not edit the SQLite database by hand.
 
 ### Legacy Purpose headers or .purpose files
 

--- a/plugins/projectatlas/.claude-plugin/plugin.json
+++ b/plugins/projectatlas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for Claude Code.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/.codex-plugin/plugin.json
+++ b/plugins/projectatlas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for coding agents.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/opencode/opencode.json
+++ b/plugins/projectatlas/opencode/opencode.json
@@ -6,7 +6,7 @@
       "command": [
         "/absolute/path/to/projectatlas",
         "--require-version",
-        "0.3.12",
+        "0.3.13",
         "--db",
         "/absolute/path/to/project/.projectatlas/projectatlas.db",
         "mcp"

--- a/plugins/projectatlas/skills/projectatlas/SKILL.md
+++ b/plugins/projectatlas/skills/projectatlas/SKILL.md
@@ -50,9 +50,10 @@ When `atlas_purpose_queue`, `projectatlas purpose queue`, `atlas_health`, `proje
 2. Use `atlas_folders`/`atlas_files` to locate the missing path.
 3. Inspect only enough context to understand the path's actual role.
 4. Write a precise one-line purpose with `atlas_purpose_set` or `projectatlas purpose set`.
-5. Run `atlas_watch_once`, `projectatlas watch --once`, or `projectatlas scan`.
-6. Rerun health/lint.
-7. Repeat until the ProjectAtlas database has reviewed folder purposes, selected high-value file purposes, and the deep index is refreshed.
+5. For a reviewed batch, use `atlas_purpose_review` or `projectatlas purpose review --from-file <json> --apply`; do not edit SQLite directly.
+6. Run `atlas_watch_once`, `projectatlas watch --once`, or `projectatlas scan`.
+7. Rerun health/lint.
+8. Repeat until the ProjectAtlas database has reviewed folder purposes, selected high-value file purposes, and the deep index is refreshed.
 
 `atlas_purpose_queue` and `projectatlas purpose queue` default to all folders and high-impact files. Use `projectatlas purpose queue --include-low-priority-files` or MCP `include_low_priority_files: true` only when intentionally doing broad file-purpose cleanup. Use `projectatlas purpose queue --include-assets`, MCP `include_assets: true`, raw `atlas_health`, or bare `projectatlas health-check` only when intentionally curating assets or generated outputs.
 Read `folder_scope` and `file_scope` in queue metadata before deciding how broad the current curation pass is.
@@ -135,7 +136,8 @@ Use the MCP tools when the harness exposes them. Normal agent navigation, search
 15. `atlas_strip_legacy_purpose` only after migrated `.purpose` metadata is safely stored in SQLite.
 16. `atlas_purpose_queue` when an agent needs a folder-first purpose curation queue before approving or correcting generated purposes.
 17. `atlas_purpose_set` when an agent-approved purpose should be written to the durable index.
-18. `atlas_health_resolve` when a deterministic conflict is intentionally correct and should not be repeated.
+18. `atlas_purpose_review` when a reviewed batch should be previewed or applied to SQLite through the ProjectAtlas MCP surface.
+19. `atlas_health_resolve` when a deterministic conflict is intentionally correct and should not be repeated.
 
 ## Command Decision Rules
 
@@ -153,7 +155,7 @@ Use the MCP tools when the harness exposes them. Normal agent navigation, search
 - After creating, moving, deleting, or editing files: call `atlas_watch_once`, `projectatlas watch --once`, or `atlas_scan` before trusting old results.
 - During a long local editing session: prefer a single continuous `projectatlas watch` process from the project root, then use MCP reads against the refreshed SQLite index. File edits refresh incrementally; directory/root/ignore-rule changes may trigger a full scan for correctness.
 - Planning cleanup/refactor/DRY work: call `atlas_health` after overview/folder/file orientation and before proposing moves/merges; use `summary_only`, `source_only`, `category`, `severity`, `path_prefix`, `limit`, and `start_index` when the health surface is large.
-- Purpose curation: call `atlas_purpose_queue` before writing purposes; then inspect enough context and call `atlas_purpose_set`.
+- Purpose curation: call `atlas_purpose_queue` before writing purposes; then inspect enough context and call `atlas_purpose_set` for one path or `atlas_purpose_review` for a reviewed batch.
 - Intentional health conflict after inspection: call `atlas_health_resolve` with a rationale.
 - User asks about saved tokens: call `atlas_token_report`.
 - Runtime looks wrong: call `projectatlas --format json runtime-info`, then `atlas_settings` and `atlas_watch_status`.
@@ -192,6 +194,7 @@ If MCP tools are unavailable, use the equivalent CLI sequence:
 | Continuous local refresh | `projectatlas watch` |
 | Cleanup/refactor signals | `projectatlas health-check --source-only --limit <n>` |
 | Purpose curation queue | `projectatlas purpose queue --limit <n>` |
+| Purpose review batch | `projectatlas purpose review --from-file <json> --apply` |
 | Purpose lint | `projectatlas lint --purpose-level low`, `projectatlas lint --purpose-level medium`, or `projectatlas lint --purpose-level strict` |
 | Token savings | `projectatlas token` |
 | Human token dashboard | `projectatlas token --view tui` |

--- a/skills/claude/ProjectAtlas.md
+++ b/skills/claude/ProjectAtlas.md
@@ -21,8 +21,9 @@ repository overview to folder, file, compressed outline, and exact source only w
 4. Run `projectatlas scan`.
 5. Add or import purpose records for important folders and files.
 6. Add non-source summaries to `.projectatlas/projectatlas-nonsource-files.toon` when needed.
-7. Run `projectatlas lint --report-untracked --purpose-level low` and fix issues. Use `--purpose-level medium` for all source files and `--purpose-level strict` only when every indexed file and folder must be agent-reviewed.
-8. Run `projectatlas map --force` only when an explicit legacy TOON map export is needed.
+7. Use `projectatlas purpose review --from-file <json> --apply` for reviewed batches; never edit the SQLite database directly.
+8. Run `projectatlas lint --report-untracked --purpose-level low` and fix issues. Use `--purpose-level medium` for all source files and `--purpose-level strict` only when every indexed file and folder must be agent-reviewed.
+9. Run `projectatlas map --force` only when an explicit legacy TOON map export is needed.
 
 ## Startup Workflow
 

--- a/skills/codex/ProjectAtlas.md
+++ b/skills/codex/ProjectAtlas.md
@@ -22,8 +22,9 @@ the folder, choose the file, inspect compressed context, and only then open exac
 4. Run `projectatlas scan`.
 5. Add or import purpose records for important folders and files.
 6. Add non-source summaries to `.projectatlas/projectatlas-nonsource-files.toon` when needed.
-7. Run `projectatlas lint --report-untracked --purpose-level low` and fix issues. Use `--purpose-level medium` for all source files and `--purpose-level strict` only when every indexed file and folder must be agent-reviewed.
-8. Run `projectatlas map --force` only when an explicit legacy TOON map export is needed.
+7. Use `projectatlas purpose review --from-file <json> --apply` for reviewed batches; never edit the SQLite database directly.
+8. Run `projectatlas lint --report-untracked --purpose-level low` and fix issues. Use `--purpose-level medium` for all source files and `--purpose-level strict` only when every indexed file and folder must be agent-reviewed.
+9. Run `projectatlas map --force` only when an explicit legacy TOON map export is needed.
 
 ## Startup Workflow
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -15,7 +15,7 @@
 11. Run `projectatlas lint --report-untracked --purpose-level low`; low fails stale, duplicate, and temporary-folder health but keeps first-pass purpose curation advisory. Use `projectatlas purpose queue` for the next curation actions, `--purpose-level medium` when all source files must be agent-reviewed, and `--purpose-level strict` only when every indexed file and folder must be agent-reviewed.
 12. Only then use symbol-level indexing, language-server lookups, or broad file reads on selected files.
 13. Run `projectatlas token` when asked for token savings.
-14. Correct wrong, stale, vague, or generic purposes opportunistically with `atlas_purpose_set` or `projectatlas purpose set` after inspecting enough context. Purpose entries live in SQLite and are preserved across scans; changed approved files become stale instead of losing their curated purpose text.
+14. Correct wrong, stale, vague, or generic purposes opportunistically with `atlas_purpose_set` or `projectatlas purpose set` after inspecting enough context. Use `atlas_purpose_review` or `projectatlas purpose review --from-file <json> --apply` for reviewed batches; never edit SQLite directly. Purpose entries live in SQLite and are preserved across scans; changed approved files become stale instead of losing their curated purpose text.
 
 ## Rust/Dependency Discipline
 - Prefer official or canonical Rust crates and standard implementations for protocols, formats, parsers, storage, watchers, token tooling, and platform integration before writing custom code.


### PR DESCRIPTION
## Summary

- Add `projectatlas purpose review --from-file` and MCP `atlas_purpose_review` for agent-reviewed batch purpose replay through ProjectAtlas commands instead of raw SQLite edits.
- Track `.projectatlas/projectatlas-purpose-review.json` and make CI/release scan, replay reviewed purposes, then enforce `lint --report-untracked --purpose-level strict`.
- Preserve reviewed purpose source/agent markers across plugin update, watch/deep refresh, scan, and MCP batch review tests.
- Remove legacy `.purpose` defaults from generated config while keeping explicit legacy migration support.
- Improve PowerShell indexing with structural function/class extraction and protect hyphenated PowerShell function names.
- Clarify Claude Code plugin packaging versus OpenCode MCP config support, and bump the release to `v0.3.13`.

## Issue

Closes #217
Closes #218
Closes #219
Closes #220
Closes #221
Closes #222

## Verification

- [x] `projectatlas scan` run when indexed context changed.
- [x] `projectatlas purpose review --from-file .projectatlas/projectatlas-purpose-review.json --apply` passes.
- [x] `projectatlas lint --report-untracked --purpose-level strict` passes.
- [x] `cargo fmt --check` clean.
- [x] `cargo check --workspace --all-targets --all-features --locked` clean.
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean.
- [x] `cargo test --workspace --all-features --locked` clean.
- [x] `cargo test --doc --all-features --locked` clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked` clean.
- [x] `cargo deny check` exits green; existing duplicate dependency warnings remain warnings.
- [x] `python .github/scripts/release-notes.py --self-test` passes.
- [x] Tests updated or added where behavior changed.
- [x] PR text contains no private or internal-only details.
