### PR TITLE
feat(navigation): add ranked reasons and next recommendations (#266 #267 #269)

### DIFF
--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -17,12 +17,12 @@ use projectatlas_core::telemetry::{
     TokenCalibrationOverview, TokenTrendWindow as CoreTokenTrendWindow,
 };
 use projectatlas_core::toon::{
-    encode_agent_payload, render_node_rows, render_nodes, render_outline, render_overview,
-    render_symbol_relations, render_symbols, render_token_overview, render_token_trends,
+    encode_agent_payload, render_outline, render_overview, render_ranked_node_rows,
+    render_ranked_nodes, render_symbol_relations, render_symbols, render_token_overview,
+    render_token_trends,
 };
 use projectatlas_core::{
-    NodeKind, PurposeSource, PurposeStatus, normalize_native_path_display,
-    normalize_repo_path_prefix,
+    PurposeSource, PurposeStatus, normalize_native_path_display, normalize_repo_path_prefix,
 };
 use projectatlas_db::{AtlasStore, DbError, HealthQuery, HealthResolution, HealthScope};
 use projectatlas_service::{
@@ -35,8 +35,9 @@ use runtime::{
     absolute_path, build_settings_report, build_symbols_for_index, byte_count_to_tokens,
     canonical_project_root, default_mcp_project_root, defaultable_cli_project_root,
     estimated_source_tokens_for_indexed_files, estimated_source_tokens_for_paths,
-    file_summary_usage_baseline, lint_database_if_present, normalized_folder_filter,
-    open_atlas_store, purpose_curation_page, ranked_file_nodes, read_indexed_file_content,
+    file_summary_usage_baseline, lint_database_if_present, next_step_report,
+    next_step_report_payload, normalized_folder_filter, open_atlas_store, purpose_curation_page,
+    ranked_file_nodes_with_reasons, ranked_folder_nodes_with_reasons, read_indexed_file_content,
     record_directory_walk_usage_estimate, record_usage_estimate, record_usage_text,
     render_health_page, render_purpose_curation_page, render_purpose_review_report,
     reset_index_files, resolved_mcp_config_path, review_purposes, run_scan_pipeline,
@@ -299,6 +300,14 @@ enum Command {
         include_content: bool,
         /// Maximum number of files to return.
         #[arg(long, default_value_t = 10)]
+        limit: usize,
+    },
+    /// Recommend the next indexed folders, files, and inspection commands.
+    Next {
+        /// Task or navigation query.
+        query: String,
+        /// Maximum number of folders and files to return.
+        #[arg(long, default_value_t = 3)]
         limit: usize,
     },
     /// Build a compact outline for a chosen file.
@@ -780,9 +789,9 @@ fn run() -> Result<(), CliError> {
         }
         Command::Folders { query, limit } => {
             let store = open_atlas_store(&cli.db)?;
-            let selected = store.load_ranked_nodes(query, NodeKind::Folder, None, *limit, 0)?;
-            let toon = render_nodes("folders", &selected);
-            let payload = render_node_rows("folders", &selected);
+            let selected = ranked_folder_nodes_with_reasons(&store, query, *limit)?;
+            let toon = render_ranked_nodes("folders", &selected);
+            let payload = render_ranked_node_rows("folders", &selected);
             print_tracked_directory_output_estimate(
                 cli.format,
                 &store,
@@ -808,7 +817,12 @@ fn run() -> Result<(), CliError> {
                 .as_deref()
                 .map(normalized_folder_filter)
                 .transpose()?;
-            let selected = ranked_file_nodes(
+            let baseline_tokens = estimated_source_tokens_for_indexed_files(
+                &store,
+                folder_filter.as_deref(),
+                file_pattern.as_deref(),
+            )?;
+            let selected = ranked_file_nodes_with_reasons(
                 &store,
                 query_text,
                 folder_filter.as_deref(),
@@ -816,13 +830,8 @@ fn run() -> Result<(), CliError> {
                 *limit,
                 *include_content,
             )?;
-            let baseline_tokens = estimated_source_tokens_for_indexed_files(
-                &store,
-                folder_filter.as_deref(),
-                file_pattern.as_deref(),
-            )?;
-            let toon = render_nodes("files", &selected);
-            let payload = render_node_rows("files", &selected);
+            let toon = render_ranked_nodes("files", &selected);
+            let payload = render_ranked_node_rows("files", &selected);
             print_tracked_output_estimate(
                 cli.format,
                 &store,
@@ -831,6 +840,23 @@ fn run() -> Result<(), CliError> {
                 file_pattern.clone().or(folder_filter),
                 query.clone(),
                 baseline_tokens,
+                &toon,
+                &payload,
+            )?;
+        }
+        Command::Next { query, limit } => {
+            let store = open_atlas_store(&cli.db)?;
+            let report = next_step_report(&store, query, Some(*limit))?;
+            let payload = next_step_report_payload(&report);
+            let toon = encode_agent_payload(&json!({ "next": payload }));
+            print_tracked_directory_output_estimate(
+                cli.format,
+                &store,
+                &cli.session,
+                "next",
+                None,
+                Some(query.clone()),
+                estimated_source_tokens_for_indexed_files(&store, None, None)?,
                 &toon,
                 &payload,
             )?;

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -7,8 +7,9 @@ use crate::runtime::{
     ScanRuntimePlan, SymbolBuildOptions, build_settings_report, build_symbols_for_index,
     byte_count_to_tokens, canonical_project_root, config_root_mismatch_error,
     default_mcp_project_root, estimated_source_tokens_for_indexed_files,
-    estimated_source_tokens_for_paths, file_summary_usage_baseline, normalized_folder_filter,
-    open_atlas_store, purpose_curation_page, ranked_file_nodes, read_indexed_file_content,
+    estimated_source_tokens_for_paths, file_summary_usage_baseline, next_step_report,
+    next_step_report_payload, normalized_folder_filter, open_atlas_store, purpose_curation_page,
+    ranked_file_nodes_with_reasons, ranked_folder_nodes_with_reasons, read_indexed_file_content,
     record_directory_walk_usage_estimate, record_usage_estimate, record_usage_text,
     render_health_page, render_purpose_curation_page, render_purpose_review_report,
     reset_index_files, review_purposes, run_scan_pipeline, run_watch_loop, strip_legacy_purpose,
@@ -23,11 +24,11 @@ use projectatlas_core::health::Severity;
 use projectatlas_core::outline::build_outline;
 use projectatlas_core::telemetry::TokenTrendWindow;
 use projectatlas_core::toon::{
-    encode_agent_payload, render_nodes, render_outline, render_overview, render_symbol_relations,
-    render_symbols, render_token_overview, render_token_trends,
+    encode_agent_payload, render_outline, render_overview, render_ranked_nodes,
+    render_symbol_relations, render_symbols, render_token_overview, render_token_trends,
 };
 use projectatlas_core::{
-    NodeKind, PurposeSource, PurposeStatus, normalize_repo_path_prefix, validated_repo_node_key,
+    PurposeSource, PurposeStatus, normalize_repo_path_prefix, validated_repo_node_key,
 };
 use projectatlas_db::{AtlasStore, HealthQuery, HealthResolution, HealthScope};
 use projectatlas_service::{
@@ -49,6 +50,7 @@ pub(crate) const REQUIRED_MCP_TOOL_NAMES: &[&str] = &[
     MCP_TOOL_ATLAS_OVERVIEW,
     MCP_TOOL_ATLAS_FOLDERS,
     MCP_TOOL_ATLAS_FILES,
+    MCP_TOOL_ATLAS_NEXT,
     MCP_TOOL_ATLAS_OUTLINE,
     MCP_TOOL_ATLAS_FILE_SUMMARY,
     MCP_TOOL_ATLAS_SEARCH,
@@ -80,6 +82,8 @@ const MCP_TOOL_ATLAS_OVERVIEW: &str = "atlas_overview";
 const MCP_TOOL_ATLAS_FOLDERS: &str = "atlas_folders";
 /// MCP tool name for file ranking.
 const MCP_TOOL_ATLAS_FILES: &str = "atlas_files";
+/// MCP tool name for next-step recommendations.
+const MCP_TOOL_ATLAS_NEXT: &str = "atlas_next";
 /// MCP tool name for file outlines.
 const MCP_TOOL_ATLAS_OUTLINE: &str = "atlas_outline";
 /// MCP tool name for file summaries.
@@ -159,12 +163,16 @@ const MCP_PAYLOAD_WATCH: &str = "watch";
 const MCP_PAYLOAD_LEGACY_PURPOSE_MIGRATION: &str = "legacy_purpose_migration";
 /// MCP payload key for reset-index reports.
 const MCP_PAYLOAD_RESET_INDEX: &str = "reset_index";
+/// MCP payload key for next-step recommendation reports.
+const MCP_PAYLOAD_NEXT: &str = "next";
 /// MCP telemetry event for overview calls.
 const MCP_EVENT_ATLAS_OVERVIEW: &str = "mcp.atlas_overview";
 /// MCP telemetry event for folder calls.
 const MCP_EVENT_ATLAS_FOLDERS: &str = "mcp.atlas_folders";
 /// MCP telemetry event for file calls.
 const MCP_EVENT_ATLAS_FILES: &str = "mcp.atlas_files";
+/// MCP telemetry event for next-step recommendation calls.
+const MCP_EVENT_ATLAS_NEXT: &str = "mcp.atlas_next";
 /// MCP telemetry event for outline calls.
 const MCP_EVENT_ATLAS_OUTLINE: &str = "mcp.atlas_outline";
 /// MCP telemetry event for file-summary calls.
@@ -1092,14 +1100,9 @@ impl ProjectAtlasMcpServer {
             let state = self.state_for_project_path(params.project_path)?;
             let store = Self::open_store(&state)?;
             let query = Self::query_or_empty(params.query);
-            let selected = store.load_ranked_nodes(
-                &query,
-                NodeKind::Folder,
-                None,
-                params.limit.unwrap_or(10),
-                0,
-            )?;
-            let toon = render_nodes(NODE_LABEL_FOLDERS, &selected);
+            let selected =
+                ranked_folder_nodes_with_reasons(&store, &query, params.limit.unwrap_or(10))?;
+            let toon = render_ranked_nodes(NODE_LABEL_FOLDERS, &selected);
             record_directory_walk_usage_estimate(
                 &store,
                 &self.session,
@@ -1128,7 +1131,7 @@ impl ProjectAtlasMcpServer {
                 .as_deref()
                 .map(normalized_folder_filter)
                 .transpose()?;
-            let selected = ranked_file_nodes(
+            let selected = ranked_file_nodes_with_reasons(
                 &store,
                 &query,
                 folder_filter.as_deref(),
@@ -1141,7 +1144,7 @@ impl ProjectAtlasMcpServer {
                 folder_filter.as_deref(),
                 params.file_pattern.as_deref(),
             )?;
-            let toon = render_nodes(NODE_LABEL_FILES, &selected);
+            let toon = render_ranked_nodes(NODE_LABEL_FILES, &selected);
             record_usage_estimate(
                 &store,
                 &self.session,
@@ -1149,6 +1152,32 @@ impl ProjectAtlasMcpServer {
                 params.file_pattern.or(folder_filter),
                 Some(query),
                 baseline_tokens,
+                &toon,
+            )?;
+            Ok(toon)
+        })())
+    }
+
+    /// Recommend the next indexed folders, files, and inspection commands.
+    #[tool(
+        name = "atlas_next",
+        description = "Recommend top indexed folders/files with reasons and deterministic follow-up commands for a task query."
+    )]
+    fn atlas_next(&self, Parameters(params): Parameters<AtlasQueryParams>) -> String {
+        Self::as_mcp_text((|| {
+            let state = self.state_for_project_path(params.project_path)?;
+            let store = Self::open_store(&state)?;
+            let query = Self::query_or_empty(params.query);
+            let report = next_step_report(&store, &query, params.limit)?;
+            let payload = next_step_report_payload(&report);
+            let toon = Self::encode_named_payload(MCP_PAYLOAD_NEXT, &payload)?;
+            record_directory_walk_usage_estimate(
+                &store,
+                &self.session,
+                MCP_EVENT_ATLAS_NEXT,
+                None,
+                Some(query),
+                estimated_source_tokens_for_indexed_files(&store, None, None)?,
                 &toon,
             )?;
             Ok(toon)

--- a/crates/projectatlas-cli/src/runtime.rs
+++ b/crates/projectatlas-cli/src/runtime.rs
@@ -24,7 +24,7 @@ use projectatlas_core::telemetry::{
     TOKEN_BUCKET_NAVIGATION_AVOIDANCE, TOKEN_CONFIDENCE_INFERRED, TOKEN_CONFIDENCE_POLICY_ESTIMATE,
     usage_from_estimates_with_context, usage_from_text,
 };
-use projectatlas_core::toon::encode_agent_payload;
+use projectatlas_core::toon::{encode_agent_payload, render_ranked_node_rows};
 use projectatlas_core::{
     Node, NodeKind, Overview, PurposeSource, PurposeStatus, normalize_native_path_display,
     normalize_native_path_display_str, normalize_repo_path, purpose_review_signal,
@@ -33,13 +33,15 @@ use projectatlas_core::{
 use projectatlas_db::{AtlasStore, HealthFindingsPage, HealthQuery, HealthScope, IndexedFileText};
 use projectatlas_fs::{ScanOptions, gitignore_excludes_path, scan_path, scan_repo};
 use projectatlas_service::{
-    FilePathMatcher, FileSummaryReport, file_summary_baseline_text, load_ranked_file_nodes,
+    FilePathMatcher, FileSummaryReport, NextStepReport, build_next_report,
+    file_summary_baseline_text, load_ranked_file_nodes_with_reasons,
+    load_ranked_folder_nodes_with_reasons,
 };
 use projectatlas_symbols::extract_symbol_graph;
 use rayon::ThreadPoolBuilder;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 use std::fs;
@@ -490,16 +492,25 @@ pub(crate) fn byte_count_to_tokens(bytes: usize) -> usize {
     if bytes == 0 { 0 } else { bytes.div_ceil(4) }
 }
 
-/// Load ranked file nodes in bounded pages and apply exact glob semantics.
-pub(crate) fn ranked_file_nodes(
+/// Load ranked folder nodes with concise reasons.
+pub(crate) fn ranked_folder_nodes_with_reasons(
+    store: &AtlasStore,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<projectatlas_core::RankedNode>, CliError> {
+    Ok(load_ranked_folder_nodes_with_reasons(store, query, limit)?)
+}
+
+/// Load ranked file nodes with concise reasons.
+pub(crate) fn ranked_file_nodes_with_reasons(
     store: &AtlasStore,
     query: &str,
     folder: Option<&str>,
     file_pattern: Option<&str>,
     limit: usize,
     include_content: bool,
-) -> Result<Vec<projectatlas_core::IndexedNode>, CliError> {
-    Ok(load_ranked_file_nodes(
+) -> Result<Vec<projectatlas_core::RankedNode>, CliError> {
+    Ok(load_ranked_file_nodes_with_reasons(
         store,
         query,
         folder,
@@ -507,6 +518,25 @@ pub(crate) fn ranked_file_nodes(
         limit,
         include_content,
     )?)
+}
+
+/// Build a next-step recommendation report from indexed metadata.
+pub(crate) fn next_step_report(
+    store: &AtlasStore,
+    query: &str,
+    limit: Option<usize>,
+) -> Result<NextStepReport, CliError> {
+    Ok(build_next_report(store, query, limit)?)
+}
+
+/// Build the flattened agent-facing next-step payload.
+pub(crate) fn next_step_report_payload(report: &NextStepReport) -> Value {
+    json!({
+        "query": &report.query,
+        "folders": render_ranked_node_rows("folders", &report.folders),
+        "files": render_ranked_node_rows("files", &report.files),
+        "suggestions": &report.suggestions,
+    })
 }
 
 /// Agent-facing purpose curation queue with bounded health metadata.

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -22,6 +22,8 @@ use std::time::{Duration, Instant};
 
 const TEST_REPO_DIR: &str = "repo";
 const SRC_DIR_NAME: &str = "src";
+const TESTS_DIR_NAME: &str = "tests";
+const INSTALLER_RS_FILE_NAME: &str = "installer.rs";
 const ATLAS_DIR_NAME: &str = ".projectatlas";
 const CODEX_CONFIG_DIR: &str = ".codex";
 const CODEX_PLUGIN_MANIFEST_DIR: &str = ".codex-plugin";
@@ -3870,6 +3872,7 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         r#"{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"atlas_health","arguments":{"category":"missing-purpose","path_prefix":".","limit":1}}}"#,
         r#"{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"atlas_token_report","arguments":{"include_chart":true}}}"#,
         r#"{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"atlas_purpose_review","arguments":{"apply":true,"items":[{"path":"src/lib.rs","confirm_existing":true}]}}}"#,
+        r#"{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"atlas_next","arguments":{"query":"indexed","limit":1}}}"#,
     ];
     let executable = assert_cmd::cargo::cargo_bin("projectatlas");
     let stdout = run_mcp_stdio(
@@ -3885,8 +3888,10 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
     if !stdout.contains(r#""id":1"#)
         || !stdout.contains(r#""serverInfo":{"name":"ProjectAtlas","version":"#)
         || !stdout.contains(r#""name":"atlas_files""#)
+        || !stdout.contains(r#""name":"atlas_next""#)
         || !stdout.contains("overview:")
         || !stdout.contains("files[1]")
+        || !stdout.contains("next:")
         || !stdout.contains("health:")
         || !stdout.contains("health_findings[1]")
         || !stdout.contains("next_start_index: 1")
@@ -3910,6 +3915,131 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         &["file_purpose"],
         "Imported Rust library purpose for MCP review.",
     )?;
+    Ok(())
+}
+
+#[test]
+fn ranked_files_and_next_include_bounded_reasons() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join(TEST_REPO_DIR);
+    fs::create_dir(&repo)?;
+    fs::create_dir(repo.join(SRC_DIR_NAME))?;
+    fs::create_dir(repo.join(TESTS_DIR_NAME))?;
+    fs::write(
+        repo.join(SRC_DIR_NAME).join(INSTALLER_RS_FILE_NAME),
+        "pub fn install_runtime() { let _marker = \"hiddenNeedle\"; }\n",
+    )?;
+    fs::write(
+        repo.join(TESTS_DIR_NAME).join(INSTALLER_RS_FILE_NAME),
+        "#[test]\nfn installer_pair() {}\n",
+    )?;
+    let db = temp.path().join("projectatlas.db");
+
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&db)
+        .args(["scan", "."])
+        .assert()
+        .success();
+    {
+        let store = AtlasStore::open(&db)?;
+        store.set_purpose(
+            SRC_DIR_NAME,
+            "Installer runtime source folder for navigation tests.",
+            PurposeSource::Agent,
+        )?;
+        store.set_purpose(
+            "src/installer.rs",
+            "Installer runtime implementation for navigation tests.",
+            PurposeSource::Agent,
+        )?;
+    }
+
+    let raw_files = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&db)
+        .args([
+            "files",
+            "installer runtime hiddenNeedle",
+            "--include-content",
+            "--limit",
+            "2",
+        ])
+        .output()?;
+    if !raw_files.status.success() {
+        return Err(io::Error::other(format!(
+            "json files command with reasons failed: {}",
+            String::from_utf8_lossy(&raw_files.stderr)
+        ))
+        .into());
+    }
+    let files_json: Value = serde_json::from_slice(&raw_files.stdout)?;
+    let file_entry = files_json
+        .as_array()
+        .and_then(|entries| {
+            entries
+                .iter()
+                .find(|entry| entry["path"] == "src/installer.rs")
+        })
+        .ok_or_else(|| io::Error::other("reasoned installer file entry was missing"))?;
+    require_json_string(
+        file_entry,
+        &["file_purpose"],
+        "Installer runtime implementation for navigation tests.",
+    )?;
+    require_json_contains(file_entry, &["reasons", "0"], "path matched")?;
+    let file_reasons = json_at(file_entry, &["reasons"])?
+        .as_array()
+        .ok_or_else(|| io::Error::other("file reasons were not an array"))?;
+    if file_reasons.len() > 6
+        || !file_reasons.iter().any(|reason| {
+            reason
+                .as_str()
+                .is_some_and(|text| text.contains("indexed text matched"))
+        })
+    {
+        return Err(io::Error::other(format!(
+            "file reasons did not stay bounded or include indexed text: {file_reasons:?}"
+        ))
+        .into());
+    }
+
+    let raw_next = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&db)
+        .args(["next", "installer runtime hiddenNeedle", "--limit", "2"])
+        .output()?;
+    if !raw_next.status.success() {
+        return Err(io::Error::other(format!(
+            "json next command failed: {}",
+            String::from_utf8_lossy(&raw_next.stderr)
+        ))
+        .into());
+    }
+    let next_json: Value = serde_json::from_slice(&raw_next.stdout)?;
+    require_json_string(&next_json, &["query"], "installer runtime hiddenNeedle")?;
+    require_json_string(&next_json, &["files", "0", "path"], "src/installer.rs")?;
+    require_json_contains(&next_json, &["files", "0", "reasons", "0"], "path matched")?;
+    let suggestions = json_at(&next_json, &["suggestions"])?
+        .as_array()
+        .ok_or_else(|| io::Error::other("next suggestions were not an array"))?;
+    if !suggestions.iter().any(|suggestion| {
+        suggestion
+            .as_str()
+            .is_some_and(|text| text == "projectatlas summary src/installer.rs --limit 25")
+    }) {
+        return Err(io::Error::other(format!(
+            "next suggestions did not include top-file summary command: {suggestions:?}"
+        ))
+        .into());
+    }
     Ok(())
 }
 

--- a/crates/projectatlas-core/src/lib.rs
+++ b/crates/projectatlas-core/src/lib.rs
@@ -326,6 +326,15 @@ pub struct IndexedNode {
     pub summary: Option<String>,
 }
 
+/// A ranked node with concise evidence for why it was selected.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct RankedNode {
+    /// Selected indexed node.
+    pub node: IndexedNode,
+    /// Bounded human-readable ranking signals.
+    pub reasons: Vec<String>,
+}
+
 /// Overview returned by startup/overview commands.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Overview {

--- a/crates/projectatlas-core/src/toon.rs
+++ b/crates/projectatlas-core/src/toon.rs
@@ -4,7 +4,7 @@ use crate::health::{HealthFinding, Severity};
 use crate::outline::FileOutline;
 use crate::symbols::{CodeSymbol, SymbolRelation};
 use crate::telemetry::{TokenOverview, TokenTrendReport};
-use crate::{IndexedNode, Overview};
+use crate::{IndexedNode, Overview, RankedNode};
 use serde::Serialize;
 use serde_json::json;
 
@@ -50,10 +50,35 @@ pub fn render_node_rows(label: &str, nodes: &[IndexedNode]) -> Vec<serde_json::V
         .collect()
 }
 
+/// Build the agent-facing ranked row projection with bounded reasons.
+#[must_use]
+pub fn render_ranked_node_rows(label: &str, nodes: &[RankedNode]) -> Vec<serde_json::Value> {
+    nodes
+        .iter()
+        .map(|ranked| {
+            let mut row = render_node_rows(label, std::slice::from_ref(&ranked.node))
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| json!({}));
+            if let Some(object) = row.as_object_mut() {
+                object.insert("reasons".to_string(), json!(ranked.reasons));
+            }
+            row
+        })
+        .collect()
+}
+
 /// Render indexed nodes as standard TOON.
 #[must_use]
 pub fn render_nodes(label: &str, nodes: &[IndexedNode]) -> String {
     let rows = render_node_rows(label, nodes);
+    encode_agent_payload(&json!({ label: rows }))
+}
+
+/// Render ranked indexed nodes as standard TOON.
+#[must_use]
+pub fn render_ranked_nodes(label: &str, nodes: &[RankedNode]) -> String {
+    let rows = render_ranked_node_rows(label, nodes);
     encode_agent_payload(&json!({ label: rows }))
 }
 

--- a/crates/projectatlas-service/src/lib.rs
+++ b/crates/projectatlas-service/src/lib.rs
@@ -8,7 +8,9 @@ use projectatlas_core::outline::estimate_tokens;
 use projectatlas_core::symbols::{
     CodeSymbol, ParserKind, RelationKind, SourceParseMetadata, SymbolKind, SymbolRelation,
 };
-use projectatlas_core::{IndexedNode, NodeKind, repo_path_to_native, validated_repo_file_key};
+use projectatlas_core::{
+    IndexedNode, NodeKind, RankedNode, repo_path_to_native, validated_repo_file_key,
+};
 use projectatlas_db::{AtlasStore, DbError, IndexedFileText};
 use regex::RegexBuilder;
 use serde::Serialize;
@@ -23,6 +25,14 @@ const CALLERS_PER_SYMBOL_LIMIT: usize = 20;
 const CALLER_RELATION_LIMIT_PER_TARGET: usize = 20;
 /// Maximum package/module symbols read for file-level metadata.
 const FILE_METADATA_SYMBOL_LIMIT: usize = 20;
+/// Maximum concise reasons attached to one ranked result.
+const RANKED_REASON_LIMIT: usize = 6;
+/// Maximum selected candidates considered when service-side ranking enriches DB output.
+const RANKED_CANDIDATE_LIMIT: usize = 100;
+/// Default number of folders and files returned by `next`.
+const NEXT_REPORT_DEFAULT_LIMIT: usize = 3;
+/// Maximum number of folders and files returned by `next`.
+const NEXT_REPORT_MAX_LIMIT: usize = 10;
 /// Status emitted when live source was read successfully.
 const SOURCE_STATUS_LIVE: &str = "live-source";
 /// Status emitted when indexed metadata had to stand in for live source.
@@ -202,6 +212,19 @@ pub struct SearchReport {
     pub truncated: bool,
     /// Search matches.
     pub results: Vec<SearchMatch>,
+}
+
+/// Agent-facing next-step recommendation report built from indexed metadata.
+#[derive(Debug, Serialize)]
+pub struct NextStepReport {
+    /// Task/navigation query.
+    pub query: String,
+    /// Top matching folders with concise ranking evidence.
+    pub folders: Vec<RankedNode>,
+    /// Top matching files with concise ranking evidence.
+    pub files: Vec<RankedNode>,
+    /// Deterministic follow-up commands for the selected index targets.
+    pub suggestions: Vec<String>,
 }
 
 /// Exact code slice returned after orientation.
@@ -646,15 +669,438 @@ pub fn load_ranked_file_nodes(
 ) -> ServiceResult<Vec<IndexedNode>> {
     let matcher = FilePathMatcher::new(file_pattern)?;
     let target = limit.max(1);
+    let candidate_target = ranked_candidate_target(query, target);
     let mut selected = if matcher.filters() {
-        load_ranked_file_nodes_matching_glob(store, query, folder, &matcher, target)?
+        load_ranked_file_nodes_matching_glob(store, query, folder, &matcher, candidate_target)?
     } else {
-        store.load_ranked_nodes(query, NodeKind::File, folder, target, 0)?
+        store.load_ranked_nodes(query, NodeKind::File, folder, candidate_target, 0)?
     };
-    if include_content && !query.trim().is_empty() && selected.len() < target {
-        append_content_ranked_file_nodes(store, query, folder, &matcher, target, &mut selected)?;
+    if include_content && !query.trim().is_empty() && selected.len() < candidate_target {
+        append_content_ranked_file_nodes(
+            store,
+            query,
+            folder,
+            &matcher,
+            candidate_target,
+            &mut selected,
+        )?;
     }
+    append_paired_file_nodes(store, &matcher, candidate_target, &mut selected)?;
+    selected = sort_ranked_file_nodes(store, query, selected)?;
+    selected.truncate(target);
     Ok(selected)
+}
+
+/// Load ranked folders with concise reasons.
+///
+/// # Errors
+///
+/// Returns an error when indexed folder metadata cannot be loaded.
+pub fn load_ranked_folder_nodes_with_reasons(
+    store: &AtlasStore,
+    query: &str,
+    limit: usize,
+) -> ServiceResult<Vec<RankedNode>> {
+    let selected = store.load_ranked_nodes(query, NodeKind::Folder, None, limit.max(1), 0)?;
+    ranked_nodes_with_reasons(store, query, selected)
+}
+
+/// Load ranked files with concise reasons.
+///
+/// # Errors
+///
+/// Returns an error when indexed file metadata cannot be loaded or filters are invalid.
+pub fn load_ranked_file_nodes_with_reasons(
+    store: &AtlasStore,
+    query: &str,
+    folder: Option<&str>,
+    file_pattern: Option<&str>,
+    limit: usize,
+    include_content: bool,
+) -> ServiceResult<Vec<RankedNode>> {
+    let selected =
+        load_ranked_file_nodes(store, query, folder, file_pattern, limit, include_content)?;
+    ranked_nodes_with_reasons(store, query, selected)
+}
+
+/// Build an indexed-metadata recommendation report for the next inspection step.
+///
+/// # Errors
+///
+/// Returns an error when indexed folder or file metadata cannot be loaded.
+pub fn build_next_report(
+    store: &AtlasStore,
+    query: &str,
+    limit: Option<usize>,
+) -> ServiceResult<NextStepReport> {
+    let target = limit
+        .unwrap_or(NEXT_REPORT_DEFAULT_LIMIT)
+        .clamp(1, NEXT_REPORT_MAX_LIMIT);
+    let folders = load_ranked_folder_nodes_with_reasons(store, query, target)?;
+    let files = load_ranked_file_nodes_with_reasons(store, query, None, None, target, true)?;
+    let suggestions = next_report_suggestions(query, &folders, &files);
+    Ok(NextStepReport {
+        query: query.to_string(),
+        folders,
+        files,
+        suggestions,
+    })
+}
+
+#[derive(Debug)]
+/// Score and evidence computed for one ranked node.
+struct RankedEvidence {
+    /// Additive deterministic score for ordering a bounded candidate set.
+    score: usize,
+    /// Concise evidence strings emitted to the agent-facing result.
+    reasons: Vec<String>,
+}
+
+/// Return the bounded candidate count used before final ranking truncation.
+fn ranked_candidate_target(query: &str, target: usize) -> usize {
+    if query.trim().is_empty() {
+        target
+    } else {
+        target
+            .saturating_mul(3)
+            .clamp(target, RANKED_CANDIDATE_LIMIT)
+    }
+}
+
+/// Attach reasons to a ranked node list without changing its order.
+fn ranked_nodes_with_reasons(
+    store: &AtlasStore,
+    query: &str,
+    selected: Vec<IndexedNode>,
+) -> ServiceResult<Vec<RankedNode>> {
+    let terms = normalize_ranking_terms(query);
+    let text_hit_paths = indexed_text_hit_paths(store, &selected, &terms)?;
+    selected
+        .into_iter()
+        .map(|node| {
+            let evidence = ranked_node_evidence(store, &node, &terms, &text_hit_paths)?;
+            Ok(RankedNode {
+                node,
+                reasons: evidence.reasons,
+            })
+        })
+        .collect()
+}
+
+/// Sort a bounded file candidate list by service-level ranking evidence.
+fn sort_ranked_file_nodes(
+    store: &AtlasStore,
+    query: &str,
+    selected: Vec<IndexedNode>,
+) -> ServiceResult<Vec<IndexedNode>> {
+    if query.trim().is_empty() || selected.len() <= 1 {
+        return Ok(selected);
+    }
+    let terms = normalize_ranking_terms(query);
+    let text_hit_paths = indexed_text_hit_paths(store, &selected, &terms)?;
+    let mut scored = selected
+        .into_iter()
+        .enumerate()
+        .map(|(index, node)| {
+            let evidence = ranked_node_evidence(store, &node, &terms, &text_hit_paths)?;
+            Ok((index, evidence.score, node))
+        })
+        .collect::<ServiceResult<Vec<_>>>()?;
+    scored.sort_by(|left, right| {
+        right
+            .1
+            .cmp(&left.1)
+            .then_with(|| left.0.cmp(&right.0))
+            .then_with(|| left.2.node.path.cmp(&right.2.node.path))
+    });
+    Ok(scored.into_iter().map(|(_, _, node)| node).collect())
+}
+
+/// Compute score and reasons for one node from indexed metadata.
+fn ranked_node_evidence(
+    store: &AtlasStore,
+    node: &IndexedNode,
+    terms: &[String],
+    text_hit_paths: &HashSet<String>,
+) -> ServiceResult<RankedEvidence> {
+    let mut score = 0usize;
+    let mut reasons = Vec::new();
+    if terms.is_empty() {
+        return Ok(RankedEvidence { score, reasons });
+    }
+
+    if let Some(term) = first_matching_term(&node.node.path, terms) {
+        score = score.saturating_add(40);
+        push_ranked_reason(&mut reasons, format!("path matched {term}"));
+    }
+    if let Some(term) = node
+        .purpose
+        .purpose
+        .as_deref()
+        .and_then(|purpose| first_matching_term(purpose, terms))
+    {
+        score = score.saturating_add(50);
+        push_ranked_reason(&mut reasons, format!("purpose matched {term}"));
+    }
+    if let Some(term) = node
+        .summary
+        .as_deref()
+        .and_then(|summary| first_matching_term(summary, terms))
+    {
+        score = score.saturating_add(20);
+        push_ranked_reason(&mut reasons, format!("summary matched {term}"));
+    }
+    if node.node.kind == NodeKind::File {
+        if let Some((symbol_name, term)) = first_symbol_match(store, &node.node.path, terms)? {
+            score = score.saturating_add(35);
+            push_ranked_reason(&mut reasons, format!("symbol {symbol_name} matched {term}"));
+        }
+        if text_hit_paths.contains(&node.node.path)
+            && let Some(term) = indexed_text_match_term(store, &node.node.path, terms)?
+        {
+            score = score.saturating_add(15);
+            push_ranked_reason(&mut reasons, format!("indexed text matched {term}"));
+        }
+        if let Some(reason) = paired_path_reason(store, &node.node.path)? {
+            score = score.saturating_add(10);
+            push_ranked_reason(&mut reasons, reason);
+        }
+    }
+
+    Ok(RankedEvidence { score, reasons })
+}
+
+/// Split a query into unique lowercase terms used by ranking evidence.
+fn normalize_ranking_terms(query: &str) -> Vec<String> {
+    let mut terms = query
+        .split(|character: char| !character.is_alphanumeric())
+        .filter(|term| !term.is_empty())
+        .map(str::to_lowercase)
+        .collect::<Vec<_>>();
+    terms.sort();
+    terms.dedup();
+    terms
+}
+
+/// Return the first normalized query term contained in a text field.
+fn first_matching_term(text: &str, terms: &[String]) -> Option<String> {
+    let haystack = normalized_search_text(text, false);
+    terms
+        .iter()
+        .find(|term| haystack.contains(term.as_str()))
+        .cloned()
+}
+
+/// Append a reason when it is unique and the per-result cap allows it.
+fn push_ranked_reason(reasons: &mut Vec<String>, reason: String) {
+    if reasons.len() < RANKED_REASON_LIMIT && !reasons.contains(&reason) {
+        reasons.push(reason);
+    }
+}
+
+/// Return selected file paths whose persisted indexed text matches any term.
+fn indexed_text_hit_paths(
+    store: &AtlasStore,
+    selected: &[IndexedNode],
+    terms: &[String],
+) -> ServiceResult<HashSet<String>> {
+    let mut hits = HashSet::new();
+    if terms.is_empty() {
+        return Ok(hits);
+    }
+    for node in selected
+        .iter()
+        .filter(|node| node.node.kind == NodeKind::File)
+    {
+        if indexed_text_match_term(store, &node.node.path, terms)?.is_some() {
+            hits.insert(node.node.path.clone());
+        }
+    }
+    Ok(hits)
+}
+
+/// Return the first query term found in one file's persisted indexed text.
+fn indexed_text_match_term(
+    store: &AtlasStore,
+    path: &str,
+    terms: &[String],
+) -> ServiceResult<Option<String>> {
+    let Some(text) = store.load_file_text(path)? else {
+        return Ok(None);
+    };
+    Ok(first_matching_term(&text.content, terms))
+}
+
+/// Return the first indexed symbol match for one file and query term set.
+fn first_symbol_match(
+    store: &AtlasStore,
+    path: &str,
+    terms: &[String],
+) -> ServiceResult<Option<(String, String)>> {
+    const RANKING_SYMBOL_KINDS: &[SymbolKind] = &[
+        SymbolKind::Function,
+        SymbolKind::Method,
+        SymbolKind::Class,
+        SymbolKind::Struct,
+        SymbolKind::Enum,
+        SymbolKind::Trait,
+        SymbolKind::Interface,
+        SymbolKind::Type,
+        SymbolKind::Module,
+        SymbolKind::Value,
+    ];
+    for symbol in store.load_symbols_by_kinds(path, RANKING_SYMBOL_KINDS, 50)? {
+        if let Some(term) = first_matching_term(&symbol.name, terms)
+            .or_else(|| first_matching_term(&symbol.signature, terms))
+        {
+            return Ok(Some((symbol.name, term)));
+        }
+    }
+    Ok(None)
+}
+
+/// Append conventional source/test counterpart files to a candidate set.
+fn append_paired_file_nodes(
+    store: &AtlasStore,
+    matcher: &FilePathMatcher,
+    target: usize,
+    selected: &mut Vec<IndexedNode>,
+) -> ServiceResult<()> {
+    if selected.len() >= target {
+        return Ok(());
+    }
+    let mut seen = selected
+        .iter()
+        .map(|node| node.node.path.clone())
+        .collect::<HashSet<_>>();
+    let seed_paths = selected
+        .iter()
+        .map(|node| node.node.path.clone())
+        .collect::<Vec<_>>();
+    for path in seed_paths {
+        for candidate in paired_path_candidates(&path) {
+            if selected.len() >= target {
+                return Ok(());
+            }
+            if seen.contains(&candidate) || !matcher.is_match(&candidate) {
+                continue;
+            }
+            if let Some(node) = store.load_node_by_path(&candidate)? {
+                seen.insert(candidate);
+                selected.push(node);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build a concise reason when a source/test counterpart is indexed.
+fn paired_path_reason(store: &AtlasStore, path: &str) -> ServiceResult<Option<String>> {
+    for candidate in paired_path_candidates(path) {
+        if store.load_node_by_path(&candidate)?.is_some() {
+            let relation = if is_test_path(path) {
+                "paired source file"
+            } else {
+                "paired test file"
+            };
+            return Ok(Some(format!("{relation} {candidate}")));
+        }
+    }
+    Ok(None)
+}
+
+/// Return conventional source/test counterpart path candidates.
+fn paired_path_candidates(path: &str) -> Vec<String> {
+    let Some((stem_path, extension)) = path.rsplit_once('.') else {
+        return Vec::new();
+    };
+    let extension = format!(".{extension}");
+    let file_stem = stem_path.rsplit('/').next().unwrap_or(stem_path);
+    let mut candidates = Vec::new();
+    if let Some(source_name) = file_stem.strip_suffix("_test") {
+        let prefix = stem_path
+            .strip_suffix(file_stem)
+            .unwrap_or("")
+            .trim_end_matches('/');
+        candidates.push(join_repo_path(prefix, &format!("{source_name}{extension}")));
+    } else if let Some(source_name) = file_stem.strip_suffix(".test") {
+        let prefix = stem_path
+            .strip_suffix(file_stem)
+            .unwrap_or("")
+            .trim_end_matches('/');
+        candidates.push(join_repo_path(prefix, &format!("{source_name}{extension}")));
+    }
+    if let Some(test_name) = stem_path.strip_prefix("tests/") {
+        candidates.push(format!("src/{test_name}{extension}"));
+    } else if let Some(source_name) = stem_path.strip_prefix("src/") {
+        candidates.push(format!("tests/{source_name}{extension}"));
+        candidates.push(format!("src/{source_name}_test{extension}"));
+    } else {
+        candidates.push(format!("tests/{file_stem}{extension}"));
+    }
+    candidates.sort();
+    candidates.dedup();
+    candidates
+}
+
+/// Return whether a path is conventionally test-owned.
+fn is_test_path(path: &str) -> bool {
+    path.starts_with("tests/")
+        || path.contains("/tests/")
+        || path.contains("_test.")
+        || path.contains(".test.")
+}
+
+/// Join repository path segments without introducing platform separators.
+fn join_repo_path(prefix: &str, leaf: &str) -> String {
+    if prefix.is_empty() {
+        leaf.to_string()
+    } else {
+        format!("{prefix}/{leaf}")
+    }
+}
+
+/// Build deterministic follow-up commands for a next-step report.
+fn next_report_suggestions(
+    query: &str,
+    folders: &[RankedNode],
+    files: &[RankedNode],
+) -> Vec<String> {
+    let mut suggestions = Vec::new();
+    if let Some(file) = files.first() {
+        let path = quoted_command_arg(&file.node.node.path);
+        suggestions.push(format!("projectatlas summary {path} --limit 25"));
+        suggestions.push(format!("projectatlas outline {path}"));
+    }
+    if let Some(folder) = folders.first() {
+        let query_arg = quoted_command_arg(query);
+        let folder_arg = quoted_command_arg(&folder.node.node.path);
+        suggestions.push(format!(
+            "projectatlas files {query_arg} --folder {folder_arg} --limit 5"
+        ));
+    }
+    if !query.trim().is_empty() {
+        let query_arg = quoted_command_arg(query);
+        suggestions.push(format!(
+            "projectatlas search {query_arg} --file-pattern **/* --context-lines 2"
+        ));
+    }
+    suggestions.truncate(4);
+    suggestions
+}
+
+/// Quote a command argument when whitespace or quotes require it.
+fn quoted_command_arg(value: &str) -> String {
+    if value.is_empty() {
+        "\"\"".to_string()
+    } else if value
+        .chars()
+        .any(|character| character.is_whitespace() || matches!(character, '"' | '\''))
+    {
+        format!("\"{}\"", value.replace('"', "\\\""))
+    } else {
+        value.to_string()
+    }
 }
 
 /// Load ranked files while applying a compiled repository-relative glob.
@@ -698,19 +1144,23 @@ fn append_content_ranked_file_nodes(
     target: usize,
     selected: &mut Vec<IndexedNode>,
 ) -> ServiceResult<()> {
-    let needle = normalized_search_text(query, false);
+    let terms = normalize_ranking_terms(query);
+    if terms.is_empty() {
+        return Ok(());
+    }
     let mut seen = selected
         .iter()
         .map(|node| node.node.path.clone())
         .collect::<HashSet<_>>();
-    store.visit_file_texts_for_search(Some(query), false, |text| {
+    store.visit_file_texts_for_search(None, false, |text| {
         if selected.len() >= target {
             return Ok(false);
         }
+        let indexed_text = normalized_search_text(&text.content, false);
         if !seen.contains(&text.path)
             && path_is_inside_folder(&text.path, folder)
             && matcher.is_match(&text.path)
-            && normalized_search_text(&text.content, false).contains(&needle)
+            && terms.iter().any(|term| indexed_text.contains(term))
             && let Some(node) = store.load_node_by_path(&text.path)?
         {
             seen.insert(text.path);
@@ -2677,6 +3127,81 @@ mod tests {
     }
 
     #[test]
+    fn ranked_file_reasons_match_indexed_ranking_signals() -> Result<(), Box<dyn Error>> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path();
+        fs::create_dir_all(root.join("src"))?;
+        fs::create_dir_all(root.join("tests"))?;
+        fs::write(
+            root.join("src").join("installer.rs"),
+            "pub fn install_runtime() { let _marker = \"hiddenNeedle\"; }\n",
+        )?;
+        fs::write(
+            root.join("tests").join("installer.rs"),
+            "#[test]\nfn installer_pair() {}\n",
+        )?;
+        fs::write(root.join("src").join("noise.rs"), "pub fn unrelated() {}\n")?;
+
+        let mut store = AtlasStore::in_memory()?;
+        store.set_project_root(root)?;
+        let nodes = [
+            test_node("src/installer.rs", "hash-installer"),
+            test_node("tests/installer.rs", "hash-installer-test"),
+            test_node("src/noise.rs", "hash-noise"),
+        ];
+        store.replace_scan(&nodes)?;
+        store.set_purpose(
+            "src/installer.rs",
+            "Installer runtime release target",
+            PurposeSource::Agent,
+        )?;
+        store.set_node_summary("src/installer.rs", "Release installer summary")?;
+        store.replace_symbol_graph(&SymbolGraph {
+            path: "src/installer.rs".to_string(),
+            language: Some("rust".to_string()),
+            parser: ParserKind::TreeSitter,
+            symbols: vec![test_symbol(
+                "src/installer.rs",
+                SymbolKind::Function,
+                "install_runtime",
+            )],
+            relations: Vec::new(),
+        })?;
+        index_test_file_texts(&mut store, root, &nodes)?;
+
+        let ranked = load_ranked_file_nodes_with_reasons(
+            &store,
+            "installer runtime release hiddenNeedle install_runtime",
+            None,
+            Some("*.rs"),
+            2,
+            true,
+        )?;
+        require_eq(&ranked.len(), &2, "ranked source/test pair count")?;
+        require_eq(
+            &ranked[0].node.node.path,
+            &"src/installer.rs".to_string(),
+            "strong indexed signal ranks first",
+        )?;
+        require_reason(&ranked[0].reasons, "path matched install")?;
+        require_reason(&ranked[0].reasons, "purpose matched install")?;
+        require_reason(&ranked[0].reasons, "summary matched install")?;
+        require_reason(&ranked[0].reasons, "symbol install_runtime matched install")?;
+        require_reason(&ranked[0].reasons, "indexed text matched hiddenneedle")?;
+        require_reason(&ranked[0].reasons, "paired test file tests/installer.rs")?;
+        if !ranked.iter().any(|node| {
+            node.node.node.path == "tests/installer.rs"
+                && node
+                    .reasons
+                    .iter()
+                    .any(|reason| reason == "paired source file src/installer.rs")
+        }) {
+            return Err(io::Error::other("paired test result/reason was missing").into());
+        }
+        Ok(())
+    }
+
+    #[test]
     fn fuzzy_search_matches_approximate_line_terms() -> Result<(), Box<dyn Error>> {
         let temp = tempfile::tempdir()?;
         let root = temp.path();
@@ -2888,6 +3413,15 @@ mod tests {
                 "{label} mismatch: expected {expected:?}, got {actual:?}"
             ))
             .into())
+        }
+    }
+
+    /// Require a ranked reason to contain a stable phrase.
+    fn require_reason(reasons: &[String], expected: &str) -> Result<(), Box<dyn Error>> {
+        if reasons.iter().any(|reason| reason.contains(expected)) {
+            Ok(())
+        } else {
+            Err(io::Error::other(format!("reason {expected:?} missing from {reasons:?}")).into())
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add service-backed ranked result reasons for `folders` and `files` while preserving existing output fields.
- Add `projectatlas next <query>` and MCP `atlas_next` with top folders/files, bounded reasons, and deterministic follow-up commands.
- Improve deterministic file ranking with a bounded candidate window, indexed-text term matching, symbol evidence, and conventional source/test pairing.

## Linked Issues
Refs #266
Refs #267
Refs #269

## Verification
- `cargo fmt --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo test -p projectatlas-cli scan_overview_and_token_flow -- --nocapture`
- `cargo test -p projectatlas-core telemetry -- --nocapture`
- `cargo run -p projectatlas-cli -- lint --report-untracked --purpose-level low`
- ProjectAtlas atlas refresh: 120 files, 66 folders, 0 missing purposes, 0 stale purposes
- ProjectAtlas source health: 0 findings

## Release Note
This PR is not a release by itself. The broader active goal still includes #268, #276, #278, #279, and #281, so cutting a version from this branch before those are resolved would be premature.
