### PR TITLE
fix(plugin,token): repair Codex drift and token TUI (#285, #286)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,10 @@ jobs:
         timeout-minutes: 5
         run: cargo test --locked -p projectatlas-cli plugin_update_leaves_current_codex_marketplace_untouched --test e2e
 
+      - name: Plugin update stale source manifest E2E
+        timeout-minutes: 5
+        run: cargo test --locked -p projectatlas-cli plugin_update_repairs_current_codex_plugin_with_stale_source_manifest --test e2e
+
       - name: Plugin update restore-on-failure E2E
         timeout-minutes: 5
         run: cargo test --locked -p projectatlas-cli plugin_update_restores_current_ref_marketplace_when_plugin_reinstall_fails --test e2e

--- a/.projectatlas/projectatlas-nonsource-files.toon
+++ b/.projectatlas/projectatlas-nonsource-files.toon
@@ -35,7 +35,10 @@ nonsource_files[]:
   docs/format.md,ProjectAtlas TOON schema reference
   docs/workflow.md,ProjectAtlas workflow and troubleshooting guide
   docs/projectatlas-3-architecture.md,ProjectAtlas 3 Rust architecture plan
+  docs/projectatlas-v0.3.23-premortem-spec.md,ProjectAtlas v0.3.23 pre-mortem and release specification for installer drift and token TUI fixes
   skills/codex/ProjectAtlas.md,Codex skill instructions for ProjectAtlas
+  skills/codex-coding-plugin/SKILL.md,Codex plugin engineering skill for stable plugin manifests installers MCP config and cache-drift checks
+  skills/codex-coding-plugin/agents/openai.yaml,Agent manifest exposing the codex-coding-plugin skill to OpenAI and Codex contexts
   skills/claude/ProjectAtlas.md,Claude skill instructions for ProjectAtlas
   plugins/projectatlas/.codex-plugin/plugin.json,ProjectAtlas Codex plugin manifest
   plugins/projectatlas/skills/projectatlas/SKILL.md,ProjectAtlas installable Codex skill

--- a/.projectatlas/projectatlas-purpose-review.json
+++ b/.projectatlas/projectatlas-purpose-review.json
@@ -549,6 +549,10 @@
       "purpose": "Document ProjectAtlas v0.3.22 pre-mortem, issue triage, edge cases, and release test plan."
     },
     {
+      "path": "docs/projectatlas-v0.3.23-premortem-spec.md",
+      "purpose": "Document the ProjectAtlas v0.3.23 pre-mortem, issue scope, token TUI accounting, installer drift fix, and release plan."
+    },
+    {
       "path": "docs/projectatlas-3-v0.3.2-hardening-spec.md",
       "purpose": "Historical v0.3.2 hardening specification covering symbol modules, path normalization, import aliases, and release gates."
     },
@@ -719,6 +723,22 @@
     {
       "path": "skills/codex/ProjectAtlas.md",
       "purpose": "Codex-oriented ProjectAtlas skill instructions for atlas-first repository navigation."
+    },
+    {
+      "path": "skills/codex-coding-plugin",
+      "purpose": "Reusable Codex skill package for engineering stable Codex plugins, manifests, installers, and cache-drift checks."
+    },
+    {
+      "path": "skills/codex-coding-plugin/agents",
+      "purpose": "Agent manifest folder for loading the codex-coding-plugin workflow in OpenAI and Codex contexts."
+    },
+    {
+      "path": "skills/codex-coding-plugin/SKILL.md",
+      "purpose": "Workflow guidance for building stable Codex plugins, plugin manifests, installers, MCP configs, and cache-drift checks."
+    },
+    {
+      "path": "skills/codex-coding-plugin/agents/openai.yaml",
+      "purpose": "OpenAI agent manifest that exposes the codex-coding-plugin skill to Codex skill discovery."
     },
     {
       "path": "templates/AGENTS.md",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-cli"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-core"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "regex",
  "serde",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-db"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "projectatlas-core",
  "rusqlite",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-fs"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "blake3",
  "ignore",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-lints"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-service"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "globset",
  "projectatlas-core",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-symbols"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "projectatlas-core",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.22"
+version = "0.3.23"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/styler-ai/ProjectAtlas"
@@ -69,11 +69,11 @@ must_use_candidate = "allow"
 missing_inline_in_public_items = "allow"
 
 [workspace.dependencies]
-projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.22" }
-projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.22" }
-projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.22" }
-projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.22" }
-projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.22" }
+projectatlas-core = { path = "crates/projectatlas-core", version = "0.3.23" }
+projectatlas-db = { path = "crates/projectatlas-db", version = "0.3.23" }
+projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.3.23" }
+projectatlas-service = { path = "crates/projectatlas-service", version = "0.3.23" }
+projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.3.23" }
 blake3 = "1.5"
 clap = { version = "4.5", features = ["derive"] }
 cssparser = "0.37"

--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -1280,7 +1280,12 @@ fn run() -> Result<(), CliError> {
                         print_output(cli.format, &render_token_overview(&overview), &overview)?;
                     }
                     TokenView::Tui => {
-                        write_stdout(&render_token_dashboard(&overview, session.as_deref()))?;
+                        let trends = token_dashboard_trends(&store, session.as_deref())?;
+                        write_stdout(&render_token_dashboard(
+                            &overview,
+                            session.as_deref(),
+                            &trends,
+                        ))?;
                     }
                 }
             }
@@ -2230,6 +2235,22 @@ fn write_stderr(text: &str) -> Result<(), CliError> {
     Ok(())
 }
 
+/// Load the standard trend windows for the token overview dashboard.
+fn token_dashboard_trends(
+    store: &AtlasStore,
+    session: Option<&str>,
+) -> Result<Vec<projectatlas_core::telemetry::TokenTrendReport>, CliError> {
+    [
+        CoreTokenTrendWindow::Day,
+        CoreTokenTrendWindow::Week,
+        CoreTokenTrendWindow::Month,
+        CoreTokenTrendWindow::Year,
+    ]
+    .into_iter()
+    .map(|window| store.token_trends(session, window).map_err(CliError::from))
+    .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::mcp::{
@@ -2253,7 +2274,9 @@ mod tests {
     use projectatlas_core::symbols::{
         CodeSymbol, ParserKind, RelationKind, SymbolGraph, SymbolKind, SymbolRelation,
     };
-    use projectatlas_core::telemetry::TokenOverview;
+    use projectatlas_core::telemetry::{
+        TokenOverview, TokenTrendPeriod, TokenTrendReport, TokenTrendWindow,
+    };
     use projectatlas_db::AtlasStore;
     use projectatlas_fs::ScanOptions;
     use rmcp::model::{CallToolRequestParams, ClientInfo};
@@ -2773,14 +2796,59 @@ mod tests {
         let dashboard = render_token_dashboard(
             &TokenOverview::from_estimated_totals(3, 12_000, 3_000),
             Some("session-a"),
+            &[
+                TokenTrendReport::new(
+                    Some("session-a".to_string()),
+                    TokenTrendWindow::Day,
+                    vec![
+                        TokenTrendPeriod::from_totals("2026-07-01".to_string(), 1, 100, 50),
+                        TokenTrendPeriod::from_totals("2026-07-02".to_string(), 2, 200, 75),
+                    ],
+                ),
+                TokenTrendReport::new(
+                    Some("session-a".to_string()),
+                    TokenTrendWindow::Week,
+                    vec![TokenTrendPeriod::from_totals(
+                        "2026-W27".to_string(),
+                        3,
+                        300,
+                        125,
+                    )],
+                ),
+                TokenTrendReport::new(
+                    Some("session-a".to_string()),
+                    TokenTrendWindow::Month,
+                    vec![TokenTrendPeriod::from_totals(
+                        "2026-07".to_string(),
+                        3,
+                        300,
+                        125,
+                    )],
+                ),
+                TokenTrendReport::new(
+                    Some("session-a".to_string()),
+                    TokenTrendWindow::Year,
+                    vec![TokenTrendPeriod::from_totals(
+                        "2026".to_string(),
+                        3,
+                        300,
+                        125,
+                    )],
+                ),
+            ],
         );
 
         assert!(dashboard.contains("ProjectAtlas Savings Overview"));
         assert!(dashboard.contains("session-a"));
-        assert!(dashboard.contains("Total tokens avoided"));
-        assert!(dashboard.contains("Measured from summaries"));
-        assert!(dashboard.contains("Narrowed to right files"));
-        assert!(dashboard.contains("Tokens: without vs with ProjectAtlas"));
+        assert!(dashboard.contains("Conservative tokens avoided"));
+        assert!(dashboard.contains("Measured summaries"));
+        assert!(dashboard.contains("Narrowed files"));
+        assert!(dashboard.contains("Gross tokens: without vs with ProjectAtlas"));
+        assert!(dashboard.contains("Saved-token trends"));
+        assert!(dashboard.contains("day | latest"));
+        assert!(dashboard.contains("week | latest"));
+        assert!(dashboard.contains("month | latest"));
+        assert!(dashboard.contains("year | latest"));
         assert!(dashboard.contains("Without ProjectAtlas"));
         assert!(dashboard.contains("With ProjectAtlas"));
         assert!(dashboard.contains("File reads avoided"));

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -1467,7 +1467,16 @@ impl ProjectAtlasMcpServer {
             }
             let overview = store.token_overview(params.session.as_deref())?;
             if include_chart {
-                let chart = render_token_dashboard(&overview, params.session.as_deref());
+                let trends = [
+                    TokenTrendWindow::Day,
+                    TokenTrendWindow::Week,
+                    TokenTrendWindow::Month,
+                    TokenTrendWindow::Year,
+                ]
+                .into_iter()
+                .map(|window| store.token_trends(params.session.as_deref(), window))
+                .collect::<Result<Vec<_>, _>>()?;
+                let chart = render_token_dashboard(&overview, params.session.as_deref(), &trends);
                 return Self::encode_two_named_payloads(
                     MCP_PAYLOAD_TOKEN_SAVINGS,
                     &overview,

--- a/crates/projectatlas-cli/src/token_tui.rs
+++ b/crates/projectatlas-cli/src/token_tui.rs
@@ -2,32 +2,30 @@
 
 use projectatlas_core::telemetry::{
     TOKEN_ACCOUNTING_OBSERVED_DELTA, TOKEN_BASELINE_DIRECTORY_WALK, TokenBucketOverview,
-    TokenOverview, TokenTrendReport,
+    TokenOverview, TokenTrendReport, TokenTrendWindow,
 };
 use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Cell, Gauge, Paragraph, Row, Sparkline, Table, Wrap};
+use ratatui::widgets::{Bar, BarChart, Block, Cell, Gauge, Paragraph, Row, Sparkline, Table, Wrap};
 use ratatui::{Frame, Terminal};
 
 /// Fixed terminal height for the token overview dashboard snapshot.
-const DASHBOARD_HEIGHT: u16 = 47;
+const DASHBOARD_HEIGHT: u16 = 55;
 /// Fixed terminal height for the token trend dashboard snapshot.
 const TREND_DASHBOARD_HEIGHT: u16 = 30;
-/// Fixed character width for each vertical token comparison column.
-const TOKEN_COMPARE_COLUMN_WIDTH: usize = 24;
-/// Fixed visual width for each filled token comparison bar.
-const TOKEN_COMPARE_BAR_WIDTH: usize = 12;
-/// Number of glyph cells in the file-read avoidance cake chart.
-const READ_AVOIDANCE_CAKE_SLOTS: usize = 12;
 
 /// Render the token overview as a human terminal dashboard.
-pub(crate) fn render_token_dashboard(overview: &TokenOverview, session: Option<&str>) -> String {
+pub(crate) fn render_token_dashboard(
+    overview: &TokenOverview,
+    session: Option<&str>,
+    trends: &[TokenTrendReport],
+) -> String {
     let width = dashboard_width().clamp(80, 140) as u16;
     render_dashboard_to_string(width, DASHBOARD_HEIGHT, |frame| {
-        render_overview_frame(frame, overview, session);
+        render_overview_frame(frame, overview, session, trends);
     })
 }
 
@@ -54,7 +52,12 @@ where
 }
 
 /// Draw the full overview dashboard frame.
-fn render_overview_frame(frame: &mut Frame<'_>, overview: &TokenOverview, session: Option<&str>) {
+fn render_overview_frame(
+    frame: &mut Frame<'_>,
+    overview: &TokenOverview,
+    session: Option<&str>,
+    trends: &[TokenTrendReport],
+) {
     let area = frame.area();
     let outer = Block::bordered()
         .title(Line::from(vec![
@@ -75,6 +78,7 @@ fn render_overview_frame(frame: &mut Frame<'_>, overview: &TokenOverview, sessio
         .constraints([
             Constraint::Length(4),
             Constraint::Length(10),
+            Constraint::Length(9),
             Constraint::Length(8),
             Constraint::Length(6),
             Constraint::Min(8),
@@ -84,10 +88,11 @@ fn render_overview_frame(frame: &mut Frame<'_>, overview: &TokenOverview, sessio
 
     render_overview_summary(frame, sections[0], overview);
     render_overview_bars(frame, sections[1], overview);
-    render_file_read_avoidance_chart(frame, sections[2], overview);
-    render_overview_gauges(frame, sections[3], overview);
-    render_bucket_table(frame, sections[4], overview);
-    render_overview_notes(frame, sections[5], overview);
+    render_overview_trends(frame, sections[2], trends);
+    render_file_handling_optimization_overview(frame, sections[3], overview);
+    render_overview_gauges(frame, sections[4], overview);
+    render_bucket_table(frame, sections[5], overview);
+    render_overview_notes(frame, sections[6], overview);
 }
 
 /// Draw the top overview metadata block.
@@ -97,14 +102,14 @@ fn render_overview_summary(frame: &mut Frame<'_>, area: Rect, overview: &TokenOv
             label("Lookups"),
             value(overview.calls),
             Span::raw("   "),
-            label("Estimated tokens"),
+            label("Gross estimate"),
             Span::raw("without "),
             value(overview.estimated_without_projectatlas),
             Span::raw(" / with "),
             value(overview.estimated_with_projectatlas),
         ]),
         Line::from(vec![
-            label("Saved estimate"),
+            label("Gross saved (without - with)"),
             signed_value(overview.legacy_gross_estimated_saved),
             Span::raw("   "),
             Span::raw(format!(
@@ -134,7 +139,7 @@ fn render_overview_gauges(frame: &mut Frame<'_>, area: Rect, overview: &TokenOve
     render_gauge(
         frame,
         chunks[0],
-        "Total tokens avoided",
+        "Saved/avoided tokens",
         overview.tokens_avoided,
         max_positive,
         Color::Green,
@@ -142,7 +147,7 @@ fn render_overview_gauges(frame: &mut Frame<'_>, area: Rect, overview: &TokenOve
     render_gauge(
         frame,
         chunks[1],
-        "Measured from summaries",
+        "Measured summaries",
         overview.measured_tokens_saved,
         max_positive,
         Color::Yellow,
@@ -150,7 +155,7 @@ fn render_overview_gauges(frame: &mut Frame<'_>, area: Rect, overview: &TokenOve
     render_gauge(
         frame,
         chunks[2],
-        "Narrowed to right files",
+        "Narrowed files",
         overview.deduped_modeled_tokens_avoided,
         max_positive,
         Color::Magenta,
@@ -181,30 +186,47 @@ fn render_overview_bars(frame: &mut Frame<'_>, area: Rect, overview: &TokenOverv
     let max_value = overview
         .estimated_without_projectatlas
         .max(overview.estimated_with_projectatlas)
-        .max(overview.tokens_avoided.max(0).unsigned_abs())
+        .max(overview.legacy_gross_estimated_saved.max(0).unsigned_abs())
         .max(1);
-    let block = Block::bordered().title("Tokens: without vs with ProjectAtlas");
+    let block = Block::bordered().title("Gross tokens: without vs with ProjectAtlas");
     let inner = block.inner(area);
     frame.render_widget(block, area);
-    let chart_height = usize::from(inner.height).saturating_sub(3).clamp(3, 6);
+
+    let sections = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(5), Constraint::Min(3)])
+        .split(inner);
+    let bars = token_comparison_columns(overview)
+        .into_iter()
+        .map(|(label, _value_text, value, color)| {
+            Bar::with_label(
+                token_comparison_short_label(label),
+                saturating_usize_to_u64(value),
+            )
+            .text_value("")
+            .style(Style::default().fg(color))
+            .value_style(Style::default().fg(color).add_modifier(Modifier::BOLD))
+        })
+        .collect::<Vec<_>>();
     frame.render_widget(
-        Paragraph::new(vertical_token_comparison_lines(
-            overview,
-            max_value,
-            chart_height,
-        ))
-        .alignment(Alignment::Center),
-        inner,
+        BarChart::vertical(bars)
+            .max(saturating_usize_to_u64(max_value))
+            .bar_width(12)
+            .bar_gap(6)
+            .label_style(Style::default().fg(Color::DarkGray))
+            .value_style(
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        sections[0],
     );
+    render_token_comparison_totals(frame, sections[1], overview);
 }
 
-/// Return fixed-width vertical bars for the main token comparison.
-fn vertical_token_comparison_lines(
-    overview: &TokenOverview,
-    max_value: usize,
-    chart_height: usize,
-) -> Vec<Line<'static>> {
-    let columns = [
+/// Return the values used by the with/without/saved comparison chart.
+fn token_comparison_columns(overview: &TokenOverview) -> [(&'static str, String, usize, Color); 3] {
+    [
         (
             "Without ProjectAtlas",
             grouped_count(overview.estimated_without_projectatlas),
@@ -219,178 +241,251 @@ fn vertical_token_comparison_lines(
         ),
         (
             "Saved by ProjectAtlas",
-            signed_count(overview.tokens_avoided),
-            overview.tokens_avoided.max(0).unsigned_abs(),
+            signed_count(overview.legacy_gross_estimated_saved),
+            overview.legacy_gross_estimated_saved.max(0).unsigned_abs(),
             Color::Green,
         ),
-    ];
+    ]
+}
 
-    let mut lines = Vec::with_capacity(chart_height + 2);
-    for level in (1..=chart_height).rev() {
-        let mut spans = Vec::with_capacity(columns.len() * 2);
-        for (index, (_, _, value, color)) in columns.iter().enumerate() {
-            if index > 0 {
-                spans.push(Span::raw("  "));
-            }
-            let filled = vertical_column_height(*value, max_value, chart_height);
-            let marker = if filled >= level {
-                "█".repeat(TOKEN_COMPARE_BAR_WIDTH)
-            } else {
-                " ".repeat(TOKEN_COMPARE_BAR_WIDTH)
-            };
-            spans.push(Span::styled(
-                format!("{marker:^TOKEN_COMPARE_COLUMN_WIDTH$}"),
-                Style::default().fg(*color).add_modifier(Modifier::BOLD),
-            ));
-        }
-        lines.push(Line::from(spans));
+/// Return a short label that fits under a compact `BarChart` bar.
+fn token_comparison_short_label(label: &str) -> &'static str {
+    match label {
+        "Without ProjectAtlas" => "Without",
+        "With ProjectAtlas" => "With",
+        "Saved by ProjectAtlas" => "Saved",
+        _ => "Value",
     }
+}
 
-    lines.push(Line::from(
-        columns
-            .iter()
-            .enumerate()
-            .flat_map(|(index, (label, _, _, _))| {
-                [
-                    if index > 0 { "  " } else { "" }.to_string(),
-                    format!("{label:^TOKEN_COMPARE_COLUMN_WIDTH$}"),
-                ]
-            })
-            .map(|cell| {
-                Span::styled(
-                    cell,
+/// Draw exact totals below the compact token comparison chart.
+fn render_token_comparison_totals(frame: &mut Frame<'_>, area: Rect, overview: &TokenOverview) {
+    let columns = token_comparison_columns(overview);
+    let table = Table::new(
+        [
+            Row::new([
+                Cell::from(columns[0].0),
+                Cell::from(columns[1].0),
+                Cell::from(columns[2].0),
+            ])
+            .style(
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Row::new([
+                Cell::from(columns[0].1.clone()).style(
                     Style::default()
-                        .fg(Color::Gray)
+                        .fg(columns[0].3)
                         .add_modifier(Modifier::BOLD),
-                )
-            })
-            .collect::<Vec<_>>(),
-    ));
-    lines.push(Line::from(
-        columns
-            .iter()
-            .enumerate()
-            .flat_map(|(index, (_, value_text, _, color))| {
-                [
-                    if index > 0 { "  " } else { "" }.to_string(),
-                    format!("{value_text:^TOKEN_COMPARE_COLUMN_WIDTH$}"),
-                ]
-                .map(|text| (text, *color))
-            })
-            .map(|(cell, color)| {
-                Span::styled(
-                    cell,
-                    Style::default().fg(color).add_modifier(Modifier::BOLD),
-                )
-            })
-            .collect::<Vec<_>>(),
-    ));
-    lines
+                ),
+                Cell::from(columns[1].1.clone()).style(
+                    Style::default()
+                        .fg(columns[1].3)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Cell::from(columns[2].1.clone()).style(
+                    Style::default()
+                        .fg(columns[2].3)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]),
+        ],
+        [
+            Constraint::Percentage(34),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ],
+    )
+    .column_spacing(2);
+    frame.render_widget(table, area);
 }
 
-/// Return how many rows should be filled for one vertical comparison column.
-fn vertical_column_height(value: usize, max_value: usize, chart_height: usize) -> usize {
-    if value == 0 || max_value == 0 || chart_height == 0 {
-        0
-    } else {
-        (((value as f64 / max_value as f64) * chart_height as f64).ceil() as usize)
-            .max(1)
-            .min(chart_height)
+/// Draw compact saved-token trends for the standard reporting windows.
+fn render_overview_trends(frame: &mut Frame<'_>, area: Rect, trends: &[TokenTrendReport]) {
+    let block = Block::bordered().title("Saved-token trends");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(inner);
+    let areas = [
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(rows[0]),
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(rows[1]),
+    ];
+    let windows = [
+        TokenTrendWindow::Day,
+        TokenTrendWindow::Week,
+        TokenTrendWindow::Month,
+        TokenTrendWindow::Year,
+    ];
+    for (index, window) in windows.into_iter().enumerate() {
+        let trend = trends.iter().find(|report| report.window == window);
+        let area = areas[index / 2][index % 2];
+        render_trend_sparkline(frame, area, window, trend);
     }
 }
 
-/// Draw a compact cake-style file-read avoidance mix.
-fn render_file_read_avoidance_chart(frame: &mut Frame<'_>, area: Rect, overview: &TokenOverview) {
+/// Draw one compact saved-token trend strip.
+fn render_trend_sparkline(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    window: TokenTrendWindow,
+    trend: Option<&TokenTrendReport>,
+) {
+    let periods = trend.map_or(0, |report| report.periods.len());
+    let latest = trend.and_then(|report| report.periods.last()).map_or_else(
+        || "no data".to_string(),
+        |period| signed_count(period.estimated_saved),
+    );
+    let data = trend
+        .map(|report| {
+            report
+                .periods
+                .iter()
+                .map(|period| saturating_usize_to_u64(period.estimated_saved.max(0).unsigned_abs()))
+                .collect::<Vec<_>>()
+        })
+        .filter(|values| !values.is_empty())
+        .unwrap_or_else(|| vec![0]);
     frame.render_widget(
-        Paragraph::new(read_avoidance_cake_lines(overview))
-            .block(Block::bordered().title("File reads avoided"))
-            .wrap(Wrap { trim: false }),
+        Sparkline::default()
+            .block(Block::bordered().title(format!("{window} | latest {latest} | {periods}p")))
+            .data(data)
+            .style(
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
         area,
     );
 }
 
-/// Return cake-style lines for observed and modeled file-read avoidance.
-fn read_avoidance_cake_lines(overview: &TokenOverview) -> Vec<Line<'static>> {
-    let total = overview.likely_file_reads_avoided;
-    let cells = read_avoidance_cake_cells(
-        overview.observed_file_read_replacements,
-        overview.modeled_file_reads_avoided,
-        READ_AVOIDANCE_CAKE_SLOTS,
+/// Draw a compact table-style file-handling optimization overview.
+fn render_file_handling_optimization_overview(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    overview: &TokenOverview,
+) {
+    let block = Block::bordered().title("File Handling Optimization Overview");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let sections = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(4),
+        ])
+        .split(inner);
+    frame.render_widget(
+        Paragraph::new(file_handling_saved_tokens_line(overview)).wrap(Wrap { trim: true }),
+        sections[0],
     );
-    let top = cells.iter().take(4).collect::<String>();
-    let middle = cells.iter().skip(4).take(4).collect::<String>();
-    let bottom = cells.iter().skip(8).take(4).collect::<String>();
-    let cell_row = cells.iter().collect::<String>();
-
-    vec![
-        Line::from(vec![
-            Span::styled(
-                format!("      ╭{cell_row}╮   "),
-                Style::default().fg(Color::Green),
-            ),
-            label("Likely file reads avoided"),
-            Span::raw(format!("{} file reads", grouped_count(total))),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                format!("      │{top}{middle}{bottom}│   "),
-                Style::default().fg(Color::Green),
-            ),
-            label("Observed summaries/slices"),
-            Span::raw(format!(
-                "{} ({})",
-                percentage_label(overview.observed_file_read_replacements, total),
-                grouped_count(overview.observed_file_read_replacements)
+    frame.render_widget(
+        Paragraph::new(file_handling_reads_line(overview)).wrap(Wrap { trim: true }),
+        sections[1],
+    );
+    let observed_ratio = ratio(
+        overview.observed_file_read_replacements,
+        overview.likely_file_reads_avoided,
+    );
+    frame.render_widget(
+        Gauge::default()
+            .gauge_style(
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .ratio(observed_ratio)
+            .label(format!(
+                "observed {} / modeled {}",
+                percentage_label(
+                    overview.observed_file_read_replacements,
+                    overview.likely_file_reads_avoided
+                ),
+                percentage_label(
+                    overview.modeled_file_reads_avoided,
+                    overview.likely_file_reads_avoided
+                )
             )),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                format!("      │{cell_row}│   "),
-                Style::default().fg(Color::Magenta),
-            ),
-            label("Search-modeled narrowing"),
-            Span::raw(format!(
-                "{} ({})",
-                percentage_label(overview.modeled_file_reads_avoided, total),
-                grouped_count(overview.modeled_file_reads_avoided)
-            )),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                format!("      ╰{cell_row}╯   "),
-                Style::default().fg(Color::DarkGray),
-            ),
-            label("confidence"),
-            Span::raw(overview.read_avoidance_confidence.clone()),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "      █ observed summaries/slices  ".to_string(),
-                Style::default().fg(Color::Green),
-            ),
-            Span::styled(
-                "▓ search-modeled narrowing".to_string(),
-                Style::default().fg(Color::Magenta),
-            ),
-        ]),
-    ]
+        sections[2],
+    );
+    render_file_handling_table(frame, sections[3], overview);
 }
 
-/// Return the cake cell mix for observed and modeled avoided file reads.
-fn read_avoidance_cake_cells(observed: usize, modeled: usize, slots: usize) -> Vec<char> {
-    let slots = slots.max(1);
-    let total = observed.saturating_add(modeled);
-    if total == 0 {
-        return vec!['○'; slots];
-    }
-    let observed_slots = (((observed as f64 / total as f64) * slots as f64).round() as usize)
-        .min(slots)
-        .max(usize::from(observed > 0));
-    let modeled_slots = slots.saturating_sub(observed_slots);
-    let mut cells = vec!['█'; observed_slots];
-    cells.extend(std::iter::repeat_n('▓', modeled_slots));
-    cells.resize(slots, '○');
-    cells
+/// Return the conservative saved-token equation for file handling.
+fn file_handling_saved_tokens_line(overview: &TokenOverview) -> Line<'static> {
+    Line::from(vec![
+        label("Saved/avoided tokens"),
+        signed_value(overview.tokens_avoided),
+        Span::raw(" = "),
+        signed_value(overview.measured_tokens_saved),
+        Span::raw(" observed + "),
+        signed_value(overview.deduped_modeled_tokens_avoided),
+        Span::raw(" avoided"),
+    ])
+}
+
+/// Return the headline file-read-avoidance equation.
+fn file_handling_reads_line(overview: &TokenOverview) -> Line<'static> {
+    Line::from(vec![
+        label("File reads avoided"),
+        value(overview.likely_file_reads_avoided),
+        Span::raw(" = observed "),
+        value(overview.observed_file_read_replacements),
+        Span::raw(" + search-modeled "),
+        value(overview.modeled_file_reads_avoided),
+        Span::raw(format!(" ({})", overview.read_avoidance_confidence)),
+    ])
+}
+
+/// Draw observed and modeled file-handling rows.
+fn render_file_handling_table(frame: &mut Frame<'_>, area: Rect, overview: &TokenOverview) {
+    let rows = [
+        Row::new(vec![
+            Cell::from("Observed summary/slices"),
+            Cell::from(grouped_count(overview.observed_file_read_replacements)),
+            Cell::from(signed_count(overview.measured_tokens_saved)),
+            Cell::from("replaced reads"),
+        ])
+        .style(Style::default().fg(Color::Green)),
+        Row::new(vec![
+            Cell::from("Search-modeled narrowing"),
+            Cell::from(grouped_count(overview.modeled_file_reads_avoided)),
+            Cell::from(signed_count(overview.deduped_modeled_tokens_avoided)),
+            Cell::from("avoided opens"),
+        ])
+        .style(Style::default().fg(Color::Magenta)),
+    ];
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(24),
+            Constraint::Length(8),
+            Constraint::Length(18),
+            Constraint::Min(18),
+        ],
+    )
+    .header(
+        Row::new(vec!["Source", "reads", "saved tokens", "meaning"])
+            .bottom_margin(1)
+            .style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+    )
+    .column_spacing(2);
+    frame.render_widget(table, area);
 }
 
 /// Draw the bucket table.
@@ -419,26 +514,23 @@ fn render_bucket_table(frame: &mut Frame<'_>, area: Rect, overview: &TokenOvervi
     let table = Table::new(
         rows,
         [
-            Constraint::Percentage(30),
-            Constraint::Percentage(10),
-            Constraint::Percentage(16),
-            Constraint::Percentage(44),
+            Constraint::Length(18),
+            Constraint::Length(7),
+            Constraint::Length(16),
+            Constraint::Min(20),
         ],
     )
     .header(
-        Row::new(vec![
-            "How ProjectAtlas helped",
-            "steps",
-            "tokens",
-            "plain meaning",
-        ])
-        .style(
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Row::new(vec!["How it helped", "steps", "tokens", "meaning"])
+            .bottom_margin(1)
+            .style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
     )
     .block(Block::bordered().title("Where the savings came from"))
+    .column_spacing(2)
     .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED));
     frame.render_widget(table, area);
 }
@@ -446,22 +538,22 @@ fn render_bucket_table(frame: &mut Frame<'_>, area: Rect, overview: &TokenOvervi
 /// Return a plain label for one token-savings bucket.
 fn bucket_display_name(bucket: &TokenBucketOverview) -> String {
     if bucket.accounting_layer == TOKEN_ACCOUNTING_OBSERVED_DELTA {
-        "Summaries and slices".to_string()
+        "Summaries/slices".to_string()
     } else if bucket.denominator_kind == TOKEN_BASELINE_DIRECTORY_WALK {
-        "Skipped broad folder walk".to_string()
+        "Skipped folders".to_string()
     } else {
-        "Opened fewer candidates".to_string()
+        "Fewer candidates".to_string()
     }
 }
 
 /// Explain one token-savings bucket without exposing accounting jargon first.
 fn bucket_plain_meaning(bucket: &TokenBucketOverview) -> String {
     if bucket.accounting_layer == TOKEN_ACCOUNTING_OBSERVED_DELTA {
-        "compact output replaced file reads".to_string()
+        "replaced reads".to_string()
     } else if bucket.denominator_kind == TOKEN_BASELINE_DIRECTORY_WALK {
-        "ranking skipped broad folders".to_string()
+        "skipped folders".to_string()
     } else {
-        "search/ranking narrowed files".to_string()
+        "narrowed files".to_string()
     }
 }
 
@@ -469,7 +561,7 @@ fn bucket_plain_meaning(bucket: &TokenBucketOverview) -> String {
 fn render_overview_notes(frame: &mut Frame<'_>, area: Rect, overview: &TokenOverview) {
     let mut lines = vec![
         Line::from(vec![
-            label("Tokens avoided"),
+            label("Conservative tokens avoided"),
             signed_value(overview.tokens_avoided),
         ]),
         Line::from(vec![
@@ -510,9 +602,7 @@ fn render_overview_notes(frame: &mut Frame<'_>, area: Rect, overview: &TokenOver
     } else {
         lines.push(Line::from(vec![
             label("calibration"),
-            Span::raw(
-                "optional: add --tokenizer o200k_base or cl100k_base for a local tokenizer audit",
-            ),
+            Span::raw("optional tokenizer audit: --tokenizer o200k_base or cl100k_base"),
         ]));
     }
     frame.render_widget(
@@ -716,6 +806,15 @@ fn percentage_label(part: usize, total: usize) -> String {
     }
 }
 
+/// Return a stable ratio for Ratatui gauges.
+fn ratio(part: usize, total: usize) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        (part as f64 / total as f64).clamp(0.0, 1.0)
+    }
+}
+
 /// Return the preferred dashboard width.
 fn dashboard_width() -> usize {
     std::env::var("COLUMNS")
@@ -753,11 +852,18 @@ fn saturating_usize_to_u64(value: usize) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{render_token_dashboard, render_token_trend_dashboard};
+    use super::{
+        DASHBOARD_HEIGHT, dashboard_width, render_overview_frame, render_token_dashboard,
+        render_token_trend_dashboard, signed_count, token_comparison_columns,
+    };
     use projectatlas_core::telemetry::{
         TokenOverview, TokenTrendPeriod, TokenTrendReport, TokenTrendWindow, usage_from_estimates,
         usage_from_text,
     };
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use ratatui::style::{Color, Modifier};
 
     #[test]
     fn overview_dashboard_renders_plain_language_savings_and_read_avoidance() {
@@ -773,39 +879,147 @@ mod tests {
             usage_from_estimates("s", "search", None, Some("token".to_string()), 400, 40),
             usage_from_estimates("s", "search", None, Some("token".to_string()), 400, 30),
         ];
-        let dashboard = render_token_dashboard(&TokenOverview::from_events(&events), Some("s"));
+        let trends = sample_trends();
+        let dashboard =
+            render_token_dashboard(&TokenOverview::from_events(&events), Some("s"), &trends);
 
         assert!(dashboard.contains("ProjectAtlas Savings Overview"));
-        assert!(dashboard.contains("Total tokens avoided"));
-        assert!(dashboard.contains("Measured from summaries"));
-        assert!(dashboard.contains("Narrowed to right files"));
-        assert!(dashboard.contains("Tokens: without vs with ProjectAtlas"));
+        assert!(dashboard.contains("Conservative tokens avoided"));
+        assert!(dashboard.contains("Measured summaries"));
+        assert!(dashboard.contains("Narrowed files"));
+        assert!(dashboard.contains("Gross tokens: without vs with ProjectAtlas"));
+        assert!(dashboard.contains("Saved-token trends"));
+        assert!(dashboard.contains("day | latest"));
+        assert!(dashboard.contains("week | latest"));
+        assert!(dashboard.contains("month | latest"));
+        assert!(dashboard.contains("year | latest"));
         assert!(dashboard.contains("Without ProjectAtlas"));
         assert!(dashboard.contains("With ProjectAtlas"));
         assert!(dashboard.contains("Saved by ProjectAtlas"));
+        assert!(dashboard.contains("File Handling Optimization Overview"));
+        assert!(dashboard.contains("Saved/avoided tokens"));
         assert!(dashboard.contains("File reads avoided"));
-        assert!(dashboard.contains("Likely file reads avoided"));
-        assert!(dashboard.contains("Observed summaries/slices"));
+        assert!(dashboard.contains("saved tokens"));
+        assert!(dashboard.contains("Observed summary/slices"));
         assert!(dashboard.contains("Search-modeled narrowing"));
-        assert!(dashboard.contains("File reads avoided"));
         assert!(dashboard.contains("Where the savings came from"));
-        assert!(dashboard.contains("Summaries and slices"));
-        assert!(dashboard.contains("Opened fewer candidates"));
+        assert!(dashboard.contains("Summaries/slices"));
+        assert!(dashboard.contains("Fewer candidates"));
         assert!(dashboard.contains("search-modeled"));
         assert!(dashboard.contains("duplicate navigation baselines collapsed"));
         assert!(dashboard.contains("█") || dashboard.contains("▌") || dashboard.contains("▏"));
 
         let compare = dashboard
-            .find("Tokens: without vs with ProjectAtlas")
+            .find("Gross tokens: without vs with ProjectAtlas")
             .unwrap_or(usize::MAX);
-        let file_reads = dashboard.find("File reads avoided").unwrap_or(usize::MAX);
+        let trend = dashboard.find("Saved-token trends").unwrap_or(usize::MAX);
+        let file_reads = dashboard
+            .find("File Handling Optimization Overview")
+            .unwrap_or(usize::MAX);
         let buckets = dashboard
             .find("Where the savings came from")
             .unwrap_or(usize::MAX);
         let notes = dashboard.find("What this means").unwrap_or(usize::MAX);
-        assert!(compare < file_reads);
+        assert!(compare < trend);
+        assert!(trend < file_reads);
         assert!(file_reads < buckets);
         assert!(buckets < notes);
+
+        assert_header_margin(&dashboard, "Source", "Observed summary/slices");
+        assert_header_margin(&dashboard, "How it helped", "Summaries/slices");
+    }
+
+    #[test]
+    fn overview_dashboard_uses_ratatui_widget_styles_for_key_headers() {
+        let events = [
+            usage_from_text(
+                "s",
+                "summary",
+                Some("src/lib.rs".to_string()),
+                None,
+                "abcdabcd",
+                "ab",
+            ),
+            usage_from_estimates("s", "search", None, Some("token".to_string()), 400, 40),
+            usage_from_estimates("s", "search", None, Some("token".to_string()), 400, 30),
+        ];
+        let overview = TokenOverview::from_events(&events);
+        let trends = sample_trends();
+        let buffer = render_overview_buffer(&overview, Some("s"), &trends);
+
+        assert_cell_style(&buffer, "Source", Color::Cyan, Modifier::BOLD);
+        assert_cell_style(&buffer, "saved tokens", Color::Cyan, Modifier::BOLD);
+        assert_cell_style(&buffer, "How it helped", Color::Cyan, Modifier::BOLD);
+        assert_cell_style(
+            &buffer,
+            "Saved by ProjectAtlas",
+            Color::DarkGray,
+            Modifier::BOLD,
+        );
+    }
+
+    #[test]
+    fn overview_dashboard_fields_use_consistent_accounting_layers() {
+        let overview = TokenOverview::from_events(&[
+            usage_from_text(
+                "s",
+                "summary",
+                Some("src/lib.rs".to_string()),
+                None,
+                "abcdabcd",
+                "ab",
+            ),
+            usage_from_estimates("s", "search", None, Some("token".to_string()), 400, 40),
+            usage_from_estimates("s", "search", None, Some("token".to_string()), 400, 30),
+            usage_from_estimates("s", "search", None, Some("token".to_string()), 400, 20),
+        ]);
+        let gross_saved = overview.legacy_gross_estimated_saved;
+        let conservative_avoided = overview.tokens_avoided;
+
+        assert_eq!(
+            overview.estimated_without_projectatlas as isize
+                - overview.estimated_with_projectatlas as isize,
+            gross_saved
+        );
+        assert_eq!(overview.estimated_saved, gross_saved);
+        assert_eq!(
+            overview.measured_tokens_saved + overview.deduped_modeled_tokens_avoided,
+            conservative_avoided
+        );
+        assert_ne!(gross_saved, conservative_avoided);
+        assert_eq!(
+            overview.observed_file_read_replacements + overview.modeled_file_reads_avoided,
+            overview.likely_file_reads_avoided
+        );
+        for bucket in &overview.buckets {
+            assert_eq!(
+                bucket.estimated_without_projectatlas as isize
+                    - bucket.estimated_with_projectatlas as isize,
+                bucket.estimated_saved
+            );
+        }
+
+        let columns = token_comparison_columns(&overview);
+        assert_eq!(columns[0].0, "Without ProjectAtlas");
+        assert_eq!(columns[0].2, overview.estimated_without_projectatlas);
+        assert_eq!(columns[1].0, "With ProjectAtlas");
+        assert_eq!(columns[1].2, overview.estimated_with_projectatlas);
+        assert_eq!(columns[2].0, "Saved by ProjectAtlas");
+        assert_eq!(columns[2].1, signed_count(gross_saved));
+        assert_eq!(columns[2].2 as isize, gross_saved);
+        assert_ne!(columns[2].1, signed_count(conservative_avoided));
+
+        let trends = sample_trends();
+        let dashboard = render_token_dashboard(&overview, Some("s"), &trends);
+        assert!(dashboard.contains(&signed_count(gross_saved)));
+        assert!(dashboard.contains(&signed_count(conservative_avoided)));
+        assert!(dashboard.contains(&format!(
+            "{} = {} observed + {} avoided",
+            signed_count(conservative_avoided),
+            signed_count(overview.measured_tokens_saved),
+            signed_count(overview.deduped_modeled_tokens_avoided)
+        )));
+        assert!(dashboard.contains("observed 1 + search-modeled 3"));
     }
 
     #[test]
@@ -826,5 +1040,99 @@ mod tests {
         assert!(dashboard.contains("2026-07"));
         assert!(dashboard.contains("period"));
         assert!(dashboard.contains("█") || dashboard.contains("▅") || dashboard.contains("▁"));
+    }
+
+    fn sample_trends() -> Vec<TokenTrendReport> {
+        [
+            TokenTrendWindow::Day,
+            TokenTrendWindow::Week,
+            TokenTrendWindow::Month,
+            TokenTrendWindow::Year,
+        ]
+        .into_iter()
+        .map(|window| {
+            TokenTrendReport::new(
+                Some("s".to_string()),
+                window,
+                vec![
+                    TokenTrendPeriod::from_totals(format!("2026-07-01-{window}"), 2, 200, 120),
+                    TokenTrendPeriod::from_totals(format!("2026-07-02-{window}"), 3, 500, 125),
+                    TokenTrendPeriod::from_totals(format!("2026-07-03-{window}"), 1, 100, 80),
+                ],
+            )
+        })
+        .collect()
+    }
+
+    fn render_overview_buffer(
+        overview: &TokenOverview,
+        session: Option<&str>,
+        trends: &[TokenTrendReport],
+    ) -> Buffer {
+        let width = dashboard_width().clamp(80, 140) as u16;
+        let backend = TestBackend::new(width, DASHBOARD_HEIGHT);
+        let mut terminal =
+            Terminal::new(backend).expect("in-memory token dashboard backend should initialize");
+        let frame = terminal
+            .draw(|frame| render_overview_frame(frame, overview, session, trends))
+            .expect("in-memory token dashboard should render");
+        frame.buffer.clone()
+    }
+
+    fn assert_header_margin(dashboard: &str, header: &str, first_row: &str) {
+        let header_index = dashboard.lines().position(|line| line.contains(header));
+        assert!(
+            header_index.is_some(),
+            "dashboard should contain table header {header:?}"
+        );
+        let Some(header_index) = header_index else {
+            return;
+        };
+        let row_index = dashboard.lines().position(|line| line.contains(first_row));
+        assert!(
+            row_index.is_some(),
+            "dashboard should contain first table row {first_row:?}"
+        );
+        let Some(row_index) = row_index else {
+            return;
+        };
+        assert!(
+            row_index >= header_index + 2,
+            "expected a visible separator row between {header:?} and {first_row:?}"
+        );
+    }
+
+    fn assert_cell_style(buffer: &Buffer, text: &str, color: Color, modifier: Modifier) {
+        let found = find_text(buffer, text);
+        assert!(found.is_some(), "rendered buffer should contain {text:?}");
+        let Some((x, y)) = found else {
+            return;
+        };
+        let cell = buffer.cell((x, y));
+        assert!(
+            cell.is_some(),
+            "located text should resolve to a buffer cell"
+        );
+        let Some(cell) = cell else {
+            return;
+        };
+        assert_eq!(cell.fg, color, "unexpected foreground color for {text:?}");
+        assert!(
+            cell.modifier.contains(modifier),
+            "missing modifier {modifier:?} for {text:?}"
+        );
+    }
+
+    fn find_text(buffer: &Buffer, text: &str) -> Option<(u16, u16)> {
+        for y in 0..buffer.area.height {
+            let mut line = String::new();
+            for x in 0..buffer.area.width {
+                line.push_str(buffer.cell((x, y))?.symbol());
+            }
+            if let Some(index) = line.find(text) {
+                return Some((u16::try_from(index).ok()?, y));
+            }
+        }
+        None
     }
 }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -329,6 +329,7 @@ fn plugin_installers_require_matching_runtime_version() -> Result<(), Box<dyn Er
     for required in [
         "plugin_update_skips_non_official_codex_marketplace",
         "plugin_update_leaves_current_codex_marketplace_untouched",
+        "plugin_update_repairs_current_codex_plugin_with_stale_source_manifest",
         "plugin_update_restores_current_ref_marketplace_when_plugin_reinstall_fails",
     ] {
         if !e2e_smoke.contains(required) {
@@ -1636,10 +1637,38 @@ fn plugin_update_leaves_current_codex_marketplace_untouched() -> Result<(), Box<
             "[marketplaces.projectatlas]\nsource_type = \"git\"\nsource = \"https://github.com/styler-ai/ProjectAtlas.git\"\nref = \"{expected_release_tag}\"\n"
         ),
     )?;
+    let fake_plugin_cache = isolated_home
+        .join(FAKE_CODEX_PLUGIN_CACHE_DIR)
+        .join("projectatlas");
+    fs::create_dir_all(fake_plugin_cache.join(CODEX_PLUGIN_MANIFEST_DIR))?;
+    fs::create_dir_all(
+        fake_plugin_cache
+            .join(PROJECTATLAS_SKILL_DIR)
+            .join(PROJECTATLAS_SKILL_NAME),
+    )?;
+    fs::write(
+        fake_plugin_cache
+            .join(CODEX_PLUGIN_MANIFEST_DIR)
+            .join("plugin.json"),
+        format!(
+            r#"{{"name":"projectatlas","version":"{}"}}"#,
+            env!("CARGO_PKG_VERSION")
+        ),
+    )?;
+    fs::write(
+        fake_plugin_cache
+            .join(PROJECTATLAS_SKILL_DIR)
+            .join(PROJECTATLAS_SKILL_NAME)
+            .join(SKILL_FILE_NAME),
+        FAKE_CODEX_SKILL_CONTENT,
+    )?;
+    let fake_plugin_cache_json =
+        serde_json::to_string(&fake_plugin_cache.to_string_lossy().to_string())?;
     let fake_codex = fake_path.join(if cfg!(windows) { "codex.cmd" } else { "codex" });
     let plugin_list_json = format!(
-        r#"{{"installed":[{{"pluginId":"projectatlas@projectatlas","name":"projectatlas","marketplaceName":"projectatlas","version":"{}"}}],"available":[]}}"#,
-        env!("CARGO_PKG_VERSION")
+        r#"{{"installed":[{{"pluginId":"projectatlas@projectatlas","name":"projectatlas","marketplaceName":"projectatlas","version":"{}","source":{{"path":{}}}}}],"available":[]}}"#,
+        env!("CARGO_PKG_VERSION"),
+        fake_plugin_cache_json
     );
     let fake_codex_script = if cfg!(windows) {
         format!(
@@ -1684,6 +1713,129 @@ fn plugin_update_leaves_current_codex_marketplace_untouched() -> Result<(), Box<
         if fake_codex_calls.contains(forbidden) {
             return Err(io::Error::other(format!(
                 "current Codex marketplace/plugin state was mutated by forbidden call {forbidden:?}:\n{fake_codex_calls}"
+            ))
+            .into());
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn plugin_update_repairs_current_codex_plugin_with_stale_source_manifest()
+-> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join(TEST_REPO_DIR);
+    fs::create_dir(&repo)?;
+    let fake_path = temp.path().join(FAKE_PATH_DIR);
+    fs::create_dir(&fake_path)?;
+    let isolated_home = temp.path().join(ISOLATED_HOME_DIR);
+    let codex_dir = isolated_home.join(CODEX_CONFIG_DIR);
+    fs::create_dir_all(&codex_dir)?;
+    let expected_release_tag = format!("v{}", env!("CARGO_PKG_VERSION"));
+    fs::write(
+        codex_dir.join("config.toml"),
+        format!(
+            "[marketplaces.projectatlas]\nsource_type = \"git\"\nsource = \"https://github.com/styler-ai/ProjectAtlas.git\"\nref = \"{expected_release_tag}\"\n"
+        ),
+    )?;
+    let fake_plugin_cache = isolated_home
+        .join(FAKE_CODEX_PLUGIN_CACHE_DIR)
+        .join("projectatlas");
+    fs::create_dir_all(fake_plugin_cache.join(CODEX_PLUGIN_MANIFEST_DIR))?;
+    fs::create_dir_all(
+        fake_plugin_cache
+            .join(PROJECTATLAS_SKILL_DIR)
+            .join(PROJECTATLAS_SKILL_NAME),
+    )?;
+    let manifest_path = fake_plugin_cache
+        .join(CODEX_PLUGIN_MANIFEST_DIR)
+        .join("plugin.json");
+    fs::write(
+        &manifest_path,
+        r#"{"name":"projectatlas","version":"0.0.1"}"#,
+    )?;
+    fs::write(
+        fake_plugin_cache
+            .join(PROJECTATLAS_SKILL_DIR)
+            .join(PROJECTATLAS_SKILL_NAME)
+            .join(SKILL_FILE_NAME),
+        FAKE_CODEX_SKILL_CONTENT,
+    )?;
+    let fake_plugin_cache_json =
+        serde_json::to_string(&fake_plugin_cache.to_string_lossy().to_string())?;
+    let fake_codex = fake_path.join(if cfg!(windows) { "codex.cmd" } else { "codex" });
+    let plugin_list_json = format!(
+        r#"{{"installed":[{{"pluginId":"projectatlas@projectatlas","name":"projectatlas","marketplaceName":"projectatlas","version":"{}","source":{{"path":{}}}}}],"available":[]}}"#,
+        env!("CARGO_PKG_VERSION"),
+        fake_plugin_cache_json
+    );
+    let current_manifest_json = format!(
+        r#"{{"name":"projectatlas","version":"{}"}}"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    let fake_codex_script = if cfg!(windows) {
+        format!(
+            "@echo off\r\necho %*>>\"%PROJECTATLAS_FAKE_CODEX_LOG%\"\r\nif \"%1\"==\"plugin\" if \"%2\"==\"marketplace\" if \"%3\"==\"list\" (\r\n  echo {{\"marketplaces\":[{{\"name\":\"projectatlas\",\"marketplaceSource\":{{\"source\":\"https://github.com/styler-ai/ProjectAtlas.git\"}}}}]}}\r\n  exit /b 0\r\n)\r\nif \"%1\"==\"plugin\" if \"%2\"==\"list\" (\r\n  echo {plugin_list_json}\r\n  exit /b 0\r\n)\r\nif \"%1\"==\"plugin\" if \"%2\"==\"add\" (\r\n  >\"%PROJECTATLAS_FAKE_PLUGIN_MANIFEST%\" echo {current_manifest_json}\r\n  exit /b 0\r\n)\r\nif \"%1\"==\"mcp\" if \"%2\"==\"get\" exit /b 1\r\nexit /b 0\r\n"
+        )
+    } else {
+        format!(
+            "#!/usr/bin/env sh\nprintf '%s\\n' \"$*\" >> \"$PROJECTATLAS_FAKE_CODEX_LOG\"\nif [ \"${{1:-}}\" = \"plugin\" ] && [ \"${{2:-}}\" = \"marketplace\" ] && [ \"${{3:-}}\" = \"list\" ]; then\n  printf '%s\\n' '{{\"marketplaces\":[{{\"name\":\"projectatlas\",\"marketplaceSource\":{{\"source\":\"https://github.com/styler-ai/ProjectAtlas.git\"}}}}]}}'\n  exit 0\nfi\nif [ \"${{1:-}}\" = \"plugin\" ] && [ \"${{2:-}}\" = \"list\" ]; then\n  printf '%s\\n' '{plugin_list_json}'\n  exit 0\nfi\nif [ \"${{1:-}}\" = \"plugin\" ] && [ \"${{2:-}}\" = \"add\" ]; then\n  printf '%s\\n' '{current_manifest_json}' > \"$PROJECTATLAS_FAKE_PLUGIN_MANIFEST\"\n  exit 0\nfi\nif [ \"${{1:-}}\" = \"mcp\" ] && [ \"${{2:-}}\" = \"get\" ]; then\n  exit 1\nfi\nexit 0\n"
+        )
+    };
+    write_executable_script(&fake_codex, &fake_codex_script)?;
+
+    let workspace_root = workspace_root()?;
+    let runtime = assert_cmd::cargo::cargo_bin("projectatlas");
+    let installer_output = run_projectatlas_plugin_installer_with_path_shadow_and_home(
+        &workspace_root,
+        &repo,
+        &runtime,
+        &fake_path,
+        &isolated_home,
+    )?;
+    let installer_output_text = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&installer_output.stdout),
+        String::from_utf8_lossy(&installer_output.stderr)
+    );
+    if !installer_output_text
+        .contains("Codex ProjectAtlas plugin source manifest version '0.0.1' does not match")
+        || !installer_output_text.contains(&format!(
+            "Codex ProjectAtlas plugin marketplace updated to {expected_release_tag}."
+        ))
+        || !installer_output_text.contains("Codex ProjectAtlas plugin skill verified at")
+    {
+        return Err(io::Error::other(format!(
+            "installer did not repair stale reported Codex plugin source manifest:\n{installer_output_text}"
+        ))
+        .into());
+    }
+    let manifest_after = fs::read_to_string(&manifest_path)?;
+    if !manifest_after.contains(env!("CARGO_PKG_VERSION")) {
+        return Err(io::Error::other(format!(
+            "fake Codex plugin source manifest was not refreshed:\n{manifest_after}"
+        ))
+        .into());
+    }
+    let fake_codex_calls = fs::read_to_string(isolated_home.join(FAKE_CODEX_LOG_FILE))?;
+    for required in [
+        "plugin remove projectatlas --marketplace projectatlas",
+        "plugin add projectatlas --marketplace projectatlas",
+    ] {
+        if !fake_codex_calls.contains(required) {
+            return Err(io::Error::other(format!(
+                "installer did not repair current-ref plugin source manifest with call {required:?}:\n{fake_codex_calls}"
+            ))
+            .into());
+        }
+    }
+    for forbidden in [
+        "plugin marketplace remove projectatlas",
+        "plugin marketplace add styler-ai/ProjectAtlas",
+    ] {
+        if fake_codex_calls.contains(forbidden) {
+            return Err(io::Error::other(format!(
+                "current-ref source manifest repair mutated marketplace by forbidden call {forbidden:?}:\n{fake_codex_calls}"
             ))
             .into());
         }
@@ -2829,17 +2981,26 @@ fn scan_overview_and_token_flow() -> Result<(), Box<dyn Error>> {
         .assert()
         .success()
         .stdout(predicate::str::contains("ProjectAtlas Savings Overview"))
-        .stdout(predicate::str::contains("Total tokens avoided"))
-        .stdout(predicate::str::contains("Measured from summaries"))
-        .stdout(predicate::str::contains("Narrowed to right files"))
+        .stdout(predicate::str::contains("Conservative tokens avoided"))
+        .stdout(predicate::str::contains("Measured summaries"))
+        .stdout(predicate::str::contains("Narrowed files"))
         .stdout(predicate::str::contains(
-            "Tokens: without vs with ProjectAtlas",
+            "Gross tokens: without vs with ProjectAtlas",
         ))
         .stdout(predicate::str::contains("Without ProjectAtlas"))
         .stdout(predicate::str::contains("With ProjectAtlas"))
+        .stdout(predicate::str::contains("Saved/avoided tokens"))
         .stdout(predicate::str::contains("File reads avoided"))
-        .stdout(predicate::str::contains("Likely file reads avoided"))
-        .stdout(predicate::str::contains("Search-modeled narrowing"))
+        .stdout(predicate::str::contains("saved tokens"))
+        .stdout(predicate::str::contains("search-modeled"))
+        .stdout(predicate::str::contains("Saved-token trends"))
+        .stdout(predicate::str::contains("day | latest"))
+        .stdout(predicate::str::contains("week | latest"))
+        .stdout(predicate::str::contains("month | latest"))
+        .stdout(predicate::str::contains("year | latest"))
+        .stdout(predicate::str::contains(
+            "File Handling Optimization Overview",
+        ))
         .stdout(predicate::str::contains("Where the savings came from"))
         .stdout(predicate::str::contains("What this means"));
     Command::cargo_bin("projectatlas")?
@@ -3730,7 +3891,7 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         || !stdout.contains("health_findings[1]")
         || !stdout.contains("next_start_index: 1")
         || !stdout.contains("ProjectAtlas Savings Overview")
-        || !stdout.contains("Total tokens avoided")
+        || !stdout.contains("Conservative tokens avoided")
         || !stdout.contains("File reads avoided")
         || !stdout.contains("purpose_review:")
         || !stdout.contains("failed: 0")
@@ -8002,6 +8163,13 @@ fn run_projectatlas_plugin_installer_with_optional_path_and_home(
             .env(
                 FAKE_CODEX_PLUGIN_ADD_FAILURE_MARKER_ENV,
                 home.join(FAKE_CODEX_PLUGIN_ADD_FAILURE_MARKER_FILE),
+            )
+            .env(
+                "PROJECTATLAS_FAKE_PLUGIN_MANIFEST",
+                home.join(FAKE_CODEX_PLUGIN_CACHE_DIR)
+                    .join("projectatlas")
+                    .join(CODEX_PLUGIN_MANIFEST_DIR)
+                    .join("plugin.json"),
             );
     }
     let output = command.output()?;

--- a/docs/projectatlas-v0.3.23-premortem-spec.md
+++ b/docs/projectatlas-v0.3.23-premortem-spec.md
@@ -1,0 +1,361 @@
+# ProjectAtlas v0.3.23 Pre-Mortem And Issue Specification
+
+Date: 2026-07-04
+
+## Release Goal
+
+Ship a patch release after `v0.3.22` that fixes the two concrete regressions
+found during Codex plugin/runtime startup:
+
+- #285 `fix(plugin): detect stale Codex marketplace source manifests`
+- #286 `fix(token): make token TUI accounting and Ratatui layout clear`
+
+The release also adds a reusable Codex plugin engineering skill so future plugin
+work keeps installer, manifest, runtime, MCP registry, and host instruction
+drift in one stability model.
+
+## Scope Decision
+
+| Issue | Decision | Rationale |
+| --- | --- | --- |
+| #285 `fix(plugin): detect stale Codex marketplace source manifests` | Implement in v0.3.23 | Official Codex ProjectAtlas plugin cache can report the current plugin version while the source manifest path is stale. Installer must repair the cache instead of trusting the reported version alone. |
+| #286 `fix(token): make token TUI accounting and Ratatui layout clear` | Implement in v0.3.23 | Token dashboard correctness is user-facing. The math must add up, and the TUI must remain understandable while using standard Ratatui widgets. |
+| #266 `feat(ranking): improve file and folder ranking for agent navigation` | Backlog, first in next tranche | Foundational for #267 and #269, but larger than a patch release. Needs deterministic scoring design and broader ranking tests. |
+| #267 `feat(navigation): add a next-step recommendation command and MCP tool` | Backlog after #266 and #269 shape | Depends on better ranking and explainable reasons so `next` recommendations are not opaque or incidental. |
+| #268 `chore(purpose): reduce low-value purpose and health noise` | Backlog, can run parallel after output scope is clear | Worth doing, but changes health/lint policy and must not encode local workspace names as product invariants. |
+| #269 `feat(output): explain why ranked ProjectAtlas results were selected` | Backlog after #266 scoring | Reasons should explain real ranking signals, not today's incidental ordering. |
+| #276 `feat(mcp): auto-detect nearest ProjectAtlas DB for addressed paths` | Backlog, independent but risky | Useful multi-project ergonomics, but root switching can break isolation if precedence rules are wrong. |
+| #278 `chore(plugin): apply installer convergence checks to Claude Code` | Backlog after shared installer convergence | Host-specific convergence should build on stable shared installer drift repair. |
+| #279 `chore(plugin): apply installer convergence checks to OpenCode` | Backlog after shared installer convergence | Same host-convergence class as #278. |
+| #281 `feat(mcp): close complete CLI command parity gaps` | Backlog, broad parity tranche | Valuable but too broad for the token/plugin patch release. Needs command-family inventory and safe MCP write boundaries. |
+
+## Global Pre-Mortem
+
+### What Can Go Wrong
+
+- Installer trusts `codex plugin list` version and marketplace ref, then installs
+  a runtime while Codex still exposes a stale ProjectAtlas skill or plugin
+  manifest from the reported source path.
+- Installer reacts to an official stale cache by hard-failing only, leaving the
+  user with a stale plugin when Codex can repair the cache through remove/add.
+- Installer mutates non-official or intentionally managed marketplaces.
+- Token TUI mixes gross token estimates with conservative deduped accounting,
+  so `without - with` does not equal the visible saved value.
+- Token TUI becomes prettier but loses old information such as conservative
+  tokens avoided, file reads avoided, observed vs modeled split, repeated
+  baselines, calibration guidance, or bucket plain meanings.
+- Token TUI uses custom hand-drawn layout where Ratatui standard widgets would
+  give better table spacing, charting, and style semantics.
+- Four trend windows make the overview cramped or unreadable.
+- Tests assert only labels and miss the actual accounting invariants or rendered
+  layout shape.
+- Release workflow fails because version pins are not bumped from `0.3.22` to
+  `0.3.23` before dispatch.
+
+### Release Constraints
+
+- Keep token telemetry data structures and JSON/TOON output schemas unchanged.
+- Keep installer behavior conservative for non-official Codex marketplaces.
+- Use Ratatui widgets for the TUI where they fit: `BarChart`, `Gauge`,
+  `Sparkline`, and `Table`.
+- Keep `projectatlas token --view tui --trend day|week|month|year` as the
+  detailed trend mode; do not add interactive click/keyboard selection in this
+  patch release.
+- Preserve deterministic string rendering for CLI/MCP chart snapshots and tests.
+- Bump all workspace and plugin manifest version pins to `0.3.23` before
+  release.
+
+## #285 Stale Codex Source Manifest Repair
+
+### Summary
+
+The ProjectAtlas installer must verify the Codex plugin source manifest at the
+path reported by `codex plugin list`, not just the installed plugin version and
+marketplace ref.
+
+### Expected Behavior
+
+- If official `projectatlas` marketplace ref, installed plugin version, and the
+  reported source manifest all match the expected release, the installer can
+  skip plugin cache repair.
+- If the official marketplace ref is current but the reported plugin source
+  manifest is stale, the installer repairs the plugin cache through Codex plugin
+  remove/add and verifies the manifest again.
+- If the cache still reports a stale source manifest after repair, the installer
+  reports a clear mismatch with the manifest path and expected version.
+- If the marketplace is not the official ProjectAtlas marketplace, the installer
+  does not mutate it.
+
+### Implementation Touch Points
+
+- `plugins/projectatlas/scripts/install-runtime.ps1`
+- `plugins/projectatlas/scripts/install-runtime.sh`
+- `crates/projectatlas-cli/tests/e2e.rs`
+- `.github/workflows/ci.yml`
+
+### Test Plan
+
+- Fake Codex reports current plugin version and current marketplace ref, but its
+  `source.path/.codex-plugin/plugin.json` contains an old version.
+- Fake `codex plugin add` rewrites that manifest to the current version.
+- Assert installer runs `plugin remove projectatlas --marketplace projectatlas`
+  and `plugin add projectatlas --marketplace projectatlas`.
+- Assert installer does not mutate the marketplace source when the marketplace
+  ref is already current.
+- Keep existing tests for non-official marketplace skip, marketplace restore on
+  reinstall failure, matching runtime version, and current cache no-op.
+
+### Acceptance Criteria
+
+- Installer repairs an official stale source manifest without requiring manual
+  cache deletion.
+- Installer output names the stale source manifest mismatch before repair.
+- Installer output verifies the ProjectAtlas skill after repair.
+- CI runs the new repair e2e smoke.
+
+## #286 Token TUI Accounting And Ratatui Layout
+
+### Summary
+
+The token TUI should keep all old token-savings information, make every visible
+field mathematically consistent, and present the dashboard with standard
+Ratatui widgets.
+
+### Expected Accounting
+
+- `estimated_without_projectatlas - estimated_with_projectatlas =
+  legacy_gross_estimated_saved`
+- The with/without/saved comparison chart uses
+  `legacy_gross_estimated_saved`, not conservative `tokens_avoided`.
+- Conservative `tokens_avoided` remains visible in the accounting section, where
+  `measured_tokens_saved + deduped_modeled_tokens_avoided = tokens_avoided`.
+- The file-handling section shows the same conservative saved-token equation as
+  `Saved/avoided tokens = measured_tokens_saved + deduped_modeled_tokens_avoided`
+  so avoided navigation tokens are visibly included alongside observed
+  summary/slice savings.
+- `observed_file_read_replacements + modeled_file_reads_avoided =
+  likely_file_reads_avoided`.
+- Each bucket row satisfies
+  `estimated_without_projectatlas - estimated_with_projectatlas =
+  estimated_saved`.
+
+### Expected TUI Shape
+
+- The overview still shows:
+  - lookup count,
+  - estimated tokens without and with ProjectAtlas,
+  - gross saved estimate,
+  - with/without/saved comparison,
+  - tokens avoided,
+  - measured summaries,
+  - narrowed navigation,
+  - likely file reads avoided,
+  - observed summaries/slices,
+  - search-modeled narrowing,
+  - confidence,
+  - bucket rows and plain meanings,
+  - repeated baseline dedupe note,
+  - tokenizer calibration guidance.
+- The comparison section uses Ratatui `BarChart` plus a totals `Table`.
+- The trend section shows compact `day`, `week`, `month`, and `year`
+  saved-token `Sparkline`s directly in the overview.
+- The file section is titled `File Handling Optimization Overview` and uses a
+  `Gauge` plus a `Table`; it shows `Saved/avoided tokens`, `File reads
+  avoided`, `Source`, `reads`, `saved tokens`, and `meaning`.
+- `Where the savings came from` uses a `Table` header with visible separation
+  before the first data row and compact labels (`How it helped`, `steps`,
+  `tokens`, `meaning`) that remain readable at 80 columns.
+
+### Non-Goals
+
+- No interactive click, mouse, tab, or keyboard selector in `v0.3.23`.
+- No schema changes to token telemetry.
+- No provider API calls for token counting or trend rendering.
+
+### Test Plan
+
+- Unit test data where gross saved and conservative avoided differ.
+- Assert gross comparison chart values and conservative accounting values both
+  appear and correlate correctly.
+- Assert the file-read equation and bucket equations.
+- Assert rendered dashboard contains the new trend windows and file-handling
+  panel.
+- Assert rendered buffer cells use Ratatui styles for key headers.
+- Run CLI smoke for:
+  - `projectatlas token --view tui`
+  - `projectatlas token --view tui --tokenizer cl100k_base`
+  - `projectatlas token --view tui --trend month`
+- Manually render the dashboard and inspect a screenshot before release.
+
+### Acceptance Criteria
+
+- A user can read the dashboard without seeing contradictory math.
+- The dashboard is more engaging and easier to scan, but keeps the old
+  information.
+- Day/week/month/year trend context is visible in the overview.
+- Tests cover math, layout, and style shape.
+
+## Codex Plugin Engineering Skill
+
+### Summary
+
+Stable ProjectAtlas plugin engineering lessons should be durable in-repo
+instructions, not only chat history.
+
+### Scope
+
+- Add `skills/codex-coding-plugin/SKILL.md`.
+- Add an agent prompt under `skills/codex-coding-plugin/agents/openai.yaml`.
+- Cover release pins, plugin manifest drift, runtime installer verification,
+  Codex plugin cache repair, MCP registry repair, and host-specific config
+  convergence.
+
+### Acceptance Criteria
+
+- Skill validates with the local Codex skill validator.
+- Skill avoids stale absolute workspace assumptions.
+- ProjectAtlas purposes are set for the skill folder and files.
+
+## Backlog Tranche Pre-Mortem
+
+### #266 Ranking Improvement
+
+Goal: improve deterministic folder/file ranking for agent navigation without
+adding embeddings or new external dependencies.
+
+Risks:
+
+- New scoring overfits current repo paths.
+- Rankings become less predictable for small repos.
+- Search/content fallback makes queries slower or noisier.
+
+Next spec needs:
+
+- Central scoring contract.
+- Bounded signals for path, purpose, content summary, text match, symbols, and
+  paired tests.
+- Golden ranking fixtures across small and medium repos.
+
+### #267 Next-Step Recommendation
+
+Goal: add `projectatlas next <query>` and `atlas_next`.
+
+Dependencies:
+
+- #266 ranking must produce stable candidates.
+- #269 reasons should explain recommendations.
+
+Risks:
+
+- Recommendations become vague task advice instead of atlas-grounded next file
+  or folder actions.
+- MCP and CLI shapes drift.
+
+### #268 Purpose And Health Noise
+
+Goal: reduce low-value purpose/health noise without hiding real drift.
+
+Risks:
+
+- Health demotion can hide stale runtime/plugin problems.
+- Local editor, cache, or agent folder names can accidentally become product
+  invariants.
+
+Constraint:
+
+- `.gitignore` remains the broad project policy; ProjectAtlas ignore config is
+  only a stricter atlas layer.
+
+### #269 Ranked Result Reasons
+
+Goal: explain why ranked folders/files were selected.
+
+Dependencies:
+
+- #266 should define real scoring signals first.
+
+Risks:
+
+- Reasons expose noisy implementation details.
+- Reasons become too verbose for token-saving workflows.
+
+### #276 Nearest DB Routing
+
+Goal: auto-detect the nearest `.projectatlas/projectatlas.db` for addressed
+paths without creating databases.
+
+Risks:
+
+- Wrong project root selection in shared MCP sessions.
+- Implicit routing undermines `project_path` isolation.
+
+Constraints:
+
+- Explicit `project_path` always wins.
+- No auto-create behavior.
+- Clear error when no indexed DB exists.
+
+### #278 Claude Code Convergence
+
+Goal: extend installer convergence checks to Claude Code generated config and
+runtime pointers.
+
+Risks:
+
+- Host-specific config writes break user-managed Claude settings.
+- Generated config status is confused with global host registry status.
+
+### #279 OpenCode Convergence
+
+Goal: extend installer convergence checks to OpenCode generated config and
+runtime pointers.
+
+Risks:
+
+- OpenCode command array handling differs from Codex/Claude config shape.
+- Host-specific repair creates stale cwd or DB assumptions.
+
+### #281 CLI/MCP Parity
+
+Goal: inventory CLI commands and close safe MCP gaps.
+
+Risks:
+
+- Unsafe write/admin commands get exposed over MCP without guardrails.
+- Parity work becomes a large refactor instead of command-family increments.
+
+Next spec needs:
+
+- Command inventory.
+- Safe read-only first tranche.
+- Explicit write-tool safety policy.
+- CLI/MCP shape tests.
+
+## Release Plan
+
+1. Finish #285 and #286 implementation.
+2. Bump workspace and plugin versions to `0.3.23`.
+3. Run focused gates:
+   - `cargo fmt --check`
+   - `cargo check --locked -p projectatlas-cli --all-targets`
+   - `cargo test --locked -p projectatlas-cli token_tui::tests`
+   - focused plugin installer e2e tests for Codex cache repair
+   - `projectatlas lint --report-untracked --purpose-level low`
+   - `git diff --check`
+4. Render and inspect `projectatlas token --view tui`.
+5. Open PR for `v0.3.23`.
+6. Merge after CI.
+7. Let `03-Auto-Release` dispatch `02-Release`, or manually dispatch
+   `release.yml` with `version=v0.3.23` if needed.
+8. Verify GitHub release `v0.3.23` exists with expected assets.
+9. Run installer/runtime verification for the new release.
+10. Close #285 and #286 with release and verification notes.
+
+## Rollback Plan
+
+- If installer repair fails in CI, revert #285 changes and publish no release.
+- If token TUI layout fails or looks worse, keep the accounting fix but reduce
+  the layout to standard Ratatui table/gauge sections before release.
+- If `v0.3.23` release automation fails after tag creation, rerun
+  `02-Release` for the same tag only when the tag points at the intended
+  commit.

--- a/plugins/projectatlas/.claude-plugin/plugin.json
+++ b/plugins/projectatlas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for Claude Code.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/.codex-plugin/plugin.json
+++ b/plugins/projectatlas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for coding agents.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/opencode/opencode.json
+++ b/plugins/projectatlas/opencode/opencode.json
@@ -6,7 +6,7 @@
       "command": [
         "/absolute/path/to/projectatlas",
         "--require-version",
-        "0.3.22",
+        "0.3.23",
         "--db",
         "/absolute/path/to/project/.projectatlas/projectatlas.db",
         "mcp"

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -564,6 +564,42 @@ function Get-ProjectAtlasCodexPluginSourcePath {
     return $null
 }
 
+function Get-ProjectAtlasCodexPluginSourceManifestVersion {
+    param(
+        [object]$ProjectAtlasPlugin
+    )
+    $pluginSourcePath = Get-ProjectAtlasCodexPluginSourcePath $ProjectAtlasPlugin
+    if ([string]::IsNullOrWhiteSpace($pluginSourcePath)) {
+        return $null
+    }
+    $manifestPath = Join-Path $pluginSourcePath ".codex-plugin\plugin.json"
+    if (-not (Test-Path -LiteralPath $manifestPath)) {
+        return ""
+    }
+    try {
+        $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+        if ($manifest.version) {
+            return [string]$manifest.version
+        }
+    }
+    catch {
+        return ""
+    }
+    return ""
+}
+
+function Test-ProjectAtlasCodexPluginSourceManifest {
+    param(
+        [object]$ProjectAtlasPlugin,
+        [string]$ExpectedVersion
+    )
+    $pluginSourcePath = Get-ProjectAtlasCodexPluginSourcePath $ProjectAtlasPlugin
+    if ([string]::IsNullOrWhiteSpace($pluginSourcePath)) {
+        return $true
+    }
+    return (Get-ProjectAtlasCodexPluginSourceManifestVersion $ProjectAtlasPlugin) -eq $ExpectedVersion
+}
+
 function Confirm-ProjectAtlasCodexSkillArtifact {
     param(
         [string]$CodexCommandPath,
@@ -650,13 +686,19 @@ function Update-ProjectAtlasCodexPlugin {
 
         $releaseTag = "v$runtimeVersion"
         $previousRef = Get-ProjectAtlasCodexMarketplaceRef
-        $currentPluginVersion = Get-ProjectAtlasCodexPluginVersion $codexCommandPath
-        if ($previousRef -eq $releaseTag -and $currentPluginVersion -eq $runtimeVersion) {
+        $projectAtlasPlugin = Get-ProjectAtlasCodexPlugin $codexCommandPath
+        $currentPluginVersion = if ($projectAtlasPlugin -and $projectAtlasPlugin.version) { $projectAtlasPlugin.version } else { $null }
+        $currentSourceManifestMatches = Test-ProjectAtlasCodexPluginSourceManifest $projectAtlasPlugin $runtimeVersion
+        if ($previousRef -eq $releaseTag -and $currentPluginVersion -eq $runtimeVersion -and $currentSourceManifestMatches) {
             Write-Output "Codex ProjectAtlas plugin marketplace already points to $releaseTag."
             Confirm-ProjectAtlasCodexSkillArtifact $codexCommandPath $ExpectedVersion
             return
         }
         if ($previousRef -eq $releaseTag) {
+            if ($currentPluginVersion -eq $runtimeVersion -and -not $currentSourceManifestMatches) {
+                $sourceManifestVersion = Get-ProjectAtlasCodexPluginSourceManifestVersion $projectAtlasPlugin
+                Write-Output "Codex ProjectAtlas plugin source manifest version '$sourceManifestVersion' does not match $runtimeVersion; refreshing official projectatlas plugin cache."
+            }
             & $codexCommandPath plugin remove projectatlas --marketplace projectatlas --json | Out-Null
             & $codexCommandPath plugin add projectatlas --marketplace projectatlas --json | Out-Null
             if ($LASTEXITCODE -ne 0) {
@@ -667,6 +709,13 @@ function Update-ProjectAtlasCodexPlugin {
             $installedVersion = Get-ProjectAtlasCodexPluginVersion $codexCommandPath
             if ($installedVersion -ne $runtimeVersion) {
                 Write-Warning "Codex ProjectAtlas plugin update failed: installed projectatlas plugin version '$installedVersion' does not match $runtimeVersion."
+                Restore-ProjectAtlasCodexMarketplace $codexCommandPath $source $previousRef
+                return
+            }
+            $installedPlugin = Get-ProjectAtlasCodexPlugin $codexCommandPath
+            if (-not (Test-ProjectAtlasCodexPluginSourceManifest $installedPlugin $runtimeVersion)) {
+                $sourceManifestVersion = Get-ProjectAtlasCodexPluginSourceManifestVersion $installedPlugin
+                Write-Warning "Codex ProjectAtlas plugin update failed: source manifest version '$sourceManifestVersion' does not match $runtimeVersion after refresh."
                 Restore-ProjectAtlasCodexMarketplace $codexCommandPath $source $previousRef
                 return
             }
@@ -696,6 +745,13 @@ function Update-ProjectAtlasCodexPlugin {
         $installedVersion = Get-ProjectAtlasCodexPluginVersion $codexCommandPath
         if ($installedVersion -ne $runtimeVersion) {
             Write-Warning "Codex ProjectAtlas plugin update failed: installed projectatlas plugin version '$installedVersion' does not match $runtimeVersion."
+            Restore-ProjectAtlasCodexMarketplace $codexCommandPath $source $previousRef
+            return
+        }
+        $installedPlugin = Get-ProjectAtlasCodexPlugin $codexCommandPath
+        if (-not (Test-ProjectAtlasCodexPluginSourceManifest $installedPlugin $runtimeVersion)) {
+            $sourceManifestVersion = Get-ProjectAtlasCodexPluginSourceManifestVersion $installedPlugin
+            Write-Warning "Codex ProjectAtlas plugin update failed: source manifest version '$sourceManifestVersion' does not match $runtimeVersion after refresh."
             Restore-ProjectAtlasCodexMarketplace $codexCommandPath $source $previousRef
             return
         }

--- a/plugins/projectatlas/scripts/install-runtime.sh
+++ b/plugins/projectatlas/scripts/install-runtime.sh
@@ -373,7 +373,7 @@ codex_projectatlas_plugin_source_manifest_version() {
     printf '%s\n' ""
     return 0
   fi
-  sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest_path" | head -n 1
+  sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest_path" | head -n 1
 }
 
 codex_projectatlas_plugin_source_manifest_matches() {

--- a/plugins/projectatlas/scripts/install-runtime.sh
+++ b/plugins/projectatlas/scripts/install-runtime.sh
@@ -365,6 +365,24 @@ codex_projectatlas_plugin_source_path() {
     head -n 1
 }
 
+codex_projectatlas_plugin_source_manifest_version() {
+  plugin_source_path=$(codex_projectatlas_plugin_source_path)
+  [ -n "$plugin_source_path" ] || return 0
+  manifest_path=$plugin_source_path/.codex-plugin/plugin.json
+  if [ ! -f "$manifest_path" ]; then
+    printf '%s\n' ""
+    return 0
+  fi
+  sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest_path" | head -n 1
+}
+
+codex_projectatlas_plugin_source_manifest_matches() {
+  expected_version=$1
+  plugin_source_path=$(codex_projectatlas_plugin_source_path)
+  [ -n "$plugin_source_path" ] || return 0
+  [ "$(codex_projectatlas_plugin_source_manifest_version)" = "$expected_version" ]
+}
+
 verify_codex_projectatlas_skill_artifact() {
   runtime_version=$(expected_runtime_version)
   if [ -z "$runtime_version" ]; then
@@ -437,18 +455,31 @@ update_codex_plugin() {
 
   release_tag=v$runtime_version
   current_plugin_version=$(codex_projectatlas_plugin_version)
-  if [ "$previous_ref" = "$release_tag" ] && [ "$current_plugin_version" = "$runtime_version" ]; then
+  if [ "$previous_ref" = "$release_tag" ] &&
+    [ "$current_plugin_version" = "$runtime_version" ] &&
+    codex_projectatlas_plugin_source_manifest_matches "$runtime_version"; then
     printf 'Codex ProjectAtlas plugin marketplace already points to %s.\n' "$release_tag"
     verify_codex_projectatlas_skill_artifact
     return 0
   fi
   if [ "$previous_ref" = "$release_tag" ]; then
+    if [ "$current_plugin_version" = "$runtime_version" ] &&
+      ! codex_projectatlas_plugin_source_manifest_matches "$runtime_version"; then
+      source_manifest_version=$(codex_projectatlas_plugin_source_manifest_version)
+      printf "Codex ProjectAtlas plugin source manifest version '%s' does not match %s; refreshing official projectatlas plugin cache.\n" "$source_manifest_version" "$runtime_version"
+    fi
     "$codex_bin" plugin remove projectatlas --marketplace projectatlas --json >/dev/null 2>&1 || true
     if "$codex_bin" plugin add projectatlas --marketplace projectatlas --json >/dev/null 2>&1; then
       installed_version=$(codex_projectatlas_plugin_version)
       if [ "$installed_version" = "$runtime_version" ]; then
-        printf 'Codex ProjectAtlas plugin marketplace updated to %s.\n' "$release_tag"
-        verify_codex_projectatlas_skill_artifact
+        if codex_projectatlas_plugin_source_manifest_matches "$runtime_version"; then
+          printf 'Codex ProjectAtlas plugin marketplace updated to %s.\n' "$release_tag"
+          verify_codex_projectatlas_skill_artifact
+        else
+          source_manifest_version=$(codex_projectatlas_plugin_source_manifest_version)
+          printf "warning: Codex ProjectAtlas plugin update failed: source manifest version '%s' does not match %s after refresh.\n" "$source_manifest_version" "$runtime_version" >&2
+          restore_codex_projectatlas_marketplace "$marketplace_source" "$previous_ref"
+        fi
       else
         printf "warning: Codex ProjectAtlas plugin update failed: installed projectatlas plugin version '%s' does not match %s.\n" "$installed_version" "$runtime_version" >&2
         restore_codex_projectatlas_marketplace "$marketplace_source" "$previous_ref"
@@ -473,8 +504,14 @@ update_codex_plugin() {
   if "$codex_bin" plugin add projectatlas --marketplace projectatlas --json >/dev/null 2>&1; then
     installed_version=$(codex_projectatlas_plugin_version)
     if [ "$installed_version" = "$runtime_version" ]; then
-      printf 'Codex ProjectAtlas plugin marketplace updated to %s.\n' "$release_tag"
-      verify_codex_projectatlas_skill_artifact
+      if codex_projectatlas_plugin_source_manifest_matches "$runtime_version"; then
+        printf 'Codex ProjectAtlas plugin marketplace updated to %s.\n' "$release_tag"
+        verify_codex_projectatlas_skill_artifact
+      else
+        source_manifest_version=$(codex_projectatlas_plugin_source_manifest_version)
+        printf "warning: Codex ProjectAtlas plugin update failed: source manifest version '%s' does not match %s after refresh.\n" "$source_manifest_version" "$runtime_version" >&2
+        restore_codex_projectatlas_marketplace "$marketplace_source" "$previous_ref"
+      fi
     else
       printf "warning: Codex ProjectAtlas plugin update failed: installed projectatlas plugin version '%s' does not match %s.\n" "$installed_version" "$runtime_version" >&2
       restore_codex_projectatlas_marketplace "$marketplace_source" "$previous_ref"

--- a/skills/codex-coding-plugin/SKILL.md
+++ b/skills/codex-coding-plugin/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: codex-coding-plugin
+description: Build, review, or fix stable Codex plugins, especially plugin runtime installers, marketplace update flows, MCP config generation, skill artifacts, version convergence, stale cache repair, and fake-host tests for Codex plugin releases.
+---
+
+# Codex Coding Plugin
+
+## Goal
+
+Make Codex plugins converge to one verified version across the plugin manifest, installed plugin metadata, runtime binary, generated MCP config, global MCP registry, skill files, and host cache.
+
+## Workflow
+
+1. Treat the plugin manifest version as the release contract, but verify it against the runtime with `runtime-info` before writing configs.
+2. Prefer official host commands for plugin and marketplace state. Inspect host cache files only after the host reports a source path and only after confirming the source is the official plugin.
+3. Never trust one version signal alone. Compare at least:
+   - plugin list version,
+   - reported plugin source manifest version,
+   - runtime `runtime-info` version,
+   - generated MCP `--require-version`,
+   - global MCP registry runtime and database path when the host exposes one.
+4. If an official marketplace cache is stale, repair it automatically with the host's remove/add or upgrade flow, then re-read the host state.
+5. Fail only after repair was attempted and the verified state still mismatches. The normal official path should work, not just report drift.
+6. Preserve user-managed environments. If the marketplace source is not clearly the official plugin source, do not mutate it.
+7. Pin generated MCP configs to absolute verified runtime, DB, and config paths. Avoid PATH-only fallbacks for installed plugin configs.
+8. Keep installer output concrete: say which version/path was verified, repaired, skipped, or still mismatched.
+
+## Version Checks
+
+Use a single small helper per host to read the host-reported plugin object. From that object, derive the source path and source manifest version. The common bug is checking `codex plugin list` version, then running installer code from a stale source path.
+
+Required guard for Codex plugin repair:
+
+```text
+if plugin_list.version == expected
+and marketplace_ref == expected_tag
+and reported_source_manifest.version == expected:
+    no-op
+else if official ProjectAtlas marketplace:
+    remove/add or upgrade the plugin
+    re-read plugin list and source manifest
+    require both to match expected
+else:
+    skip mutation with clear user-managed message
+```
+
+## Tests
+
+Use fake host commands instead of real Codex state. The minimum regression matrix is:
+
+- official marketplace, stale plugin list version -> repairs;
+- official marketplace, current plugin list version but stale reported source manifest -> repairs;
+- official marketplace, current plugin and source manifest -> no-op;
+- non-official marketplace -> no mutation;
+- failed repair -> restores when possible and reports the mismatched field;
+- generated MCP config launches the verified runtime.
+
+For installer tests, assert exact command fragments for remove/add/update calls and inspect the generated config files, not just process success.
+
+## Release Gates
+
+Before calling a Codex plugin release stable, verify:
+
+- plugin manifest version matches release tag;
+- runtime `runtime-info` reports the release version, ProjectAtlas identity, MCP capability, and TOON output;
+- installer writes project-local MCP config with `--require-version`;
+- installer repairs or reports global MCP registry drift;
+- installer verifies the skill artifact path/version when Codex exposes it;
+- release tests run on Windows and POSIX paths when both installer scripts exist.

--- a/skills/codex-coding-plugin/agents/openai.yaml
+++ b/skills/codex-coding-plugin/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Codex Plugin Coding"
+  short_description: "Build stable Codex plugins and installers"
+  default_prompt: "Use $codex-coding-plugin to design or review a Codex plugin runtime, installer, MCP config, or marketplace update flow."


### PR DESCRIPTION
## Summary
- fixes Codex ProjectAtlas installer drift detection so a stale plugin source manifest is repaired or reported instead of silently accepting a mismatched cache
- rebuilds the token TUI around Ratatui widgets with explicit gross, conservative saved/avoided, file-read, and day/week/month/year trend accounting
- adds a reusable `codex-coding-plugin` skill and a v0.3.23 pre-mortem/spec covering #285, #286, and the larger backlog sequence
- bumps ProjectAtlas workspace and plugin manifests to 0.3.23

## Verification
- `cargo fmt --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `cargo test --doc --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked`
- focused TUI/e2e/plugin tests included in the full suite and separately rerun during implementation
- `python C:/Users/styler/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/codex-coding-plugin`
- PowerShell installer parse check: `PSParser::Tokenize(...)`
- `projectatlas lint --report-untracked --purpose-level low`
- visual QA artifact: `C:\Users\styler\AppData\Local\Temp\projectatlas-token-tui-v0.3.23-final.png`

## Notes
- `bash -n plugins/projectatlas/scripts/install-runtime.sh` could not run on this Windows host because `bash.exe` is the WSL launcher and no WSL distribution is installed.
- Local stable ProjectAtlas runtime was installed and verified at `0.3.23`; Codex MCP now points at the built `0.3.23` runtime. The Codex marketplace plugin still reports `0.3.22` until `v0.3.23` exists as a GitHub release tag.

Refs #285
Refs #286
