### PR TITLE
chore(deps): bump install action to v2.83.2 (#316)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           rustup default "$RUSTUP_TOOLCHAIN"
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2
         with:
           tool: cargo-deny@0.20.2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           rustup default "$RUSTUP_TOOLCHAIN"
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2
         with:
           tool: cargo-deny@0.20.2
 


### PR DESCRIPTION
## Summary

- update the SHA-pinned `taiki-e/install-action` in CI and release workflows to v2.83.2
- keep the exact `cargo-deny@0.20.2` tool pin while allowing the action to install that release directly
- route the existing Dependabot update through `dev` instead of merging it into `main`

## Verification

- `cargo fmt --all --check`
- focused `repository_delivery_and_dependency_policy_is_enforced` E2E test
- strict OpenSpec validation and IssueOps synchronization

Refs #316
