### PR TITLE
docs(memory): scope recovery skill routes (#314)

### DIFF
--- a/openspec/changes/persist-agent-project-context/design.md
+++ b/openspec/changes/persist-agent-project-context/design.md
@@ -50,13 +50,15 @@ Use a closed `MemoryAtlasKind` with responsibility-owned records:
 - `system_pattern`: durable patterns and critical paths;
 - `decision`: accepted decisions and supersession links;
 - `workflow`: operating and release workflows;
-- `skill_route`: logical skill identifiers and applicability;
+- `skill_route`: logical skill identifiers and applicability for the overarching project goal or active issue/checkpoint;
 - `plugin_route`: logical plugin/capability identifiers and applicability;
 - `checkpoint`: the current initiative/issue checkpoint, blockers, and next action.
 
 Each record has a stable key, short summary, optional bounded detail, lifecycle class, attribution, reviewed/current state, timestamps, and typed references/selectors. Stable facts replace by `(kind, stable_key)`. Volatile checkpoints use a stable initiative key and replace in place. Decisions may explicitly supersede earlier keys; old decisions are removed or marked superseded rather than retained as an unbounded narrative. Expiry is valid only for explicitly volatile records; durable goal, scope, architecture, pattern, decision, workflow, skill-route, and plugin-route records never expire automatically.
 
-Source selectors are portable and project-relative: folder, file, optional symbol identity/span, issue, OpenSpec change/task, or public documentation reference. Machine-specific absolute paths are rejected. Skill and plugin routes contain only logical identifiers, bounded task-match terms, host-resolvable selectors, capability summaries, and optional fingerprints; they cannot carry executable commands, automatic-install instructions, or copied instruction bodies.
+Source selectors are portable and project-relative: folder, file, optional symbol identity/span, issue, OpenSpec change/task, or public documentation reference. Machine-specific absolute paths are rejected. A skill route uses a closed `project_goal` or `active_issue` scope and records required versus recommended status, deterministic read order, a concise applicability rationale, a portable logical host-resolvable selector, current/stale/unavailable resolution state, and an optional fingerprint or capability identity. It stores no copied skill body, install command, executable path, or machine-local path. Plugin routes follow the same portable-reference boundary.
+
+Recovery deduplicates a skill required by both scopes while retaining both applicability reasons and the strongest requirement. Project-goal routes remain visible and ordered ahead of issue-only routes; issue-scoped routes cannot hide them. When the active checkpoint or issue changes, its routes are replaced or retired rather than accumulating, while project-goal routes remain until explicitly replaced or removed. Memory Atlas routing stays below system, developer, user, repository-instruction, and current-skill authority; the harness resolves every returned route through its trusted registry and reads the complete current instructions before implementation.
 
 This preserves the useful Cline responsibilities without copying its file hierarchy:
 
@@ -133,7 +135,7 @@ Recovery mode returns, in order:
 3. architecture and system-pattern digest;
 4. current initiative checkpoint, blockers, and next action;
 5. applicable decisions and workflows;
-6. task-ranked skills/plugins and required reads;
+6. deduplicated project-goal and active-issue skill routes in deterministic required-read order, followed by applicable plugin routes;
 7. reusable folder/file/symbol/tracker selectors and the best next atlas call.
 
 Rows are deterministically ranked and bounded. Repeated reads are byte-stable for the same database state, request, and effective lifecycle evaluation instant. The service captures one concrete evaluation instant per operation so expiry cannot change midway through a projection; tests inject a fixed value without introducing a clock trait or dependency. Truncation includes returned/omitted counts and a revision-bound cursor. The default view never dumps all memory.
@@ -154,7 +156,7 @@ The Memory Atlas does not decide which source is current. #308 freshness remains
 
 Host integration is capability-driven and truthful:
 
-- Codex: use `SessionStart` for `startup`, `resume`, `clear`, and `compact` plus `SubagentStart` when the plugin hook is trusted and enabled. The hook injects a fixed instruction to request read-only recovery; it does not write memory or goals. Stable native goals may carry the current execution target. Experimental memories remain host-owned and optional. `AGENTS.md`, skills, and plugins remain their own instruction/workflow surfaces.
+- Codex: use `SessionStart` for `startup`, `resume`, `clear`, and `compact` plus `SubagentStart` when the plugin hook is trusted and enabled. The hook injects a fixed instruction to request read-only recovery; it does not write memory or goals. Recovery directs the agent to resolve and completely read the required project-goal skills followed by active-issue skills before implementation. Stable native goals may carry the current execution target. Experimental memories remain host-owned and optional. `AGENTS.md`, skills, and plugins remain their own instruction/workflow surfaces.
 - Claude Code and OpenCode: use only documented skill/plugin/MCP/task lifecycle capabilities. Where automatic startup recovery is unavailable, packaged guidance makes the manual `atlas_session_brief` recovery explicit.
 - Generic MCP: use the two Memory Atlas tools and session brief without assuming any native memory or goal API.
 

--- a/openspec/changes/persist-agent-project-context/proposal.md
+++ b/openspec/changes/persist-agent-project-context/proposal.md
@@ -9,7 +9,7 @@ Agent harnesses can preserve a recent transcript, compact a long conversation, r
 - Extend the existing session brief so a fresh session, resumed session, post-compaction continuation, or supported subagent can recover the smallest useful bird's-eye context and then continue the normal purpose-led atlas funnel.
 - Add bounded typed Memory Atlas reads and one atomic update batch that also replaces the protected `project_goal` record, plus CLI administration over shared services; keep MCP streamlined and reuse session brief/settings for recovery and content-free status instead of adding a family of overlapping tools.
 - Reconcile retention during every successful write: replace stable facts, expire or supersede volatile checkpoints, and reject irreducible pressure rather than letting the database grow without limit or silently deleting protected current facts.
-- Store portable logical references to required skills, plugins, governing docs, issues, OpenSpec changes, and project-relative source selectors; resolve and read the current owning artifacts at recovery time instead of copying their bodies or machine-local paths.
+- Store portable logical references to required skills, plugins, governing docs, issues, OpenSpec changes, and project-relative source selectors. Skill routes explicitly cover the overarching project goal and the active issue/checkpoint, preserve governing project-level routes when issue routes change, and direct the harness to resolve and read the current owning artifacts instead of copying their bodies or machine-local paths.
 - Preserve Memory Atlas rows as authored state across source scans, graph publication, supported migrations, repair, backup/restore, and rollback.
 - Package truthful host guidance that uses documented lifecycle hooks when available and a visible manual fallback otherwise. Automatic recovery is read-only and quiet; harness-owned background maintenance may submit the same explicit conflict-safe reflection batch at meaningful checkpoints, but the Rust runtime never crawls, summarizes, or mutates context on its own.
 
@@ -21,6 +21,30 @@ Agent harnesses can preserve a recent transcript, compact a long conversation, r
 - A background daemon, generic memory-provider abstraction, generic database export/import product, or one MCP tool per administrative operation.
 
 This change is planned for v0.4.0 and is ready for implementation only after #308 stabilizes the database, publication, freshness, session-brief, and MCP-surface boundaries it depends on.
+
+## Acceptance criteria
+
+- One bounded recovery view restores the overarching project goal, architecture/patterns, accepted decisions/workflows, active issue checkpoint, blockers, next action, and governing skill/plugin routes without replaying a transcript.
+- Skill recovery distinguishes project-goal and active-issue routes, keeps project-level requirements visible, deduplicates shared routes, gives a deterministic complete-read order, and reports stale or unavailable routes without caching instruction bodies.
+- Stable records replace rather than accumulate; every successful update finishes within hard row/byte/checkpoint/output limits, advances one conditional revision at most once, and leaves exact no-ops unchanged.
+- Recovery and updates stay offline, selected-root-bound, current-local-source-aware, and independent from Git history; they neither initialize nor refresh another project and never read or mutate host-private memory, goals, tasks, transcripts, or global configuration.
+- MCP adds only `atlas_memory` and `atlas_memory_update`; optional recovery composes into `atlas_session_brief`, content-free status composes into settings, and existing requests retain compatible defaults.
+- Recovery rejoins the purpose-led navigation sieve through folder purpose plus graph role, file purpose plus relevant connections, summary plus trust/coverage, and exact slice using reusable selectors and accurate next calls.
+- Quiet maintenance uses the same bounded conflict-safe update, remains silent on success/no-op, never overwrites a newer revision, and never blocks source navigation.
+- Shared positive, negative, failure, concurrency, migration, compatibility, privacy, root-isolation, CLI/MCP, and host-contract tests pass within the existing seven crates; line coverage and mutation run once after the complete issue is implemented.
+
+## Pre-mortem
+
+| Likely failure | Prevention and acceptance signal |
+| --- | --- |
+| The Memory Atlas becomes an unbounded diary or second transcript. | Closed record kinds, stable-key replacement, volatile checkpoint retirement, hard budgets on every write, and repeated-update steady-state tests. |
+| It duplicates or overrides host goals, memories, tasks, rules, or trackers. | Explicit ownership boundaries, data-below-instructions precedence, privacy sentinels, and no host-private reads or writes. |
+| An issue checkpoint hides the overarching project goal or governing skills. | Separate project-goal and active-issue scopes, project-first ordering, deduplication that retains both reasons, and issue-transition tests. |
+| Stored skill or source references become stale and mislead the agent. | Portable logical selectors, current/stale/unavailable resolution state, trusted-registry complete reads, structural-generation checks, and purpose/graph fallback. |
+| Recovery adds more calls and tokens than it saves. | Optional bounded recovery in the existing session brief, deterministic ranking, compact TOON rows, typed topology only for real paths, and representative agent-workflow comparison. |
+| Hidden maintenance races, overwrites newer context, or spams the user. | Revision-conditional atomic batches, exact no-op semantics, stale-writer loss without retry, quiet success behavior, and recovery that never waits. |
+| Cleanup silently deletes durable orientation to satisfy a cap. | Protected current records, eligible-only deterministic cleanup, atomic rollback, and content-free pressure requiring explicit agent action. |
+| The feature forks database/root/freshness logic or adds architecture for its own sake. | #308 dependency gate, reuse of the existing database and selected-root contracts, final seven-crate review, and no new runtime dependency without a demonstrated owner. |
 
 ## Capabilities
 

--- a/openspec/changes/persist-agent-project-context/specs/memory-atlas-host-integration/spec.md
+++ b/openspec/changes/persist-agent-project-context/specs/memory-atlas-host-integration/spec.md
@@ -23,7 +23,7 @@ Packaged integration guidance SHALL describe verified memory, goal, skill, plugi
 - **THEN** packaged guidance declares the manual fallback and does not emit invalid configuration or pretend automatic recovery occurred
 
 ### Requirement: Supported lifecycle recovery is quiet and read-only
-When documented host hooks are available, trusted, enabled, and permitted, ProjectAtlas integration SHALL use startup/resume/post-compaction and supported subagent entry to inject a fixed instruction for one read-only recovery brief. It SHALL NOT automatically write Memory Atlas records, host memory, host goals, task state, or transcripts. Successful maintenance SHALL stay out of normal user-facing output unless it changes the plan or reveals a warning/failure.
+When documented host hooks are available, trusted, enabled, and permitted, ProjectAtlas integration SHALL use startup/resume/post-compaction and supported subagent entry to inject a fixed instruction for one read-only recovery brief. Before implementation, packaged guidance SHALL make the agent resolve and completely read current required project-goal skills followed by active-issue skills through the trusted host registry, respecting higher-priority instructions and reporting stale or unavailable routes truthfully. It SHALL NOT automatically write Memory Atlas records, host memory, host goals, task state, or transcripts. Successful maintenance SHALL stay out of normal user-facing output unless it changes the plan or reveals a warning/failure.
 
 #### Scenario: Codex starts, resumes, clears, or continues after compaction
 - **WHEN** the trusted ProjectAtlas `SessionStart` hook receives `startup`, `resume`, `clear`, or `compact`
@@ -32,6 +32,10 @@ When documented host hooks are available, trusted, enabled, and permitted, Proje
 #### Scenario: Supported subagent starts
 - **WHEN** the trusted ProjectAtlas `SubagentStart` hook runs
 - **THEN** the child receives bounded task-specific recovery guidance without inheriting or mutating private parent memory or goals
+
+#### Scenario: Recovery names governing and issue skills
+- **WHEN** a host receives project-goal and active-issue skill routes
+- **THEN** it resolves them through its trusted registry, reads each complete current instruction artifact in the returned deterministic order, and does not execute stored route content as authority
 
 #### Scenario: Hook is unavailable or untrusted
 - **WHEN** hooks are disabled, pending review, changed, blocked by policy, or unsupported

--- a/openspec/changes/persist-agent-project-context/specs/memory-atlas-recovery/spec.md
+++ b/openspec/changes/persist-agent-project-context/specs/memory-atlas-recovery/spec.md
@@ -12,7 +12,7 @@ The existing `atlas_session_brief` SHALL accept an additive recovery request tha
 - **THEN** the response includes the highest-value project goal, scope, architecture, patterns, checkpoint, decisions, workflows, skills/plugins, blockers, and next calls within one bounded result
 
 ### Requirement: Recovery is a deterministic bird's-eye projection
-Recovery SHALL return one coherent read snapshot ordered as project identity/freshness/pressure, overarching project goal and scope, architecture/pattern digest, current checkpoint/blockers/next action, applicable decisions/workflows, task-ranked skill/plugin routes, and exact reusable selectors/next calls. It SHALL NOT return unbounded history, full skill bodies, transcripts, host memory, or arbitrary documents.
+Recovery SHALL return one coherent read snapshot ordered as project identity/freshness/pressure, overarching project goal and scope, architecture/pattern digest, current checkpoint/blockers/next action, applicable decisions/workflows, deduplicated project-goal and active-issue skill routes in deterministic required-read order, applicable plugin routes, and exact reusable selectors/next calls. It SHALL NOT return unbounded history, full skill bodies, transcripts, host memory, or arbitrary documents.
 
 #### Scenario: Long-running issue resumes
 - **WHEN** the selected project contains a durable project goal and an active issue checkpoint
@@ -27,7 +27,23 @@ Recovery SHALL return one coherent read snapshot ordered as project identity/fre
 - **THEN** normalized output is byte-identical and performs no write
 
 ### Requirement: Recovery references current skills, plugins, and source selectors
-Skill and plugin routes SHALL store logical identifiers, bounded applicability terms, host-resolvable selectors, capability summaries, and optional fingerprints rather than copied bodies, executable commands, installation directives, or machine-local paths. Recovery SHALL return stale/unavailable state and SHALL direct the harness to resolve and read the complete current owning skill or plugin instructions through its trusted registry and policy before implementation. Source references SHALL use exact reusable project-relative folder, file, optional symbol/span, issue, OpenSpec change/task, or public documentation selectors.
+Skill routes SHALL use closed `project_goal` or `active_issue` scopes and store logical identifiers, required/recommended status, deterministic read order, concise applicability rationale, portable host-resolvable selectors, current/stale/unavailable resolution state, and optional fingerprints or capability identities rather than copied bodies, executable commands, installation directives, or machine-local paths. Recovery SHALL deduplicate shared routes without losing either scope, preserve governing project-goal routes when issue routes change, and direct the harness to resolve and read the complete current owning instructions through its trusted registry and policy before implementation. Plugin routes use the same portable-reference boundary. Source references SHALL use exact reusable project-relative folder, file, optional symbol/span, issue, OpenSpec change/task, or public documentation selectors.
+
+#### Scenario: Project goal requires governing skills
+- **WHEN** recovery finds required skill routes scoped to the overarching project goal
+- **THEN** it returns them before issue-only routes with exact logical selectors, read order, rationale, requirement status, and resolution state
+
+#### Scenario: Active issue requires additional skills
+- **WHEN** the current checkpoint names an active issue with additional required or recommended skill routes
+- **THEN** recovery returns those routes after governing project-level requirements and before implementation-oriented next calls
+
+#### Scenario: Project and issue share a skill
+- **WHEN** the same logical skill applies to both the project goal and active issue
+- **THEN** recovery returns one deduplicated route with both scopes, the strongest requirement, and the earliest deterministic read order
+
+#### Scenario: Active issue changes
+- **WHEN** a reflection batch replaces the active checkpoint with a different issue
+- **THEN** obsolete issue-scoped routes are replaced or retired while project-goal routes remain visible
 
 #### Scenario: Rust architecture task resumes
 - **WHEN** the task query matches Rust architecture and OpenSpec routes
@@ -35,7 +51,7 @@ Skill and plugin routes SHALL store logical identifiers, bounded applicability t
 
 #### Scenario: Skill source changed or disappeared
 - **WHEN** a stored route fingerprint or selector no longer resolves
-- **THEN** recovery marks it stale or unavailable and does not return cached skill instructions as current truth
+- **THEN** recovery marks it stale or unavailable, preserves the logical route and required-read ordering, and does not return cached skill instructions as current truth
 
 #### Scenario: Memory record points into source
 - **WHEN** an architecture or checkpoint record references a file and symbol

--- a/openspec/changes/persist-agent-project-context/specs/memory-atlas-storage/spec.md
+++ b/openspec/changes/persist-agent-project-context/specs/memory-atlas-storage/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Memory Atlas stores typed project-owned orientation
-ProjectAtlas SHALL persist reviewed project goal, scope, architecture, system pattern, decision, workflow, skill route, plugin route, and checkpoint records in the selected project's SQLite database using closed kinds, canonical stable keys, bounded fields, attribution, reviewed/current lifecycle state, and typed portable references. It SHALL NOT ingest host memory, transcripts, arbitrary source files, or network content implicitly.
+ProjectAtlas SHALL persist reviewed project goal, scope, architecture, system pattern, decision, workflow, skill route, plugin route, and checkpoint records in the selected project's SQLite database using closed kinds, canonical stable keys, bounded fields, attribution, reviewed/current lifecycle state, and typed portable references. Skill routes SHALL use closed project-goal or active-issue scope, required/recommended priority, deterministic read order, applicability rationale, logical host-resolvable selector, and resolution state fields. It SHALL NOT ingest host memory, transcripts, arbitrary source files, or network content implicitly.
 
 #### Scenario: Store a project architecture fact
 - **WHEN** an agent writes a valid architecture record against the selected project and current context revision
@@ -10,6 +10,10 @@ ProjectAtlas SHALL persist reviewed project goal, scope, architecture, system pa
 #### Scenario: Reject an unknown or oversized record
 - **WHEN** a caller supplies an unknown kind, noncanonical key, ambiguous operation, invalid selector, or oversized field
 - **THEN** ProjectAtlas rejects the complete batch before cleanup or persistence and does not log the rejected content
+
+#### Scenario: Skill route contains host-local or executable content
+- **WHEN** a route contains a copied skill body, installation command, executable path, machine-local path, unknown scope, or invalid ordering metadata
+- **THEN** ProjectAtlas rejects the complete batch and preserves the prior revision and rows
 
 ### Requirement: Stable facts replace instead of accumulating history
 Memory Atlas updates SHALL atomically replace records by `(kind, stable_key)`, remove exact obsolete identities named by the caller, and apply explicit supersession without creating an unbounded revision log. One opaque nonnegative context revision SHALL advance exactly once for each successful state-changing transaction and remain unchanged for read-only, failed, stale, or exact no-op requests.
@@ -25,6 +29,10 @@ Memory Atlas updates SHALL atomically replace records by `(kind, stable_key)`, r
 #### Scenario: Reflection batch retires obsolete context
 - **WHEN** one update batch replaces current facts and removes or supersedes obsolete stable identities
 - **THEN** all requested changes and deterministic cleanup commit atomically under one revision
+
+#### Scenario: Active issue transition replaces its routes
+- **WHEN** a reflection batch replaces an issue checkpoint and names the obsolete active-issue skill routes
+- **THEN** those issue routes retire atomically while unrelated project-goal routes remain unchanged
 
 ### Requirement: Every successful write remains within hard budgets
 ProjectAtlas SHALL enforce configured per-record, retained-byte, row, checkpoint, and recovery limits below compiled hard maxima. Every successful state-changing update SHALL reconcile lifecycle cleanup in the same transaction and end within all budgets. Automatic cleanup SHALL remove only expired, superseded, explicitly obsolete, or excess volatile records in deterministic order and SHALL NOT silently delete protected current project goal, scope, architecture, decisions, patterns, workflows, or active skill/plugin routes. Expiry SHALL be accepted only for explicitly volatile records; durable records require explicit removal or supersession.

--- a/openspec/changes/persist-agent-project-context/tasks.md
+++ b/openspec/changes/persist-agent-project-context/tasks.md
@@ -6,10 +6,10 @@
 
 ## 2. Typed Memory Atlas model and measured budgets
 
-- [ ] 2.1 Add closed responsibility-named core types for Memory Atlas kinds, stable identities, attribution, reviewed/current lifecycle state, portable typed references, conditional revisions, pressure, warnings, and recovery/update payloads.
-- [ ] 2.2 Define validated project-relative folder/file/symbol/span, issue, OpenSpec, public-documentation, skill, and plugin selectors that reject machine-local paths, executable/install directives, and invalid cross-boundary content.
+- [ ] 2.1 Add closed responsibility-named core types for Memory Atlas kinds, stable identities, attribution, reviewed/current lifecycle state, portable typed references, conditional revisions, pressure, warnings, recovery/update payloads, and project-goal/active-issue skill-route scope, requirement, read-order, rationale, and resolution fields.
+- [ ] 2.2 Define validated project-relative folder/file/symbol/span, issue, OpenSpec, public-documentation, skill, and plugin selectors that reject copied bodies, machine-local paths, executable/install directives, invalid route scope/order metadata, and other cross-boundary content.
 - [ ] 2.3 Measure representative goal, scope, architecture, pattern, decision, workflow, route, and checkpoint fixtures; derive compatible configurable defaults below compiled per-record, row, retained-byte, checkpoint, recovery-row, and recovery-output maxima.
-- [ ] 2.4 Add shared core/config tests for positive and negative serialization, canonical stable keys and revision strings, Unicode byte accounting, lifecycle/expiry rules, invalid selector/content rejection, exact limits, pressure thresholds, and backwards-compatible defaults.
+- [ ] 2.4 Add shared core/config tests for positive and negative serialization, canonical stable keys and revision strings, Unicode byte accounting, lifecycle/expiry rules, scoped skill-route validation and ordering metadata, invalid selector/content rejection, exact limits, pressure thresholds, and backwards-compatible defaults.
 
 ## 3. SQLite authored-state lifecycle
 
@@ -21,11 +21,11 @@
 
 ## 4. Reflection and recovery services
 
-- [ ] 4.1 Implement service validation, task relevance ranking, one-instant lifecycle evaluation, pressure planning, bounded pagination, and deterministic bird's-eye recovery over concrete types and existing service boundaries.
+- [ ] 4.1 Implement service validation, task relevance ranking, one-instant lifecycle evaluation, pressure planning, bounded pagination, and deterministic bird's-eye recovery that preserves project-goal governing skill routes, ranks active-issue routes, deduplicates shared routes, and returns their required-read order over concrete types and existing service boundaries.
 - [ ] 4.2 Implement atomic reflection batches that require the observed revision, replace current facts, remove or supersede obsolete identities, protect durable current context, and return content-free typed conflicts or pressure.
 - [ ] 4.3 Implement quiet harness-owned maintenance semantics: bounded input only, exact no-op silence, stale background writers lose without overwriting/retrying, recovery never waits, and only actionable conflict/pressure/root/content failures surface.
 - [ ] 4.4 Route recovery references back into the local-source sieve: folder purpose plus graph role, file purpose plus relevant connections, summary plus trust/coverage, then exact slice, with reusable selectors and accurate next-call hints even when structural references are stale.
-- [ ] 4.5 Add shared service tests for replacement without growth, eligible-only reconciliation, conflicts/failure rollback, fixed-instant deterministic recovery, root isolation, positive reusable selectors and next-call funneling, stale structural selectors, task-ranked skill/plugin routes, quiet maintenance, offline behavior, and privacy sentinels.
+- [ ] 4.5 Add shared service tests for replacement without growth, eligible-only reconciliation, conflicts/failure rollback, fixed-instant deterministic recovery, root isolation, positive reusable selectors and next-call funneling, stale structural selectors, project-goal/active-issue route preservation, deduplication, ordering and issue-transition retirement, quiet maintenance, offline behavior, and privacy sentinels.
 
 ## 5. CLI, MCP, settings, and compatibility
 
@@ -37,12 +37,12 @@
 ## 6. Host integration and agent workflow
 
 - [ ] 6.1 Encode and document verified capability-based startup, resume, clear, post-compaction, and supported subagent recovery for Codex, Claude Code, OpenCode, and generic MCP, with trusted-hook activation state and truthful manual fallbacks.
-- [ ] 6.2 Update packaged ProjectAtlas skills, plugin guidance, `AGENTS.md` snippets, and user documentation so agents reread current governing skills/plugins, checkpoint only meaningful bird's-eye changes, keep successful maintenance quiet, and never crawl or duplicate host-private memory/goals/tasks.
-- [ ] 6.3 Add isolated host-contract tests for startup/resume/clear/compact/subagent paths, disabled/untrusted hooks, synthetic homes/configs, offline behavior, logical route resolution, privacy sentinels, and no host-global mutation or capability invention.
+- [ ] 6.2 Update packaged ProjectAtlas skills, plugin guidance, `AGENTS.md` snippets, and user documentation so agents resolve and completely read current required project-goal skills followed by active-issue skills, checkpoint only meaningful bird's-eye changes, keep successful maintenance quiet, and never crawl or duplicate host-private memory/goals/tasks.
+- [ ] 6.3 Add isolated host-contract tests for startup/resume/clear/compact/subagent paths, disabled/untrusted hooks, synthetic homes/configs, offline behavior, project-goal/active-issue route resolution and complete-read ordering, stale/unavailable routes, privacy sentinels, and no host-global mutation or capability invention.
 
 ## 7. Issue-level verification and completion
 
 - [ ] 7.1 Run the ordinary locked workspace gates on the complete implementation: formatting, all-target/all-feature check, Clippy with warnings denied, workspace and doc tests, and rustdoc warnings denied; keep ProjectAtlas scan/purpose/lint maintenance local rather than adding hosted self-scans.
 - [ ] 7.2 After the complete #314 surface is implemented, run line coverage and mutation once, close real gaps or document justified exclusions, and do not create per-task coverage/mutation campaigns.
 - [ ] 7.3 Run bounded final reviews for architecture/crate ownership, Rust skill and pattern fit, OpenSpec task truth, shared-test adequacy, privacy/root/migration safety, streamlined MCP usefulness, and whether the result materially improves agent recovery without an eighth crate.
-- [ ] 7.4 Synchronize completed OpenSpec/GitHub task states, add the required committed OpenSpec permalinks, verify the issue checklist gate and packaged documentation, and close #314 only after the implementation is merged and the complete issue checks pass.
+- [ ] 7.4 Synchronize completed OpenSpec/GitHub task states, verify the issue checklist gate and packaged documentation, and close #314 only after the implementation is merged and the complete issue checks pass.


### PR DESCRIPTION
## Summary

Clarifies #314 Memory Atlas skill recovery so the agent always receives both project-goal and active-issue skill routes, with deterministic complete-read order, deduplication, route resolution state, and no copied skill bodies or machine-local paths.

Also restores the concise v0.3.26-style issue-level acceptance criteria and pre-mortem for the Memory Atlas contract.

## Validation

- `openspec validate persist-agent-project-context --strict --no-interactive`
- `openspec validate --all --strict --no-interactive`
- `python .github/scripts/issue-checklists.py --self-test`
- `python .github/scripts/issue-checklists.py --repo styler-ai/ProjectAtlas --root . --issue-map openspec/issue-map.json`
- `git diff --check`

No implementation task is newly checked; #314 remains 1/28 and dependency-gated behind #308.
