### PR TITLE
Fix token event dedupe accounting (#252, #254)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-cli"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-core"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "regex",
  "serde",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-db"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "projectatlas-core",
  "rusqlite",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-fs"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "blake3",
  "ignore",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-service"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "globset",
  "projectatlas-core",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-symbols"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "projectatlas-core",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.17"
+version = "0.3.18"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/styler-ai/ProjectAtlas"
@@ -68,11 +68,11 @@ must_use_candidate = "allow"
 missing_inline_in_public_items = "allow"
 
 [workspace.dependencies]
-projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.17" }
-projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.17" }
-projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.17" }
-projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.17" }
-projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.17" }
+projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.18" }
+projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.18" }
+projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.18" }
+projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.18" }
+projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.18" }
 blake3 = "1.5"
 clap = { version = "4.5", features = ["derive"] }
 cssparser = "0.37"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.3.17"><img alt="release" src="https://img.shields.io/badge/release-v0.3.17-blue"></a>
+  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.3.18"><img alt="release" src="https://img.shields.io/badge/release-v0.3.18-blue"></a>
   <img alt="rust" src="https://img.shields.io/badge/Rust-2024-orange">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-green">
 </p>
@@ -25,7 +25,7 @@ No required `.purpose` files. No source-header tax. No hosted index. The project
 ## Quickstart
 
 ```bash
-codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.17
+codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.18
 codex plugin add projectatlas --marketplace projectatlas
 ```
 
@@ -44,7 +44,7 @@ correctly keeps that pinned ref. In that case, replace only the dedicated `style
 
 ```bash
 codex plugin marketplace remove projectatlas
-codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.17
+codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.3.18
 ```
 
 Then tell Codex: "Use ProjectAtlas for this repo."
@@ -177,7 +177,7 @@ Most users can stop at the plugin install. The CLI is here for local debugging, 
 Only need the CLI yourself? Install it from the released tag:
 
 ```bash
-cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.3.17 projectatlas-cli --locked
+cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.3.18 projectatlas-cli --locked
 ```
 
 From this checkout:
@@ -276,7 +276,7 @@ ProjectAtlas scans with `.gitignore` awareness, hashes files with BLAKE3, stores
 
 ## Release Quality
 
-`v0.3.17` ships through the full release matrix:
+`v0.3.18` ships through the full release matrix:
 
 - Rust format, check, clippy, dependency policy, tests, doctests, and rustdoc.
 - ProjectAtlas scan, parity, database-backed purpose lint, and health checks.

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -7245,7 +7245,7 @@ fn serve_release_assets(
     listener.set_nonblocking(true)?;
     let base_url = format!("http://{}", listener.local_addr()?);
     let handle = thread::spawn(move || {
-        let deadline = Instant::now() + Duration::from_secs(20);
+        let deadline = Instant::now() + Duration::from_mins(1);
         let mut served_archive = false;
         let mut served_checksums = false;
         loop {

--- a/crates/projectatlas-core/src/telemetry.rs
+++ b/crates/projectatlas-core/src/telemetry.rs
@@ -583,6 +583,7 @@ impl TokenAccountingSummary {
     fn from_events(events: &[UsageEvent]) -> Self {
         let mut measured_tokens_saved = 0isize;
         let mut gross_modeled_tokens_avoided = 0isize;
+        let mut event_scoped_modeled_tokens_avoided = 0isize;
         let mut modeled_baselines = BTreeMap::<ModeledBaselineKey, ModeledBaselineTotals>::new();
 
         for event in events {
@@ -602,6 +603,11 @@ impl TokenAccountingSummary {
             }
             gross_modeled_tokens_avoided =
                 saturating_isize_add(gross_modeled_tokens_avoided, delta);
+            if event.dedupe_scope == TOKEN_DEDUPE_SCOPE_EVENT {
+                event_scoped_modeled_tokens_avoided =
+                    saturating_isize_add(event_scoped_modeled_tokens_avoided, delta);
+                continue;
+            }
             let entry = modeled_baselines
                 .entry(ModeledBaselineKey::from_event(event))
                 .or_default();
@@ -611,7 +617,7 @@ impl TokenAccountingSummary {
                 entry.emitted_with_projectatlas.saturating_add(with as u128);
         }
 
-        let mut deduped_modeled_tokens_avoided = 0isize;
+        let mut deduped_modeled_tokens_avoided = event_scoped_modeled_tokens_avoided;
         let mut repeated_baselines_deduped = 0usize;
         for totals in modeled_baselines.values() {
             if totals.calls > 1 {

--- a/crates/projectatlas-db/src/lib.rs
+++ b/crates/projectatlas-db/src/lib.rs
@@ -7,8 +7,8 @@ use projectatlas_core::symbols::{
 };
 use projectatlas_core::telemetry::{
     TokenBucketOverview, TokenOverview, TokenTrendPeriod, TokenTrendReport, TokenTrendWindow,
-    UsageEvent, default_dedupe_scope, default_estimate_method, default_token_accuracy,
-    default_token_model, default_token_provider, default_token_trace, default_tokenizer_backend,
+    UsageEvent, default_estimate_method, default_token_accuracy, default_token_model,
+    default_token_provider, default_token_trace, default_tokenizer_backend,
 };
 use projectatlas_core::{
     AGENT_REVIEWED_SOURCE_VALUES, HIGH_IMPACT_FILE_NAMES, HIGH_IMPACT_PATH_PREFIXES,
@@ -3445,7 +3445,7 @@ impl AtlasStore {
                    estimated_tokens_with_projectatlas,
                    token_savings_bucket, baseline_kind, confidence,
                    accounting_layer, denominator_kind,
-                   baseline_identity, baseline_fingerprint
+                   baseline_identity, baseline_fingerprint, dedupe_scope
             FROM usage_events
             WHERE session_id = ?1
               AND estimated_tokens_without_projectatlas IS NOT NULL
@@ -3459,7 +3459,7 @@ impl AtlasStore {
                    estimated_tokens_with_projectatlas,
                    token_savings_bucket, baseline_kind, confidence,
                    accounting_layer, denominator_kind,
-                   baseline_identity, baseline_fingerprint
+                   baseline_identity, baseline_fingerprint, dedupe_scope
             FROM usage_events
             WHERE estimated_tokens_without_projectatlas IS NOT NULL
               AND estimated_tokens_with_projectatlas IS NOT NULL
@@ -3489,7 +3489,7 @@ impl AtlasStore {
                 denominator_kind: row.get(10)?,
                 baseline_identity: row.get(11)?,
                 baseline_fingerprint: row.get(12)?,
-                dedupe_scope: default_dedupe_scope(),
+                dedupe_scope: row.get(13)?,
             })
         };
         let rows = if let Some(session) = session_id {
@@ -4603,8 +4603,10 @@ fn resolved_ids_for_category(resolved_ids: &[String], category: &str) -> Vec<Str
 mod tests {
     use super::*;
     use projectatlas_core::telemetry::{
-        TOKEN_ACCURACY_HEURISTIC, TOKEN_BUCKET_FULL_FILE_COMPRESSION,
-        TOKEN_BUCKET_NAVIGATION_AVOIDANCE, usage_from_estimates, usage_from_text,
+        TOKEN_ACCOUNTING_MODELED_AVOIDANCE, TOKEN_ACCURACY_HEURISTIC,
+        TOKEN_BASELINE_SELECTED_CANDIDATES, TOKEN_BUCKET_FULL_FILE_COMPRESSION,
+        TOKEN_BUCKET_NAVIGATION_AVOIDANCE, TOKEN_CONFIDENCE_INFERRED, TOKEN_DEDUPE_SCOPE_EVENT,
+        usage_from_estimates, usage_from_estimates_with_accounting, usage_from_text,
     };
     use projectatlas_core::{NodeKind, normalized_parent};
     use std::error::Error;
@@ -4781,6 +4783,51 @@ mod tests {
             &deduped.tokens_avoided,
             &331,
             "headline avoided tokens use measured plus deduped modeled",
+        )?;
+
+        store.record_usage(&usage_from_estimates_with_accounting(
+            "event-scoped",
+            "folders",
+            None,
+            Some("token".to_string()),
+            400,
+            40,
+            TOKEN_BUCKET_NAVIGATION_AVOIDANCE,
+            TOKEN_BASELINE_SELECTED_CANDIDATES,
+            TOKEN_CONFIDENCE_INFERRED,
+            TOKEN_ACCOUNTING_MODELED_AVOIDANCE,
+            TOKEN_BASELINE_SELECTED_CANDIDATES,
+            TOKEN_DEDUPE_SCOPE_EVENT,
+        ))?;
+        store.record_usage(&usage_from_estimates_with_accounting(
+            "event-scoped",
+            "folders",
+            None,
+            Some("token".to_string()),
+            400,
+            30,
+            TOKEN_BUCKET_NAVIGATION_AVOIDANCE,
+            TOKEN_BASELINE_SELECTED_CANDIDATES,
+            TOKEN_CONFIDENCE_INFERRED,
+            TOKEN_ACCOUNTING_MODELED_AVOIDANCE,
+            TOKEN_BASELINE_SELECTED_CANDIDATES,
+            TOKEN_DEDUPE_SCOPE_EVENT,
+        ))?;
+        let event_scoped = store.token_overview(Some("event-scoped"))?;
+        require_eq(
+            &event_scoped.gross_modeled_tokens_avoided,
+            &730,
+            "event-scoped gross modeled avoided tokens",
+        )?;
+        require_eq(
+            &event_scoped.deduped_modeled_tokens_avoided,
+            &730,
+            "event-scoped modeled events are not collapsed",
+        )?;
+        require_eq(
+            &event_scoped.repeated_baselines_deduped,
+            &0,
+            "event-scoped modeled events do not count as deduped repeats",
         )?;
 
         let mut negative_event = usage_from_estimates("negative", "outline", None, None, 20, 50);

--- a/docs/benchmarks/large-application-token-savings.md
+++ b/docs/benchmarks/large-application-token-savings.md
@@ -44,8 +44,8 @@ Current reports preserve the historical `estimated_saved`/`legacy_gross_estimate
 
 - `measured_tokens_saved`: observed full-file/source-compression before/after deltas.
 - `gross_modeled_tokens_avoided`: modeled navigation avoidance before dedupe.
-- `deduped_modeled_tokens_avoided`: modeled navigation avoidance after retaining one repeated session baseline per identity and subtracting every ProjectAtlas payload emitted for it.
-- `repeated_baselines_deduped`: duplicate modeled events collapsed by that repeated-baseline dedupe.
+- `deduped_modeled_tokens_avoided`: modeled navigation avoidance after retaining one repeated session-scoped baseline per identity and subtracting every ProjectAtlas payload emitted for it; modeled rows with `dedupe_scope = "event"` are kept as individual events.
+- `repeated_baselines_deduped`: duplicate session-scoped modeled events collapsed by that repeated-baseline dedupe.
 - `tokens_avoided`: conservative headline value, equal to measured saved plus deduped modeled avoided.
 
 ## Responsiveness Sample

--- a/docs/projectatlas-3-architecture.md
+++ b/docs/projectatlas-3-architecture.md
@@ -648,10 +648,11 @@ Token accounting model:
   deduped_modeled_tokens_avoided`. `measured_tokens_saved` is observed
   before/after source-compression evidence. `gross_modeled_tokens_avoided` is
   counterfactual navigation avoidance before dedupe. `deduped_modeled_tokens_avoided`
-  counts repeated modeled baselines once per session/baseline identity/fingerprint
-  and subtracts every ProjectAtlas payload emitted for that repeated baseline.
-  `repeated_baselines_deduped` counts duplicate modeled events collapsed, not
-  unique baseline groups.
+  counts session-scoped repeated modeled baselines once per session/baseline
+  identity/fingerprint and subtracts every ProjectAtlas payload emitted for
+  that repeated baseline. Modeled rows with `dedupe_scope = "event"` are kept
+  as individual events. `repeated_baselines_deduped` counts duplicate
+  session-scoped modeled events collapsed, not unique baseline groups.
 - Compute `savings_rate = saved / estimated_tokens_without_projectatlas` only
   when the baseline is greater than zero. A zero baseline yields an unknown rate
   instead of a fake percentage.

--- a/plugins/projectatlas/.claude-plugin/plugin.json
+++ b/plugins/projectatlas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for Claude Code.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/.codex-plugin/plugin.json
+++ b/plugins/projectatlas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for coding agents.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/opencode/opencode.json
+++ b/plugins/projectatlas/opencode/opencode.json
@@ -6,7 +6,7 @@
       "command": [
         "/absolute/path/to/projectatlas",
         "--require-version",
-        "0.3.17",
+        "0.3.18",
         "--db",
         "/absolute/path/to/project/.projectatlas/projectatlas.db",
         "mcp"


### PR DESCRIPTION
## Summary

- Load persisted `dedupe_scope` in the token accounting read path used by `token_overview()`.
- Keep modeled `dedupe_scope = event` rows out of session-baseline collapse.
- Update token accounting docs/specs for event-scoped modeled rows.
- Bump the release version to v0.3.18.
- Loosen the Windows release-asset e2e helper timeout to one minute after CI exposed a flaky 20 second asset-request wait.

Fixes #252.
Fixes #254.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p projectatlas-db records_token_overview -- --nocapture`
- `cargo test -p projectatlas-core --lib telemetry -- --nocapture`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `python .github/scripts/release-notes.py --self-test`
- `projectatlas scan .`
