### PR TITLE
Fix locked mirror guidance and release notes (#249, #250)

### DIFF
--- a/.github/scripts/release-notes.py
+++ b/.github/scripts/release-notes.py
@@ -28,6 +28,23 @@ def note_title(text):
 SECTIONS = ("New Features", "Bug Fixes", "Chores")
 
 
+def semver_key(tag):
+    match = re.fullmatch(r"v([0-9]+)\.([0-9]+)\.([0-9]+)", tag or "")
+    return tuple(int(part) for part in match.groups()) if match else None
+
+
+def previous_tag_from(tags, version):
+    current = semver_key(version)
+    if current is None:
+        return ""
+    candidates = []
+    for tag in tags:
+        key = semver_key(tag)
+        if key and key < current:
+            candidates.append((key, tag))
+    return max(candidates)[1] if candidates else ""
+
+
 def pr_summary(body, fallback):
     lines = (body or "").splitlines()
     in_summary = False
@@ -88,8 +105,8 @@ def gh_json(endpoint):
 
 
 def previous_tag(version):
-    process = run(["git", "describe", "--tags", "--abbrev=0", f"{version}^"], False)
-    return process.stdout.strip() if process.returncode == 0 else ""
+    process = run(["git", "tag", "--merged", "HEAD"], False)
+    return previous_tag_from(process.stdout.splitlines(), version) if process.returncode == 0 else ""
 
 
 def merged_prs(repo, start_tag):
@@ -178,6 +195,8 @@ def self_test():
     assert note_title("bug: stale runtime remains") == "Stale runtime remains"
     assert section_for("fix(db): reject stale paths") == "Bug Fixes"
     assert section_for("feat(cli): add root diagnostics") == "New Features"
+    assert previous_tag_from(["v0.3.15", "v0.3.16"], "v0.3.17") == "v0.3.16"
+    assert previous_tag_from(["v0.3.15", "v0.3.16", "v0.3.17"], "v0.3.17") == "v0.3.16"
     print("release notes self-test passed")
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-cli"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-core"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "regex",
  "serde",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-db"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "projectatlas-core",
  "rusqlite",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-fs"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "blake3",
  "ignore",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-service"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "globset",
  "projectatlas-core",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-symbols"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "projectatlas-core",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.16"
+version = "0.3.17"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/styler-ai/ProjectAtlas"
@@ -68,11 +68,11 @@ must_use_candidate = "allow"
 missing_inline_in_public_items = "allow"
 
 [workspace.dependencies]
-projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.16" }
-projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.16" }
-projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.16" }
-projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.16" }
-projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.16" }
+projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.17" }
+projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.17" }
+projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.17" }
+projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.17" }
+projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.17" }
 blake3 = "1.5"
 clap = { version = "4.5", features = ["derive"] }
 cssparser = "0.37"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.3.16"><img alt="release" src="https://img.shields.io/badge/release-v0.3.16-blue"></a>
+  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.3.17"><img alt="release" src="https://img.shields.io/badge/release-v0.3.17-blue"></a>
   <img alt="rust" src="https://img.shields.io/badge/Rust-2024-orange">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-green">
 </p>
@@ -25,7 +25,7 @@ No required `.purpose` files. No source-header tax. No hosted index. The project
 ## Quickstart
 
 ```bash
-codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.16
+codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.17
 codex plugin add projectatlas --marketplace projectatlas
 ```
 
@@ -44,7 +44,7 @@ correctly keeps that pinned ref. In that case, replace only the dedicated `style
 
 ```bash
 codex plugin marketplace remove projectatlas
-codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.16
+codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.17
 ```
 
 Then tell Codex: "Use ProjectAtlas for this repo."
@@ -177,7 +177,7 @@ Most users can stop at the plugin install. The CLI is here for local debugging, 
 Only need the CLI yourself? Install it from the released tag:
 
 ```bash
-cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.3.16 projectatlas-cli --locked
+cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.3.17 projectatlas-cli --locked
 ```
 
 From this checkout:
@@ -276,7 +276,7 @@ ProjectAtlas scans with `.gitignore` awareness, hashes files with BLAKE3, stores
 
 ## Release Quality
 
-`v0.3.16` ships through the full release matrix:
+`v0.3.17` ships through the full release matrix:
 
 - Rust format, check, clippy, dependency policy, tests, doctests, and rustdoc.
 - ProjectAtlas scan, parity, database-backed purpose lint, and health checks.

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -800,6 +800,13 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
     fs::create_dir_all(&app_data)?;
     fs::create_dir_all(&local_app_data)?;
 
+    let fake_codex_log = isolated_home.join("fake-codex.log");
+    let fake_codex = isolated_home.join("codex.cmd");
+    fs::write(
+        &fake_codex,
+        "@echo off\r\necho %*>>\"%PROJECTATLAS_FAKE_CODEX_LOG%\"\r\nif \"%1\"==\"mcp\" if \"%2\"==\"get\" (\r\n  echo projectatlas\r\n  echo   command: %LOCALAPPDATA%\\ProjectAtlas\\bin\\projectatlas.exe\r\n  echo   args: --require-version 0.3.15 --db C:\\old\\.projectatlas\\projectatlas.db mcp\r\n  exit /b 0\r\n)\r\nexit /b 0\r\n",
+    )?;
+
     let stable_runtime = local_app_data
         .join("ProjectAtlas")
         .join("bin")
@@ -858,7 +865,8 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             .env("APPDATA", &app_data)
             .env("LOCALAPPDATA", &local_app_data)
             .env("PROJECTATLAS_SKIP_USER_PATH_UPDATE", "1")
-            .env("PROJECTATLAS_SKIP_CODEX_MCP_REGISTRY_UPDATE", "1")
+            .env("PROJECTATLAS_CODEX_COMMAND", &fake_codex)
+            .env("PROJECTATLAS_FAKE_CODEX_LOG", &fake_codex_log)
             .env("PROJECTATLAS_NO_TELEMETRY", "1")
             .output()?;
         let server_result = release_server.join().map_err(|panic_payload| {
@@ -883,11 +891,22 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             ))
             .into());
         }
-        if !installer_output_text.contains("ProjectAtlas LocalAppData mirror skipped") {
-            return Err(io::Error::other(format!(
-                "installer did not report the locked LocalAppData mirror\n{installer_output_text}"
-            ))
-            .into());
+        let normalized_installer_output = installer_output_text
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        for required in [
+            "ProjectAtlas LocalAppData mirror skipped",
+            "Close any running ProjectAtlas or Codex session using that file",
+            "then rerun this installer",
+            "Codex MCP and generated configs continue to use verified",
+        ] {
+            if !normalized_installer_output.contains(required) {
+                return Err(io::Error::other(format!(
+                    "installer did not provide locked LocalAppData mirror guidance {required:?}\n{installer_output_text}"
+                ))
+                .into());
+            }
         }
         if !installer_output_text
             .contains("Active process resolves bare projectatlas to verified runtime")
@@ -908,6 +927,22 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             return Err(io::Error::other(format!(
                 "release binary was not installed to the versioned runtime path: {}",
                 versioned_runtime.display()
+            ))
+            .into());
+        }
+        let fake_codex_calls = fs::read_to_string(&fake_codex_log)?;
+        if !fake_codex_calls.contains("mcp add projectatlas --")
+            || !fake_codex_calls.contains(versioned_runtime.to_string_lossy().as_ref())
+            || fake_codex_calls.contains(stable_runtime.to_string_lossy().as_ref())
+        {
+            return Err(io::Error::other(format!(
+                "locked mirror Codex MCP registry was not repaired to the versioned runtime:\n{fake_codex_calls}"
+            ))
+            .into());
+        }
+        if !installer_output_text.contains("Codex MCP registry updated to ProjectAtlas runtime") {
+            return Err(io::Error::other(format!(
+                "installer did not report locked mirror Codex registry repair\n{installer_output_text}"
             ))
             .into());
         }

--- a/plugins/projectatlas/.claude-plugin/plugin.json
+++ b/plugins/projectatlas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for Claude Code.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/.codex-plugin/plugin.json
+++ b/plugins/projectatlas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for coding agents.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/opencode/opencode.json
+++ b/plugins/projectatlas/opencode/opencode.json
@@ -6,7 +6,7 @@
       "command": [
         "/absolute/path/to/projectatlas",
         "--require-version",
-        "0.3.16",
+        "0.3.17",
         "--db",
         "/absolute/path/to/project/.projectatlas/projectatlas.db",
         "mcp"

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -313,7 +313,7 @@ function Sync-ProjectAtlasRuntimeToLocalAppData {
             Copy-Item -LiteralPath $FilePath -Destination $target -Force
         }
         catch {
-            Write-Warning "ProjectAtlas LocalAppData mirror skipped because ${target} is locked: $($_.Exception.Message)"
+            Write-Warning "ProjectAtlas LocalAppData mirror skipped because ${target} is locked: $($_.Exception.Message) Close any running ProjectAtlas or Codex session using that file, then rerun this installer. Codex MCP and generated configs continue to use verified runtime $FilePath."
             return $FilePath
         }
     }
@@ -369,7 +369,7 @@ function Write-ProjectAtlasPathShadowReport {
         }
         if (-not (Test-ProjectAtlasRuntime $candidate $ExpectedVersion)) {
             $version = Get-ProjectAtlasRuntimeVersion $candidate
-            Write-Warning "Obsolete ProjectAtlas runtime or shim still exists on PATH: $candidate version '$version'. It was not removed automatically."
+            Write-Warning "Obsolete ProjectAtlas runtime or shim still exists on PATH: $candidate version '$version'. It was not removed automatically. Close any process using that file, then rerun this installer or remove the shim manually; generated MCP configs use the verified runtime $VerifiedPath."
         }
     }
 }


### PR DESCRIPTION
## Summary

- make the Windows locked LocalAppData mirror warning actionable while keeping MCP configs pinned to the verified runtime
- extend the locked-mirror e2e to prove Codex MCP registry repair uses the versioned runtime even when the stable mirror is locked
- fix release notes so a not-yet-created release tag uses the latest existing lower semver tag as the compare base
- bump ProjectAtlas to v0.3.17

Fixes #249.
Fixes #250.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo test --doc --workspace --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- `cargo deny check` (passes with documented duplicate warnings)
- `python .github/scripts/release-notes.py --self-test`
- generated notes smoke for `v0.3.17` produced `Full Changelog: .../compare/v0.3.16...v0.3.17`
- `projectatlas --format json scan .`
- `projectatlas purpose review --from-file .projectatlas/projectatlas-purpose-review.json --apply`
- `projectatlas lint --report-untracked --purpose-level strict`
