### PR TITLE
fix(purpose): demote low-value stale file noise (#268)

### DIFF
--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -7430,6 +7430,48 @@ fn lint_purpose_levels_require_agent_review_at_configured_scope() -> Result<(), 
         .assert()
         .success();
 
+    fs::write(
+        repo.join("Cargo.toml"),
+        "# Purpose: Rust manifest for purpose lint strictness tests.\n[package]\nname = \"purpose-lint-demo\"\nversion = \"0.1.1\"\nedition = \"2024\"\n",
+    )?;
+    fs::write(
+        repo.join(SRC_DIR_NAME).join("detail.rs"),
+        "// Purpose: Rust implementation detail for purpose lint strictness tests.\npub fn detail_changed() {}\n",
+    )?;
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--config")
+        .arg(&config)
+        .arg("--db")
+        .arg(&db)
+        .args(["scan", "."])
+        .assert()
+        .success();
+    let stale_low = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--config")
+        .arg(&config)
+        .arg("--db")
+        .arg(&db)
+        .args(["lint", "--purpose-level", "low"])
+        .output()?;
+    if stale_low.status.success() {
+        return Err(io::Error::other("low purpose lint missed stale high-impact file").into());
+    }
+    let stale_low_stderr = String::from_utf8(stale_low.stderr)?;
+    if !stale_low_stderr.contains("[stale-purpose] Cargo.toml:") {
+        return Err(io::Error::other(format!(
+            "low purpose lint missed stale high-impact file:\n{stale_low_stderr}"
+        ))
+        .into());
+    }
+    if stale_low_stderr.contains("src/detail.rs") {
+        return Err(io::Error::other(format!(
+            "low purpose lint included low-value stale source file:\n{stale_low_stderr}"
+        ))
+        .into());
+    }
+
     Ok(())
 }
 

--- a/crates/projectatlas-core/src/lib.rs
+++ b/crates/projectatlas-core/src/lib.rs
@@ -234,6 +234,7 @@ pub fn purpose_review_signal(node: &Node, purpose: &Purpose) -> PurposeReviewSig
     if node.kind == NodeKind::File
         && purpose.status == PurposeStatus::Stale
         && purpose.source == PurposeSource::Agent
+        && is_high_impact_file_path(&node.path)
     {
         return PurposeReviewSignal {
             priority: PurposeReviewPriority::High,
@@ -609,6 +610,12 @@ mod tests {
             source: PurposeSource::Agent,
             status: PurposeStatus::Approved,
         };
+        let stale = Purpose {
+            path: "src/helper.rs".to_string(),
+            purpose: Some("Reviewed helper implementation".to_string()),
+            source: PurposeSource::Agent,
+            status: PurposeStatus::Stale,
+        };
 
         let folder_signal = purpose_review_signal(&folder, &approved);
         assert_eq!(folder_signal.priority, PurposeReviewPriority::High);
@@ -621,6 +628,14 @@ mod tests {
         let build_signal = purpose_review_signal(&build_file, &suggested);
         assert_eq!(build_signal.priority, PurposeReviewPriority::High);
         assert_eq!(build_signal.reason, "high_impact_file");
+
+        let low_stale_signal = purpose_review_signal(&file, &stale);
+        assert_eq!(low_stale_signal.priority, PurposeReviewPriority::Low);
+        assert_eq!(low_stale_signal.reason, "selective_file_review");
+
+        let high_stale_signal = purpose_review_signal(&build_file, &stale);
+        assert_eq!(high_stale_signal.priority, PurposeReviewPriority::High);
+        assert_eq!(high_stale_signal.reason, "stale_agent_reviewed_file");
         assert!(is_high_impact_file_path(".github/workflows/release.yml"));
     }
 

--- a/crates/projectatlas-db/src/lib.rs
+++ b/crates/projectatlas-db/src/lib.rs
@@ -4519,16 +4519,17 @@ fn purpose_default_queue_order_expression(node_alias: &str, purpose_alias: &str)
             WHEN {node_alias}.kind = 'folder' THEN 0 \
             WHEN {node_alias}.kind = 'file' \
                 AND {purpose_alias}.status = 'stale' \
-                AND {purpose_alias}.source IN ({stale_queue_sources}) THEN 1 \
+                AND ({purpose_alias}.source IN ({stale_queue_sources}) OR {}) THEN 1 \
             WHEN {node_alias}.kind = 'file' AND {} THEN 2 \
             ELSE 3 \
         END, {node_alias}.path",
+        high_impact_file_path_expression(&format!("lower({node_alias}.path)")),
         high_impact_file_path_expression(&format!("lower({node_alias}.path)"))
     )
 }
 
-/// Purpose sources whose stale file purposes stay in the default queue.
-const STALE_FILE_PURPOSE_QUEUE_SOURCE_VALUES: &[&str] = &["agent", "human", "imported"];
+/// Purpose sources whose stale file purposes stay in the default queue regardless of path impact.
+const STALE_FILE_PURPOSE_QUEUE_SOURCE_VALUES: &[&str] = &["human", "imported"];
 
 /// Return whether `source_only` should run before queue-specific folder/file selection.
 fn source_filter_applies_before_queue(scope: HealthScope) -> bool {
@@ -5724,8 +5725,7 @@ mod tests {
     }
 
     #[test]
-    fn high_impact_purpose_queue_pages_stale_reviewed_files_before_high_impact_files()
-    -> Result<(), Box<dyn Error>> {
+    fn high_impact_purpose_queue_omits_low_value_stale_files() -> Result<(), Box<dyn Error>> {
         let mut store = AtlasStore::in_memory()?;
         store.replace_scan(&[
             test_file_node("src/helper.rs", "hash-a"),
@@ -5737,9 +5737,14 @@ mod tests {
             "Reviewed helper implementation.",
             PurposeSource::Agent,
         )?;
+        store.set_purpose(
+            "Cargo.toml",
+            "Reviewed Cargo manifest.",
+            PurposeSource::Agent,
+        )?;
         store.replace_scan(&[
             test_file_node("src/helper.rs", "hash-b"),
-            test_file_node("Cargo.toml", "hash-cargo"),
+            test_file_node("Cargo.toml", "hash-cargo-new"),
             test_file_node("package.json", "hash-package"),
         ])?;
 
@@ -5756,17 +5761,36 @@ mod tests {
             },
         )?;
 
-        require_eq(&page.total, &3, "default actionable total")?;
+        require_eq(&page.total, &2, "default actionable total")?;
         require_eq(&page.returned, &1, "small page returned")?;
         require_eq(
             &page.findings[0].category,
             &"stale-purpose".to_string(),
-            "stale reviewed file is globally prioritized",
+            "stale high-impact file is still prioritized",
         )?;
         require_eq(
             &page.findings[0].path,
-            &"src/helper.rs".to_string(),
-            "stale reviewed file path",
+            &"Cargo.toml".to_string(),
+            "stale high-impact file path",
+        )?;
+
+        let broad_page = store.unresolved_health_findings_page(
+            &[],
+            &HealthQuery {
+                start_index: 0,
+                limit: 10,
+                category: Some(CATEGORY_STALE_PURPOSE.to_string()),
+                severity: Some(Severity::Warning),
+                path_prefix: Some(".".to_string()),
+                summary_only: false,
+                scope: HealthScope::purpose_with_source_files(),
+            },
+        )?;
+        require_eq(&broad_page.total, &2, "broad source stale rows")?;
+        require_eq(
+            &health_paths(&broad_page),
+            &vec!["Cargo.toml", "src/helper.rs"],
+            "broad scope includes low-value stale source files",
         )?;
         Ok(())
     }


### PR DESCRIPTION
## Summary
- demote stale agent-reviewed low-value source files out of the default purpose queue
- keep stale high-impact files and trusted human/imported stale purposes visible in the default queue
- add e2e coverage that low purpose lint fails on stale high-impact files without surfacing low-value stale source noise

## Verification
- `cargo fmt --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run --locked -p projectatlas-lints --bin cargo-projectatlas-lints -- strict-strings`
- `cargo run -p projectatlas-cli -- lint --report-untracked --purpose-level low`
- `projectatlas overview` => 120 files, 66 folders, 0 missing purposes, 0 stale purposes
- `projectatlas health-check --source-only --limit 10` => 0 findings
- `git diff --check`

Refs #268
