### PR TITLE
docs(intelligence): define agent navigation contract (#308)

### DIFF
--- a/.projectatlas/projectatlas-purpose-review.json
+++ b/.projectatlas/projectatlas-purpose-review.json
@@ -1339,6 +1339,90 @@
     {
       "path": "openspec/changes/centralize-cargo-dependency-management/tasks.md",
       "purpose": "Implementation and verification checklist for centralized Cargo dependency management."
+    },
+    {
+      "path": "docs/agent-navigation.md",
+      "purpose": "Define the agent-facing contract for navigating live local source through purposes, graph context, trust signals, and exact slices."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence",
+      "purpose": "OpenSpec change package for fresh typed repository intelligence and purpose-led graph navigation."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs",
+      "purpose": "Group capability requirements for repository graphs, indexing integrity, language intelligence, optional packs, federation, and benchmarks."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/cross-repository-intelligence",
+      "purpose": "Define explicit read-only bounded cross-repository intelligence requirements."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/graph-retrieval-and-analysis",
+      "purpose": "Define purpose-led graph navigation, bounded analysis, compact MCP discovery, and quiet purpose-curation requirements."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/incremental-index-integrity",
+      "purpose": "Define atomic publication, local-source freshness, convergence, and bounded indexing requirements."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/language-intelligence-registry",
+      "purpose": "Define registry-owned language detection, parser capability truth, resolution, and optional parser containment requirements."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/optional-intelligence-packs",
+      "purpose": "Define optional intelligence lifecycle, supply-chain containment, resource isolation, and snapshot-integrity requirements."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/repository-intelligence-benchmarks",
+      "purpose": "Define correctness-first agent workflow comparisons, separate resource measures, and lean verification requirements."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/repository-knowledge-graph",
+      "purpose": "Define typed graph identity, indexed relation ownership, capability coverage, and authored-data preservation requirements."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/.openspec.yaml",
+      "purpose": "Declare the OpenSpec schema and creation metadata for the repository-intelligence change."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/design.md",
+      "purpose": "Record architecture, dependency order, compatibility, freshness, and agent-navigation decisions for repository intelligence."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/proposal.md",
+      "purpose": "Propose fresh typed repository intelligence that enriches the existing purpose-led agent workflow."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/tasks.md",
+      "purpose": "Track implementation and verification tasks for typed repository intelligence and graph-enriched agent navigation."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/cross-repository-intelligence/spec.md",
+      "purpose": "Specify explicit-root read-only federation, project-qualified results, and bounded static protocol-field tracing."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/graph-retrieval-and-analysis/spec.md",
+      "purpose": "Specify graph-enriched navigation, quiet purpose curation, bounded analysis, compact MCP discovery, and cursor contracts."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/incremental-index-integrity/spec.md",
+      "purpose": "Specify atomic graph publication, dependency-aware local freshness, clean-scan convergence, and bounded work."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/language-intelligence-registry/spec.md",
+      "purpose": "Specify generated language capability truth, parser compatibility, semantic resolution, and optional parser isolation."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/optional-intelligence-packs/spec.md",
+      "purpose": "Specify optional semantic lifecycle, default-core independence, pack containment, evaluation, and snapshot integrity."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/repository-intelligence-benchmarks/spec.md",
+      "purpose": "Specify correctness-first benchmarks for agent workflow improvement, resource trade-offs, and lean verification."
+    },
+    {
+      "path": "openspec/changes/advance-rust-repository-intelligence/specs/repository-knowledge-graph/spec.md",
+      "purpose": "Specify typed stable graph identities, relation occurrences, indexed storage, capability truth, and authored-data preservation."
     }
   ]
 }

--- a/docs/agent-navigation.md
+++ b/docs/agent-navigation.md
@@ -1,0 +1,313 @@
+# Agent Navigation Contract
+
+## Status
+
+This document defines the required agent-navigation contract for ProjectAtlas 0.4.0. ProjectAtlas 0.3.26 provides the baseline workflow described below; graph enrichment, automatic read freshness, direct relationship jumps, and the compact MCP surface remain target behavior until issue #308 is complete.
+
+## Product Goal
+
+ProjectAtlas is a local-source navigation tool for agents. Its primary truth is the selected source tree as it exists on disk now, including saved uncommitted edits, new or deleted files, dirty worktrees, and non-Git projects. Version-control state is optional context for revision-aware impact and change classification; it never replaces current local paths and bytes.
+
+The desired result is not the largest graph or the largest MCP inventory. The desired result is an agent reaching correct exact source with fewer calls, fewer wrong selections, fewer full-file reads, less backtracking, and less total context.
+
+## Strengths Preserved From 0.3.26
+
+ProjectAtlas keeps these existing strengths as hard compatibility and quality constraints:
+
+- purpose-led folder and file narrowing;
+- current deterministic content summaries;
+- exact line and symbol slices;
+- explicit parser and fallback trust;
+- deterministic ranking and search;
+- TOON-first compact uniform records where TOON fits the data;
+- conservative token and file-read avoidance accounting;
+- project-local databases and independent worktree identity;
+- a normal workflow that does not require an agent to learn a graph schema or query language.
+
+Graph intelligence fails acceptance if it weakens any of these strengths.
+
+## The Progressive Navigation Sieve
+
+Purposes remain the first architectural filter. Graph context is introduced early enough to improve file selection, but it does not replace responsibility metadata.
+
+```text
+session brief / overview
+→ folder purpose + crisp graph role
+→ file purpose + crisp relevant connections
+→ selected-file summary + parser/coverage trust
+→ exact source slice
+```
+
+The stages answer different questions:
+
+| Stage | Agent question | Expected response |
+| --- | --- | --- |
+| Folder purpose | Where does this responsibility belong? | One reviewed purpose line plus a bounded graph role/reason |
+| File purpose | Which file owns the likely behavior? | One reviewed purpose line plus crisp relevant connections |
+| Summary | What is currently in the selected file? | Current content, symbols, relationships, coverage, ambiguity, and exact-span hints |
+| Trust | How much of this result is safe to rely on? | Parser kind, resolution state, coverage, limits, and truncation |
+| Slice | What exact implementation must I inspect? | Verbatim current source for one bounded line or symbol range |
+
+Folder purposes should be curated broadly because they drive the highest-value narrowing step. File purposes should remain selective and focus on public APIs, runtime behavior, build/configuration, tests, commands, adapters, migrations, and other high-impact files. Generated purpose suggestions are not reviewed truth. A meaningful responsibility change makes a reviewed purpose stale instead of silently overwriting it.
+
+When purposes are missing or stale, ProjectAtlas reports that state and falls back deterministically to path, current content, symbols, and graph context. It must not pretend a suggestion is authoritative.
+
+### Background Purpose Curator
+
+Purpose maintenance can run as a bounded low-reasoning “speedboat” beside the main task:
+
+```text
+main agent continues source work immediately
+        │
+        └─ purpose handoff for relevant missing/stale intent
+              → low-reasoning curator inspects bounded current context
+              → curator writes only through purpose set/review APIs
+              → later rankings use the approved purpose
+```
+
+At startup and relevant task/source transitions, a supported agent host launches the packaged purpose-curator lane without blocking the main task. The curator claims a coalesced task/generation/path-scoped queue directly; ordinary session/folder/file responses do not carry a purpose-maintenance handoff or status section. ProjectAtlas itself does not pretend an MCP server can spawn a host agent.
+
+Successful curation is silent in the main conversation: no per-file progress, approval, or completion messages. Later navigation simply benefits from the improved purposes. If a host requires a terminal result, it should be a minimal machine-facing state. Task-relevant conflicts that would make ranking unsafe and repeated degraded/failure state remain available through compact blockers or explicit health/settings diagnostics.
+
+The default background scope is `low`: all folders plus task-relevant/high-impact files. `medium` means every source file must be reviewed. `strict` means every indexed file and folder must be reviewed. Medium and strict are explicit expensive choices and are never started implicitly.
+
+The curator receives queue rows plus bounded file summary, graph role, outline, or exact source context. It never browses the whole repository without a bounded assignment, never edits source, and never edits SQLite directly. Purposes written through ProjectAtlas APIs are agent-approved and can be corrected later by any agent that finds them wrong, stale, vague, or generic.
+
+## What Repository-Wide Graph Intelligence Adds
+
+Version 0.3.26 already exposes symbols, imports, calls, and relations, but agents mostly combine those facts from individual files. Version 0.4 turns the selected local source state into a persistent typed cross-file graph.
+
+| Capability | 0.3.26 baseline | 0.4 requirement |
+| --- | --- | --- |
+| Cross-file identity | Symbols and relations are primarily inspected per file | Stable project-qualified entity identities connect files and languages |
+| Inbound traversal | Callers/importers often require search and multiple inspections | Direct bounded callers, importers, references, tests, routes, and configuration |
+| Outbound traversal | A summary exposes local calls/imports | Bounded dependency/call paths across files with exact targets |
+| Impact discovery | The agent combines searches and local facts | Typed affected relationships and VCS-aware impact over current local source |
+| Candidate ranking | Purposes, paths, summaries, symbols, and text rank candidates | Purpose remains dominant while current graph proximity adds crisp reasons |
+| Topology/path retrieval | No strong project-wide topology/path view | Bounded aggregates, neighborhoods, and node-simple ranked paths |
+| Graph reuse | Several file-level calls may be required | Persisted typed facts are reusable across normal navigation calls |
+| Coverage visibility | Parser state is visible mainly during file inspection | Bounded graph/parser coverage is visible beside results and through health pages |
+| Traversal bounds | Individual calls are bounded | Uniform totals, returned counts, truncation, cursors, and byte/row/depth limits |
+| Refresh | Watch refreshes changed source | Every normal indexed read prevents silent stale results after edits or restart |
+
+The graph must support practical questions such as:
+
+- Which package exports this symbol?
+- Which route or protocol reaches this handler?
+- Which configuration controls this implementation?
+- Which tests exercise this behavior?
+- Who calls or imports this target?
+- What will this local change likely affect?
+- What is the shortest trustworthy path from an entry point to an implementation?
+- Where is graph coverage incomplete, ambiguous, unresolved, stale, or parser-limited?
+
+## Purpose Plus Connection Rows
+
+Folder and file selection should expose only enough graph information to choose the next target. A representative file row is:
+
+```text
+path: crates/auth/src/session.rs
+purpose: Own session validation and renewal.
+why_relevant: exact-purpose, called-by-api, covered-by-tests
+connections: callers 4, tests 2, config 1
+returned_connections: 3
+truncated: true
+next:
+  tool: atlas_file_summary
+  file: crates/auth/src/session.rs
+```
+
+The normal folder/file response must not dump complete edge lists. Exact path/name and strong reviewed-purpose matches remain ahead of weaker graph popularity. Graph context can surface a small explained adjacent candidate outside the selected folder when it materially improves the task.
+
+## Direct Relationship Jumps
+
+A connection must contain an exact reusable selector, not only a display label:
+
+```text
+relation: tested_by
+target:
+  file: crates/auth/tests/session.rs
+  symbol: rejects_expired_session
+  kind: function
+  line: 84
+resolution: resolved
+confidence: exact
+source:
+  file: crates/auth/src/session.rs
+  line: 117
+next:
+  tool: atlas_slice
+  file: crates/auth/tests/session.rs
+  symbol: rejects_expired_session
+  kind: function
+  line: 84
+```
+
+The target selector can be passed directly to file summary, relation, or exact-slice calls. Useful jumps include:
+
+```text
+route → handler
+handler → service
+service → repository/storage
+implementation → callers
+implementation → tests
+implementation → configuration
+manifest/package → owning source
+protocol client → protocol handler
+symbol → definition/reference/import
+```
+
+ProjectAtlas does not need a separate `atlas_jump` tool. Existing summary, relation, and slice calls provide the capability when relation results contain reusable selectors and accurate next-call hints.
+
+## Graph Overview And Ranked Paths
+
+A complete overview means complete structural understanding of the selected bounded scope, not an unbounded dump of every node and edge. A graph overview should report:
+
+- selected project, local-source fingerprint, and graph generation;
+- coverage, ambiguity, unresolved, stale, and parser-trust counts;
+- packages/components and their responsibility roles;
+- relationship-family totals;
+- bounded important nodes and edges;
+- total, returned, truncated, cursor, and hard-budget state;
+- recommended paths or exact next calls.
+
+A longer question can request a bounded ranked path such as:
+
+```text
+API route
+→ session handler
+→ token validator
+→ key configuration
+→ integration test
+```
+
+Every step carries its relationship, exact file/symbol selector, source span, resolution, confidence, coverage, and generation. Paths are node-simple, deterministic, and constrained by row, node, edge, depth, time, memory, output, and cancellation budgets.
+
+## Freshness Contract
+
+The watcher is a latency optimization, not the freshness authority. Every normal index-backed read performs a lightweight comparison between persisted fingerprints and the current local source/configuration state.
+
+The response must do one of two things:
+
+1. reconcile a safe bounded delta before answering; or
+2. return a compact typed `refresh_required` state.
+
+It must never silently return known-stale facts.
+
+The contract covers:
+
+- immediate read after a saved edit;
+- added, renamed, moved, and deleted files;
+- ignore and ProjectAtlas configuration changes;
+- parser, registry, and provider changes;
+- process restart after offline edits or checkout changes;
+- clean and dirty Git worktrees;
+- non-Git directories;
+- transient path, permission, encoding, or root uncertainty;
+- re-resolution of inbound dependents after exported identities change;
+- no repeated publication for unchanged dirty state.
+
+## Streamlined MCP Surface
+
+ProjectAtlas 0.3.26 registers 40 MCP tools and its complete `tools/list` response is about 29 KB before any source answer. Version 0.4 keeps every old route available through an explicit full compatibility surface while installer-generated agent configurations advertise a compact surface.
+
+The initial compact agent surface is:
+
+```text
+atlas_init
+atlas_scan
+atlas_session_brief
+atlas_folders
+atlas_files
+atlas_search
+atlas_file_summary
+atlas_slice
+atlas_symbols
+atlas_symbol_relations
+atlas_health
+atlas_purpose_queue
+atlas_purpose_set
+atlas_purpose_review
+```
+
+The full surface preserves all 0.3.26 names, request schemas, defaults, and payload compatibility. Deprecated routes delegate to the same service implementation. A closed `agent | full` MCP surface selection is sufficient; ProjectAtlas does not need a dynamic tool plugin system or one ambiguous administration mega-tool.
+
+The normal already-indexed coding workflow should be three calls:
+
+```text
+atlas_session_brief(task)
+→ atlas_file_summary(selected file)
+→ atlas_slice(selected symbol/range)
+```
+
+Optional branches are:
+
+- `atlas_search` when the identifier or text is uncertain;
+- `atlas_symbol_relations` when callers, impact, architecture, or a path is material;
+- `atlas_folders` then `atlas_files` only when the brief cannot confidently choose the work area;
+- purpose queue/set/review when navigation exposes missing or stale intent.
+
+`atlas_session_brief` must not recommend rerunning folder/file ranking it already performed. Its next call should be a ready-to-use summary, search, relation, or exact-slice request.
+
+No new mandatory MCP tool is justified. Architecture, impact, and trace should first use a closed view on the existing bounded relation service. At most one optional analysis tool may be added later if real agent tasks prove that extending the relation request makes tool selection or schema size worse.
+
+## Output Shapes
+
+Output representation follows the task:
+
+- uniform purpose, candidate, coverage, and relation rows use compact TOON by default;
+- exact source slices remain verbatim source;
+- graph overviews use typed bounded aggregates plus node/edge records;
+- paths use typed ordered step records;
+- supported JSON remains available for programmatic compatibility;
+- clear prose is allowed for diagnostics where it improves recovery.
+
+Every repeated result section uses uniform metadata:
+
+```text
+total
+returned
+truncated
+next_cursor
+output_bytes
+```
+
+TOON is not a substitute for selection. A broad unbounded graph remains a context problem even when encoded compactly.
+
+## Frozen Navigation Scenarios
+
+The preserved baseline is ProjectAtlas `v0.3.26` at commit `d3b3e157f954c7d360d821ed0385762e8b044385`. The paired harness pins source bytes, configuration, task wording, limits, and correctness owners. One coherent behavior harness may replay all rows; these are product scenarios, not per-task evidence tests.
+
+| Scenario | Initial state and task intent | 0.3.26 baseline path | 0.4 candidate ceiling | Correctness oracle |
+| --- | --- | --- | --- | --- |
+| Startup root ownership | Indexed ProjectAtlas source; “Where does ProjectAtlas select and validate a project root for MCP calls?” | `session_brief`, then its redundant `folders` + `files` recommendation before summary | One brief to useful candidates; at most brief → summary → slice | Root selection/validation owners include CLI `mcp.rs`, `runtime.rs`, and entry composition without unrelated files displacing them |
+| Dependency ownership | Indexed ProjectAtlas source; “Where are Cargo workspace dependencies and package versions owned?” | Brief ranks root manifests, then still recommends folders/files | One brief to root `Cargo.toml`/`Cargo.lock` and package manifests | Workspace dependency/version ownership is ranked ahead of unrelated Cargo consumers |
+| Summary owner selection | Indexed ProjectAtlas source; “Where does ProjectAtlas generate compact file summaries and exact next-call hints for agents?” | Brief ranks CLI E2E before `projectatlas-service/src/lib.rs`, requiring correction/backtracking | One brief selects the service owner; summary is the next call | `projectatlas-service/src/lib.rs` summary/report ownership ranks ahead of E2E consumers |
+| Known-file summary | Known large service file; understand its current summary surface | `file_summary` emits a large fixed collection of functions/types/calls | One summary call with bounded purpose, connections, trust, counts, and exact-span next call | Required owners/symbols remain present while emitted bytes and total workflow context do not regress |
+| Uncertain identifier | Indexed polyglot fixture; locate a partly remembered identifier and implementation | `search` → candidate summary → slice | At most search → summary → slice | Exact implementation and language/parser trust are correct; no broad filesystem read |
+| Relations and direct jump | Known file/symbol; find inbound caller, route, configuration, and exercising test | Relation/file-local facts plus searches and target inspections | One bounded relation/path call → direct target summary or slice | Every returned jump has the correct relation, reusable selector, source span, resolution, and coverage |
+| Exact slice | Known file and unambiguous symbol/range | One slice call | One slice call | Returned bytes equal the current saved local source range |
+| Dirty restart freshness | Index exists; process stopped; saved local edit/rename/delete occurs before restart | Explicit watch/scan is required before trusted indexed reads | First normal indexed read reconciles safely or returns `refresh_required` | No pre-edit path, symbol, relation, summary, or search fact is silently served as current |
+| Non-Git freshness | Indexed directory without `.git`; saved edit/add/delete occurs | Explicit refresh is required | First normal indexed read reconciles safely or returns `refresh_required` | Filesystem fingerprints provide the same current-source guarantee as a Git worktree |
+
+For every row, correctness is decided before performance. No row may increase mandatory calls, full-file reads, broad-read escapes, or total context. Aggregate discovery bytes, calls, wrong selections, backtracking, and context must improve.
+
+## Acceptance Contract
+
+The main agent must prefer the 0.4 candidate as its first local-source navigation tool. Representative clean, dirty-worktree, and non-Git tasks validate:
+
+- correct folder, file, symbol, and span selection;
+- freshness of local source, graph, search, summary, and relation results;
+- usefulness of purpose-plus-connection rows before summary;
+- exact reusable relationship targets and ranked paths;
+- parser, coverage, ambiguity, and truncation honesty;
+- calls to first useful context and exact source;
+- total tool calls, wrong selections, and backtracking;
+- full-file reads and broad filesystem escapes;
+- MCP discovery bytes, response bytes, and conservative total context;
+- deterministic next-call guidance;
+- elapsed time and resource dimensions without collapsing trade-offs.
+
+The candidate fails if graph enrichment is stale, noisy, unbounded, purpose-displacing, commit-centric, accessible only through extra mandatory calls, or larger without avoiding at least as much later work. Correctness must not regress on any task. Mandatory calls, full-file reads, and total context must not regress on any normal workflow; aggregate calls, reads, wrong selections, backtracking, and context must improve.
+
+Feature count, graph size, parser count, compact encoding alone, or self-reported token savings cannot substitute for this agent workflow result.

--- a/openspec/changes/advance-rust-repository-intelligence/.openspec.yaml
+++ b/openspec/changes/advance-rust-repository-intelligence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/advance-rust-repository-intelligence/design.md
+++ b/openspec/changes/advance-rust-repository-intelligence/design.md
@@ -1,0 +1,176 @@
+## Context
+
+ProjectAtlas is an agent tool. Its successful 0.3.26 contract is the atlas-first funnel:
+
+```text
+overview -> folders -> files -> summary/outline/symbols -> slice
+```
+
+Version 0.4 must improve what an agent learns from that funnel without adding mandatory orchestration. The selected local source tree on disk is the indexed truth, including uncommitted edits and non-Git projects; VCS state is optional context, never a substitute for current bytes. SQLite remains the project-local index source of truth, TOON remains the compact default agent format, `.gitignore` remains dynamically authoritative, and authored purposes/settings/telemetry remain outside disposable derived data.
+
+The earlier implementation branch mixed useful graph/storage work with a per-task proof system. Recovery therefore happens commit by commit: reapply behavior that still fits this design, independently verify it on current `dev`, reject the proof machinery, and delete the old branches after their useful source has been taken over.
+
+## Goals
+
+- Reach correct source context faster than 0.3.26 with the same normal command/tool vocabulary.
+- Reduce wrong selections, redundant calls, broad file reads, backtracking, output bytes, and total context tokens.
+- Preserve purpose-led folder and file selection as the architectural-responsibility layer and make graph context improve it rather than displace it.
+- Keep graph and language truth typed, deterministic, bounded, and fresh after edits.
+- Preserve every existing valid CLI/MCP request and default unless an explicit delta requirement says otherwise.
+- Keep optional breadth and semantic capabilities removable and absent from default-core cost when unused.
+- Use ordinary behavior tests and locked Rust/workspace gates, not a second evidence system.
+
+## Non-Goals
+
+- No generic graph UI, mutable ADR store, custom Cypher language, or required semantic model.
+- No execution of repository code, build hooks, compilers, language servers, or downloaded parsers during normal indexing.
+- No hidden global repository cache, implicit cross-root discovery, or cross-project write.
+- No mechanical translation or mirrored source topology from another implementation.
+- No per-task test identifiers, verification ledgers, SHA receipts, managed evidence comments, issue sealing, or repository-wide mutation/coverage campaign.
+
+## Dependency Order
+
+1. Restore the lean workflow and dependency safety through issues #309 and #316.
+2. Normalize this OpenSpec and recover only useful product source from the old #308 branches.
+3. Stabilize storage and freshness before adding dependent graph navigation.
+4. Stabilize language and relation contracts before richer analysis or optional packs.
+5. Complete issue #308 before bounded project memory in #314 consumes the database/session boundaries.
+6. Run combined compatibility, packaging, platform, benchmark, and release readiness in #311 after #308 and #314 stabilize.
+
+## Decisions
+
+### 1. Preserve the atlas-first public workflow
+
+Existing scan, watch, overview, folder, file, search, summary, relation, outline, and slice calls remain the normal route. Graph extraction and freshness are automatic behind scan/watch. Default responses add only bounded relationship counts, high-value related identities, coverage, ranking reasons, and next-call hints. Full graph detail remains opt-in.
+
+Reviewed `folder_purpose` and high-impact `file_purpose` remain first-class intent signals. Folder purposes are curated broadly; file purposes remain selective. Generated suggestions are not treated as reviewed truth, and meaningful responsibility changes make reviewed purposes stale rather than silently replacing them. Exact path/name and strong purpose matches remain ahead of weaker graph popularity signals.
+
+Packaged agent guidance launches a low-reasoning purpose curator alongside the main task at startup and relevant task/source transitions when the host supports isolated bounded subagents. The curator obtains task-scoped missing/stale/suggested rows directly from the purpose queue, then uses bounded summary, graph-role, outline, or exact-slice context and writes only through purpose APIs. Project/generation/path ownership coalesces duplicate attempts.
+
+Successful low-scope curation is silent in the main conversation and normal session/folder/file responses: no per-path progress, approval, or completion prose is rendered. Later navigation simply consumes the improved approved purposes. If the host requires a terminal result, the curator returns only a minimal machine-facing state. Task-relevant conflicts that would make ranking unsafe and repeated degraded/failure state remain available through compact blockers or explicit health/settings diagnostics.
+
+`low` remains the default background scope: folders plus task-relevant/high-impact files. `medium` intentionally requires every source file to be reviewed. `strict` intentionally requires every indexed file and folder and is never started implicitly. A host without isolated subagent support keeps the task-scoped queue available and does not claim invisible background work; normal source answers remain available.
+
+Architecture, impact, and trace begin as closed typed views of the existing bounded relation/summary/health services. At most one optional `atlas_analyze`-style surface may be added if real agent tasks prove that extending the relation request makes tool selection or schema size worse. Analysis is never a prerequisite for normal navigation, and complexity/bottleneck candidates do not receive a separate tool.
+
+### 2. Use typed graph contracts with one owner
+
+`projectatlas-core` owns closed enums and validated newtypes for entity identity, relation family, resolution, confidence, coverage, generation, optional selected-slot detail when justified, and limits. `projectatlas-service` owns use-case requests, reports, ranking, traversal, and cursors. `projectatlas-db` owns their SQLite representation.
+
+Legacy relation values remain compatible. New graph-only relation families use an additive typed field rather than expanding the old exhaustive enum. Generic JSON property bags and duplicated schema strings are rejected.
+
+One versioned accepted relation-family inventory is the compatibility authority for direct structural/type, package, test, route/protocol, configuration/environment, deployment/infrastructure, and bounded static read/write families plus separately gated inferred similarity/co-change families. Persistence, invalidation, settings, queries, fixtures, and generated documentation derive from it. Removing or weakening an accepted row requires an explicit compatibility decision and inventory-version change; an implementation cannot pass by silently ceasing to advertise the family. Counts are derived from the inventory rather than duplicated in Rust or tests.
+
+### 3. Publish structural data atomically
+
+A full scan builds derived data away from the currently queryable generation, validates it, rechecks source/configuration freshness, and publishes one complete new generation through one parent-owned transaction. The last valid generation stays queryable while work runs and remains current on failure. Physical slots or retained rollback generations are allowed only when a measured recovery or concurrency requirement justifies their storage and migration cost.
+
+An incremental refresh computes one affected closure and applies its deletes/inserts/updates in one transaction, advancing the generation exactly once. A failed transaction exposes neither partial rows nor a new generation. Authored data is never owned by disposable derived publication state.
+
+### 4. Fix freshness before richer navigation
+
+Every normal index-backed read performs a lightweight freshness preflight against persisted local file and source-state fingerprints. A bounded safe delta is reconciled before answering; otherwise the call returns a compact typed `refresh_required` state instead of silently serving known-stale facts. This applies after process restart, in dirty worktrees, and in non-Git source directories. The watcher remains a latency optimization, not the freshness authority.
+
+Watch and one-shot refresh use the same current-content, ignore/configuration, parser/capability, and optional VCS-context contract. Local bytes and paths remain authoritative. True deletes are distinguished from transient access or root uncertainty. Exported identity changes invalidate inbound dependents. An unchanged dirty state coalesces without repeated publication.
+
+For the same final repository state, incremental refresh must converge to the same canonical structural graph, coverage, and lexical results as a clean full scan. Source changes observed during full staging prevent publication or make the new generation observably stale for bounded follow-up.
+
+### 5. Generate honest language capability truth
+
+One versioned registry owns detection order, aliases, exact filenames, compound extensions, content/dialect rules, parser ownership, optional pack ownership, fixtures, and support tiers. Generated Rust tables, settings, tests, and documentation derive from it.
+
+The registry also owns an explicit accepted capability-set manifest. Every accepted row declares its required membership, tier, natural fixtures, provenance/license inputs, and required platforms. Removing or weakening an accepted row requires an explicit compatibility decision and capability-set version change; generated validation refuses silent shrinkage and derives all counts instead of hardcoding them in product code or tests.
+
+Current built-in parsers remain closed compile-time choices. New language breadth must pass non-vacuous fixtures and platform checks before it is advertised. Language-specific semantic providers stay small and independently gated; ambiguity and external targets are explicit rather than guessed. Optional parser packs bind a pinned provenance, digest, license, and ABI to their capability rows and run offline during normal use behind a supervised out-of-process or capability-denied WASM/native boundary. They cannot execute repository code, and hard time, memory, output, and cancellation limits prevent pack failure from harming the MCP process or active generation.
+
+Where translation-unit languages require compiler metadata for correct resolution, ProjectAtlas accepts only typed bounded data such as working directory, include roots, dialect/target, and opaque define identity. It never executes compilers, shells, response-file commands, builds, or repository code, and it never persists or emits secret-bearing raw values.
+
+### 6. Keep lexical correctness authoritative
+
+Deterministic literal, regex, fuzzy, case, context, ordering, pagination, punctuation, short-string, and Unicode behavior remains available without FTS or a model. FTS may narrow only query shapes for which it can produce a complete candidate superset, and exact matching verifies candidates. Unsafe or unsupported query shapes use the existing path without semantic drift.
+
+Optional semantic retrieval has an explicit install/enable/build/ready/stale/update/rollback/disable/remove lifecycle. Explicit `semantic` or `hybrid` search returns a typed capability error unless a compatible ready generation exists; omitted mode remains lexical. Hybrid ranking preserves lexical completeness, exposes bounded score reasons, and is enabled only after labeled retrieval-quality and resource checks. The pack never downloads implicitly, never blocks structural publication, and is not linked or initialized by default core when absent.
+
+### 7. Bound every analysis and cursor
+
+Ranking keeps exact path/name and strong purpose matches ahead of weaker graph signals and exposes compact deterministic reasons. Coverage discovery, relations, architecture, language-valid complexity/bottleneck candidates, VCS-aware impact, and trace have hard row, depth, visited-node, edge, time, memory, output, and cancellation budgets. Complexity and dead-code results remain labeled candidates, never proof. VCS input uses a maintained Git crate or shell-free argument-vector process boundary and never mutates, replaces local bytes, or implicitly scans the source tree. Trace paths are node-simple.
+
+Opaque cursors bind project/root identity, active generation, query, filters, ordering version, capability digest, and membership-affecting budgets. Any binding change returns a typed stale/mismatch error instead of mixing generations.
+
+Output shape follows the agent task rather than forcing one renderer everywhere. Uniform purpose, candidate, coverage, and relation rows remain compact TOON by default; exact slices remain verbatim source; graph overview/path results use bounded typed aggregates plus node/edge/path records that preserve topology. JSON compatibility remains available where already supported. Every repeated section reports total, returned, truncated, and continuation state.
+
+### 8. Federate only explicit read-only call roots
+
+A federated analysis call supplies its complete ordered root set. Every root must already have a valid index and is opened read-only/query-only. One invalid, stale, corrupt, or mismatched participant fails the whole call. Cross-root relationships are computed in bounded call memory and discarded afterward; no roots, edges, or cache are remembered.
+
+### 9. Prefer the smallest Rust-native mechanism
+
+Closed variants use enums and exhaustive matching. Stable identities use validated newtypes. Concrete modules own one implementation. Traits or dynamic dispatch require a real runtime extension boundary or multiple implementations. Bounded owned messages are used only where worker isolation requires them. SQLite transactions own publication atomicity; no actor, overlay chain, unconditional multi-slot framework, raw page writer, or generic command framework is added.
+
+Canonical maintained crates are preferred for parsing, Git data, storage, serialization, and platform containment. New dependencies remain workspace-centralized and must justify their default features, security, maintenance, compile/package, and runtime cost.
+
+### 10. Make agent improvement observable
+
+The issue cannot close on feature count alone. Repeated representative tasks compare 0.3.26 with the current candidate for:
+
+- answer/source-selection correctness;
+- calls and elapsed time to first useful context;
+- wrong or redundant selections and backtracking;
+- full-file reads and broad-read escapes;
+- total tool calls, emitted bytes, and conservative context tokens;
+- usefulness and correctness of next-call guidance;
+- compatibility of the normal overview-to-slice workflow.
+
+Each normal workflow must use the same or fewer mandatory calls and must not regress file reads or total context. Extra bounded context is acceptable only when it avoids at least as much later context and improves the task result. Comparative public claims remain deferred to validated release results in #311.
+
+The final main-agent acceptance check uses the candidate as the first navigation tool for real local-source tasks and verifies this combined contract:
+
+```text
+live local source state tells me what exists now
+reviewed folder/file purpose tells me where and why
+crisp graph context tells me how each candidate participates
+content summary verifies what is currently in the selected file
+parser and coverage state tell me how much to trust
+slice gives me the exact source
+```
+
+The candidate fails acceptance if the graph is stale, noisy, unbounded, purpose-displacing, repository-commit-centric, or reachable only through extra expert calls. It passes only when the normal streamlined MCP funnel selects correct source with fewer or equal calls, full-file reads, backtracking, emitted bytes, and total context than 0.3.26 and meets the stronger predefined agent-navigation targets.
+
+The durable agent-facing contract is documented in `docs/agent-navigation.md`. It is a target contract until the combined behavior passes task 7.3 and must be reconciled against the implemented candidate before issue closure.
+
+## Verification Model
+
+A coherent behavior slice gets the smallest meaningful owning test plus any integration, CLI/MCP E2E, fault, concurrency, or affected-platform smoke required by its actual risk. One test may cover several tasks. Documentation, generated data, and policy changes use their natural validators.
+
+Significant compiling slices pass:
+
+```text
+cargo fmt --all --check
+cargo check --workspace --all-targets --all-features --locked
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo test --workspace --all-features --locked
+cargo test --doc --all-features --locked
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked
+```
+
+Repository source lints, dependency policy, OpenSpec validation, and IssueOps synchronization remain ordinary gates. Exact release packaging/platform/benchmark gates belong to #311 after the combined surface stabilizes.
+
+## Migration And Rollback
+
+- Read-only schema/root/integrity preflight occurs before any migration write.
+- Supported migrations run transactionally and preserve project identity plus authored data.
+- Unknown future schemas, ledger mismatches, failed checks, or insufficient resources fail without destructive rebuild.
+- Full publication failure leaves the active generation unchanged; incremental failure rolls back the delta and generation.
+- Snapshot import, if enabled, validates a temporary artifact and publishes derived data through the normal atomic generation path rather than replacing the live authored database.
+
+## Acceptance
+
+- Existing CLI/MCP inventory and normal workflow remain compatible.
+- Freshness after edits is reliable and incremental output equals clean-scan output.
+- Current saved local source state, including dirty worktrees and non-Git directories, remains authoritative over optional VCS context.
+- Purpose-led navigation remains first-class and gains graph-aware ranking without making purpose curation exhaustive or mandatory for every file.
+- Graph identities, relations, coverage, publication, and queries are typed, deterministic, indexed, and bounded.
+- Advertised language and relation capabilities are derived from validated registries and fixtures.
+- Default-core startup, package, and runtime behavior do not depend on optional packs.
+- Representative agent tasks are better than 0.3.26 in practical navigation and do not regress calls, reads, or context.
+- Old #308 branches are deleted after useful product source has been independently reapplied and verified.

--- a/openspec/changes/advance-rust-repository-intelligence/proposal.md
+++ b/openspec/changes/advance-rust-repository-intelligence/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+ProjectAtlas 0.3.26 gives agents a fast atlas-first route from repository overview to exact source, but its index is still mostly file-local. Cross-file identity, dependency-aware freshness, language capability truth, and compact relationship context must become first-class if ProjectAtlas is to keep agents out of broad source reads as repositories grow.
+
+Version 0.4 keeps the successful 0.3.26 workflow and advances the intelligence behind it. The goal is not a larger human-facing graph product. The goal is an agent reaching correct source context sooner, with fewer calls, fewer full-file reads, less backtracking, and lower total context use.
+
+## What Changes
+
+- Add a typed graph of the selected live local source state, with stable project, file, symbol, package, relation, resolution, coverage, and generation identities; current saved bytes remain authoritative over optional VCS context.
+- Publish full and incremental structural data atomically while preserving authored purposes, settings, and telemetry.
+- Keep reviewed folder/file purposes as the responsibility layer for navigation, then combine them with current content, parser trust, and graph proximity rather than replacing them with edge counts.
+- Let supported agent hosts run a quiet bounded low-reasoning purpose curator beside the main task, using a task-scoped queue without adding purpose-maintenance chatter to normal navigation responses.
+- Make normal index-backed reads, watch, and incremental refresh freshness-aware so results stay current after edits, offline changes, and restarts without repeated whole-repository work.
+- Generate one versioned language capability registry with an explicit accepted capability set, honest detected, parsed, symbols, semantic, and benchmarked tiers, and no silent loss of accepted language breadth.
+- Enrich existing folder, file, search, summary, and relation calls automatically with compact graph context and next-call guidance.
+- Keep deterministic lexical search as the always-available baseline; optional acceleration or semantic capabilities must preserve explicit behavior and remain outside the default core when unused.
+- Add a versioned accepted relation-family inventory plus bounded coverage, architecture, complexity/bottleneck candidate, VCS-aware impact, and trace inspection where existing calls cannot express the result cleanly.
+- Allow cross-repository analysis only for explicit indexed roots supplied to one read-only call.
+- Evaluate agent workflows against 0.3.26 using correctness, time to useful context, tool calls, file reads, backtracking, output bytes, and context tokens.
+- Keep implementation slices lean: one meaningful behavior test may cover several tasks, ordinary locked workspace gates remain authoritative, and no task receipts, SHA ledgers, rendered evidence, or unique test-per-task scheme is introduced.
+
+## Capabilities
+
+### New Capabilities
+
+- `repository-knowledge-graph`: Typed stable repository identities, relationships, source context, resolution state, coverage, and generation ownership.
+- `incremental-index-integrity`: Atomic publication, dependency-aware refresh, full/incremental equivalence, and authored-data preservation.
+- `language-intelligence-registry`: Generated capability truth, deterministic language selection, parser ownership, and independently gated semantic support.
+- `graph-retrieval-and-analysis`: Automatic graph-aware navigation plus bounded relations, architecture, impact, and trace services.
+- `optional-intelligence-packs`: Explicit parser and semantic capability lifecycles that do not burden default-core startup or indexing.
+- `cross-repository-intelligence`: Explicit-root, call-only, read-only federation with project-qualified identities.
+- `repository-intelligence-benchmarks`: Reproducible compatibility, correctness, resource, and agent-efficiency decisions.
+
+## Impact
+
+- `projectatlas-core` owns shared typed graph and capability contracts.
+- `projectatlas-db` owns migrations, generation publication, indexed graph storage, and integrity checks.
+- `projectatlas-symbols` owns registry-driven extraction and language-specific resolution.
+- `projectatlas-fs` and runtime composition own safe discovery, freshness planning, and bounded work.
+- `projectatlas-service` owns ranking, summaries, relations, analysis, cursors, and optional federation.
+- CLI and MCP remain thin compatible adapters over the same services.
+- No new crate is added without a real independently consumed ownership boundary.

--- a/openspec/changes/advance-rust-repository-intelligence/specs/cross-repository-intelligence/spec.md
+++ b/openspec/changes/advance-rust-repository-intelligence/specs/cross-repository-intelligence/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Federation Is Explicit, Call-Only, And Read-Only
+
+Federated relation or analysis calls SHALL receive their complete ordered set of already indexed roots explicitly. Participating databases SHALL be opened read-only/query-only and validated before rows are returned. Federation SHALL not discover roots, initialize or scan a root, change the active project, persist roots/edges/cache, write telemetry/settings, or mutate any project.
+
+#### Scenario: One selected root is invalid
+- **WHEN** a root is missing, stale beyond the request contract, corrupt, unsupported, or bound to another project
+- **THEN** the whole call fails without returning a plausible partial result or mutating any root
+
+#### Scenario: Existing single-project request omits roots
+- **WHEN** a client uses the pre-change request shape
+- **THEN** only the selected project is queried and behavior remains compatible
+
+### Requirement: Cross-Root Results Remain Project-Qualified And Fresh
+
+Every result SHALL retain original project identity and source context plus the captured generation for each root. Typed package/protocol/configuration rendezvous MAY be normalized in bounded call memory, including statically supported route/client/handler, RPC, schema, topic/channel, and configuration identities, but ambiguity SHALL remain explicit and the derived state SHALL be discarded when the call ends. Similar strings alone SHALL not establish a cross-root relationship.
+
+#### Scenario: Two projects contain the same relative path
+- **WHEN** both roots participate in one query
+- **THEN** their entities remain distinct through project-qualified identity
+
+#### Scenario: A root changes between pages
+- **WHEN** a federated cursor no longer matches one root's captured generation
+- **THEN** continuation fails stale rather than serving mixed-root generations
+
+### Requirement: Static Protocol Boundary Fields Remain Traceable
+
+Within one selected source tree or explicit federated roots, statically supported protocol relationships MAY map caller argument/request fields to handler parameter/request fields. Each mapping SHALL retain normalized protocol and endpoint identity, source and target field/parameter paths and types, exact spans, resolution or ambiguity, coverage, invalidation identity, active generation, bounded output metadata, and secret-value exclusion. This capability SHALL NOT claim general interprocedural def-use or taint analysis.
+
+#### Scenario: Request fields align statically
+- **WHEN** a client and handler expose compatible statically visible protocol identities and field paths
+- **THEN** ProjectAtlas returns the bounded mapping with both source spans and a reusable handler target selector
+
+#### Scenario: Dynamic or secret-bearing field cannot be mapped safely
+- **WHEN** identity or field flow depends on runtime behavior or contains a secret literal/value
+- **THEN** ProjectAtlas reports partial, ambiguous, or unsupported coverage and does not persist or return the secret value

--- a/openspec/changes/advance-rust-repository-intelligence/specs/graph-retrieval-and-analysis/spec.md
+++ b/openspec/changes/advance-rust-repository-intelligence/specs/graph-retrieval-and-analysis/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Existing Calls Gain Automatic Bounded Graph Context
+
+Existing folder, file, symbol, search, summary, and relation calls SHALL preserve the progressive narrowing funnel of folder purpose plus crisp graph role, file purpose plus crisp relevant connections, selected-file summary and trust state, then exact slice. Reviewed purposes plus current graph context SHALL be consumed automatically when available and fall back deterministically when unavailable. Exact path/name and strong reviewed-purpose matches SHALL keep priority over weaker popularity/proximity signals. Folder/file rows SHALL expose only compact reason codes, relationship counts, a bounded high-value connection sample, truncation, and the next recommended call; agents SHALL NOT need a new mandatory call or learn a graph-query language. Generated purpose suggestions SHALL not be treated as reviewed truth.
+
+#### Scenario: Several lexical matches exist
+- **WHEN** one candidate has strong current package/import/call/test context
+- **THEN** it may rank higher with a compact deterministic reason while exact path matches remain dominant
+
+#### Scenario: Purpose and graph popularity disagree
+- **WHEN** a reviewed responsibility purpose strongly matches the task but another file merely has higher graph degree
+- **THEN** the responsibility match remains ahead and graph proximity is exposed only as a bounded secondary reason
+
+#### Scenario: File has many relationships
+- **WHEN** the default summary limit is exceeded
+- **THEN** the response reports counts/truncation and recommends a detailed relation call instead of dumping edges
+
+### Requirement: Purpose Curation Can Run Quietly Beside Navigation
+
+The purpose queue SHALL support bounded task/generation/path-scoped selection of folders and high-impact files whose purposes are missing, stale, suggested, vague, or generic. When the host supports isolated bounded subagents, packaged guidance SHALL direct a low-reasoning curator to process the default `low` scope beside the main task at startup and relevant transitions using only queue rows, bounded current summary/graph/outline/slice context, and ProjectAtlas purpose APIs. Navigation SHALL not wait for successful low-scope curation. Duplicate project/generation/path work SHALL coalesce, and conflicting or ambiguous proposals SHALL not overwrite reviewed intent.
+
+Successful low-scope maintenance SHALL NOT add per-path progress, approval, or completion prose to normal session, folder, file, summary, or conversational output. Later navigation SHALL simply consume approved purposes. A host-required terminal result SHALL be minimal and machine-facing. Only task-relevant unsafe conflicts or repeated degraded/failure state may surface as compact blockers or explicit health/settings diagnostics.
+
+`medium` and `strict` purpose enforcement SHALL remain explicit choices and SHALL NOT start implicitly. A host without isolated subagents SHALL keep the task-scoped queue available without a false claim that ProjectAtlas spawned background work.
+
+#### Scenario: Task candidates contain stale purposes
+- **WHEN** startup ranks files whose reviewed responsibilities may have changed
+- **THEN** the main response remains focused on the coding task while the supported curator independently claims the bounded task-scoped rows and later rankings consume approved updates
+
+#### Scenario: Background curation succeeds
+- **WHEN** the low-reasoning curator approves several bounded purpose updates
+- **THEN** normal navigation emits no purpose-maintenance chatter and explicit diagnostics expose only aggregate state on request
+
+#### Scenario: Strict purpose enforcement exists
+- **WHEN** a normal coding session uses default purpose policy
+- **THEN** ProjectAtlas does not silently expand background work from task-relevant low scope to every indexed file and folder
+
+### Requirement: Lexical Correctness Is Always Available
+
+Literal, regex, fuzzy, case, context, pagination, ordering, punctuation, short-string, and Unicode behavior SHALL remain deterministic without FTS or semantic capability. FTS/BM25 MAY narrow only safe complete candidate supersets and every result SHALL be exact-verified. Unsafe query shapes SHALL use the existing path without logical drift. Omitted retrieval mode SHALL remain lexical. Explicit `semantic` or `hybrid` mode SHALL return a typed capability error without a compatible ready generation, and hybrid mode SHALL retain lexical completeness with bounded versioned scoring reasons.
+
+#### Scenario: Acceleration cannot guarantee completeness
+- **WHEN** a query is regex, fuzzy, short, punctuation-sensitive, or tokenizer-sensitive
+- **THEN** ProjectAtlas runs the correctness-authoritative fallback and preserves result semantics
+
+#### Scenario: Optional semantic generation is unavailable
+- **WHEN** a caller explicitly requests semantic or hybrid retrieval without a compatible ready generation
+- **THEN** ProjectAtlas returns the pack state and recovery guidance rather than silently relabeling lexical results
+
+### Requirement: Coverage Is Discoverable Without A New Scan
+
+Existing summary and health surfaces SHALL expose bounded relationship/parse coverage digests and opt-in project-wide pages for complete, partial, failed, ignored, oversized, quarantined, and stale states. Every coverage row SHALL include an actionable path or bounded range, extraction pass or relation family, reason, reached limit when applicable, active generation, and trust state. Pages SHALL include total, returned, truncated, continuation, and output-byte metadata and SHALL use current indexed rows without a new tool or implicit scan.
+
+#### Scenario: Agent investigates missing relationships
+- **WHEN** a summary reports partial relationship coverage
+- **THEN** the agent can request the bounded affected coverage page and distinguish parser, limit, quarantine, ignore, and stale causes
+
+### Requirement: Detailed Relations And Analysis Are Typed And Bounded
+
+Existing relation requests SHALL retain legacy defaults, rows, ordering, and relation kinds. Additive closed view, direction, extended family, depth, confidence, resolution, source occurrence, exact reusable target selector/next call, cursor, and hard-limit fields MAY expose richer graph detail without a separate jump tool. Architecture, language-valid complexity/bottleneck candidate, VCS-aware impact, and trace begin as typed views of existing relation/summary/health services; trace paths SHALL be node-simple and complexity, bottleneck, and dead-code output SHALL remain explicitly heuristic candidate-only. VCS selectors SHALL be closed typed working-tree/index/revision-range values, use a maintained Git crate or shell-free argument-vector boundary, and SHALL NOT mutate, replace local source truth, or implicitly scan the source tree.
+
+#### Scenario: Old relation request is repeated
+- **WHEN** a client supplies only pre-change fields
+- **THEN** the legacy projection remains compatible with only bounded additive metadata
+
+#### Scenario: Cyclic graph is traced
+- **WHEN** traversal encounters cycles or a high-degree node
+- **THEN** returned paths do not repeat nodes and all row/depth/edge/time/memory/output/cancellation limits are enforced
+
+#### Scenario: Agent follows a relationship target
+- **WHEN** a relation resolves to a file or symbol in the selected local source generation
+- **THEN** the result includes an exact selector accepted directly by summary, relation, or slice plus the supporting source span and trust state
+
+### Requirement: MCP Discovery Is Compact With Full Compatibility Available
+
+Installer-generated agent configurations SHALL advertise only the compact inventory documented in `docs/agent-navigation.md`; its complete `tools/list` response SHALL remain within 16 KiB. A closed full surface SHALL preserve every pre-change tool name, request schema, default, and payload behavior. Compatibility aliases SHALL delegate to the same service implementation. No new mandatory graph or jump tool SHALL be added.
+
+`atlas_session_brief` SHALL perform startup overview and purpose/graph candidate ranking once, then recommend the best ready-to-use summary, search, relation, or slice call. It SHALL NOT recommend rerunning folder/file ranking already included in the brief.
+
+#### Scenario: New installer config starts an agent session
+- **WHEN** the MCP host requests tools and then asks for a task-oriented session brief
+- **THEN** only the compact agent inventory is advertised and the brief advances to the next unresolved navigation step without duplicate ranking calls
+
+#### Scenario: Existing client selects full compatibility
+- **WHEN** a pre-change MCP request is replayed through the full surface
+- **THEN** its old route, schema, defaults, and compatible payload remain available through the shared implementation
+
+### Requirement: Cursors Bind Result-Defining State
+
+Every resumable cursor SHALL bind project/root identity, active generation, capability/algorithm version, normalized query/filters/order, and membership-affecting budgets. Any change SHALL return a typed stale or mismatched-cursor error. Uniform rows SHALL remain compact TOON by default, exact slices SHALL remain verbatim source, and topology-oriented results SHALL use typed bounded aggregate/node/edge/path records rather than flattening away relationships. Supported TOON/JSON SHALL remain valid, deterministic, bounded, and UTF-8 safe.
+
+#### Scenario: Publication occurs between pages
+- **WHEN** a cursor is resumed after the active generation changes
+- **THEN** continuation is rejected with restart guidance rather than mixing generations

--- a/openspec/changes/advance-rust-repository-intelligence/specs/incremental-index-integrity/spec.md
+++ b/openspec/changes/advance-rust-repository-intelligence/specs/incremental-index-integrity/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Atomic Full And Incremental Publication
+
+Full indexing SHALL build derived data away from the currently queryable generation, validate and recheck its complete inputs, and publish one complete generation through one parent-owned transaction. Incremental indexing SHALL apply one complete affected delta and advance its generation once in one transaction. Failure SHALL preserve the prior visible generation. Physical slots or retained rollback generations SHALL be introduced only when a measured recovery or concurrency requirement justifies them.
+
+#### Scenario: Full staging fails late
+- **WHEN** validation, source recheck, import, reconciliation, cancellation, or commit fails
+- **THEN** the prior generation remains current and no partial generation is queryable
+
+#### Scenario: Incremental write fails late
+- **WHEN** any affected delete, insert, update, lexical change, or reconciliation step fails before commit
+- **THEN** both rows and generation identity roll back to the prior complete state
+
+### Requirement: Fresh Dependency-Aware Refresh
+
+Every normal index-backed read, watch, and one-shot refresh SHALL compare persisted fingerprints with current local content, path, rename/delete, ignore/configuration, parser/provider, and optional VCS state. A read SHALL reconcile a safe bounded delta before answering or return typed `refresh_required`; it SHALL NOT silently bless a stale database after restart. Current saved local bytes and paths SHALL remain authoritative in dirty worktrees and non-Git roots. Transient access uncertainty SHALL retain last-valid facts. Exported identity changes SHALL invalidate and re-resolve affected inbound dependents. Unchanged dirty state SHALL coalesce without repeated publication or write amplification.
+
+#### Scenario: Source changes after a prior scan
+- **WHEN** an indexed file is edited and refresh runs
+- **THEN** file, summary, symbol, relationship, coverage, and search results reflect the current bounded affected closure rather than stale data
+
+#### Scenario: Process restarts after offline source changes
+- **WHEN** files or the checked-out source state changed while no watcher was running
+- **THEN** the first index-backed read detects the persisted mismatch and reconciles it or returns `refresh_required` before serving indexed facts
+
+#### Scenario: Non-Git source directory changes
+- **WHEN** an indexed directory without `.git` has edited, added, renamed, or deleted files
+- **THEN** persisted filesystem fingerprints provide the same no-silent-stale contract
+
+#### Scenario: File cannot be inspected reliably
+- **WHEN** path, permission, encoding, or root state is uncertain
+- **THEN** ProjectAtlas reports uncertainty and does not misclassify the file as deleted
+
+### Requirement: Incremental Equals Clean Scan
+
+For the same final structural inputs, a mutation sequence SHALL converge to the same canonical structural graph, coverage, and lexical results as a clean full scan, excluding publication identifiers and telemetry. Cancellation or restart SHALL never expose partial rows.
+
+#### Scenario: Mutation sequence is replayed
+- **WHEN** create, modify, move, rename, delete, ignore, and configuration changes reach a final repository state
+- **THEN** incremental and clean-scan canonical results compare equal
+
+### Requirement: Bounded Work Preserves Service Availability
+
+Index work SHALL enforce explicit file, relation, worker, time, memory, output, and cancellation limits. Failed work SHALL leave last-valid queries available. Explicitly isolated project databases SHALL not be serialized by one process-global indexing lock.
+
+#### Scenario: Worker exceeds a limit
+- **WHEN** bounded parsing or enrichment hangs, crashes, or exceeds its resource policy
+- **THEN** the task fails with context, the active generation remains valid, and normal reads remain responsive

--- a/openspec/changes/advance-rust-repository-intelligence/specs/language-intelligence-registry/spec.md
+++ b/openspec/changes/advance-rust-repository-intelligence/specs/language-intelligence-registry/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Generated Honest Capability Registry
+
+One versioned registry SHALL generate language identifiers, aliases, detection precedence, parser ownership, optional pack ownership, fixtures, support tiers, settings, and documentation inputs. Support SHALL be reported independently as detected, parsed, symbols, semantic, and benchmarked. Counts or aliases SHALL NOT hide a missing required capability.
+
+#### Scenario: Parser exists without semantic resolution
+- **WHEN** a language parses but lacks validated project-wide resolution
+- **THEN** settings and documentation report only its achieved tier
+
+#### Scenario: Registry entries conflict
+- **WHEN** two entries claim the same detection precedence without an explicit rule
+- **THEN** generation fails with both owning entries
+
+### Requirement: Existing Parser Behavior Remains Compatible
+
+Generated selection SHALL preserve current exact-filename, compound-extension, extension, content/dialect, and explicit-override behavior before new modes are enabled. Built-in parsers remain closed compile-time choices. Fallback parsing SHALL be identified honestly and SHALL NOT be presented as grammar-backed symbol support.
+
+#### Scenario: Existing fixture is rescanned
+- **WHEN** registry-driven selection replaces hand-maintained selection
+- **THEN** every current fixture selects the same effective built-in parser and compatible output
+
+### Requirement: Accepted Language Capability Cannot Shrink Silently
+
+The versioned registry SHALL contain an explicit accepted capability-set manifest. Each accepted row SHALL declare required membership and tier, natural positive/negative fixtures, provenance and license inputs, and required-platform applicability. Generated runtime tables, settings, validation, and documentation SHALL derive from those rows, including their counts. Removing or weakening an accepted row SHALL require an explicit compatibility decision and capability-set version change; validation SHALL fail when generated output omits or understates a still-accepted row. Product Rust and tests SHALL NOT duplicate mutable accepted membership or totals as literals.
+
+#### Scenario: A generator drops an accepted language row
+- **WHEN** generated parser tables, settings, fixtures, or documentation omit a still-accepted capability or advertise a lower tier
+- **THEN** validation fails with the owning capability row instead of accepting a smaller advertised set
+
+### Requirement: Advertised Semantic Families Are Independently Validated
+
+Project-wide resolution SHALL use small language-owned providers over normalized registries and candidates. Resolved, ambiguous, unresolved, and external outcomes SHALL remain distinct. Every advertised language/relation family SHALL have non-vacuous positive, negative, malformed, duplicate-name, and ambiguity fixtures; aggregate success SHALL NOT mask one failing family.
+
+#### Scenario: Static source cannot choose one target
+- **WHEN** several scoped candidates remain valid
+- **THEN** the provider abstains with bounded candidates rather than choosing the first name match
+
+### Requirement: Compiler Metadata Is Bounded Non-Executable Input
+
+Translation-unit providers MAY consume typed working-directory, include-root, dialect/target, forced-include, and opaque define identity data when required for correct resolution. ProjectAtlas SHALL parse that metadata as data, SHALL NOT execute compilers, shells, response-file commands, builds, or repository code, and SHALL NOT persist, log, serialize, snapshot, benchmark, or return secret-bearing raw define values.
+
+#### Scenario: Metadata requires execution or contains a secret
+- **WHEN** a compiler entry requires command execution, unsafe indirection, an out-of-scope path, or a secret-bearing raw value
+- **THEN** ProjectAtlas returns a typed partial/unsupported outcome, uses only safe opaque invalidation identity, and emits no secret value
+
+### Requirement: Optional Parser Breadth Does Not Burden Core
+
+Broad parser capability SHALL be installed, verified, enabled, updated, rolled back, disabled, and removed explicitly. Normal core scan/query SHALL not download, compile, link, initialize, or execute an absent optional pack. Pack work SHALL be bounded and isolated from the long-lived service.
+
+#### Scenario: No optional parser pack is installed
+- **WHEN** normal ProjectAtlas scan and navigation run
+- **THEN** existing built-in language support remains fully functional without network or pack-runtime cost
+
+### Requirement: Installed Parser Packs Are Contained And Non-Executable
+
+Every installed parser pack SHALL bind pinned provenance, digest, license, ABI/runtime compatibility, and accepted capability rows. Normal pack use SHALL be offline and SHALL run through a supervised out-of-process boundary or a capability-denied WASM/native boundary that cannot execute repository code, shell commands, builds, compilers, or network requests. Hard time, process-tree memory, output, and cancellation limits SHALL apply. Pack crash, timeout, invalid output, or containment failure SHALL leave the MCP process responsive and the active structural generation unchanged.
+
+#### Scenario: Optional parser exceeds its boundary
+- **WHEN** a pack crashes, hangs, exceeds a resource limit, requests a forbidden capability, or emits invalid output
+- **THEN** the pack operation fails with bounded diagnostics while normal built-in navigation and the active generation remain available

--- a/openspec/changes/advance-rust-repository-intelligence/specs/optional-intelligence-packs/spec.md
+++ b/openspec/changes/advance-rust-repository-intelligence/specs/optional-intelligence-packs/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Optional Semantic Capability Has An Explicit Lifecycle
+
+Semantic retrieval SHALL remain optional and project-local. Its typed lifecycle SHALL cover absent, installed-disabled, building, ready, stale, updating, rollback-ready, incompatible, failed, removing, and removed behavior with explicit allowed operations and generation identity. Normal scan and lexical/graph queries SHALL not require or implicitly download a model/runtime.
+
+#### Scenario: Semantic mode is requested while unavailable
+- **WHEN** no compatible ready generation exists
+- **THEN** ProjectAtlas returns a typed capability/state error and does not silently relabel lexical results
+
+#### Scenario: Semantic update fails
+- **WHEN** model verification, vector build, cancellation, or activation fails
+- **THEN** structural/lexical data remains valid and any rollback generation remains explicit
+
+### Requirement: Default Core Is Independent From Optional Runtime Cost
+
+An absent parser/semantic pack SHALL contribute no runtime initialization, network call, model/ANN/WASM linkage, or pack process to default-core operation. Optional dependencies and artifacts SHALL remain at the outer supervised boundary and receive their own size, startup, memory, security, and platform decisions.
+
+#### Scenario: Default core is packaged without packs
+- **WHEN** dependency, binary-link, and packaged-file inventories are inspected
+- **THEN** optional parser/model/ANN/WASM runtimes are absent while built-in scan/navigation/search/graph behavior works
+
+### Requirement: Installed Packs Are Supply-Chain Bound And Contained
+
+Every installed pack SHALL bind pinned provenance, digest, license, ABI/runtime compatibility, and accepted capability rows. Normal use SHALL be offline and SHALL run through a supervised out-of-process boundary or a capability-denied WASM/native boundary with no repository-code execution, shell/build/compiler execution, or network capability. Hard time, process-tree memory, output, and cancellation limits SHALL apply. Pack crash, timeout, invalid output, or containment failure SHALL leave the MCP process responsive and SHALL NOT publish, invalidate, or damage the active structural generation.
+
+#### Scenario: Pack violates a resource or capability boundary
+- **WHEN** a pack crashes, hangs, exceeds a limit, requests a forbidden capability, or returns invalid output
+- **THEN** the pack operation fails with bounded diagnostics while built-in navigation and the active structural generation remain available
+
+### Requirement: Semantic And Hybrid Retrieval Are Evaluated And Explainable
+
+A selected optional semantic pack SHALL bind vectors to one structural generation plus model/tokenizer/preprocessing identity, support bounded changed-row rebuild and cancellation, and expose deterministic versioned semantic/hybrid score reasons. Hybrid results SHALL preserve lexical completeness. Semantic or hybrid capability SHALL not be advertised until labeled retrieval quality, determinism, update cost, latency, process-tree memory, package size, licensing, and required-platform checks pass.
+
+#### Scenario: Vector update or model evaluation fails
+- **WHEN** a vector build, changed-row update, quality gate, timeout, or resource gate fails
+- **THEN** the candidate generation is not advertised or activated and lexical/structural behavior remains unchanged
+
+### Requirement: Derived Snapshots Are Integrity-First
+
+Snapshot export SHALL use a consistent SQLite backup, bounded compression, schema/runtime/root/generation metadata, and a digest. Import SHALL validate in a temporary path, enforce size/path/integrity/schema/root rules, preserve authored data and destination project identity, and publish derived data only through the normal atomic generation path.
+
+#### Scenario: Snapshot is torn or incompatible
+- **WHEN** digest, expansion, integrity, schema, root, or generation checks fail
+- **THEN** import is rejected before live activation and current project data remains unchanged

--- a/openspec/changes/advance-rust-repository-intelligence/specs/repository-intelligence-benchmarks/spec.md
+++ b/openspec/changes/advance-rust-repository-intelligence/specs/repository-intelligence-benchmarks/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Compatibility And Correctness Precede Performance Claims
+
+Representative comparisons SHALL pin repository bytes, configuration, capabilities, commands, limits, runtime versions, and result schemas. A run with missing capability, incomplete coverage, timeout, crash, invalid output, or undeclared fallback SHALL remain a failure or ineligible result. Faster incomplete output SHALL not support a performance claim.
+
+#### Scenario: Faster candidate omits relationships
+- **WHEN** the candidate is faster but fails graph or language correctness
+- **THEN** the performance cell is ineligible and the correctness deficit remains visible
+
+### Requirement: Agent Workflow Improvement Is Observable
+
+Representative paired tasks SHALL compare the current candidate with ProjectAtlas 0.3.26 using the same local source bytes, configuration, prompt, model, permissions, and budgets, including dirty-worktree and non-Git cases. Results SHALL include source-selection correctness, purpose-plus-connection usefulness before summary, calls/time to first useful context, wrong/redundant choices, backtracking, full-file reads, broad-read escapes, total tool calls, emitted bytes, conservative context tokens, next-call usefulness, and task completion. Every normal startup, locate, inspect/summary, relations, and exact-slice workflow SHALL keep the same or fewer mandatory calls and SHALL not regress reads or total context. The candidate SHALL also meet the stronger predefined navigation targets used to ensure it is not merely equal to the prior release.
+
+#### Scenario: Extra summary context avoids no later work
+- **WHEN** an enriched response grows but does not improve correctness or reduce later calls/reads/context
+- **THEN** the enrichment is simplified, made opt-in, or removed
+
+#### Scenario: Candidate improves navigation
+- **WHEN** paired tasks reach correct source with fewer wrong selections, reads, calls, or context and no correctness regression
+- **THEN** the candidate may be accepted as the preferred first repository tool for issue #308
+
+#### Scenario: Graph feature weakens the existing sieve
+- **WHEN** graph enrichment displaces a stronger purpose match, requires an extra mandatory call, trusts stale committed state over current local bytes, or adds context that prevents no later work
+- **THEN** the enrichment fails acceptance and is simplified, moved behind an opt-in view, or removed
+
+### Requirement: Resource Dimensions Remain Separate
+
+Index time, incremental time, query latency, process-tree memory, database/WAL/staging writes, persistent bytes, package/install bytes, startup, and dependency/public-surface growth SHALL be reported and decided separately. Correctness or agent value MAY justify a trade-off but SHALL NOT convert a regressed resource into a superiority claim.
+
+#### Scenario: Agent value improves while package size regresses
+- **WHEN** behavior is accepted despite a larger package
+- **THEN** documentation reports the trade-off and does not claim package-size superiority
+
+### Requirement: Lean Verification Uses Normal Gates
+
+Each coherent behavior slice SHALL run the smallest meaningful owning test plus risk-required integration, real CLI/MCP, concurrency, corruption, Unicode, cancellation, or affected-platform checks. One test MAY cover several tasks. Ordinary locked Rust/workspace, source, dependency, OpenSpec, and IssueOps gates remain authoritative. No unique test-per-task, task receipt, SHA ledger, evidence renderer, issue sealing, or repository-wide mutation/coverage campaign SHALL be required.
+
+#### Scenario: One behavior check covers related tasks
+- **WHEN** one focused integration test proves atomic refresh, freshness, and compatible query results together
+- **THEN** the related tasks may complete without duplicate test wrappers or receipt rows

--- a/openspec/changes/advance-rust-repository-intelligence/specs/repository-knowledge-graph/spec.md
+++ b/openspec/changes/advance-rust-repository-intelligence/specs/repository-knowledge-graph/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Typed Stable Repository Graph
+
+ProjectAtlas SHALL represent projects, files, packages, declarations, external targets, relationships, source context, resolution, confidence, coverage, and generation identity through typed Rust contracts with one smallest owning module. Stable keys SHALL survive unchanged-content rescans and line movement while independent project instances, scopes, and overloads remain distinct. Legacy public relation values SHALL remain compatible; graph-only families SHALL use additive typed fields rather than changing the old exhaustive enum.
+
+#### Scenario: Repeated scan keeps identity
+- **WHEN** unchanged declarations move only by formatting or line position
+- **THEN** their stable identities remain unchanged and inbound relationships can be reconciled without name-only matching
+
+#### Scenario: Stable key collides
+- **WHEN** two distinct canonical identities produce the same compact stable key
+- **THEN** ProjectAtlas detects the conflicting canonical material and fails or keeps the identities separate instead of silently merging entities
+
+#### Scenario: Reference cannot be resolved uniquely
+- **WHEN** several targets remain valid or no target is supported by static source context
+- **THEN** ProjectAtlas records typed ambiguous or unresolved context and does not fabricate a traversable edge
+
+### Requirement: Logical Relations Retain Every Source Occurrence
+
+ProjectAtlas SHALL represent one logical source-kind-target relationship separately from its distinct source/evidence occurrences. Traversal, ranking, and impact SHALL deduplicate the logical edge, while detailed relation output MAY return bounded call sites, import sites, or other occurrences with exact source spans and total/returned/truncated metadata.
+
+#### Scenario: One caller invokes the same target twice
+- **WHEN** two source spans support the same logical call relationship
+- **THEN** traversal follows one logical edge and detailed output retains both bounded call-site occurrences
+
+### Requirement: One Indexed Storage Owner
+
+Typed entities, relationships, source occurrences, coverage, and generation fields SHALL be persisted as typed SQLite columns under one schema owner. Queries SHALL use bounded indexed source/target/kind/path/stable-key access, propagate SQLite terminal failures, and SHALL NOT depend on per-edge JSON decoding or whole-graph scans. Graph publication SHALL not own, overwrite, or silently approve folder/file purposes.
+
+#### Scenario: Row iteration fails after returning rows
+- **WHEN** SQLite reports corruption, I/O failure, cancellation, or schema mismatch during iteration
+- **THEN** the entire query fails and partial rows are not returned as successful output
+
+### Requirement: Advertised Relation Families Are End-To-End Live
+
+Every advertised relation family SHALL have one responsibility owner, producer/provider, typed persistence projection, invalidation rule, settings/capability row, query consumer, current coverage state, positive fixture, and negative or ambiguity fixture. Validation SHALL reject a family that is registered but cannot be produced, persisted, invalidated, queried, reported, or meaningfully tested.
+
+#### Scenario: Registry entry has no query consumer
+- **WHEN** a relation family appears in capability state but no current query path can return its persisted rows
+- **THEN** validation fails and the family is not advertised
+
+### Requirement: Accepted Relation Families Cannot Shrink Silently
+
+One versioned accepted relation-family inventory SHALL own required direct structural/type, package/manifest, test, route/protocol, configuration/environment, deployment/infrastructure, and bounded static read/write families plus separately gated inferred similarity/co-change families. Persistence, invalidation, settings/capability rows, query consumers, positive/negative/ambiguity fixtures, and generated documentation SHALL derive from the inventory. Removing or weakening an accepted row SHALL require an explicit compatibility decision and inventory-version change; validation SHALL fail when an accepted row is omitted from any required end-to-end owner. Product Rust and tests SHALL NOT duplicate mutable family totals as literals.
+
+#### Scenario: An implementation stops advertising an accepted relation
+- **WHEN** an accepted family is removed from generated capability state or lacks a producer, persistence projection, invalidation rule, query consumer, fixture, or documentation row
+- **THEN** validation fails against the accepted inventory rather than treating the smaller advertised set as complete
+
+### Requirement: Existing Settings Report Graph Truth
+
+The existing settings surface SHALL report schema compatibility and migration state, active generation, optional physical-slot details only when slotting is selected, registry/provider/relation capability digests, actionable coverage state, lexical/FTS/search modes, and optional parser/semantic lifecycle readiness. It SHALL not expose secret-bearing values or new machine-local paths.
+
+#### Scenario: Optional pack is stale
+- **WHEN** the selected graph generation no longer matches the optional pack generation
+- **THEN** settings reports structural state as valid and the pack/search mode as stale rather than collapsing them into one readiness value
+
+### Requirement: Authored Data And Project Identity Are Preserved
+
+Migrations, full publication, incremental updates, cleanup, rollback, and snapshot operations SHALL preserve project identity, purposes, review state, settings, and telemetry. Verified root moves preserve one project instance; independent copies/worktrees initialize or explicitly detach to a different instance. Snapshot import SHALL never overwrite destination identity.
+
+#### Scenario: Independent checkout copies an index
+- **WHEN** an accessible old root still owns the copied project identity
+- **THEN** identity-preserving rebind is rejected and the copy must detach or initialize independently

--- a/openspec/changes/advance-rust-repository-intelligence/tasks.md
+++ b/openspec/changes/advance-rust-repository-intelligence/tasks.md
@@ -1,0 +1,59 @@
+## 0. Execution Order
+
+Work in dependency order. Land significant compiling behavior slices into `dev` after focused behavior checks and ordinary locked Rust/workspace gates pass. A single coherent test may cover several related tasks. Do not add per-task tests, receipts, SHA ledgers, rendered evidence, issue sealing, or repository-wide mutation/coverage machinery.
+
+## 1. Lean Planning And Source Recovery
+
+- [x] 1.1 Replace the old evidence-driven #308 plan with lean proposal, design, capability specs, and behavior-slice tasks that preserve the accepted product scope.
+- [x] 1.2 Map the change to issue #308, replace the stale GitHub status/checklist with this exact task list, and pass strict OpenSpec plus IssueOps validation.
+- [ ] 1.3 Review every retained old #308 branch and dirty worktree, independently reapply useful product behavior on current `dev`, reject obsolete evidence/workflow machinery, and delete the old branches after recovery.
+- [x] 1.4 Freeze representative 0.3.26 agent workflows and tasks for startup, purpose-led folder/file selection, inspect/summary, relations, and exact slice so navigation improvement can be evaluated without changing the normal funnel.
+
+## 2. Typed Graph And Safe Storage
+
+- [ ] 2.1 Add responsibility-owned typed graph identities, entities, logical relations, retained source occurrences, resolution, confidence, coverage, generation, reusable target selectors, and limits while preserving legacy relation compatibility and failing closed on stable-key collisions.
+- [ ] 2.2 Add read-only database/root/schema preflight and append-only migration ownership that preserves project identity, purposes, review state, settings, and telemetry on supported upgrades and refuses incompatible state without mutation.
+- [ ] 2.3 Implement validated full-scan staging and one-transaction generation publication that keeps the last valid generation queryable; add physical slotting or retained rollback generations only when a measured recovery/concurrency need justifies them.
+- [ ] 2.4 Implement one-transaction incremental structural deltas, with affected-row invalidation, one generation advance, and complete rollback on late failure.
+- [ ] 2.5 Persist and query typed graph, source-context, coverage, and lexical rows through indexed prepared operations that propagate corruption/iteration failures and avoid whole-graph scans or generic JSON hot paths.
+- [ ] 2.6 Implement explicit verified root-move and copy/detach behavior so independent worktrees or clones cannot collapse project identity and snapshots cannot overwrite destination identity.
+
+## 3. Freshness, Invalidation, And Bounded Work
+
+- [ ] 3.1 Make every normal index-backed read, watch, and one-shot refresh detect relevant local edits, deletes, renames, ignore/configuration changes, and optional VCS-state changes after edits or restart; reconcile a safe bounded delta or return typed `refresh_required` instead of serving known-stale file, summary, symbol, relation, or search results in git or non-git source trees.
+- [ ] 3.2 Preserve last-valid facts on transient path/root/permission uncertainty and re-resolve inbound dependents when exported identities or dependency keys change.
+- [ ] 3.3 Prove create, modify, move, rename, delete, ignore/unignore, parser/configuration change, interruption, and unchanged-dirty sequences converge to clean-scan graph, coverage, and lexical results without repeated no-change publication.
+- [ ] 3.4 Keep indexing cancellable and resource-bounded, preserve last-valid queries during failed work, and allow isolated projects to progress without one process-global lock; when isolated workers/packs exist, derive an effective resource envelope from configured safe limits plus supported host/container/job constraints.
+
+## 4. Language Capability And Resolution
+
+- [ ] 4.1 Generate deterministic detection, parser ownership, fixtures, tiers, settings, and documentation inputs from one versioned language capability registry and accepted capability-set manifest with honest detected/parsed/symbols/semantic/benchmarked states, derived counts, and no silent loss or weakening of accepted rows.
+- [ ] 4.2 Preserve every current built-in language and parser behavior while adding deterministic exact-filename, compound-extension, extension, content/dialect, and explicit-override precedence.
+- [ ] 4.3 Keep broad grammar/parser capabilities in an explicit supply-chain-verified optional pack with pinned provenance/digest/license/ABI, offline normal use, supervised out-of-process or capability-denied WASM/native containment, hard resource/cancellation limits, no repository execution, and no default-core download, compilation, linkage, or initialization; implement lifecycle only alongside a selected consuming runtime and preserve the MCP process plus active generation on pack failure.
+- [ ] 4.4 Add normalized project-wide registries and independently structured semantic providers with resolved, ambiguous, unresolved, and external outcomes plus non-vacuous positive and negative fixtures for every advertised family; accept typed compiler metadata only as bounded non-executable, secret-redacted data where required.
+- [ ] 4.5 Make existing settings report schema/migration compatibility, active generation, optional selected-slot detail, registry/provider/relation digests, actionable coverage, lexical/FTS/search state, and optional-pack lifecycle from validated state without secrets or new machine-local paths; derive capability matrices, provenance/license inventory, and public support claims from the same authority.
+
+## 5. Agent-First Navigation And Analysis
+
+- [ ] 5.1 Extend the purpose queue with coalesced task/generation/path-scoped rows and update packaged host-neutral guidance/agent profiles to run isolated low-reasoning `low`-scope curation beside the main task at startup/relevant transitions when supported; keep successful maintenance out of normal responses, never start `medium`/`strict` implicitly, and never write SQLite directly.
+- [ ] 5.2 Enrich existing folder and file rows before summary with reviewed one-line purposes plus crisp bounded package/import/call/reference/test/route/config connections, while preserving exact path/name and strong purpose priority with deterministic compact reason codes.
+- [ ] 5.3 Add deeper bounded relationship/coverage digests, opt-in project-wide coverage discovery, and typed next-call hints to selected-file summaries/health surfaces so agents gain useful context without default edge dumps or extra mandatory calls.
+- [ ] 5.4 Preserve deterministic lexical search semantics, use FTS/BM25 only as exact-verified candidate acceleration, and add explicit optional `semantic`/`hybrid` modes with typed unavailable-state errors, lexical-complete hybrid ranking, and differential fallback-equivalence coverage.
+- [ ] 5.5 Extend existing relation queries additively with typed direction, extended family, depth, confidence, resolution, retained source occurrences, reusable exact target selectors/next calls, pagination, and hard limits while old requests retain legacy rows and ordering.
+- [ ] 5.6 Add bounded architecture, language-valid complexity/bottleneck candidate, VCS-aware impact/dead-code candidate, and node-simple trace views through existing summary/health/relation services; add at most one optional closed analysis tool only if real agent tasks prove the relation request becomes less clear, and do not add a generic query language or fourth complexity tool.
+- [ ] 5.7 Bind cursors to project/root, active generation, capability, query, filters, ordering, and result-defining budgets; keep task-appropriate TOON, typed graph/path, verbatim slice, and supported JSON output valid, deterministic, UTF-8 safe, and uniformly bounded under serial or parallel execution.
+
+## 6. Enrichments, Explicit Federation, And Optional Capabilities
+
+- [ ] 6.1 Add one versioned accepted relation-family inventory and independently gated typed structural/type, package/manifest, test, route/protocol, configuration/environment, deployment/infrastructure, bounded static read/write, and optional inferred similarity/co-change relationships with source context, ambiguity, secret exclusion, invalidation, derived settings/query/docs/fixture coverage, and adversarial negative fixtures; include bounded caller-argument/request-field to handler-parameter/request-field context only where statically supported, and reject silent loss or weakening of accepted rows.
+- [ ] 6.2 Add explicit ordered-root, call-only, read-only federation for approved relation/analysis calls with project-qualified identities, all-roots fail-closed validation, bounded in-memory resolution, and no persisted roots or cross-project writes.
+- [ ] 6.3 Add an optional semantic retrieval lifecycle whose install, enable, build, ready, stale, update, rollback, disable, failure, and removal states cannot affect structural/lexical publication or default-core operation; select ANN/model composition only after labeled retrieval quality, determinism, update-cost, memory, package, and platform checks.
+- [ ] 6.4 Add safe derived-graph snapshot export/import only through consistent SQLite backup, bounded archive validation, root/schema/digest checks, authored-data preservation, and normal atomic generation publication.
+
+## 7. Integrated Behavior And Issue Completion
+
+- [ ] 7.1 Add focused owning unit/integration tests plus risk-required real CLI/MCP, concurrency, corruption, Unicode, cancellation, and affected-platform checks for the coherent behavior slices above; reuse one test across related tasks when it proves the behavior.
+- [ ] 7.2 Add a closed `agent | full` MCP surface: installer-generated configs advertise the compact documented agent inventory within its discovery-byte budget, bare/manual full mode preserves every old name/schema/default, redundant aliases share services, and representative purpose-led local-source workflows prove no mandatory call growth or semantic drift.
+- [ ] 7.3 Use the candidate as the main agent's first navigation tool on representative dirty-worktree, clean, and non-git tasks; require correct fresh source selection through purpose-plus-crisp-connections before summary, then trust and exact slice, with no regression in calls, reads, backtracking, emitted bytes, or total context against 0.3.26 and the stronger predefined comparison targets.
+- [ ] 7.4 Pass focused checks, ordinary locked Rust/workspace gates, source/dependency policy, strict OpenSpec, and IssueOps synchronization on the combined #308 surface; resolve bounded Rust/storage/performance/security/platform/KISS/agent-workflow reviews.
+- [ ] 7.5 Reconcile `docs/agent-navigation.md` plus generated capability and user/agent documentation against validated behavior, add exact-commit OpenSpec links to issue #308, delete the fully recovered old #308 branches/worktrees, synchronize the completed checklist, and close the issue before #314 and #311 proceed.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -4,6 +4,7 @@
     "add-agent-session-brief": 292,
     "add-mcp-task-progress-model": 295,
     "add-nearest-project-routing": 276,
+    "advance-rust-repository-intelligence": 308,
     "centralize-cargo-dependency-management": 316,
     "close-mcp-cli-parity": 281,
     "converge-claude-code-installer": 278,


### PR DESCRIPTION
## Summary

- replace the obsolete evidence-driven #308 plan with a lean 35-task OpenSpec that preserves the accepted product scope
- define the agent-first local-source navigation contract: purpose-led narrowing, bounded graph context, reusable relationship selectors, automatic freshness, and task-appropriate TOON
- specify a compact agent MCP surface with full compatibility mode and quiet low-reasoning purpose curation that does not spam normal navigation
- preserve accepted language and relation breadth through versioned manifests and define optional-pack containment without restoring per-task proof machinery

## Verification

- openspec validate advance-rust-repository-intelligence --strict --no-interactive
- python .github/scripts/issue-checklists.py --repo styler-ai/ProjectAtlas --root . --issue-map openspec/issue-map.json
- git diff --check
- bounded Rust/KISS, MCP-surface, capability-preservation, and agent-navigation reviews
- #308 local and GitHub task checklists match: 35 total, 3 complete

Refs #308