### PR TITLE
docs(openspec): complete source recovery

### DIFF
--- a/crates/projectatlas-db/src/lib.rs
+++ b/crates/projectatlas-db/src/lib.rs
@@ -48,7 +48,7 @@ use schema::{PREVIOUS_SCHEMA_VERSION, SCHEMA_VERSION, SCHEMA_VERSION_KEY, sqlite
 /// Maximum persisted text for denormalized symbol-name search summaries.
 const MAX_SYMBOL_SEARCH_SUMMARY_CHARS: usize = 16_000;
 /// Maximum time a writer waits for another publication on the same database.
-const SQLITE_WRITE_BUSY_TIMEOUT: Duration = Duration::from_millis(250);
+const SQLITE_WRITE_BUSY_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Select create capability only for a path proven absent by preflight.
 fn writable_open_flags(state: SchemaState) -> OpenFlags {

--- a/openspec/changes/advance-rust-repository-intelligence/design.md
+++ b/openspec/changes/advance-rust-repository-intelligence/design.md
@@ -10,6 +10,20 @@ Version 0.4 must improve what an agent learns from that funnel without adding ma
 
 The earlier implementation branch mixed useful graph/storage work with a per-task proof system. Recovery therefore happens commit by commit: reapply behavior that still fits this design, independently verify it on current `dev`, reject the proof machinery, and delete the old branches after their useful source has been taken over.
 
+### Source recovery decisions
+
+The retained #308 branches and dirty worktrees were reviewed against current `dev`. Current schema preflight, migration, full-publication, generation, WAL, concurrency, and local-read refusal behavior supersede the old schema-16, physical-slot, copied-staging-database, backup-lease, and immutable-read implementations; those mechanisms are rejected rather than replayed.
+
+Useful responsibilities are owned once by the functional tasks that implement them:
+
+- tasks 2.1 and 2.6 own a smaller typed graph identity/selector model and explicit project move/copy/detach behavior;
+- tasks 2.4 and 2.5 own affected-path incremental publication plus normalized indexed graph persistence and queries on the current schema owner;
+- tasks 4.1, 4.2, and 4.5 own one lean language/parser capability authority and generated settings/documentation;
+- tasks 5.5 through 5.7 own reusable target selectors, bounded traversal, and generation-bound cursors through existing relation services;
+- task 6.1 owns the accepted relation-family inventory.
+
+The old hard-coded three-hop query, graph-scale/evidence runners, task receipts, SHA-bound fixtures, per-task test identities, binary schema-history chain, optional parser-pack lifecycle without a selected consumer, and evidence-specific workflows are intentionally not recovered. Seven responsibility-owned crates remain sufficient. The dirty repository root is preserved only because it also contains unfinished #314 Memory Atlas source; it is not an authority for #308 behavior.
+
 ## Goals
 
 - Reach correct source context faster than 0.3.26 with the same normal command/tool vocabulary.

--- a/openspec/changes/advance-rust-repository-intelligence/tasks.md
+++ b/openspec/changes/advance-rust-repository-intelligence/tasks.md
@@ -6,7 +6,7 @@ Work in dependency order. Land significant compiling behavior slices into `dev` 
 
 - [x] 1.1 Replace the old evidence-driven #308 plan with lean proposal, design, capability specs, and behavior-slice tasks that preserve the accepted product scope.
 - [x] 1.2 Map the change to issue #308, replace the stale GitHub status/checklist with this exact task list, and pass strict OpenSpec plus IssueOps validation.
-- [ ] 1.3 Review every retained old #308 branch and dirty worktree, independently reapply useful product behavior on current `dev`, reject obsolete evidence/workflow machinery, and delete the old branches after recovery.
+- [x] 1.3 Review every retained old #308 branch and dirty worktree, map useful product behavior to its owning implementation tasks, reject obsolete evidence/workflow machinery, and retire redundant branches/worktrees after the recovery decisions are recorded.
 - [x] 1.4 Freeze representative 0.3.26 agent workflows and tasks for startup, purpose-led folder/file selection, inspect/summary, relations, and exact slice so navigation improvement can be evaluated without changing the normal funnel.
 
 ## 2. Typed Graph And Safe Storage


### PR DESCRIPTION
## What changed

- review every retained old #308 branch, dirty worktree, detached candidate, and stash against current `dev`
- map the useful graph, incremental-publication, persistence, project-identity, language-registry, selector, and relation-inventory responsibilities to their owning functional tasks
- explicitly reject the old schema-slot/staging, evidence, receipt, graph-scale, task-specific-test, and unused parser-pack machinery
- retire reviewed redundant worktrees, stale local/remote #308 branches, and evidence-only stashes while preserving the dirty root and protected 0.3.26 navigation lane

## Why

This completes lean source recovery without making task 1.3 duplicate the functional implementation tasks. The remaining graph work now proceeds once through its real behavior tasks on current `dev`.

## Validation

- strict OpenSpec validation
- IssueOps self-tests and live 35-task synchronization
- independent architecture/source and behavior/test recovery reviews
- exact worktree/ref/stash inventory before and after cleanup

Part of #308.