### PR TITLE
docs(memory): specify the Memory Atlas (#314)

### DIFF
--- a/openspec/changes/persist-agent-project-context/.openspec.yaml
+++ b/openspec/changes/persist-agent-project-context/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/persist-agent-project-context/design.md
+++ b/openspec/changes/persist-agent-project-context/design.md
@@ -1,0 +1,209 @@
+## Context
+
+ProjectAtlas already solves source orientation with a purpose-led funnel and an indexed local-source view. It does not yet preserve the small set of project-wide facts an agent needs to understand why the project exists, how the system is shaped, which decisions govern it, which skills apply, and where a long-running initiative currently stands.
+
+The Cline Memory Bank demonstrates the value of separating project brief, product context, active context, system patterns, technical context, and progress. Its Markdown hierarchy is intentionally simple, but it asks the agent to reread every file and can grow or drift without transactional bounds. The Memory Atlas keeps the useful responsibility separation while adapting it to ProjectAtlas: typed SQLite records, stable keys, bounded recovery, exact local-root ownership, and direct links back into purpose/graph/summary/slice navigation.
+
+Current Codex capabilities narrow the gap but do not remove it. Codex can resume sessions, compact conversation history, persist a task goal, optionally generate personal memories, load `AGENTS.md`, discover skills progressively, connect MCP servers, and run trusted lifecycle hooks for startup, resume, clear, compact, and subagent start. These surfaces have different owners:
+
+- transcript resume and compaction preserve recent conversational continuity;
+- native goals preserve a current execution target;
+- memories preserve useful host/user context and are not a project database contract;
+- `AGENTS.md` preserves durable rules;
+- skills and plugins preserve reusable workflows and integrations;
+- ProjectAtlas preserves the selected project's current local-source atlas.
+
+The Memory Atlas fills only the remaining project-local bird's-eye role. It must work for hosts with weaker native memory/goal support, but it must not become a second transcript, rule system, task tracker, or private host-memory writer.
+
+Implementation is dependency-gated behind #308. The storage migration, authored/derived-state boundary, fresh read snapshot, selected-root rules, session brief, and streamlined MCP inventory must be stable before #314 lands.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Recover the overarching product goal, project scope, architecture, accepted decisions, system patterns, operating workflows, relevant skills/plugins, active checkpoint, blockers, and next action in one small deterministic view.
+- Keep retained project context bounded after every successful mutation and force agents to replace, retire, or compact obsolete state instead of appending session history.
+- Make each write an explicit reflection point: the caller submits current replacements plus obsolete/superseded identities, while deterministic lifecycle cleanup removes expired volatile state in the same transaction.
+- Preserve durable authored facts across source and graph publication while keeping them independent from structural generations.
+- Integrate recovery into startup, resume, post-compaction, and supported subagent entry without adding noisy success messages or hidden background mutation.
+- Link orientation records to exact reusable folder, file, symbol, issue, OpenSpec, documentation, skill, and plugin selectors.
+- Return reviewed/current attribution, lifecycle, trust, and selector-resolution state so project-authored context guides navigation without becoming higher-priority agent instruction.
+- Keep MCP small: one bounded read tool, one atomic update tool, and additive recovery in the existing session brief.
+
+**Non-Goals:**
+
+- Storing transcripts, chain-of-thought, tool output, arbitrary notes, secrets, credentials, user profiles, or host-private memory.
+- Replacing host goals, host memories, `AGENTS.md`, skills, plugins, GitHub issues, OpenSpec, or task/todo systems.
+- Automatic semantic summarization inside the Rust runtime, network access, embeddings, vector search, or a cleanup daemon.
+- A generic memory provider trait, event-sourced history, cross-project global memory, or one MCP tool per CRUD operation.
+- Repeating #308 lane, migration, publication, root, or MCP infrastructure inside #314; #314 consumes those stabilized contracts.
+
+## Decisions
+
+### Model a bird's-eye atlas, not a transcript bank
+
+Use a closed `MemoryAtlasKind` with responsibility-owned records:
+
+- `project_goal`: the durable overarching outcome, distinct from a host's current execution goal;
+- `project_scope`: product purpose, users, boundaries, and non-goals;
+- `architecture`: component and ownership shape;
+- `system_pattern`: durable patterns and critical paths;
+- `decision`: accepted decisions and supersession links;
+- `workflow`: operating and release workflows;
+- `skill_route`: logical skill identifiers and applicability;
+- `plugin_route`: logical plugin/capability identifiers and applicability;
+- `checkpoint`: the current initiative/issue checkpoint, blockers, and next action.
+
+Each record has a stable key, short summary, optional bounded detail, lifecycle class, attribution, reviewed/current state, timestamps, and typed references/selectors. Stable facts replace by `(kind, stable_key)`. Volatile checkpoints use a stable initiative key and replace in place. Decisions may explicitly supersede earlier keys; old decisions are removed or marked superseded rather than retained as an unbounded narrative. Expiry is valid only for explicitly volatile records; durable goal, scope, architecture, pattern, decision, workflow, skill-route, and plugin-route records never expire automatically.
+
+Source selectors are portable and project-relative: folder, file, optional symbol identity/span, issue, OpenSpec change/task, or public documentation reference. Machine-specific absolute paths are rejected. Skill and plugin routes contain only logical identifiers, bounded task-match terms, host-resolvable selectors, capability summaries, and optional fingerprints; they cannot carry executable commands, automatic-install instructions, or copied instruction bodies.
+
+This preserves the useful Cline responsibilities without copying its file hierarchy:
+
+| Memory Bank responsibility | Memory Atlas projection |
+| --- | --- |
+| project brief and product context | `project_goal` plus `project_scope` |
+| system and technical patterns | `architecture`, `system_pattern`, `decision`, `workflow` |
+| active context | one replaceable `checkpoint` per active initiative |
+| progress | compact checkpoint/blocker/next-action state plus tracker references |
+| rules and tools needed to continue | `skill_route` and `plugin_route` references |
+
+Public documentation remains authoritative for full rationale. GitHub/OpenSpec remain authoritative for issue/task status. Memory Atlas rows are compact orientation and routing facts with references back to those authorities.
+
+Alternative rejected: Markdown files. They are portable, but they cannot atomically enforce root binding, byte/row budgets, conditional updates, lifecycle cleanup, authored-state preservation, or coherent concurrent recovery. Export can be considered later only if an agent workflow proves it necessary.
+
+### Use one context revision and atomic reflection updates
+
+The database owns one nonnegative context revision. Read results return it as an opaque decimal string. `atlas_memory_update` carries the revision observed by the caller and one atomic batch:
+
+- `upsert`: complete replacement records;
+- `remove`: exact stable identities no longer useful;
+- optional `supersedes` links and expiry for volatile records.
+
+Validation, expected-revision comparison, replacement/removal, deterministic cleanup, budget reconciliation, and revision advance occur in one transaction. A successful state-changing batch advances once. An exact no-op does not alter revision, timestamps, or cleanup metadata. A stale writer, malformed record, wrong root, busy database, exhausted revision, or irreducible pressure changes nothing.
+
+The host guidance makes each meaningful checkpoint a reflection boundary. Before calling the update tool, the agent must compare the proposed bird's-eye state with returned stable identities, remove facts that became obsolete, replace facts that changed, and leave unrelated durable facts untouched. The Rust runtime performs deterministic lifecycle cleanup; it does not pretend to understand semantic obsolescence without an agent decision.
+
+Alternative rejected: an append-only event log. The product needs current orientation, not transcript archaeology. Stable replacement plus authoritative external references is smaller and bounded.
+
+### Enforce hard budgets during every write
+
+Configuration defines per-record, total retained UTF-8 byte, row, checkpoint, recovery-row, and recovery-output budgets below compiled hard maxima. Defaults are selected from representative ProjectAtlas fixtures during implementation, not guessed or duplicated across code and docs.
+
+Every successful update ends within all budgets. Cleanup order is deterministic:
+
+1. expired checkpoints;
+2. records explicitly superseded or removed by the batch;
+3. older volatile checkpoints beyond the configured allowance;
+4. other lifecycle-expired volatile records using stable identity as the final tie-breaker.
+
+Current `project_goal`, `project_scope`, `architecture`, active decisions/patterns/workflows, and active skill/plugin routes are protected from implicit deletion. If protected records prevent the new state fitting, the transaction rolls back and returns a content-free pressure report with sizes, identities, and suggested candidates. Explicit CLI compaction uses the same policy in dry-run/apply form.
+
+This provides the user's required forcing function: memory cannot silently run over, and every write either includes an honest cleanup reflection, triggers deterministic expiry cleanup, or fails until the atlas is made smaller.
+
+Alternative rejected: periodic cleanup. It permits persistent overflow after crashes and adds a daemon without improving agent orientation.
+
+### Reuse existing authored-state and root ownership
+
+Memory Atlas tables are authored state. Full scans, incremental graph publication, source deletion, watcher refresh, and derived-slot cleanup never replace them. Supported schema migration, repair, backup/restore, and rollback preserve them under the #308 database contracts.
+
+All reads and writes use the selected project's canonical/physical root and per-call `project_path` rules. Missing, wrong-root, incompatible, or refresh-required databases fail explicitly; memory operations never initialize, scan, migrate, switch active roots, or fall back to another repository.
+
+The context revision is independent from the structural generation. Recovery returns both when structural selectors are included, and cursors bind each stamp independently.
+
+### Expose two Memory Atlas tools and enrich session brief
+
+The agent MCP surface gains only:
+
+- `atlas_memory`: bounded status/list/detail retrieval with kind/key/task filters, pressure, stable identities, and revision-bound pagination;
+- `atlas_memory_update`: atomic conditional upsert/remove/reflection batches.
+
+`atlas_session_brief` gains an optional recovery mode that composes the highest-value Memory Atlas rows with existing project identity, freshness, and next-call orientation. `atlas_settings` reports capability, effective budgets, pressure, revision, and counts without content. CLI provides the same read/update behavior plus validation and explicit compaction administration.
+
+There is no separate Memory Atlas goal tool. The overarching project goal is a protected `project_goal` record; a host-native goal remains the current execution mechanism. This avoids the dual-goal system in the earlier draft and keeps tracker/task ownership clear.
+
+TOON remains the default for uniform rows. The recovery projection may use a small typed topology when references form a path. Exact source remains available only through normal slice calls.
+
+### Make recovery a small ordered bird's-eye view
+
+Recovery mode returns, in order:
+
+1. selected project identity, freshness, context revision, and pressure;
+2. overarching project goal and scope;
+3. architecture and system-pattern digest;
+4. current initiative checkpoint, blockers, and next action;
+5. applicable decisions and workflows;
+6. task-ranked skills/plugins and required reads;
+7. reusable folder/file/symbol/tracker selectors and the best next atlas call.
+
+Rows are deterministically ranked and bounded. Repeated reads are byte-stable for the same database state, request, and effective lifecycle evaluation instant. The service captures one concrete evaluation instant per operation so expiry cannot change midway through a projection; tests inject a fixed value without introducing a clock trait or dependency. Truncation includes returned/omitted counts and a revision-bound cursor. The default view never dumps all memory.
+
+This output rejoins the normal navigation sieve:
+
+```text
+Memory Atlas bird's-eye context
+→ folder purpose plus graph role
+→ file purpose plus relevant connections
+→ summary plus trust/coverage
+→ exact slice
+```
+
+The Memory Atlas does not decide which source is current. #308 freshness remains authoritative; stale structural state is reported separately from stale memory context.
+
+### Complement documented host capabilities
+
+Host integration is capability-driven and truthful:
+
+- Codex: use `SessionStart` for `startup`, `resume`, `clear`, and `compact` plus `SubagentStart` when the plugin hook is trusted and enabled. The hook injects a fixed instruction to request read-only recovery; it does not write memory or goals. Stable native goals may carry the current execution target. Experimental memories remain host-owned and optional. `AGENTS.md`, skills, and plugins remain their own instruction/workflow surfaces.
+- Claude Code and OpenCode: use only documented skill/plugin/MCP/task lifecycle capabilities. Where automatic startup recovery is unavailable, packaged guidance makes the manual `atlas_session_brief` recovery explicit.
+- Generic MCP: use the two Memory Atlas tools and session brief without assuming any native memory or goal API.
+
+Successful recovery and routine checkpoint updates stay out of user-facing narration unless they change the plan, reveal pressure/conflict, or fail. No host integration reads transcript paths, personal memory directories, global config, or private caches.
+
+Memory updates occur at meaningful recovery, architecture-decision, issue/task-transition, and final-verification boundaries—not after every file edit. This is frequent enough to remain useful and sparse enough to avoid noise and churn.
+
+When a harness uses a quiet background maintainer, it supplies only the bounded current brief and the explicit task outcome/checkpoint. The maintainer uses the normal `atlas_memory_update` revision precondition, exact stable identities, and reflection rules. An exact no-op remains fully silent and changes neither revision nor timestamps. A stale background writer loses without retrying over newer accepted facts; conflicts, protected pressure, invalid roots, rejected content, and decisions requiring an owner are surfaced, while recovery and source navigation never wait for maintenance.
+
+Alternative rejected: automatic PreCompact/PostCompact mutation. Those events do not provide a reliable semantic checkpoint transaction, and hidden writes could race or capture low-quality state. Session-start recovery is automatic when supported; authored updates remain explicit agent actions.
+
+### Treat Memory Atlas as reviewed project data, not agent authority
+
+Recovery labels every record's attribution, lifecycle/review state, and stale or unresolved references. Memory Atlas content cannot override system, developer, user, repository `AGENTS.md`, or currently loaded skill instructions. A route recommends only a logical installed capability and must be resolved through the harness's trusted registry and policy before its complete current instructions are read.
+
+No stored field is interpolated into shell commands, SQL identifiers, filesystem roots, or plugin installation inputs. Validation failures and diagnostics never echo rejected content. This keeps useful project prose from becoming an execution or prompt-priority boundary.
+
+### Rust pattern fit and crate ownership
+
+- `projectatlas-core`: closed kinds, identities, references, lifecycle, revision, pressure, recovery, and request/response types.
+- `projectatlas-db`: migration, constraints, coherent snapshots, conditional transaction, retained-byte accounting, and authored-state preservation.
+- `projectatlas-service`: validation, task ranking, cleanup plan, recovery projection, and conflict/pressure policy.
+- `projectatlas-cli`: CLI/MCP/settings adapters, host capability rendering, and plugin guidance.
+
+Concrete structs/enums and existing service boundaries are sufficient. No trait objects, actors, background tasks, new dependency, or eighth crate are justified.
+
+## Risks / Trade-offs
+
+- **[Facts become stale]** → Store attribution, review time, references, and optional fingerprints; surface stale/unresolved selectors and require replacement rather than silently trusting them.
+- **[Agents append low-value notes]** → Closed kinds, short field limits, stable keys, protected/volatile lifecycle, write-time reflection, and hard total budgets reject diary-like growth.
+- **[Cleanup removes valuable context]** → Automatic cleanup targets only expired/superseded volatile rows; protected current facts require explicit revision/removal and pressure is visible before failure.
+- **[Memory duplicates host or tracker state]** → Store the overarching project goal and compact checkpoint/reference only; hosts own live goals/memories and trackers own task status.
+- **[Recovery becomes a context dump]** → Fixed priority, row/byte limits, typed truncation, and bounded follow-up reads.
+- **[Private data leaks]** → Explicit bounded input only, no implicit ingestion, no content in ordinary settings/telemetry/logs/errors, and hostile sentinel tests. The runtime does not claim universal secret detection for caller-authored prose.
+- **[Lifecycle hooks are unavailable or untrusted]** → Capability/status reporting and packaged manual recovery remain correct; no automatic behavior is claimed when the host cannot run it.
+- **[Schema work races #308]** → Do not implement until #308's storage/session/compatibility surface is merged and frozen for this consumer.
+
+## Migration Plan
+
+1. Land the lean OpenSpec and synchronized issue without Memory Atlas runtime code.
+2. After #308 stabilizes, add typed contracts, measured budgets, and migration/storage in one behavior slice.
+3. Add shared service lifecycle, reflection batches, bounded reads, and recovery projection with shared tests.
+4. Add CLI/MCP/settings and replay every existing request/default.
+5. Add host guidance/hooks and ProjectAtlas dogfooding through the public tools.
+6. Run focused tests after each significant slice; run the complete workspace, line-coverage, and mutation campaign once after all #314 behavior is finished.
+7. Merge only when OpenSpec/GitHub tasks are synchronized and the combined issue is reviewed.
+
+Before release, rollback removes the unshipped migration and additive surfaces together. After release, supported rollback uses the existing verified database backup/restore path; older runtimes reject the newer schema rather than downgrading it.
+
+## Open Questions
+
+No architecture choice blocks the specification. Exact default and hard budgets must be selected from representative recovery fixtures during implementation and then exposed through settings and documentation.

--- a/openspec/changes/persist-agent-project-context/proposal.md
+++ b/openspec/changes/persist-agent-project-context/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Agent harnesses can preserve a recent transcript, compact a long conversation, resume a saved session, and—in Codex—persist goals or optional personal memories. Those mechanisms still do not reliably restore the project-wide goal, architecture, accepted decisions, system patterns, required skills, and current checkpoint as one small project-local bird's-eye view. ProjectAtlas should add that missing orientation layer without duplicating host memory or creating an unbounded transcript store.
+
+## What Changes
+
+- Add a bounded project-local **Memory Atlas** to the existing SQLite database for reviewed project scope, product goal, architecture, decisions, system patterns, workflows, skill/plugin routes, and replaceable recovery checkpoints.
+- Make the Memory Atlas complement host-owned transcripts, compaction summaries, personal memories, native goals, task lists, and execution state; it never crawls or overwrites those stores.
+- Extend the existing session brief so a fresh session, resumed session, post-compaction continuation, or supported subagent can recover the smallest useful bird's-eye context and then continue the normal purpose-led atlas funnel.
+- Add bounded typed Memory Atlas reads and one atomic update batch that also replaces the protected `project_goal` record, plus CLI administration over shared services; keep MCP streamlined and reuse session brief/settings for recovery and content-free status instead of adding a family of overlapping tools.
+- Reconcile retention during every successful write: replace stable facts, expire or supersede volatile checkpoints, and reject irreducible pressure rather than letting the database grow without limit or silently deleting protected current facts.
+- Store portable logical references to required skills, plugins, governing docs, issues, OpenSpec changes, and project-relative source selectors; resolve and read the current owning artifacts at recovery time instead of copying their bodies or machine-local paths.
+- Preserve Memory Atlas rows as authored state across source scans, graph publication, supported migrations, repair, backup/restore, and rollback.
+- Package truthful host guidance that uses documented lifecycle hooks when available and a visible manual fallback otherwise. Automatic recovery is read-only and quiet; harness-owned background maintenance may submit the same explicit conflict-safe reflection batch at meaningful checkpoints, but the Rust runtime never crawls, summarizes, or mutates context on its own.
+
+### Non-goals
+
+- Chat transcripts, chain-of-thought, tool logs, arbitrary documents, credentials, secrets, personal profiles, global cross-project memory, embeddings, vector search, or network summarization.
+- Replacing Codex memories/goals, Claude Code or OpenCode task state, `AGENTS.md`, skills, plugins, GitHub issues, OpenSpec, or the MCP task registry.
+- Treating Git history or a hosted repository as more authoritative than the selected current local source state.
+- A background daemon, generic memory-provider abstraction, generic database export/import product, or one MCP tool per administrative operation.
+
+This change is planned for v0.4.0 and is ready for implementation only after #308 stabilizes the database, publication, freshness, session-brief, and MCP-surface boundaries it depends on.
+
+## Capabilities
+
+### New Capabilities
+
+- `memory-atlas-storage`: Persist typed project-owned orientation and goal records with stable identities, conflict-safe transactions, deterministic retention, hard budgets, authored-state preservation, and offline root isolation.
+- `memory-atlas-recovery`: Return a small deterministic bird's-eye recovery view for startup and post-compaction continuation through the existing atlas-first workflow.
+- `memory-atlas-host-integration`: Complement supported harness memory, goals, skills, plugins, lifecycle hooks, and task state without dual ownership or private-state access.
+
+### Modified Capabilities
+
+- None. The capability is additive; requests that do not ask for Memory Atlas recovery preserve existing behavior and defaults.
+
+## Impact
+
+- Rust ownership remains within the existing seven crates: typed contracts in `projectatlas-core`, transactional persistence in `projectatlas-db`, lifecycle/ranking/recovery policy in `projectatlas-service`, and CLI/MCP/settings/host adapters in `projectatlas-cli`.
+- The existing SQLite schema and migration path gain authored Memory Atlas tables and one bounded context revision; no new runtime dependency or crate is expected.
+- `atlas_session_brief`, settings, packaged ProjectAtlas skills, plugin lifecycle guidance, generated host artifacts, and agent documentation gain additive Memory Atlas behavior.
+- Shared unit, integration, concurrency, migration, CLI/MCP, host-contract, security, and compatibility tests verify behavior. Line coverage and mutation testing run once against the completed issue, not between task slices.

--- a/openspec/changes/persist-agent-project-context/specs/memory-atlas-host-integration/spec.md
+++ b/openspec/changes/persist-agent-project-context/specs/memory-atlas-host-integration/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Memory Atlas complements host-owned context surfaces
+ProjectAtlas SHALL own only reviewed project-local bird's-eye orientation and checkpoints. Each harness SHALL retain ownership of transcripts, compaction summaries, personal/global memory, native goals, tasks, rules, skills, plugins, credentials, configuration, and execution controls.
+
+#### Scenario: Codex has an unfinished native goal and memories enabled
+- **WHEN** Memory Atlas recovery runs
+- **THEN** ProjectAtlas returns its project goal and checkpoint without importing, editing, completing, or duplicating Codex-owned goal or memory state
+
+#### Scenario: Host lacks native memory or goals
+- **WHEN** a supported host resumes a project
+- **THEN** the Memory Atlas still supplies project orientation while the host uses only its documented execution/task capabilities
+
+### Requirement: Host capabilities are declared rather than invented
+Packaged integration guidance SHALL describe verified memory, goal, skill, plugin, MCP, lifecycle, restart, compaction, and subagent capabilities for supported hosts, including activation, trust, policy, maturity, automatic/manual behavior, and truthful fallbacks. Durable guidance SHALL target observable capabilities rather than model-version folklore.
+
+#### Scenario: Optional or experimental host memory is disabled
+- **WHEN** the host does not enable that feature
+- **THEN** ProjectAtlas recovery remains functional and guidance does not claim the host store was read or updated
+
+#### Scenario: Capability is unavailable in a host
+- **WHEN** a host lacks a documented lifecycle or goal API
+- **THEN** packaged guidance declares the manual fallback and does not emit invalid configuration or pretend automatic recovery occurred
+
+### Requirement: Supported lifecycle recovery is quiet and read-only
+When documented host hooks are available, trusted, enabled, and permitted, ProjectAtlas integration SHALL use startup/resume/post-compaction and supported subagent entry to inject a fixed instruction for one read-only recovery brief. It SHALL NOT automatically write Memory Atlas records, host memory, host goals, task state, or transcripts. Successful maintenance SHALL stay out of normal user-facing output unless it changes the plan or reveals a warning/failure.
+
+#### Scenario: Codex starts, resumes, clears, or continues after compaction
+- **WHEN** the trusted ProjectAtlas `SessionStart` hook receives `startup`, `resume`, `clear`, or `compact`
+- **THEN** it directs the agent to the selected project's recovery brief before broad source reads and performs no authored-state mutation
+
+#### Scenario: Supported subagent starts
+- **WHEN** the trusted ProjectAtlas `SubagentStart` hook runs
+- **THEN** the child receives bounded task-specific recovery guidance without inheriting or mutating private parent memory or goals
+
+#### Scenario: Hook is unavailable or untrusted
+- **WHEN** hooks are disabled, pending review, changed, blocked by policy, or unsupported
+- **THEN** ProjectAtlas exposes a visible truthful manual recovery path and does not label the startup automatic
+
+### Requirement: Agents checkpoint at meaningful boundaries
+Packaged guidance SHALL update Memory Atlas state at meaningful recovery, architecture-decision, issue/task-transition, and final-verification boundaries. Before each update, the agent SHALL compare current stable identities, replace changed facts, remove or supersede obsolete facts, keep unrelated protected facts, and submit one bounded conditional batch. Routine file edits SHALL NOT create diary entries or user-facing maintenance spam.
+
+#### Scenario: Agent completes a significant issue slice
+- **WHEN** the slice changes the durable checkpoint, accepted decision, architecture, blocker, or next action
+- **THEN** the agent writes one compact reflection batch and retires obsolete context before continuing
+
+#### Scenario: File edit changes no bird's-eye context
+- **WHEN** implementation details change without altering durable orientation
+- **THEN** no Memory Atlas write or maintenance message is required
+
+#### Scenario: Context pressure blocks an update
+- **WHEN** protected state cannot fit after deterministic cleanup
+- **THEN** the agent receives pressure details, explicitly rewrites/removes low-value context, and does not hide the failure
+
+#### Scenario: Quiet background maintenance has no durable change
+- **WHEN** a harness-owned maintainer receives the bounded current brief plus an explicit checkpoint and submits an exact no-op batch
+- **THEN** revision, timestamps, rows, and user-facing output remain unchanged
+
+#### Scenario: Quiet background maintenance loses a revision race
+- **WHEN** a background maintainer writes from a stale revision after a newer accepted update commits
+- **THEN** the stale batch changes nothing, does not overwrite or automatically retry over newer facts, and surfaces only the typed conflict while recovery remains available
+
+### Requirement: MCP and CLI surfaces remain streamlined and equivalent
+The agent MCP surface SHALL add only `atlas_memory` for bounded reads and `atlas_memory_update` for atomic reflection batches, while recovery remains in `atlas_session_brief` and pressure summary remains in settings. CLI SHALL provide equivalent read/update behavior plus validation and explicit compaction administration. No separate Memory Atlas goal tool or generic admin multiplexer SHALL be added unless later measured agent workflows prove the two-tool design insufficient.
+
+#### Scenario: Agent updates the overarching project goal
+- **WHEN** the agent replaces the protected `project_goal` record
+- **THEN** it uses the same `atlas_memory_update` batch as other Memory Atlas facts rather than a separate goal tool
+
+#### Scenario: Human or agent needs deeper maintenance
+- **WHEN** full validation or explicit compaction is required
+- **THEN** the typed CLI performs it through the same service policy without expanding the default MCP inventory
+
+### Requirement: Host integration never crosses private or project boundaries
+Lifecycle and recovery integration SHALL ignore transcript paths and private memory locations, bind the current workspace through ProjectAtlas root rules, remain offline, and never mutate host-global configuration, registries, memories, goals, or task state without an explicit owning host operation. Returned Memory Atlas content SHALL be labelled as reviewed project data and SHALL NOT override higher-priority host or repository instructions.
+
+#### Scenario: Hook receives transcript and plugin paths
+- **WHEN** host lifecycle input contains private transcript or plugin-data locations
+- **THEN** ProjectAtlas ignores them for project context, resolves only the verified workspace/index, and fails closed for missing or wrong-root state
+
+#### Scenario: Integration tests run on a clean host
+- **WHEN** packaged host behavior is tested
+- **THEN** isolated homes/configs prove recovery semantics while real host-global state remains unchanged
+
+### Requirement: Existing host and ProjectAtlas behavior stays compatible
+Existing CLI/MCP requests, normal session brief behavior, generated configs, purpose-led navigation, and supported host guidance SHALL retain their established defaults when Memory Atlas recovery is not requested. New output SHALL remain TOON-first and bounded, with JSON equivalence where supported.
+
+#### Scenario: Pre-Memory Atlas client connects
+- **WHEN** it uses existing tool names and request shapes
+- **THEN** the runtime preserves compatible responses and does not require Memory Atlas initialization or follow-up calls

--- a/openspec/changes/persist-agent-project-context/specs/memory-atlas-recovery/spec.md
+++ b/openspec/changes/persist-agent-project-context/specs/memory-atlas-recovery/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: Session brief returns an optional Memory Atlas recovery view
+The existing `atlas_session_brief` SHALL accept an additive recovery request that returns bounded Memory Atlas orientation in the same read-only startup call. Requests that omit recovery SHALL preserve existing fields, defaults, behavior, and discovery budget.
+
+#### Scenario: Existing client requests a normal brief
+- **WHEN** a pre-change client calls session brief without Memory Atlas recovery
+- **THEN** ProjectAtlas preserves the compatible response and requires no new mandatory call
+
+#### Scenario: Agent resumes after compaction
+- **WHEN** an agent calls session brief with recovery and its current task query
+- **THEN** the response includes the highest-value project goal, scope, architecture, patterns, checkpoint, decisions, workflows, skills/plugins, blockers, and next calls within one bounded result
+
+### Requirement: Recovery is a deterministic bird's-eye projection
+Recovery SHALL return one coherent read snapshot ordered as project identity/freshness/pressure, overarching project goal and scope, architecture/pattern digest, current checkpoint/blockers/next action, applicable decisions/workflows, task-ranked skill/plugin routes, and exact reusable selectors/next calls. It SHALL NOT return unbounded history, full skill bodies, transcripts, host memory, or arbitrary documents.
+
+#### Scenario: Long-running issue resumes
+- **WHEN** the selected project contains a durable project goal and an active issue checkpoint
+- **THEN** recovery shows both the overarching outcome and the issue-level next action so the issue does not replace the project goal in the agent's orientation
+
+#### Scenario: Memory Atlas is empty
+- **WHEN** a compatible project has no reviewed Memory Atlas rows
+- **THEN** recovery reports an empty capability and continues with the normal purpose-led overview/folder/file/summary/slice path without inventing context
+
+#### Scenario: Repeated recovery reads use unchanged state
+- **WHEN** request parameters, context revision, structural generation, and the effective lifecycle evaluation instant are unchanged
+- **THEN** normalized output is byte-identical and performs no write
+
+### Requirement: Recovery references current skills, plugins, and source selectors
+Skill and plugin routes SHALL store logical identifiers, bounded applicability terms, host-resolvable selectors, capability summaries, and optional fingerprints rather than copied bodies, executable commands, installation directives, or machine-local paths. Recovery SHALL return stale/unavailable state and SHALL direct the harness to resolve and read the complete current owning skill or plugin instructions through its trusted registry and policy before implementation. Source references SHALL use exact reusable project-relative folder, file, optional symbol/span, issue, OpenSpec change/task, or public documentation selectors.
+
+#### Scenario: Rust architecture task resumes
+- **WHEN** the task query matches Rust architecture and OpenSpec routes
+- **THEN** recovery ranks those routes, returns their current selectors, and omits unrelated routes within the default budget
+
+#### Scenario: Skill source changed or disappeared
+- **WHEN** a stored route fingerprint or selector no longer resolves
+- **THEN** recovery marks it stale or unavailable and does not return cached skill instructions as current truth
+
+#### Scenario: Memory record points into source
+- **WHEN** an architecture or checkpoint record references a file and symbol
+- **THEN** the response includes an exact selector and next summary/slice call rather than only a display label
+
+#### Scenario: Durable decision points to changed local source
+- **WHEN** a referenced file or symbol is stale, ambiguous, or missing in the current structural generation
+- **THEN** recovery preserves the reviewed decision, labels the selector unresolved, and directs the agent through current purpose/graph navigation instead of deleting or rewriting the decision
+
+### Requirement: Recovery is bounded and independently versioned
+Recovery rows and serialized bytes SHALL have configured limits, stable tie-breakers, explicit returned/omitted counts, and context-revision-bound pagination. When a page also includes structural selectors, it SHALL bind structural generation independently. A memory-only change SHALL invalidate the context cursor; a source-only publication SHALL invalidate only the structural portion it affects.
+
+#### Scenario: Relevant context exceeds the default budget
+- **WHEN** more applicable records exist than fit
+- **THEN** ProjectAtlas returns the highest-priority rows, exact truncation counts, and a bounded next read through `atlas_memory`
+
+#### Scenario: Memory changes between pages
+- **WHEN** a context update commits after page one
+- **THEN** the old cursor fails with typed stale-context state instead of mixing revisions
+
+#### Scenario: Structural generation changes independently
+- **WHEN** source publication advances without a Memory Atlas update
+- **THEN** the context revision remains current while stale structural selectors are reported independently
+
+### Requirement: Recovery rejoins the purpose-led source funnel
+Memory Atlas recovery SHALL provide orientation and candidate-reducing references, then direct the agent through folder purpose plus graph role, file purpose plus relevant connections, summary plus trust/coverage, and exact slice. It SHALL NOT replace current-source freshness, purpose navigation, graph retrieval, summaries, or slices.
+
+#### Scenario: Agent needs implementation details
+- **WHEN** recovery identifies the owning architecture area and checkpoint
+- **THEN** the next call narrows folders/files through purpose and graph evidence before source summary or slice
+
+### Requirement: Recovery performs no implicit mutation
+Memory Atlas recovery SHALL NOT initialize, scan, refresh, migrate, compact, update timestamps, write telemetry, advance revisions, change active project state, create SQLite sidecars, read host-private memory/transcripts, or access the network.
+
+#### Scenario: Read-only recovery against stable state
+- **WHEN** the database and selected root are captured before and after recovery
+- **THEN** database bytes, sidecars, timestamps, revisions, telemetry, root selection, and private host state are unchanged
+
+#### Scenario: Recovery detects pressure or conflict
+- **WHEN** the Memory Atlas is pressured, a checkpoint is stale, or a route is unresolved
+- **THEN** the response returns a typed warning/blocker and explicit next action rather than silently mutating or guessing

--- a/openspec/changes/persist-agent-project-context/specs/memory-atlas-storage/spec.md
+++ b/openspec/changes/persist-agent-project-context/specs/memory-atlas-storage/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Memory Atlas stores typed project-owned orientation
+ProjectAtlas SHALL persist reviewed project goal, scope, architecture, system pattern, decision, workflow, skill route, plugin route, and checkpoint records in the selected project's SQLite database using closed kinds, canonical stable keys, bounded fields, attribution, reviewed/current lifecycle state, and typed portable references. It SHALL NOT ingest host memory, transcripts, arbitrary source files, or network content implicitly.
+
+#### Scenario: Store a project architecture fact
+- **WHEN** an agent writes a valid architecture record against the selected project and current context revision
+- **THEN** ProjectAtlas stores one complete typed row and returns its stable identity, revision, size, and lifecycle state
+
+#### Scenario: Reject an unknown or oversized record
+- **WHEN** a caller supplies an unknown kind, noncanonical key, ambiguous operation, invalid selector, or oversized field
+- **THEN** ProjectAtlas rejects the complete batch before cleanup or persistence and does not log the rejected content
+
+### Requirement: Stable facts replace instead of accumulating history
+Memory Atlas updates SHALL atomically replace records by `(kind, stable_key)`, remove exact obsolete identities named by the caller, and apply explicit supersession without creating an unbounded revision log. One opaque nonnegative context revision SHALL advance exactly once for each successful state-changing transaction and remain unchanged for read-only, failed, stale, or exact no-op requests.
+
+#### Scenario: Update the current project goal
+- **WHEN** an agent replaces the existing `project_goal` record with the same stable key
+- **THEN** the row count does not grow solely because the fact changed and one new context revision becomes visible
+
+#### Scenario: Concurrent agent writes are conditional
+- **WHEN** two agents update from the same observed revision and one commits first
+- **THEN** the second receives a typed stale-revision conflict and cannot overwrite or partially combine with the committed state
+
+#### Scenario: Reflection batch retires obsolete context
+- **WHEN** one update batch replaces current facts and removes or supersedes obsolete stable identities
+- **THEN** all requested changes and deterministic cleanup commit atomically under one revision
+
+### Requirement: Every successful write remains within hard budgets
+ProjectAtlas SHALL enforce configured per-record, retained-byte, row, checkpoint, and recovery limits below compiled hard maxima. Every successful state-changing update SHALL reconcile lifecycle cleanup in the same transaction and end within all budgets. Automatic cleanup SHALL remove only expired, superseded, explicitly obsolete, or excess volatile records in deterministic order and SHALL NOT silently delete protected current project goal, scope, architecture, decisions, patterns, workflows, or active skill/plugin routes. Expiry SHALL be accepted only for explicitly volatile records; durable records require explicit removal or supersession.
+
+#### Scenario: Expired checkpoints recover space
+- **WHEN** a valid update would exceed a budget and expired or superseded checkpoints provide sufficient space
+- **THEN** ProjectAtlas removes those volatile rows in deterministic order and commits the update within the same transaction
+
+#### Scenario: Protected facts exceed the budget
+- **WHEN** no permitted lifecycle cleanup can make the proposed state fit
+- **THEN** ProjectAtlas rolls back the update and cleanup and returns a content-free pressure report naming stable identities, sizes, and required agent action
+
+#### Scenario: Repeated checkpoints reach a steady state
+- **WHEN** an agent repeatedly replaces the same initiative checkpoint and retires obsolete state at meaningful boundaries
+- **THEN** retained bytes and rows remain bounded and do not grow with session count
+
+#### Scenario: Durable record supplies an expiry
+- **WHEN** a caller assigns expiry to a project goal, scope, architecture, decision, pattern, workflow, skill route, or plugin route
+- **THEN** ProjectAtlas rejects the complete batch and preserves the prior revision and rows
+
+### Requirement: Memory Atlas is authored state with isolated revisions
+Memory Atlas rows SHALL be classified as authored state preserved across full scan, incremental graph publication, watch refresh, derived cleanup, supported repair, migration, backup/restore, and rollback. The Memory Atlas context revision SHALL be independent from the structural generation, and cursors containing both SHALL validate them independently.
+
+#### Scenario: Source graph publishes a new generation
+- **WHEN** a successful source refresh advances structural generation
+- **THEN** Memory Atlas rows and context revision remain byte-for-byte unchanged
+
+#### Scenario: Memory changes without source changes
+- **WHEN** a Memory Atlas update commits
+- **THEN** the context revision advances while structural generation remains unchanged
+
+#### Scenario: Supported old database upgrades
+- **WHEN** a copied supported database is opened by the new runtime
+- **THEN** migration creates complete constrained Memory Atlas state atomically and older runtimes reject the newer schema instead of downgrading it
+
+### Requirement: Memory Atlas operations are offline and root-bound
+Every Memory Atlas read and write SHALL use the same canonical and physical selected-root plus per-call `project_path` isolation as other ProjectAtlas tools. Missing, incompatible, wrong-root, busy, or refresh-required state SHALL fail explicitly without initializing, scanning, migrating another project, changing the active default root, reading host-private data, or attempting network access.
+
+#### Scenario: Shared MCP server addresses two projects
+- **WHEN** concurrent calls include two explicit project paths
+- **THEN** each Memory Atlas operation remains bound to its verified project and neither changes the process default
+
+#### Scenario: Wrong-root database is addressed
+- **WHEN** the selected root does not match the database identity
+- **THEN** ProjectAtlas returns a typed root error before disclosing or mutating any Memory Atlas content
+
+#### Scenario: Project has no index
+- **WHEN** a Memory Atlas read targets a project without an existing compatible index
+- **THEN** ProjectAtlas reports the missing index and creates no `.projectatlas` state
+
+### Requirement: Diagnostics exclude Memory Atlas content by default
+ProjectAtlas SHALL accept only explicit bounded caller content and SHALL exclude Memory Atlas content from ordinary settings, logs, errors, telemetry, benchmarks, scan output, and non-requesting tool responses. Settings and status MAY expose capability, counts, sizes, pressure, revision, and compatibility without record text.
+
+#### Scenario: Secret sentinel is stored explicitly
+- **WHEN** a test record contains a sentinel string
+- **THEN** unrelated commands, logs, errors, settings, telemetry, and benchmark output do not disclose the sentinel
+
+#### Scenario: Status approaches pressure threshold
+- **WHEN** retained state crosses the configured warning threshold
+- **THEN** settings and Memory Atlas status report pressure and the next safe maintenance action without returning record content
+
+### Requirement: Stored context is data rather than executable authority
+Memory Atlas records SHALL remain reviewed project data below system, developer, user, repository-instruction, and current skill authority. Portable references SHALL reject machine-specific absolute paths, executable commands, automatic-install directives, SQL identifiers, or filesystem roots, and no stored field SHALL be interpolated into those execution boundaries.
+
+#### Scenario: Route attempts to install or execute a capability
+- **WHEN** a skill or plugin route contains a command, automatic-install directive, or machine-local executable path
+- **THEN** ProjectAtlas rejects the complete batch without echoing the rejected content

--- a/openspec/changes/persist-agent-project-context/tasks.md
+++ b/openspec/changes/persist-agent-project-context/tasks.md
@@ -1,0 +1,48 @@
+## 1. Contract and dependency order
+
+- [x] 1.1 Finalize the lean Memory Atlas proposal, design, capability specs, issue title/body, `checklist-v1` ownership mapping, synchronized OpenSpec/GitHub checklist, and shared issue-level verification plan.
+- [ ] 1.2 Before runtime implementation, confirm #308 has stabilized the schema epoch, authored/derived publication boundary, freshness preflight, coherent read snapshot, selected-root behavior, `atlas_session_brief` extension point, and streamlined MCP inventory consumed by this change.
+- [ ] 1.3 Trace the existing core, database, service, CLI/MCP, settings, host-plugin, and migration callers; record the Rust pattern-fit decision and keep ownership within the existing seven crates unless a demonstrated durable boundary requires otherwise.
+
+## 2. Typed Memory Atlas model and measured budgets
+
+- [ ] 2.1 Add closed responsibility-named core types for Memory Atlas kinds, stable identities, attribution, reviewed/current lifecycle state, portable typed references, conditional revisions, pressure, warnings, and recovery/update payloads.
+- [ ] 2.2 Define validated project-relative folder/file/symbol/span, issue, OpenSpec, public-documentation, skill, and plugin selectors that reject machine-local paths, executable/install directives, and invalid cross-boundary content.
+- [ ] 2.3 Measure representative goal, scope, architecture, pattern, decision, workflow, route, and checkpoint fixtures; derive compatible configurable defaults below compiled per-record, row, retained-byte, checkpoint, recovery-row, and recovery-output maxima.
+- [ ] 2.4 Add shared core/config tests for positive and negative serialization, canonical stable keys and revision strings, Unicode byte accounting, lifecycle/expiry rules, invalid selector/content rejection, exact limits, pressure thresholds, and backwards-compatible defaults.
+
+## 3. SQLite authored-state lifecycle
+
+- [ ] 3.1 Add the append-only SQLite migration, constrained tables/indexes, one context revision, retained-size accounting, and schema inventory for authored Memory Atlas rows without adding a database, crate, or runtime dependency.
+- [ ] 3.2 Implement coherent root-bound read/list snapshots and one revision-conditional transaction for complete-batch validation, stable-key upsert, exact remove/supersession, deterministic volatile cleanup, budget reconciliation, and one revision advance.
+- [ ] 3.3 Preserve exact no-op semantics and rollback guarantees: no revision/timestamp change for identical state, and no partial cleanup or mutation after stale revision, busy database, malformed input, revision exhaustion, or protected pressure.
+- [ ] 3.4 Preserve Memory Atlas rows and independent revision across supported migrations, repair/rollback, backup/restore, full and incremental source publication, watcher refresh, and derived-state cleanup while older runtimes reject the newer schema.
+- [ ] 3.5 Add shared database tests covering migration, repair/rollback, backup/restore, full and incremental publication, watcher refresh, derived-cleanup authored-state preservation, wrong-root and missing-index failure, concurrent stale writers, repeated-write steady state, exact budget boundaries, eligible-only cleanup, interrupted transactions, future-schema rejection, and no implicit scan/migration/write.
+
+## 4. Reflection and recovery services
+
+- [ ] 4.1 Implement service validation, task relevance ranking, one-instant lifecycle evaluation, pressure planning, bounded pagination, and deterministic bird's-eye recovery over concrete types and existing service boundaries.
+- [ ] 4.2 Implement atomic reflection batches that require the observed revision, replace current facts, remove or supersede obsolete identities, protect durable current context, and return content-free typed conflicts or pressure.
+- [ ] 4.3 Implement quiet harness-owned maintenance semantics: bounded input only, exact no-op silence, stale background writers lose without overwriting/retrying, recovery never waits, and only actionable conflict/pressure/root/content failures surface.
+- [ ] 4.4 Route recovery references back into the local-source sieve: folder purpose plus graph role, file purpose plus relevant connections, summary plus trust/coverage, then exact slice, with reusable selectors and accurate next-call hints even when structural references are stale.
+- [ ] 4.5 Add shared service tests for replacement without growth, eligible-only reconciliation, conflicts/failure rollback, fixed-instant deterministic recovery, root isolation, positive reusable selectors and next-call funneling, stale structural selectors, task-ranked skill/plugin routes, quiet maintenance, offline behavior, and privacy sentinels.
+
+## 5. CLI, MCP, settings, and compatibility
+
+- [ ] 5.1 Add typed CLI Memory Atlas read/update plus deeper validate and explicit compact dry-run/apply administration through the shared services, with bounded JSON/TOON output and no generic admin multiplexer.
+- [ ] 5.2 Add only `atlas_memory` and `atlas_memory_update` to MCP for bounded retrieval and atomic reflection; keep project goal updates in the same batch and reject any separate goal or jump tool unless measured workflows later justify it.
+- [ ] 5.3 Extend `atlas_session_brief` with optional recovery and `atlas_settings` with content-free capability, budget, pressure, count, and revision state while preserving omitted-request behavior and existing CLI/MCP request/response defaults.
+- [ ] 5.4 Add shared adapter/E2E tests for CLI/MCP parity, TOON/JSON equivalence, pagination/cursor invalidation, configured limits, normal session-brief compatibility, project-goal replacement, CLI validation and compact dry-run/apply, MCP inventory, wrong-root/missing-index behavior, and symbol-build/source-refresh independence.
+
+## 6. Host integration and agent workflow
+
+- [ ] 6.1 Encode and document verified capability-based startup, resume, clear, post-compaction, and supported subagent recovery for Codex, Claude Code, OpenCode, and generic MCP, with trusted-hook activation state and truthful manual fallbacks.
+- [ ] 6.2 Update packaged ProjectAtlas skills, plugin guidance, `AGENTS.md` snippets, and user documentation so agents reread current governing skills/plugins, checkpoint only meaningful bird's-eye changes, keep successful maintenance quiet, and never crawl or duplicate host-private memory/goals/tasks.
+- [ ] 6.3 Add isolated host-contract tests for startup/resume/clear/compact/subagent paths, disabled/untrusted hooks, synthetic homes/configs, offline behavior, logical route resolution, privacy sentinels, and no host-global mutation or capability invention.
+
+## 7. Issue-level verification and completion
+
+- [ ] 7.1 Run the ordinary locked workspace gates on the complete implementation: formatting, all-target/all-feature check, Clippy with warnings denied, workspace and doc tests, and rustdoc warnings denied; keep ProjectAtlas scan/purpose/lint maintenance local rather than adding hosted self-scans.
+- [ ] 7.2 After the complete #314 surface is implemented, run line coverage and mutation once, close real gaps or document justified exclusions, and do not create per-task coverage/mutation campaigns.
+- [ ] 7.3 Run bounded final reviews for architecture/crate ownership, Rust skill and pattern fit, OpenSpec task truth, shared-test adequacy, privacy/root/migration safety, streamlined MCP usefulness, and whether the result materially improves agent recovery without an eighth crate.
+- [ ] 7.4 Synchronize completed OpenSpec/GitHub task states, add the required committed OpenSpec permalinks, verify the issue checklist gate and packaged documentation, and close #314 only after the implementation is merged and the complete issue checks pass.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -17,6 +17,17 @@
     "enhance-projectatlas-init-first-run": 305,
     "fix-token-tui-reference-visual-regression": 304,
     "match-token-impact-reference-tui": 302,
+    "persist-agent-project-context": {
+      "contract": "checklist-v1",
+      "primary_issue": 314,
+      "owners": [
+        {
+          "issue": 314,
+          "first_task": "1.1",
+          "last_task": "7.4"
+        }
+      ]
+    },
     "publish-rustdoc-readme-links": 300,
     "simplify-token-tui-dashboard": 296
   }


### PR DESCRIPTION
## Summary

- specifies the bounded project-local Memory Atlas for #314
- preserves host ownership while adding project goal, scope, architecture, decisions, patterns, workflows, skill/plugin routes, and replaceable checkpoints
- keeps MCP to `atlas_memory` plus `atlas_memory_update`, with optional recovery through `atlas_session_brief`
- maps and synchronizes a lean 28-task OpenSpec checklist with shared behavior-focused tests

## Issue

Refs #314

This planning pull request does not close #314; runtime implementation remains dependency-gated on #308.

## Validation

- `openspec validate persist-agent-project-context --strict --no-interactive`
- `openspec validate --all --strict --no-interactive` (19 passed, 0 failed)
- `python .github/scripts/issue-checklists.py --self-test`
- scoped #314 local/GitHub comparison (28/28 exact, 1 checked)
- ProjectAtlas 0.3.26 isolated local `atlas_watch_once`
- ProjectAtlas local `atlas_lint --report-untracked --purpose-level low`
- `git diff --check`
- bounded architecture/Rust/task/test review: no blockers; seven crates remain sufficient

The repository-wide live checklist check still sees #308 task 2.3 checked on GitHub but not on `dev`; PR #321 owns that implementation/checklist update. This PR should merge after #321 brings that truthful state to `dev`.

## Checklist

- [x] ProjectAtlas local index refreshed after the OpenSpec files changed.
- [x] ProjectAtlas low-purpose lint passes and the touched #314 purpose queue is empty.
- [x] OpenSpec strict validation and checklist self-test pass.
- [x] Issue #314 exactly mirrors the local checklist.
- [x] No Rust behavior changed in this specification-only slice; hosted Rust gates remain authoritative.
- [x] PR text contains no private or internal-only details.
