### PR TITLE
feat(token): show agent-efficiency benchmark evidence (#340)

### DIFF
--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -1080,6 +1080,9 @@ enum Command {
         /// Optional local tokenizer calibration for indexed UTF-8 files.
         #[arg(long, value_parser = ["o200k_base", "cl100k_base"])]
         tokenizer: Option<String>,
+        /// Optional repository-relative agent-navigation benchmark result.
+        #[arg(long, value_name = "PATH")]
+        benchmark_results: Option<PathBuf>,
         /// Color theme for the human terminal dashboard.
         #[arg(long, value_enum, default_value_t = TokenTheme::Dark)]
         theme: TokenTheme,
@@ -2443,6 +2446,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
             view,
             trend,
             tokenizer,
+            benchmark_results,
             theme,
         } => {
             let store = open_index_for_current_read(cli)?;
@@ -2450,6 +2454,12 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                 if tokenizer.is_some() {
                     return Err(CliError::InvalidInput(
                         "--tokenizer is only supported for token overview reports".to_string(),
+                    ));
+                }
+                if benchmark_results.is_some() {
+                    return Err(CliError::InvalidInput(
+                        "--benchmark-results is only supported for token overview reports"
+                            .to_string(),
                     ));
                 }
                 let report = match load_token_report(
@@ -2482,6 +2492,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                     &store,
                     TokenReportRequest::Overview {
                         caller_label: session.as_deref(),
+                        benchmark_results: benchmark_results.as_deref(),
                     },
                 )? {
                     TokenReport::Overview(overview) => overview,
@@ -3851,6 +3862,7 @@ impl RequiredCliCommand {
                 view: TokenView::Agent,
                 trend: None,
                 tokenizer: None,
+                benchmark_results: None,
                 theme: TokenTheme::Dark,
             },
             Self::Parity => Command::Parity {

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -531,6 +531,9 @@ const SEVERITY_EXPECTED_SEPARATOR: &str = ", ";
 const SEVERITY_EXPECTED_FINAL_SEPARATOR: &str = ", or ";
 /// Token trend validation error suffix.
 const TOKEN_TREND_WINDOW_ERROR_SUFFIX: &str = "expected day, week, month, or year";
+/// Validation error for benchmark evidence on token trend requests.
+const TOKEN_TREND_BENCHMARK_ERROR: &str =
+    "benchmark_results is only supported for token overview reports";
 /// Internal mismatch when a trend request returns the overview variant.
 const TOKEN_TRENDS_RESULT_VARIANT_MISMATCH: &str = "token trend request returned an overview";
 /// Internal mismatch when an overview request returns the trends variant.
@@ -1118,6 +1121,8 @@ struct AtlasTokenParams {
     include_chart: Option<bool>,
     /// Optional trend grouping window: day, week, month, or year.
     trend_window: Option<String>,
+    /// Optional repository-relative agent-navigation benchmark result.
+    benchmark_results: Option<String>,
     /// Optional chart theme for TUI output: dark or light.
     theme: Option<String>,
 }
@@ -6812,6 +6817,11 @@ impl ProjectAtlasMcpServer {
             let include_chart = params.include_chart.unwrap_or(false);
             let chart_theme = Self::parse_token_chart_theme(params.theme.as_deref())?;
             if let Some(window) = params.trend_window.as_deref() {
+                if params.benchmark_results.is_some() {
+                    return Err(CliError::InvalidInput(
+                        TOKEN_TREND_BENCHMARK_ERROR.to_string(),
+                    ));
+                }
                 let window = TokenTrendWindow::parse(window).ok_or_else(|| {
                     CliError::InvalidInput(format!(
                         "unsupported token trend window {window:?}; {TOKEN_TREND_WINDOW_ERROR_SUFFIX}"
@@ -6846,6 +6856,7 @@ impl ProjectAtlasMcpServer {
                 &store,
                 TokenReportRequest::Overview {
                     caller_label: params.session.as_deref(),
+                    benchmark_results: params.benchmark_results.as_deref().map(Path::new),
                 },
             )? {
                 TokenReport::Overview(overview) => overview,

--- a/crates/projectatlas-cli/src/token_tui.rs
+++ b/crates/projectatlas-cli/src/token_tui.rs
@@ -1,9 +1,12 @@
 //! Purpose: Render token telemetry as package-backed terminal dashboards.
 
 use projectatlas_core::telemetry::{
-    TOKEN_ACCOUNTING_OBSERVED_DELTA, TOKEN_BASELINE_DIRECTORY_WALK, TOKEN_BASELINE_FULL_FILE,
-    TOKEN_BASELINE_SELECTED_CANDIDATES, TOKEN_BUCKET_FULL_FILE_COMPRESSION, TokenBucketOverview,
-    TokenOverview, TokenTrendPeriod, TokenTrendReport,
+    AgentEfficiencyBaseline, AgentEfficiencyBaselineRow, AgentEfficiencyCapability,
+    AgentEfficiencyCapabilityContribution, AgentEfficiencyComparison, AgentEfficiencyEvidenceState,
+    AgentEfficiencyMetricComparison, AgentEfficiencyMetricKind, TOKEN_ACCOUNTING_OBSERVED_DELTA,
+    TOKEN_BASELINE_DIRECTORY_WALK, TOKEN_BASELINE_FULL_FILE, TOKEN_BASELINE_SELECTED_CANDIDATES,
+    TOKEN_BUCKET_FULL_FILE_COMPRESSION, TokenBucketOverview, TokenOverview, TokenTrendPeriod,
+    TokenTrendReport,
 };
 use ratatui::backend::TestBackend;
 use ratatui::buffer::Buffer;
@@ -17,7 +20,7 @@ use std::cell::Cell as StdCell;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Fixed terminal height for the token overview dashboard snapshot.
-const DASHBOARD_HEIGHT: u16 = 48;
+const DASHBOARD_HEIGHT: u16 = 60;
 /// Fixed terminal height for the token trend dashboard snapshot.
 const TREND_DASHBOARD_HEIGHT: u16 = 30;
 /// Reserved terminal-canvas color; overview frames leave the shell background visible.
@@ -242,6 +245,7 @@ fn render_overview_frame(frame: &mut Frame<'_>, overview: &TokenOverview, sessio
             Constraint::Length(6),
             Constraint::Length(6),
             Constraint::Min(8),
+            Constraint::Length(12),
             Constraint::Length(4),
             Constraint::Length(1),
         ])
@@ -252,8 +256,9 @@ fn render_overview_frame(frame: &mut Frame<'_>, overview: &TokenOverview, sessio
     render_file_reads_card(frame, sections[2], overview);
     render_composition_and_signal(frame, sections[3], overview);
     render_savings_breakdown_table(frame, sections[4], overview);
-    render_calibration_notes(frame, sections[5], overview);
-    render_status_bar(frame, sections[6]);
+    render_agent_efficiency(frame, sections[5], overview);
+    render_calibration_notes(frame, sections[6], overview);
+    render_status_bar(frame, sections[7]);
 }
 
 /// Return a screenshot-matched dashboard panel.
@@ -885,6 +890,474 @@ fn render_savings_breakdown_table(frame: &mut Frame<'_>, area: Rect, overview: &
         .column_spacing(1)
         .block(panel("WHERE THE SAVINGS CAME FROM"));
     frame.render_widget(table, area);
+}
+
+/// Draw validated benchmark evidence without mixing it into live token accounting.
+fn render_agent_efficiency(frame: &mut Frame<'_>, area: Rect, overview: &TokenOverview) {
+    let block = panel("AGENT EFFICIENCY");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let comparison = &overview.agent_efficiency;
+    let compact = inner.width < 136;
+    let mut lines = Vec::with_capacity(10);
+    lines.push(agent_efficiency_identity_line(comparison, compact));
+
+    if matches!(
+        comparison.state,
+        AgentEfficiencyEvidenceState::Compatible | AgentEfficiencyEvidenceState::Partial
+    ) {
+        for baseline in [
+            AgentEfficiencyBaseline::FrozenProjectAtlasV0326,
+            AgentEfficiencyBaseline::PlainCodex,
+        ] {
+            if let Some(row) = comparison
+                .baselines
+                .iter()
+                .find(|row| row.baseline == baseline)
+            {
+                lines.extend(agent_efficiency_baseline_lines(
+                    row,
+                    compact,
+                    usize::from(inner.width),
+                ));
+            }
+        }
+        lines.extend(agent_efficiency_capability_lines(
+            &comparison.capabilities,
+            compact,
+        ));
+    }
+
+    if let Some(reason) = comparison.reason.as_deref() {
+        let prefix = if comparison.state == AgentEfficiencyEvidenceState::Partial {
+            "Note: "
+        } else {
+            "Reason: "
+        };
+        let available = usize::from(inner.width).saturating_sub(prefix.len());
+        lines.push(Line::from(vec![
+            Span::styled(prefix, muted_bold_style().bg(THEME_PANEL)),
+            Span::styled(
+                bounded_dashboard_text(reason, available),
+                Style::default()
+                    .fg(agent_efficiency_state_color(comparison.state))
+                    .bg(THEME_PANEL),
+            ),
+        ]));
+    }
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .style(body_style().bg(THEME_PANEL))
+            .wrap(Wrap { trim: true }),
+        inner,
+    );
+}
+
+/// Return the evidence state and bounded artifact identity line.
+fn agent_efficiency_identity_line(
+    comparison: &AgentEfficiencyComparison,
+    compact: bool,
+) -> Line<'static> {
+    let state_label = if compact { "State " } else { "Evidence " };
+    let mut spans = vec![
+        Span::styled(state_label, muted_bold_style().bg(THEME_PANEL)),
+        Span::styled(
+            comparison.state.as_str(),
+            Style::default()
+                .fg(agent_efficiency_state_color(comparison.state))
+                .bg(THEME_PANEL)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ];
+    if let Some(artifact) = comparison.artifact.as_ref() {
+        let identity = if compact {
+            format!(
+                " | artifact s{} cand {} sha {}",
+                artifact.schema_version,
+                bounded_dashboard_text(&artifact.candidate_version, 22),
+                short_identity(&artifact.artifact_digest)
+            )
+        } else {
+            format!(
+                " | artifact {} schema {} | candidate {} | runtime {} | source {}",
+                short_identity(&artifact.artifact_digest),
+                artifact.schema_version,
+                bounded_dashboard_text(&artifact.candidate_version, 28),
+                short_identity(&artifact.candidate_runtime_sha256),
+                short_identity(&artifact.candidate_functional_head)
+            )
+        };
+        spans.push(Span::styled(identity, body_style().bg(THEME_PANEL)));
+    }
+    Line::from(spans)
+}
+
+/// Return the bounded normal or compact rows for one typed baseline.
+fn agent_efficiency_baseline_lines(
+    row: &AgentEfficiencyBaselineRow,
+    compact: bool,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let label = agent_efficiency_baseline_label(row.baseline);
+    let color = agent_efficiency_baseline_color(row.baseline);
+    let productive_files =
+        agent_efficiency_metric_pair(row, AgentEfficiencyMetricKind::ProductiveFiles);
+    let wrong_files = agent_efficiency_metric_pair(row, AgentEfficiencyMetricKind::WrongFiles);
+    let counts = if compact {
+        format!(
+            "{label} [{}] m={} f(c/b)={}/{} u={}",
+            row.state.as_str(),
+            grouped_count(row.matched_trials),
+            grouped_count(row.candidate_failed_trials),
+            grouped_count(row.baseline_failed_trials),
+            grouped_count(row.unmatched_trials)
+        )
+    } else {
+        format!(
+            "{label} [{}] | matched {} | failed candidate/baseline {}/{} | unmatched {} | file visits p/w c/b {productive_files} {wrong_files}",
+            row.state.as_str(),
+            grouped_count(row.matched_trials),
+            grouped_count(row.candidate_failed_trials),
+            grouped_count(row.baseline_failed_trials),
+            grouped_count(row.unmatched_trials)
+        )
+    };
+    let calls = agent_efficiency_metric_pair(row, AgentEfficiencyMetricKind::TotalToolCalls);
+    let broad_reads = agent_efficiency_metric_pair(row, AgentEfficiencyMetricKind::BroadReads);
+    let full_reads = agent_efficiency_metric_pair(row, AgentEfficiencyMetricKind::FullReads);
+    let backtracks = agent_efficiency_metric_pair(row, AgentEfficiencyMetricKind::Backtracks);
+    let context = agent_efficiency_metric_pair(row, AgentEfficiencyMetricKind::NetNavigationBytes);
+    let context_saving =
+        agent_efficiency_metric_saving_label(row, AgentEfficiencyMetricKind::NetNavigationBytes);
+    let metrics = if compact {
+        format!("c/b calls {calls} | reads {broad_reads} | net ctx {context} ({context_saving})")
+    } else {
+        format!(
+            "candidate/baseline calls {calls} | reads broad/full {broad_reads} {full_reads} | backtracks {backtracks} | net context {context} ({context_saving})"
+        )
+    };
+
+    let mut lines = vec![
+        Line::from(Span::styled(
+            counts,
+            Style::default()
+                .fg(color)
+                .bg(THEME_PANEL)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(metrics, body_style().bg(THEME_PANEL))),
+    ];
+    if !compact {
+        lines.push(agent_efficiency_runtime_line(row, color, width));
+    }
+    lines
+}
+
+/// Return runtime, clamped context-savings bar, and typed break-even truth.
+fn agent_efficiency_runtime_line(
+    row: &AgentEfficiencyBaselineRow,
+    color: Color,
+    width: usize,
+) -> Line<'static> {
+    let runtime = agent_efficiency_metric_pair(row, AgentEfficiencyMetricKind::RuntimeWallSeconds);
+    let context_saving =
+        agent_efficiency_metric_saving(row, AgentEfficiencyMetricKind::NetNavigationBytes);
+    let runtime_prefix = format!("runtime c/b {runtime} | context saved ");
+    let mut spans = vec![Span::styled(
+        runtime_prefix.clone(),
+        body_style().bg(THEME_PANEL),
+    )];
+    let saving_label = context_saving.map(bounded_percentage);
+    let saving_width = if let Some(label) = saving_label.as_ref() {
+        7usize.saturating_add(label.chars().count())
+    } else {
+        3
+    };
+    if let Some(percent) = context_saving {
+        spans.extend(block_bar(6, percent / 100.0, color).spans);
+        spans.push(Span::styled(
+            format!(" {}", saving_label.as_deref().unwrap_or("n/a")),
+            Style::default().fg(color).bg(THEME_PANEL),
+        ));
+    } else {
+        spans.push(Span::styled("n/a", muted_style().bg(THEME_PANEL)));
+    }
+    let break_even_prefix = " | break-even: ";
+    let break_even_width = width.saturating_sub(
+        runtime_prefix
+            .chars()
+            .count()
+            .saturating_add(saving_width)
+            .saturating_add(break_even_prefix.len()),
+    );
+    spans.push(Span::styled(
+        format!(
+            "{break_even_prefix}{}",
+            bounded_dashboard_text(&agent_efficiency_break_even_label(row), break_even_width)
+        ),
+        body_style().bg(THEME_PANEL),
+    ));
+    Line::from(spans)
+}
+
+/// Return bounded capability call/byte rows without causal savings claims.
+fn agent_efficiency_capability_lines(
+    capabilities: &[AgentEfficiencyCapabilityContribution],
+    compact: bool,
+) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from(Span::styled(
+        if compact {
+            "MCP capability calls/bytes only (no causal savings):"
+        } else {
+            "Capability calls/emitted bytes only; no causal savings attribution:"
+        },
+        muted_bold_style().bg(THEME_PANEL),
+    ))];
+    if capabilities.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "none recorded",
+            muted_style().bg(THEME_PANEL),
+        )));
+        return lines;
+    }
+
+    let entries = capabilities
+        .iter()
+        .map(|capability| {
+            format!(
+                "{} {}/{}",
+                agent_efficiency_capability_label(capability.capability, compact),
+                grouped_count(capability.calls),
+                compact_bytes(capability.emitted_bytes)
+            )
+        })
+        .collect::<Vec<_>>();
+    let chunk_size = if compact { 3 } else { entries.len() };
+    for chunk in entries.chunks(chunk_size.max(1)) {
+        lines.push(Line::from(Span::styled(
+            chunk.join(" | "),
+            Style::default().fg(THEME_INK_WHITE).bg(THEME_PANEL),
+        )));
+    }
+    lines
+}
+
+/// Return the display label for one closed baseline identity.
+fn agent_efficiency_baseline_label(baseline: AgentEfficiencyBaseline) -> &'static str {
+    match baseline {
+        AgentEfficiencyBaseline::FrozenProjectAtlasV0326 => "Frozen v0.3.26",
+        AgentEfficiencyBaseline::PlainCodex => "Plain Codex",
+    }
+}
+
+/// Return the semantic color for one baseline identity.
+fn agent_efficiency_baseline_color(baseline: AgentEfficiencyBaseline) -> Color {
+    match baseline {
+        AgentEfficiencyBaseline::FrozenProjectAtlasV0326 => THEME_BLUE,
+        AgentEfficiencyBaseline::PlainCodex => THEME_INK_WHITE,
+    }
+}
+
+/// Return the semantic color for one evidence state.
+fn agent_efficiency_state_color(state: AgentEfficiencyEvidenceState) -> Color {
+    match state {
+        AgentEfficiencyEvidenceState::Compatible => THEME_GREEN,
+        AgentEfficiencyEvidenceState::Partial => THEME_YELLOW,
+        AgentEfficiencyEvidenceState::Unavailable => THEME_MUTED,
+        AgentEfficiencyEvidenceState::Failed | AgentEfficiencyEvidenceState::Incompatible => {
+            THEME_RED
+        }
+    }
+}
+
+/// Find one metric row without copying comparison arithmetic into the adapter.
+fn agent_efficiency_metric(
+    row: &AgentEfficiencyBaselineRow,
+    metric: AgentEfficiencyMetricKind,
+) -> Option<&AgentEfficiencyMetricComparison> {
+    row.metrics.iter().find(|value| value.metric == metric)
+}
+
+/// Format the typed candidate/baseline medians for one metric.
+fn agent_efficiency_metric_pair(
+    row: &AgentEfficiencyBaselineRow,
+    metric: AgentEfficiencyMetricKind,
+) -> String {
+    let Some(value) = agent_efficiency_metric(row, metric) else {
+        return "n/a".to_string();
+    };
+    format!(
+        "{}/{}",
+        agent_efficiency_metric_value(metric, value.candidate_median),
+        agent_efficiency_metric_value(metric, value.baseline_median)
+    )
+}
+
+/// Return the typed savings percentage for one metric.
+fn agent_efficiency_metric_saving(
+    row: &AgentEfficiencyBaselineRow,
+    metric: AgentEfficiencyMetricKind,
+) -> Option<f64> {
+    agent_efficiency_metric(row, metric)?
+        .median_percent_saving
+        .filter(|value| value.is_finite())
+}
+
+/// Format a typed saving without substituting a zero denominator.
+fn agent_efficiency_metric_saving_label(
+    row: &AgentEfficiencyBaselineRow,
+    metric: AgentEfficiencyMetricKind,
+) -> String {
+    agent_efficiency_metric_saving(row, metric)
+        .map_or_else(|| "n/a".to_string(), bounded_percentage)
+}
+
+/// Format one benchmark metric with a compact durable unit.
+fn agent_efficiency_metric_value(metric: AgentEfficiencyMetricKind, value: f64) -> String {
+    match metric {
+        AgentEfficiencyMetricKind::GrossNavigationBytes
+        | AgentEfficiencyMetricKind::NetNavigationBytes
+        | AgentEfficiencyMetricKind::PersistentBytes => compact_byte_value(value),
+        AgentEfficiencyMetricKind::SetupWallSeconds
+        | AgentEfficiencyMetricKind::RuntimeWallSeconds => format!("{value:.1}s"),
+        _ => compact_numeric_value(value),
+    }
+}
+
+/// Format a finite percentage in a bounded dashboard field.
+fn bounded_percentage(value: f64) -> String {
+    if value.abs() >= 10_000.0 {
+        format!("{value:.1e}%")
+    } else {
+        format!("{value:.1}%")
+    }
+}
+
+/// Format a validated count or token value with bounded decimal units.
+fn compact_numeric_value(value: f64) -> String {
+    for (unit, suffix) in [
+        (1_000_000_000_000_000.0, "P"),
+        (1_000_000_000_000.0, "T"),
+        (1_000_000_000.0, "G"),
+        (1_000_000.0, "M"),
+        (1_000.0, "K"),
+    ] {
+        if value.abs() >= unit {
+            return format!("{:.1}{suffix}", value / unit);
+        }
+    }
+    if value.fract().abs() < f64::EPSILON {
+        format!("{value:.0}")
+    } else {
+        format!("{value:.1}")
+    }
+}
+
+/// Format workload-specific break-even values without deriving a replacement aggregate.
+fn agent_efficiency_break_even_label(row: &AgentEfficiencyBaselineRow) -> String {
+    if row.break_even.is_empty() {
+        return "n/a".to_string();
+    }
+    row.break_even
+        .iter()
+        .map(|value| {
+            let workload = match value.workload.as_str() {
+                "small-clean" => "clean",
+                "small-dirty" => "dirty",
+                "small-non-git" => "non-git",
+                "huge-vscode" => "huge",
+                workload => workload,
+            };
+            format!(
+                "{}={}",
+                bounded_dashboard_text(workload, 16),
+                value
+                    .wall_time_tasks
+                    .map_or_else(|| "n/a".to_string(), |tasks| tasks.to_string())
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Return the compact label for one closed navigation capability.
+fn agent_efficiency_capability_label(
+    capability: AgentEfficiencyCapability,
+    compact: bool,
+) -> &'static str {
+    match (capability, compact) {
+        (AgentEfficiencyCapability::Search, _) => "search",
+        (AgentEfficiencyCapability::Other, _) => "other",
+        (AgentEfficiencyCapability::Discovery, true) => "disc",
+        (AgentEfficiencyCapability::SummaryAndSlice, true) => "sum/slice",
+        (AgentEfficiencyCapability::SymbolsAndRelations, true) => "sym/rel",
+        (AgentEfficiencyCapability::Discovery, false) => "discovery",
+        (AgentEfficiencyCapability::SummaryAndSlice, false) => "summary+slice",
+        (AgentEfficiencyCapability::SymbolsAndRelations, false) => "symbols+relations",
+    }
+}
+
+/// Format exact byte counts compactly for bounded dashboard rows.
+fn compact_bytes(value: u64) -> String {
+    if value >= 1_125_899_906_842_624 {
+        compact_integer_unit(value, 1_125_899_906_842_624, "PiB")
+    } else if value >= 1_099_511_627_776 {
+        compact_integer_unit(value, 1_099_511_627_776, "TiB")
+    } else if value >= 1_073_741_824 {
+        compact_integer_unit(value, 1_073_741_824, "GiB")
+    } else if value >= 1_048_576 {
+        compact_integer_unit(value, 1_048_576, "MiB")
+    } else if value >= 1_024 {
+        compact_integer_unit(value, 1_024, "KiB")
+    } else {
+        format!("{value}B")
+    }
+}
+
+/// Format one integer value to one decimal place in the selected binary unit.
+fn compact_integer_unit(value: u64, unit: u64, suffix: &str) -> String {
+    let rounded_tenths = (u128::from(value) * 10 + u128::from(unit) / 2) / u128::from(unit);
+    let whole = rounded_tenths / 10;
+    let tenth = rounded_tenths % 10;
+    format!("{whole}.{tenth}{suffix}")
+}
+
+/// Format a validated floating-point byte metric compactly.
+fn compact_byte_value(value: f64) -> String {
+    if value >= 1_125_899_906_842_624.0 {
+        format!("{:.1}PiB", value / 1_125_899_906_842_624.0)
+    } else if value >= 1_099_511_627_776.0 {
+        format!("{:.1}TiB", value / 1_099_511_627_776.0)
+    } else if value >= 1_073_741_824.0 {
+        format!("{:.1}GiB", value / 1_073_741_824.0)
+    } else if value >= 1_048_576.0 {
+        format!("{:.1}MiB", value / 1_048_576.0)
+    } else if value >= 1_024.0 {
+        format!("{:.1}KiB", value / 1_024.0)
+    } else {
+        format!("{value:.0}B")
+    }
+}
+
+/// Return a short digest or commit identity for the bounded TUI.
+fn short_identity(value: &str) -> String {
+    value.chars().take(12).collect()
+}
+
+/// Bound trusted display text without allowing it to consume adjacent fields.
+fn bounded_dashboard_text(value: &str, max_chars: usize) -> String {
+    let character_count = value.chars().count();
+    if character_count <= max_chars {
+        return value.to_string();
+    }
+    if max_chars <= 3 {
+        return ".".repeat(max_chars);
+    }
+    let mut output = value.chars().take(max_chars - 3).collect::<String>();
+    output.push_str("...");
+    output
 }
 
 /// Draw calibration notes without duplicating headline totals.
@@ -1816,17 +2289,22 @@ fn signed_count(value: isize) -> String {
 mod tests {
     use super::{
         DASHBOARD_HEIGHT, THEME_BAR_EMPTY, THEME_BG, THEME_BLUE, THEME_GREEN, THEME_INK_WHITE,
-        THEME_YELLOW, TokenDashboardTheme, block_bar, dashboard_width, grouped_count,
-        reconciled_without_projectatlas, reference_title, render_dashboard_to_string,
-        render_overview_frame, render_token_dashboard, render_token_dashboard_with_theme,
-        render_token_trend_dashboard, render_token_trend_dashboard_with_theme,
-        savings_source_rows_for_width, signed_count, signed_trend_points, signed_y_bounds,
+        THEME_MUTED, THEME_RED, THEME_YELLOW, TokenDashboardTheme, block_bar, dashboard_width,
+        grouped_count, reconciled_without_projectatlas, reference_title,
+        render_dashboard_to_string, render_overview_frame, render_token_dashboard,
+        render_token_dashboard_with_theme, render_token_trend_dashboard,
+        render_token_trend_dashboard_with_theme, savings_source_rows_for_width, signed_count,
+        signed_trend_points, signed_y_bounds,
     };
     use projectatlas_core::telemetry::{
-        TOKEN_ACCOUNTING_MODELED_AVOIDANCE, TOKEN_BASELINE_DIRECTORY_WALK,
-        TOKEN_BASELINE_SELECTED_CANDIDATES, TOKEN_BUCKET_NAVIGATION_AVOIDANCE,
-        TOKEN_CONFIDENCE_INFERRED, TOKEN_CONFIDENCE_POLICY_ESTIMATE, TOKEN_DEDUPE_SCOPE_SESSION,
-        TokenOverview, TokenTrendPeriod, TokenTrendReport, TokenTrendWindow, usage_from_estimates,
+        AgentEfficiencyArtifactIdentity, AgentEfficiencyBaseline, AgentEfficiencyBaselineRow,
+        AgentEfficiencyBreakEven, AgentEfficiencyCapability, AgentEfficiencyCapabilityContribution,
+        AgentEfficiencyComparison, AgentEfficiencyEvidenceState, AgentEfficiencyMetricComparison,
+        AgentEfficiencyMetricKind, TOKEN_ACCOUNTING_MODELED_AVOIDANCE,
+        TOKEN_BASELINE_DIRECTORY_WALK, TOKEN_BASELINE_SELECTED_CANDIDATES,
+        TOKEN_BUCKET_NAVIGATION_AVOIDANCE, TOKEN_CONFIDENCE_INFERRED,
+        TOKEN_CONFIDENCE_POLICY_ESTIMATE, TOKEN_DEDUPE_SCOPE_SESSION, TokenOverview,
+        TokenTrendPeriod, TokenTrendReport, TokenTrendWindow, usage_from_estimates,
         usage_from_estimates_with_accounting, usage_from_text,
     };
     use ratatui::Terminal;
@@ -1884,6 +2362,7 @@ mod tests {
             "SAVINGS COMPOSITION",
             "SIGNAL",
             "WHERE THE SAVINGS CAME FROM",
+            "AGENT EFFICIENCY",
             "CALIBRATION & NOTES",
         ] {
             assert!(dashboard.contains(&reference_title(title)));
@@ -1907,6 +2386,7 @@ mod tests {
                 &reference_title("FILE READS AVOIDED"),
                 &reference_title("SAVINGS COMPOSITION"),
                 &reference_title("WHERE THE SAVINGS CAME FROM"),
+                &reference_title("AGENT EFFICIENCY"),
                 &reference_title("CALIBRATION & NOTES"),
             ],
         );
@@ -2190,6 +2670,7 @@ mod tests {
         assert!(dashboard.contains(&reference_title("FILE READS AVOIDED")));
         assert!(dashboard.contains(&reference_title("WHERE THE SAVINGS CAME FROM")));
         assert!(dashboard.contains("Fewer candidates"));
+        assert!(dashboard.contains(&reference_title("AGENT EFFICIENCY")));
         assert!(dashboard.contains(&reference_title("CALIBRATION & NOTES")));
         assert!(!dashboard.contains("Saved-token trends"));
     }
@@ -2296,6 +2777,280 @@ mod tests {
 
         let empty = block_bar(10, -1.0, THEME_BLUE);
         assert_bar_segments(&empty, 0, 10, THEME_BLUE);
+    }
+
+    #[test]
+    fn agent_efficiency_panel_renders_compatible_and_partial_typed_evidence() {
+        let mut compatible = sample_overview();
+        compatible.agent_efficiency = sample_agent_efficiency(false);
+        let compatible_buffer = render_overview_buffer_at_width(&compatible, Some("s"), 140);
+        let compatible_panel = agent_efficiency_panel_text(&compatible_buffer);
+
+        for text in [
+            "Evidence compatible",
+            "artifact 111111111111 schema 1",
+            "candidate projectatlas 0.4.0",
+            "Frozen v0.3.26 [compatible]",
+            "Plain Codex [compatible]",
+            "matched 12",
+            "candidate/baseline calls 12/30",
+            "file visits p/w c/b 4/10 0/3",
+            "reads broad/full 2/8 1/5",
+            "backtracks 0/1",
+            "net context 16.0KiB/64.0KiB (75.0%)",
+            "runtime c/b 30.0s/50.0s",
+            "break-even: clean=1",
+            "huge=n/a",
+            "Capability calls/emitted bytes only; no causal savings attribution:",
+            "discovery 7/2.0KiB",
+            "summary+slice 11/4.0KiB",
+            "search 5/1.0KiB",
+            "symbols+relations 3/512B",
+        ] {
+            assert!(
+                compatible_panel.contains(text),
+                "compatible panel should contain {text:?}"
+            );
+        }
+        assert_cell_style(
+            &compatible_buffer,
+            "compatible",
+            THEME_GREEN,
+            Modifier::BOLD,
+        );
+        assert_cell_style(
+            &compatible_buffer,
+            "Frozen v0.3.26",
+            THEME_BLUE,
+            Modifier::BOLD,
+        );
+        assert_cell_style(
+            &compatible_buffer,
+            "Plain Codex",
+            THEME_INK_WHITE,
+            Modifier::BOLD,
+        );
+
+        let mut partial = sample_overview();
+        partial.agent_efficiency = sample_agent_efficiency(true);
+        let partial_buffer = render_overview_buffer_at_width(&partial, Some("s"), 140);
+        let partial_panel = agent_efficiency_panel_text(&partial_buffer);
+        assert!(partial_panel.contains("Evidence partial"));
+        assert!(partial_panel.contains("Frozen v0.3.26 [partial]"));
+        assert!(partial_panel.contains("failed candidate/baseline 0/3"));
+        assert!(partial_panel.contains("unmatched 3"));
+        assert!(partial_panel.contains("Plain Codex [compatible]"));
+        assert!(partial_panel.contains("frozen huge-corpus setup retained three failures"));
+        assert_cell_style(&partial_buffer, "partial", THEME_YELLOW, Modifier::BOLD);
+    }
+
+    #[test]
+    fn agent_efficiency_panel_preserves_explicit_invalid_states_without_zero_rows() {
+        for (state, reason, color) in [
+            (
+                AgentEfficiencyEvidenceState::Unavailable,
+                "benchmark artifact not supplied",
+                THEME_MUTED,
+            ),
+            (
+                AgentEfficiencyEvidenceState::Failed,
+                "benchmark artifact could not be decoded",
+                THEME_RED,
+            ),
+            (
+                AgentEfficiencyEvidenceState::Incompatible,
+                "candidate identity does not match the supported release",
+                THEME_RED,
+            ),
+        ] {
+            let mut overview = sample_overview();
+            overview.agent_efficiency = AgentEfficiencyComparison {
+                state,
+                reason: Some(reason.to_string()),
+                artifact: None,
+                baselines: Vec::new(),
+                capabilities: Vec::new(),
+                provider_counters_descriptive_only: true,
+            };
+            let buffer = render_overview_buffer_at_width(&overview, Some("s"), 140);
+            let panel = agent_efficiency_panel_text(&buffer);
+
+            assert!(panel.contains(&format!("Evidence {}", state.as_str())));
+            assert!(panel.contains(reason));
+            assert!(!panel.contains("Frozen v0.3.26"));
+            assert!(!panel.contains("Plain Codex"));
+            assert!(!panel.contains("candidate/baseline calls"));
+            assert!(!panel.contains("0.0%"));
+            assert_cell_style(&buffer, state.as_str(), color, Modifier::BOLD);
+        }
+    }
+
+    #[test]
+    fn agent_efficiency_panel_keeps_compact_evidence_visible_without_overflow() {
+        let mut overview = sample_overview();
+        overview.agent_efficiency = sample_agent_efficiency(true);
+        let buffer = render_overview_buffer_at_width(&overview, Some("s"), 80);
+        let panel = agent_efficiency_panel_text(&buffer);
+
+        for text in [
+            "State partial",
+            "artifact s1 cand projectatlas 0.4.0",
+            "Frozen v0.3.26 [partial] m=12 f(c/b)=0/3 u=3",
+            "Plain Codex [compatible] m=15 f(c/b)=0/0 u=0",
+            "c/b calls 12/30",
+            "reads 2/8",
+            "net ctx 16.0KiB/64.0KiB (75.0%)",
+            "MCP capability calls/bytes only (no causal savings):",
+            "disc 7/2.0KiB",
+            "sum/slice 11/4.0KiB",
+            "search 5/1.0KiB",
+            "sym/rel 3/512B",
+            "frozen huge-corpus setup retained three failures",
+        ] {
+            assert!(
+                panel.contains(text),
+                "compact panel should contain {text:?}"
+            );
+        }
+        assert!(
+            !panel.contains("runtime c/b"),
+            "compact layout should spend its bounded rows on required call/read/context truth"
+        );
+
+        let Some((_, title_y)) = find_text(&buffer, &reference_title("AGENT EFFICIENCY")) else {
+            unreachable!("agent-efficiency title should render");
+        };
+        for y in (title_y + 1)..(title_y + 11) {
+            assert_eq!(
+                buffer.cell((78, y)).map(ratatui::buffer::Cell::symbol),
+                Some("│"),
+                "compact panel right border should remain intact at row {y}"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_efficiency_panel_uses_compact_rows_below_normal_width() {
+        let mut overview = sample_overview();
+        overview.agent_efficiency = sample_agent_efficiency(true);
+        let buffer = render_overview_buffer_at_width(&overview, Some("s"), 120);
+        let panel = agent_efficiency_panel_text(&buffer);
+
+        for text in [
+            "State partial",
+            "Frozen v0.3.26 [partial]",
+            "Plain Codex [compatible]",
+            "MCP capability calls/bytes only (no causal savings):",
+            "sym/rel 3/512B",
+            "frozen huge-corpus setup retained three failures",
+        ] {
+            assert!(
+                panel.contains(text),
+                "120-column panel should contain {text:?}; panel:\n{panel}"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_efficiency_panel_bounds_maximum_valid_values_and_other_capability() {
+        let mut overview = sample_overview();
+        overview.agent_efficiency = sample_agent_efficiency(true);
+        for baseline in &mut overview.agent_efficiency.baselines {
+            for metric in &mut baseline.metrics {
+                metric.candidate_median = 9_007_199_254_740_991.0;
+                metric.baseline_median = 9_007_199_254_740_991.0;
+                metric.candidate_maximum = 9_007_199_254_740_991.0;
+                metric.baseline_maximum = 9_007_199_254_740_991.0;
+            }
+        }
+        overview
+            .agent_efficiency
+            .capabilities
+            .push(AgentEfficiencyCapabilityContribution {
+                capability: AgentEfficiencyCapability::Other,
+                calls: 4_096,
+                emitted_bytes: 9_007_199_254_740_991,
+            });
+
+        let buffer = render_overview_buffer_at_width(&overview, Some("s"), 80);
+        let panel = agent_efficiency_panel_text(&buffer);
+        for text in [
+            "State partial",
+            "Frozen v0.3.26 [partial]",
+            "Plain Codex [compatible]",
+            "c/b calls 9.0P/9.0P",
+            "net ctx 8.0PiB/8.0PiB",
+            "MCP capability calls/bytes only (no causal savings):",
+            "other 4,096/8.0PiB",
+            "frozen huge-corpus setup retained three failures",
+        ] {
+            assert!(
+                panel.contains(text),
+                "maximum-value panel should contain {text:?}; panel:\n{panel}"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_efficiency_panel_clamps_visual_ratio_and_preserves_unavailable_ratio() {
+        let mut overview = sample_overview();
+        overview.agent_efficiency = sample_agent_efficiency(false);
+        let frozen = overview
+            .agent_efficiency
+            .baselines
+            .iter_mut()
+            .find(|row| row.baseline == AgentEfficiencyBaseline::FrozenProjectAtlasV0326);
+        let Some(frozen) = frozen else {
+            unreachable!("sample comparison should contain the frozen baseline");
+        };
+        let context = frozen
+            .metrics
+            .iter_mut()
+            .find(|value| value.metric == AgentEfficiencyMetricKind::NetNavigationBytes);
+        let Some(context) = context else {
+            unreachable!("sample comparison should contain net context");
+        };
+        context.median_percent_saving = Some(250.0);
+
+        let clamped_buffer = render_overview_buffer_at_width(&overview, Some("s"), 140);
+        let Some((_, clamped_y)) = find_text(&clamped_buffer, "context saved") else {
+            unreachable!("normal comparison should render the context-savings bar");
+        };
+        let clamped_line = line_symbols(&clamped_buffer, clamped_y);
+        assert!(clamped_line.contains("250.0%"));
+        assert_eq!(
+            clamped_line.chars().filter(|value| *value == '█').count(),
+            6
+        );
+        assert_eq!(
+            clamped_line.chars().filter(|value| *value == '░').count(),
+            0
+        );
+
+        let context = overview
+            .agent_efficiency
+            .baselines
+            .iter_mut()
+            .find(|row| row.baseline == AgentEfficiencyBaseline::FrozenProjectAtlasV0326)
+            .and_then(|row| {
+                row.metrics
+                    .iter_mut()
+                    .find(|value| value.metric == AgentEfficiencyMetricKind::NetNavigationBytes)
+            });
+        let Some(context) = context else {
+            unreachable!("sample comparison should retain net context");
+        };
+        context.median_percent_saving = None;
+
+        let unavailable_buffer = render_overview_buffer_at_width(&overview, Some("s"), 140);
+        let Some((_, unavailable_y)) = find_text(&unavailable_buffer, "context saved") else {
+            unreachable!("normal comparison should render unavailable context savings");
+        };
+        let unavailable_line = line_symbols(&unavailable_buffer, unavailable_y);
+        assert!(unavailable_line.contains("context saved n/a"));
+        assert!(!unavailable_line.contains('█'));
+        assert!(!unavailable_line.contains('░'));
+        assert!(!unavailable_line.contains("0.0%"));
     }
 
     #[test]
@@ -2454,6 +3209,184 @@ mod tests {
                 TOKEN_DEDUPE_SCOPE_SESSION,
             ),
         ])
+    }
+
+    fn sample_agent_efficiency(partial: bool) -> AgentEfficiencyComparison {
+        let frozen_state = if partial {
+            AgentEfficiencyEvidenceState::Partial
+        } else {
+            AgentEfficiencyEvidenceState::Compatible
+        };
+        AgentEfficiencyComparison {
+            state: frozen_state,
+            reason: partial.then(|| "frozen huge-corpus setup retained three failures".to_string()),
+            artifact: Some(AgentEfficiencyArtifactIdentity {
+                schema_version: 1,
+                artifact_digest_kind: "sha256".to_string(),
+                artifact_digest: "1111111111111111111111111111111111111111111111111111111111111111"
+                    .to_string(),
+                candidate_version: "projectatlas 0.4.0".to_string(),
+                candidate_runtime_sha256:
+                    "2222222222222222222222222222222222222222222222222222222222222222".to_string(),
+                candidate_functional_head: "3333333333333333333333333333333333333333".to_string(),
+                candidate_checklist_head: "4444444444444444444444444444444444444444".to_string(),
+                frozen_version: "projectatlas 0.3.26".to_string(),
+                frozen_runtime_sha256:
+                    "5555555555555555555555555555555555555555555555555555555555555555".to_string(),
+            }),
+            baselines: vec![
+                sample_agent_efficiency_baseline(
+                    AgentEfficiencyBaseline::FrozenProjectAtlasV0326,
+                    frozen_state,
+                    12,
+                    if partial { 3 } else { 0 },
+                ),
+                sample_agent_efficiency_baseline(
+                    AgentEfficiencyBaseline::PlainCodex,
+                    AgentEfficiencyEvidenceState::Compatible,
+                    15,
+                    0,
+                ),
+            ],
+            capabilities: vec![
+                AgentEfficiencyCapabilityContribution {
+                    capability: AgentEfficiencyCapability::Discovery,
+                    calls: 7,
+                    emitted_bytes: 2_048,
+                },
+                AgentEfficiencyCapabilityContribution {
+                    capability: AgentEfficiencyCapability::SummaryAndSlice,
+                    calls: 11,
+                    emitted_bytes: 4_096,
+                },
+                AgentEfficiencyCapabilityContribution {
+                    capability: AgentEfficiencyCapability::Search,
+                    calls: 5,
+                    emitted_bytes: 1_024,
+                },
+                AgentEfficiencyCapabilityContribution {
+                    capability: AgentEfficiencyCapability::SymbolsAndRelations,
+                    calls: 3,
+                    emitted_bytes: 512,
+                },
+            ],
+            provider_counters_descriptive_only: true,
+        }
+    }
+
+    fn sample_agent_efficiency_baseline(
+        baseline: AgentEfficiencyBaseline,
+        state: AgentEfficiencyEvidenceState,
+        matched_trials: usize,
+        baseline_failed_trials: usize,
+    ) -> AgentEfficiencyBaselineRow {
+        AgentEfficiencyBaselineRow {
+            baseline,
+            state,
+            matched_trials,
+            candidate_failed_trials: 0,
+            baseline_failed_trials,
+            unmatched_trials: baseline_failed_trials,
+            metrics: vec![
+                sample_agent_efficiency_metric(
+                    AgentEfficiencyMetricKind::TotalToolCalls,
+                    12.0,
+                    30.0,
+                    Some(60.0),
+                ),
+                sample_agent_efficiency_metric(
+                    AgentEfficiencyMetricKind::BroadReads,
+                    2.0,
+                    8.0,
+                    Some(75.0),
+                ),
+                sample_agent_efficiency_metric(
+                    AgentEfficiencyMetricKind::FullReads,
+                    1.0,
+                    5.0,
+                    Some(80.0),
+                ),
+                sample_agent_efficiency_metric(
+                    AgentEfficiencyMetricKind::ProductiveFiles,
+                    4.0,
+                    10.0,
+                    Some(60.0),
+                ),
+                sample_agent_efficiency_metric(
+                    AgentEfficiencyMetricKind::WrongFiles,
+                    0.0,
+                    3.0,
+                    Some(100.0),
+                ),
+                sample_agent_efficiency_metric(
+                    AgentEfficiencyMetricKind::Backtracks,
+                    0.0,
+                    1.0,
+                    Some(100.0),
+                ),
+                sample_agent_efficiency_metric(
+                    AgentEfficiencyMetricKind::NetNavigationBytes,
+                    16_384.0,
+                    65_536.0,
+                    Some(75.0),
+                ),
+                sample_agent_efficiency_metric(
+                    AgentEfficiencyMetricKind::RuntimeWallSeconds,
+                    30.0,
+                    50.0,
+                    Some(40.0),
+                ),
+            ],
+            break_even: vec![
+                AgentEfficiencyBreakEven {
+                    workload: "small-clean".to_string(),
+                    wall_time_tasks: Some(1),
+                },
+                AgentEfficiencyBreakEven {
+                    workload: "small-dirty".to_string(),
+                    wall_time_tasks: Some(1),
+                },
+                AgentEfficiencyBreakEven {
+                    workload: "small-non-git".to_string(),
+                    wall_time_tasks: None,
+                },
+                AgentEfficiencyBreakEven {
+                    workload: "medium".to_string(),
+                    wall_time_tasks: None,
+                },
+                AgentEfficiencyBreakEven {
+                    workload: "huge-vscode".to_string(),
+                    wall_time_tasks: None,
+                },
+            ],
+            provider_usage_descriptive_only: Vec::new(),
+        }
+    }
+
+    fn sample_agent_efficiency_metric(
+        metric: AgentEfficiencyMetricKind,
+        candidate_median: f64,
+        baseline_median: f64,
+        median_percent_saving: Option<f64>,
+    ) -> AgentEfficiencyMetricComparison {
+        AgentEfficiencyMetricComparison {
+            metric,
+            candidate_median,
+            baseline_median,
+            candidate_maximum: candidate_median,
+            baseline_maximum: baseline_median,
+            median_percent_saving,
+        }
+    }
+
+    fn agent_efficiency_panel_text(buffer: &Buffer) -> String {
+        let Some((_, title_y)) = find_text(buffer, &reference_title("AGENT EFFICIENCY")) else {
+            unreachable!("agent-efficiency title should render");
+        };
+        (title_y..(title_y + 12).min(buffer.area.height))
+            .map(|y| line_symbols(buffer, y))
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     fn render_overview_buffer(overview: &TokenOverview, session: Option<&str>) -> Buffer {

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -7799,16 +7799,27 @@ fn write_fully_matched_benchmark_fixture(destination: &Path) -> Result<(), Box<d
         .get_mut("runs")
         .and_then(Value::as_array_mut)
         .ok_or_else(|| io::Error::other("benchmark runs are missing"))?;
+    let frozen_trace = runs
+        .iter()
+        .find(|run| {
+            run.get("arm").and_then(Value::as_str) == Some("v0.3.26")
+                && run.get("execution_status").and_then(Value::as_str) == Some("completed")
+        })
+        .and_then(|run| run.get("trace"))
+        .cloned()
+        .ok_or_else(|| io::Error::other("completed frozen benchmark trace is missing"))?;
     for run in runs {
         if run.get("case").and_then(Value::as_str) == Some("huge-vscode")
             && run.get("arm").and_then(Value::as_str) == Some("v0.3.26")
         {
-            run.as_object_mut()
-                .ok_or_else(|| io::Error::other("benchmark run is not an object"))?
-                .insert(
-                    "execution_status".to_string(),
-                    Value::String("completed".to_string()),
-                );
+            let run = run
+                .as_object_mut()
+                .ok_or_else(|| io::Error::other("benchmark run is not an object"))?;
+            run.insert(
+                "execution_status".to_string(),
+                Value::String("completed".to_string()),
+            );
+            run.insert("trace".to_string(), frozen_trace.clone());
         }
     }
 

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -116,7 +116,10 @@ const MCP_CONTRACT_EXECUTABLE_ENV: &str = "PROJECTATLAS_MCP_CONTRACT_EXECUTABLE"
 const MCP_CONTRACT_PLUGIN_ROOT_ENV: &str = "PROJECTATLAS_MCP_CONTRACT_PLUGIN_ROOT";
 const MCP_CONTRACT_METADATA_CANARY: &str = "mcp_contract_metadata_canary";
 const MCP_V040_TOOLS_SHA256: &str =
-    "68e8af9502420a3a51d8094096c3ed0d9f0badea9d0b4762ece56635b652ea09";
+    "0c21ea673bdb9cdff48203a274db04fbaccb888bd362407d46fc1bcc0e506b28";
+const AGENT_EFFICIENCY_BENCHMARK_PATH: &str =
+    "../../docs/benchmarks/v0.4-agent-navigation-results.json";
+const AGENT_EFFICIENCY_PARTIAL_FILE: &str = "partial.json";
 const SUBDIR_CONFIG_DIR: &str = "config";
 const SESSION_TEST_FILE_NAME: &str = "session.rs";
 #[cfg(any(
@@ -7783,6 +7786,349 @@ fn no_telemetry_readonly_cli_smoke() -> Result<(), Box<dyn Error>> {
     for suffix in ["-wal", "-shm", "-journal"] {
         if sqlite_sidecar_path(&db, suffix).exists() {
             return Err(io::Error::other("pure report created a SQLite sidecar").into());
+        }
+    }
+    Ok(())
+}
+
+/// Write a synthetic fully matched variant of the published benchmark.
+fn write_fully_matched_benchmark_fixture(destination: &Path) -> Result<(), Box<dyn Error>> {
+    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(AGENT_EFFICIENCY_BENCHMARK_PATH);
+    let mut artifact: Value = serde_json::from_slice(&fs::read(source)?)?;
+    let runs = artifact
+        .get_mut("runs")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| io::Error::other("benchmark runs are missing"))?;
+    for run in runs {
+        if run.get("case").and_then(Value::as_str) == Some("huge-vscode")
+            && run.get("arm").and_then(Value::as_str) == Some("v0.3.26")
+        {
+            run.as_object_mut()
+                .ok_or_else(|| io::Error::other("benchmark run is not an object"))?
+                .insert(
+                    "execution_status".to_string(),
+                    Value::String("completed".to_string()),
+                );
+        }
+    }
+
+    let aggregate = artifact
+        .get_mut("aggregate")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| io::Error::other("benchmark aggregate is missing"))?;
+    aggregate.insert("completed".to_string(), Value::from(45));
+    aggregate.insert("failed".to_string(), Value::from(0));
+    let groups = aggregate
+        .get_mut("groups")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| io::Error::other("benchmark groups are missing"))?;
+    let matched_group = groups
+        .get("huge-vscode/plain")
+        .cloned()
+        .ok_or_else(|| io::Error::other("matched benchmark donor group is missing"))?;
+    let frozen_group = groups
+        .get_mut("huge-vscode/v0.3.26")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| io::Error::other("frozen benchmark group is missing"))?;
+    let frozen_run_ids = frozen_group
+        .get("run_ids")
+        .cloned()
+        .ok_or_else(|| io::Error::other("frozen benchmark run ids are missing"))?;
+    *frozen_group = matched_group
+        .as_object()
+        .cloned()
+        .ok_or_else(|| io::Error::other("matched benchmark group is not an object"))?;
+    frozen_group.insert("run_ids".to_string(), frozen_run_ids);
+
+    let comparisons = aggregate
+        .get_mut("comparisons")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| io::Error::other("benchmark comparisons are missing"))?;
+    let matched_comparison = comparisons
+        .get("huge-vscode/v0.4-vs-plain")
+        .cloned()
+        .ok_or_else(|| io::Error::other("matched benchmark comparison is missing"))?;
+    comparisons.insert(
+        "huge-vscode/v0.4-vs-v0.3.26".to_string(),
+        matched_comparison,
+    );
+    fs::write(destination, serde_json::to_vec(&artifact)?)?;
+    Ok(())
+}
+
+/// Run one telemetry-disabled JSON token overview.
+fn token_overview_json(
+    repo: &Path,
+    database: &Path,
+    benchmark_results: Option<&str>,
+) -> Result<Value, Box<dyn Error>> {
+    let mut command = Command::cargo_bin("projectatlas")?;
+    command
+        .current_dir(repo)
+        .env("PROJECTATLAS_NO_TELEMETRY", "1")
+        .args(["--format", "json", "--db"])
+        .arg(database)
+        .arg("token");
+    if let Some(path) = benchmark_results {
+        command.args(["--benchmark-results", path]);
+    }
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "token overview failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+        .into());
+    }
+    Ok(serde_json::from_slice(&output.stdout)?)
+}
+
+/// Compare adapter payloads while allowing equivalent floating-point text round-trips.
+fn json_values_equivalent(left: &Value, right: &Value) -> bool {
+    match (left, right) {
+        (Value::Number(left), Value::Number(right)) => left
+            .as_f64()
+            .zip(right.as_f64())
+            .is_some_and(|(left, right)| {
+                (left - right).abs() <= f64::EPSILON * 8.0 * left.abs().max(right.abs()).max(1.0)
+            }),
+        (Value::Array(left), Value::Array(right)) => {
+            left.len() == right.len()
+                && left
+                    .iter()
+                    .zip(right)
+                    .all(|(left, right)| json_values_equivalent(left, right))
+        }
+        (Value::Object(left), Value::Object(right)) => {
+            left.len() == right.len()
+                && left.iter().all(|(key, left)| {
+                    right
+                        .get(key)
+                        .is_some_and(|right| json_values_equivalent(left, right))
+                })
+        }
+        _ => left == right,
+    }
+}
+
+#[test]
+fn agent_efficiency_cli_mcp_contract_is_typed_read_only_and_isolated() -> Result<(), Box<dyn Error>>
+{
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join(TEST_REPO_DIR);
+    fs::create_dir_all(repo.join(SRC_DIR_NAME))?;
+    fs::write(
+        repo.join(SRC_DIR_NAME).join("lib.rs"),
+        "pub fn atlas() {}\n",
+    )?;
+    let database = temp.path().join("projectatlas.db");
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&database)
+        .args(["scan", "."])
+        .assert()
+        .success();
+
+    let published_source =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(AGENT_EFFICIENCY_BENCHMARK_PATH);
+    let partial_path = repo.join(AGENT_EFFICIENCY_PARTIAL_FILE);
+    let compatible_path = repo.join("compatible.json");
+    let stale_path = repo.join("stale.json");
+    let malformed_path = repo.join("malformed.json");
+    let outside_path = temp.path().join("outside.json");
+    fs::copy(&published_source, &partial_path)?;
+    fs::copy(&published_source, &outside_path)?;
+    write_fully_matched_benchmark_fixture(&compatible_path)?;
+    let mut stale: Value = serde_json::from_slice(&fs::read(&published_source)?)?;
+    stale
+        .as_object_mut()
+        .ok_or_else(|| io::Error::other("published benchmark is not an object"))?
+        .insert("schema_version".to_string(), Value::from(2));
+    fs::write(&stale_path, serde_json::to_vec(&stale)?)?;
+    fs::write(&malformed_path, b"{")?;
+
+    #[cfg(unix)]
+    let indirect_argument = {
+        std::os::unix::fs::symlink(&partial_path, repo.join("indirect.json"))?;
+        "indirect.json"
+    };
+    #[cfg(windows)]
+    let indirect_argument = {
+        let junction_target = repo.join("benchmark-target");
+        let junction = repo.join("indirect");
+        fs::create_dir(&junction_target)?;
+        fs::copy(
+            &partial_path,
+            junction_target.join(AGENT_EFFICIENCY_PARTIAL_FILE),
+        )?;
+        let output = StdCommand::new("cmd")
+            .args(["/d", "/c", "mklink", "/J"])
+            .arg(&junction)
+            .arg(&junction_target)
+            .output()?;
+        if !output.status.success() {
+            return Err(io::Error::other(format!(
+                "failed to create benchmark reparse-point fixture: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ))
+            .into());
+        }
+        "indirect/partial.json"
+    };
+
+    let mcp_config = mcp_config_for_harness(&repo, &database, "mcp-json")?;
+    let (mcp_command, mcp_args) = mcp_command_and_args(&mcp_config)?;
+    let connection = Connection::open(&database)?;
+    connection.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    drop(connection);
+    let unavailable = token_overview_json(&repo, &database, None)?;
+    require_json_string(&unavailable, &["agent_efficiency", "state"], "unavailable")?;
+    require_json_string(&unavailable, &["estimate_kind"], "heuristic")?;
+    let database_before = fs::read(&database)?;
+    let sidecars_before = ["-wal", "-shm", "-journal"].map(|suffix| {
+        let path = sqlite_sidecar_path(&database, suffix);
+        let bytes = path.exists().then(|| fs::read(&path)).transpose();
+        (path, bytes)
+    });
+    let sidecars_before = sidecars_before
+        .into_iter()
+        .map(|(path, bytes)| Ok((path, bytes?)))
+        .collect::<Result<Vec<_>, io::Error>>()?;
+    let artifact_snapshots = [
+        (&partial_path, fs::read(&partial_path)?),
+        (&compatible_path, fs::read(&compatible_path)?),
+        (&stale_path, fs::read(&stale_path)?),
+        (&malformed_path, fs::read(&malformed_path)?),
+        (&outside_path, fs::read(&outside_path)?),
+    ];
+
+    let partial = token_overview_json(&repo, &database, Some(AGENT_EFFICIENCY_PARTIAL_FILE))?;
+    require_json_string(&partial, &["agent_efficiency", "state"], "partial")?;
+    require_json_usize(
+        &partial,
+        &[
+            "agent_efficiency",
+            "baselines",
+            "0",
+            "baseline_failed_trials",
+        ],
+        3,
+    )?;
+    let compatible = token_overview_json(&repo, &database, Some("compatible.json"))?;
+    require_json_string(&compatible, &["agent_efficiency", "state"], "compatible")?;
+    let stale = token_overview_json(&repo, &database, Some("stale.json"))?;
+    require_json_string(&stale, &["agent_efficiency", "state"], "incompatible")?;
+    let malformed = token_overview_json(&repo, &database, Some("malformed.json"))?;
+    require_json_string(&malformed, &["agent_efficiency", "state"], "failed")?;
+    let missing = token_overview_json(&repo, &database, Some("missing.json"))?;
+    require_json_string(&missing, &["agent_efficiency", "state"], "failed")?;
+
+    let toon = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .env("PROJECTATLAS_NO_TELEMETRY", "1")
+        .arg("--db")
+        .arg(&database)
+        .args([
+            "token",
+            "--benchmark-results",
+            AGENT_EFFICIENCY_PARTIAL_FILE,
+        ])
+        .output()?;
+    if !toon.status.success() {
+        return Err(io::Error::other("TOON benchmark token overview failed").into());
+    }
+    let toon: Value = toon_format::decode_default(&String::from_utf8(toon.stdout)?)?;
+    if !json_values_equivalent(
+        &toon["token_savings"]["agent_efficiency"],
+        &partial["agent_efficiency"],
+    ) {
+        return Err(io::Error::other("CLI JSON and TOON benchmark reports diverged").into());
+    }
+
+    let absolute_argument = outside_path.to_string_lossy().to_string();
+    let messages = [
+        serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"projectatlas-agent-efficiency-e2e","version":"0.1.0"}}}).to_string(),
+        serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}).to_string(),
+        serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"atlas_token_report","arguments":{"benchmark_results":AGENT_EFFICIENCY_PARTIAL_FILE}}}).to_string(),
+        serde_json::json!({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"atlas_token_report","arguments":{"benchmark_results":"compatible.json"}}}).to_string(),
+        serde_json::json!({"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"atlas_token_report","arguments":{}}}).to_string(),
+        serde_json::json!({"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"atlas_token_report","arguments":{"benchmark_results":"stale.json"}}}).to_string(),
+        serde_json::json!({"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"atlas_token_report","arguments":{"benchmark_results":"malformed.json"}}}).to_string(),
+        serde_json::json!({"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"atlas_token_report","arguments":{"benchmark_results":"../outside.json"}}}).to_string(),
+        serde_json::json!({"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"atlas_token_report","arguments":{"benchmark_results":absolute_argument}}}).to_string(),
+        serde_json::json!({"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"atlas_token_report","arguments":{"benchmark_results":indirect_argument}}}).to_string(),
+    ];
+    let mcp_stdout = run_mcp_stdio_with_env(
+        &mcp_command,
+        &repo,
+        &mcp_args,
+        &messages,
+        &[("PROJECTATLAS_NO_TELEMETRY", Some("1"))],
+    )?;
+    for (id, cli_report) in [
+        (2, &partial),
+        (3, &compatible),
+        (4, &unavailable),
+        (5, &stale),
+        (6, &malformed),
+    ] {
+        let mcp: Value = toon_format::decode_default(&mcp_tool_text(&mcp_stdout, id)?)?;
+        if !json_values_equivalent(
+            &mcp["token_savings"]["agent_efficiency"],
+            &cli_report["agent_efficiency"],
+        ) {
+            return Err(io::Error::other(format!(
+                "MCP and CLI benchmark reports diverged for response {id}"
+            ))
+            .into());
+        }
+    }
+    for id in [7, 8, 9] {
+        if !mcp_tool_text(&mcp_stdout, id)?.contains("invalid input") {
+            return Err(io::Error::other(format!(
+                "MCP benchmark path boundary did not reject response {id}"
+            ))
+            .into());
+        }
+    }
+
+    for path in [
+        absolute_argument.as_str(),
+        "../outside.json",
+        indirect_argument,
+    ] {
+        Command::cargo_bin("projectatlas")?
+            .current_dir(&repo)
+            .env("PROJECTATLAS_NO_TELEMETRY", "1")
+            .arg("--db")
+            .arg(&database)
+            .args(["token", "--benchmark-results", path])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("invalid input"));
+    }
+
+    if fs::read(&database)? != database_before {
+        return Err(io::Error::other("benchmark reports mutated the SQLite database").into());
+    }
+    for (path, before) in artifact_snapshots {
+        if fs::read(path)? != before {
+            return Err(
+                io::Error::other(format!("benchmark report rewrote {}", path.display())).into(),
+            );
+        }
+    }
+    for (path, before) in sidecars_before {
+        let after = path.exists().then(|| fs::read(&path)).transpose()?;
+        if after != before {
+            return Err(io::Error::other(format!(
+                "benchmark report changed SQLite sidecar {}: before={:?}, after={:?}",
+                path.display(),
+                before.as_ref().map(Vec::len),
+                after.as_ref().map(Vec::len)
+            ))
+            .into());
         }
     }
     Ok(())

--- a/crates/projectatlas-core/src/telemetry.rs
+++ b/crates/projectatlas-core/src/telemetry.rs
@@ -326,6 +326,251 @@ pub struct TokenCalibrationOverview {
     pub heuristic_to_calibrated_ratio: Option<f64>,
 }
 
+/// Validation state for optional agent-efficiency benchmark evidence.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentEfficiencyEvidenceState {
+    /// No benchmark artifact was requested.
+    #[default]
+    Unavailable,
+    /// The requested artifact could not be read or decoded safely.
+    Failed,
+    /// The artifact decoded but does not match the supported release contract.
+    Incompatible,
+    /// Some matched evidence is valid while retained failures remain explicit.
+    Partial,
+    /// All required candidate and baseline trials matched successfully.
+    Compatible,
+}
+
+impl AgentEfficiencyEvidenceState {
+    /// Return the stable serialized label.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unavailable => "unavailable",
+            Self::Failed => "failed",
+            Self::Incompatible => "incompatible",
+            Self::Partial => "partial",
+            Self::Compatible => "compatible",
+        }
+    }
+}
+
+/// Baseline arm compared with the `v0.4` candidate.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentEfficiencyBaseline {
+    /// Frozen `ProjectAtlas` `v0.3.26` runtime and packaged skill.
+    FrozenProjectAtlasV0326,
+    /// Codex navigation without `ProjectAtlas`.
+    PlainCodex,
+}
+
+/// Identity retained from one validated benchmark artifact.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentEfficiencyArtifactIdentity {
+    /// Supported benchmark schema version.
+    pub schema_version: u32,
+    /// Digest algorithm used for `artifact_digest`.
+    pub artifact_digest_kind: String,
+    /// Digest of the exact validated artifact bytes.
+    pub artifact_digest: String,
+    /// Candidate runtime semantic version.
+    pub candidate_version: String,
+    /// Candidate runtime SHA-256 identity.
+    pub candidate_runtime_sha256: String,
+    /// Candidate functional source commit.
+    pub candidate_functional_head: String,
+    /// Candidate checklist source commit.
+    pub candidate_checklist_head: String,
+    /// Frozen `ProjectAtlas` runtime semantic version.
+    pub frozen_version: String,
+    /// Frozen `ProjectAtlas` runtime `SHA-256` identity.
+    pub frozen_runtime_sha256: String,
+}
+
+/// Closed navigation metric projected from matched benchmark trials.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentEfficiencyMetricKind {
+    /// All tool calls made by the agent.
+    TotalToolCalls,
+    /// Calls made through the `ProjectAtlas` MCP server.
+    ProjectAtlasCalls,
+    /// Productive folder selections.
+    ProductiveFolders,
+    /// Productive file selections.
+    ProductiveFiles,
+    /// Productive relation selections.
+    ProductiveRelations,
+    /// Wrong folder selections.
+    WrongFolders,
+    /// Wrong file selections.
+    WrongFiles,
+    /// Wrong relation selections.
+    WrongRelations,
+    /// Broad source reads.
+    BroadReads,
+    /// Full source-file reads.
+    FullReads,
+    /// Navigation backtracks.
+    Backtracks,
+    /// Gross navigation-context bytes.
+    GrossNavigationBytes,
+    /// Net navigation-context bytes including setup material.
+    NetNavigationBytes,
+    /// Gross navigation-context heuristic tokens.
+    GrossNavigationTokens,
+    /// Net navigation-context heuristic tokens including setup material.
+    NetNavigationTokens,
+    /// Candidate setup wall time.
+    SetupWallSeconds,
+    /// Per-task runtime wall time after setup.
+    RuntimeWallSeconds,
+    /// Persistent bytes retained after the trial.
+    PersistentBytes,
+}
+
+/// Candidate and baseline distribution summary for one navigation metric.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct AgentEfficiencyMetricComparison {
+    /// Metric represented by this row.
+    pub metric: AgentEfficiencyMetricKind,
+    /// Median across matched candidate trials.
+    pub candidate_median: f64,
+    /// Median across matched baseline trials.
+    pub baseline_median: f64,
+    /// Observed maximum across matched candidate trials.
+    pub candidate_maximum: f64,
+    /// Observed maximum across matched baseline trials.
+    pub baseline_maximum: f64,
+    /// Lower-is-better median percentage saving, absent for a zero denominator.
+    pub median_percent_saving: Option<f64>,
+}
+
+/// Workload-specific setup/runtime break-even truth.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentEfficiencyBreakEven {
+    /// Validated benchmark workload name.
+    pub workload: String,
+    /// Tasks required to repay setup wall time, or `None` when no positive saving exists.
+    pub wall_time_tasks: Option<u64>,
+}
+
+/// Provider counter represented only as descriptive benchmark context.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentEfficiencyProviderMetricKind {
+    /// Provider input-token counter.
+    InputTokens,
+    /// Provider cached-input-token counter.
+    CachedInputTokens,
+    /// Provider cache-write input-token counter.
+    CacheWriteInputTokens,
+    /// Provider output-token counter.
+    OutputTokens,
+    /// Provider reasoning-output-token counter.
+    ReasoningOutputTokens,
+}
+
+/// Descriptive-only candidate and baseline provider counter.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct AgentEfficiencyProviderMetric {
+    /// Provider counter represented by this row.
+    pub metric: AgentEfficiencyProviderMetricKind,
+    /// Candidate median reported by the provider.
+    pub candidate_median: f64,
+    /// Baseline median reported by the provider.
+    pub baseline_median: f64,
+    /// Candidate observed maximum reported by the provider.
+    pub candidate_maximum: f64,
+    /// Baseline observed maximum reported by the provider.
+    pub baseline_maximum: f64,
+    /// Always false because provider counters do not prove navigation causality.
+    pub causal_attribution: bool,
+}
+
+/// One matched baseline comparison projected from the benchmark artifact.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct AgentEfficiencyBaselineRow {
+    /// Compared baseline arm.
+    pub baseline: AgentEfficiencyBaseline,
+    /// Evidence state for this baseline.
+    pub state: AgentEfficiencyEvidenceState,
+    /// Candidate and baseline trials that completed the same workload and repeat.
+    pub matched_trials: usize,
+    /// Failed candidate trials retained outside matched denominators.
+    pub candidate_failed_trials: usize,
+    /// Failed baseline trials retained outside matched denominators.
+    pub baseline_failed_trials: usize,
+    /// Completed trials without a completed counterpart.
+    pub unmatched_trials: usize,
+    /// Bounded matched navigation distributions.
+    pub metrics: Vec<AgentEfficiencyMetricComparison>,
+    /// Workload-specific setup/runtime break-even truth.
+    pub break_even: Vec<AgentEfficiencyBreakEven>,
+    /// Provider counters retained as descriptive-only context.
+    pub provider_usage_descriptive_only: Vec<AgentEfficiencyProviderMetric>,
+}
+
+/// Durable `ProjectAtlas` navigation capability represented in the benchmark.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentEfficiencyCapability {
+    /// Initial project, purpose, and connection discovery.
+    Discovery,
+    /// Summary, outline, and exact-slice compression.
+    SummaryAndSlice,
+    /// Lexical search narrowing.
+    Search,
+    /// Symbol and relation navigation.
+    SymbolsAndRelations,
+    /// Trace-completed `ProjectAtlas` calls outside the supported named groups.
+    Other,
+}
+
+/// Trace-completed `v0.4` MCP calls grouped by navigation responsibility.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentEfficiencyCapabilityContribution {
+    /// Capability responsibility represented by this row.
+    pub capability: AgentEfficiencyCapability,
+    /// Trace-completed `ProjectAtlas` MCP calls.
+    pub calls: usize,
+    /// Bytes emitted by those MCP calls.
+    pub emitted_bytes: u64,
+}
+
+/// Optional controlled benchmark comparison attached to live token telemetry.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct AgentEfficiencyComparison {
+    /// Overall evidence state.
+    pub state: AgentEfficiencyEvidenceState,
+    /// Bounded explanation for unavailable, failed, incompatible, or partial evidence.
+    pub reason: Option<String>,
+    /// Validated artifact and runtime identity.
+    pub artifact: Option<AgentEfficiencyArtifactIdentity>,
+    /// Frozen-v0.3.26 and plain-control rows.
+    pub baselines: Vec<AgentEfficiencyBaselineRow>,
+    /// Trace-completed candidate MCP calls grouped without causal token attribution.
+    pub capabilities: Vec<AgentEfficiencyCapabilityContribution>,
+    /// Whether provider counters are explicitly non-causal.
+    pub provider_counters_descriptive_only: bool,
+}
+
+impl Default for AgentEfficiencyComparison {
+    fn default() -> Self {
+        Self {
+            state: AgentEfficiencyEvidenceState::Unavailable,
+            reason: Some("benchmark artifact not supplied".to_string()),
+            artifact: None,
+            baselines: Vec::new(),
+            capabilities: Vec::new(),
+            provider_counters_descriptive_only: true,
+        }
+    }
+}
+
 /// Token savings overview.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct TokenOverview {
@@ -379,6 +624,9 @@ pub struct TokenOverview {
     /// Availability of caller-label and retained raw detail for this report.
     #[serde(default)]
     pub detail_availability: UsageDetailAvailability,
+    /// Optional validated controlled benchmark evidence kept separate from live accounting.
+    #[serde(default)]
+    pub agent_efficiency: AgentEfficiencyComparison,
 }
 
 /// Token trend grouping window.
@@ -659,6 +907,7 @@ impl TokenOverview {
             read_avoidance_confidence: READ_AVOIDANCE_CONFIDENCE_NOT_RECORDED.to_string(),
             calibration: None,
             detail_availability: UsageDetailAvailability::Retained,
+            agent_efficiency: AgentEfficiencyComparison::default(),
             buckets,
         }
     }
@@ -666,6 +915,11 @@ impl TokenOverview {
     /// Attach a local tokenizer calibration section.
     pub fn set_calibration(&mut self, calibration: TokenCalibrationOverview) {
         self.calibration = Some(calibration);
+    }
+
+    /// Attach one validated controlled benchmark comparison.
+    pub fn set_agent_efficiency(&mut self, comparison: AgentEfficiencyComparison) {
+        self.agent_efficiency = comparison;
     }
 
     /// Apply exact separated accounting totals loaded from durable aggregates.
@@ -1450,12 +1704,13 @@ fn is_modeled_bucket(bucket: &TokenBucketOverview) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        READ_AVOIDANCE_CONFIDENCE_MODELED, READ_AVOIDANCE_CONFIDENCE_NOT_RECORDED,
-        READ_AVOIDANCE_CONFIDENCE_OBSERVED, READ_AVOIDANCE_SCOPE,
-        TOKEN_BUCKET_FULL_FILE_COMPRESSION, TOKEN_BUCKET_NAVIGATION_AVOIDANCE, TOKEN_ESTIMATE_KIND,
-        TOKEN_ESTIMATE_SCOPE, TOKEN_ESTIMATOR, TelemetryContractError, TokenAccountingTotals,
-        TokenOverview, TokenTrendReport, TokenTrendWindow, UsageDetailAvailability,
-        UsageInstanceId, UsageInstanceOwner, usage_from_estimates, usage_from_text,
+        AgentEfficiencyEvidenceState, READ_AVOIDANCE_CONFIDENCE_MODELED,
+        READ_AVOIDANCE_CONFIDENCE_NOT_RECORDED, READ_AVOIDANCE_CONFIDENCE_OBSERVED,
+        READ_AVOIDANCE_SCOPE, TOKEN_BUCKET_FULL_FILE_COMPRESSION,
+        TOKEN_BUCKET_NAVIGATION_AVOIDANCE, TOKEN_ESTIMATE_KIND, TOKEN_ESTIMATE_SCOPE,
+        TOKEN_ESTIMATOR, TelemetryContractError, TokenAccountingTotals, TokenOverview,
+        TokenTrendReport, TokenTrendWindow, UsageDetailAvailability, UsageInstanceId,
+        UsageInstanceOwner, usage_from_estimates, usage_from_text,
     };
     use std::io;
 
@@ -1542,11 +1797,27 @@ mod tests {
             .as_object_mut()
             .ok_or_else(|| io::Error::other("serialized token overview was not an object"))?;
         overview_object.remove("detail_availability");
+        overview_object.remove("agent_efficiency");
         let decoded_overview: TokenOverview = serde_json::from_value(overview_value)?;
         require_eq(
             &decoded_overview.detail_availability,
             &UsageDetailAvailability::Unavailable,
             "missing overview detail availability",
+        )?;
+        require_eq(
+            &decoded_overview.agent_efficiency.state,
+            &AgentEfficiencyEvidenceState::Unavailable,
+            "missing agent-efficiency evidence state",
+        )?;
+        require_eq(
+            &decoded_overview.agent_efficiency.baselines,
+            &Vec::new(),
+            "missing agent-efficiency baseline rows",
+        )?;
+        require_eq(
+            &AgentEfficiencyEvidenceState::Partial.as_str(),
+            &"partial",
+            "agent-efficiency evidence encoding",
         )?;
 
         let trends = TokenTrendReport::new(None, TokenTrendWindow::Day, Vec::new());

--- a/crates/projectatlas-core/src/toon.rs
+++ b/crates/projectatlas-core/src/toon.rs
@@ -178,6 +178,7 @@ pub fn render_token_overview(overview: &TokenOverview) -> String {
                 "confidence": overview.read_avoidance_confidence,
                 "plain_language": "ProjectAtlas summaries, search results, and slices were used instead of opening likely whole files.",
             },
+            "agent_efficiency": overview.agent_efficiency,
             "calibration": overview.calibration,
             "savings_rate": savings_rate,
             "totals": {

--- a/crates/projectatlas-service/src/agent_efficiency.rs
+++ b/crates/projectatlas-service/src/agent_efficiency.rs
@@ -1,0 +1,2017 @@
+//! Validate and project read-only agent-efficiency benchmark evidence.
+
+use crate::{ServiceError, ServiceResult};
+use projectatlas_core::telemetry::{
+    AgentEfficiencyArtifactIdentity, AgentEfficiencyBaseline, AgentEfficiencyBaselineRow,
+    AgentEfficiencyBreakEven, AgentEfficiencyCapability, AgentEfficiencyCapabilityContribution,
+    AgentEfficiencyComparison, AgentEfficiencyEvidenceState, AgentEfficiencyMetricComparison,
+    AgentEfficiencyMetricKind, AgentEfficiencyProviderMetric, AgentEfficiencyProviderMetricKind,
+};
+use projectatlas_core::{repo_path_to_native, validated_repo_file_key};
+use projectatlas_db::CapturedProjectBinding;
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::Read;
+use std::path::Path;
+
+/// Maximum benchmark-result bytes admitted by one optional token request.
+pub(super) const BENCHMARK_MAX_BYTES: usize = 8 * 1024 * 1024;
+/// Maximum retained schedule or run rows.
+const BENCHMARK_MAX_RUNS: usize = 256;
+/// Maximum aggregate workload/arm groups.
+const BENCHMARK_MAX_GROUPS: usize = 64;
+/// Maximum candidate/baseline comparison groups.
+const BENCHMARK_MAX_COMPARISONS: usize = 64;
+/// Maximum values retained by one distribution.
+const BENCHMARK_MAX_DISTRIBUTION_VALUES: usize = 32;
+/// Maximum MCP calls retained by one run.
+const BENCHMARK_MAX_MCP_CALLS_PER_RUN: usize = 128;
+/// Maximum trace-completed `ProjectAtlas` MCP calls retained by one artifact.
+const BENCHMARK_MAX_TOTAL_MCP_CALLS: usize = 4_096;
+/// Largest integer admitted through JSON without loss of exactness.
+const BENCHMARK_MAX_EXACT_INTEGER: u64 = (1_u64 << 53) - 1;
+/// Maximum supported wall-clock duration for one benchmark measurement.
+const BENCHMARK_MAX_WALL_SECONDS: f64 = 7.0 * 24.0 * 60.0 * 60.0;
+/// Maximum caller-visible validation reason bytes.
+const BENCHMARK_REASON_MAX_BYTES: usize = 240;
+/// Supported benchmark result schema.
+const BENCHMARK_SCHEMA_VERSION: u32 = 1;
+/// Minimum publication repeat count.
+const BENCHMARK_MIN_REPEAT_COUNT: usize = 3;
+/// Defensive repeat-count ceiling.
+const BENCHMARK_MAX_REPEAT_COUNT: usize = 16;
+/// Candidate arm identifier.
+const CANDIDATE_ARM: &str = "v0.4";
+/// Frozen `ProjectAtlas` arm identifier.
+const FROZEN_ARM: &str = "v0.3.26";
+/// Plain Codex arm identifier.
+const PLAIN_ARM: &str = "plain";
+/// Supported candidate semantic identity.
+const CANDIDATE_VERSION: &str = "projectatlas 0.4.0";
+/// Supported frozen semantic identity.
+const FROZEN_VERSION: &str = "projectatlas 0.3.26";
+/// Required provider-accounting separation note.
+const PROVIDER_USAGE_NOTE: &str =
+    "Provider counters are reported separately and are not attributed causally to navigation.";
+/// Candidate setup wall-time distribution key.
+const SETUP_WALL_SECONDS_METRIC: &str = "setup_wall_seconds";
+/// Per-task runtime wall-time distribution key.
+const RUNTIME_WALL_SECONDS_METRIC: &str = "wall_seconds";
+/// Required benchmark workloads.
+const WORKLOADS: [&str; 5] = [
+    "small-clean",
+    "small-dirty",
+    "small-non-git",
+    "medium",
+    "huge-vscode",
+];
+/// Required benchmark arms.
+const ARMS: [&str; 3] = [CANDIDATE_ARM, FROZEN_ARM, PLAIN_ARM];
+/// Metrics projected into the public typed comparison.
+const METRICS: [(AgentEfficiencyMetricKind, &str); 18] = [
+    (AgentEfficiencyMetricKind::TotalToolCalls, "tool_calls"),
+    (AgentEfficiencyMetricKind::ProjectAtlasCalls, "mcp_calls"),
+    (
+        AgentEfficiencyMetricKind::ProductiveFolders,
+        "productive_folders",
+    ),
+    (
+        AgentEfficiencyMetricKind::ProductiveFiles,
+        "productive_files",
+    ),
+    (
+        AgentEfficiencyMetricKind::ProductiveRelations,
+        "productive_relations",
+    ),
+    (AgentEfficiencyMetricKind::WrongFolders, "wrong_folders"),
+    (AgentEfficiencyMetricKind::WrongFiles, "wrong_files"),
+    (AgentEfficiencyMetricKind::WrongRelations, "wrong_relations"),
+    (AgentEfficiencyMetricKind::BroadReads, "broad_reads"),
+    (AgentEfficiencyMetricKind::FullReads, "full_reads"),
+    (AgentEfficiencyMetricKind::Backtracks, "backtracks"),
+    (
+        AgentEfficiencyMetricKind::GrossNavigationBytes,
+        "gross_navigation_bytes",
+    ),
+    (
+        AgentEfficiencyMetricKind::NetNavigationBytes,
+        "net_navigation_bytes",
+    ),
+    (
+        AgentEfficiencyMetricKind::GrossNavigationTokens,
+        "gross_navigation_tokens",
+    ),
+    (
+        AgentEfficiencyMetricKind::NetNavigationTokens,
+        "net_navigation_tokens",
+    ),
+    (
+        AgentEfficiencyMetricKind::SetupWallSeconds,
+        SETUP_WALL_SECONDS_METRIC,
+    ),
+    (
+        AgentEfficiencyMetricKind::RuntimeWallSeconds,
+        RUNTIME_WALL_SECONDS_METRIC,
+    ),
+    (
+        AgentEfficiencyMetricKind::PersistentBytes,
+        "post_trial_persistent_bytes",
+    ),
+];
+/// Provider counters retained only as descriptive context.
+const PROVIDER_METRICS: [(AgentEfficiencyProviderMetricKind, &str); 5] = [
+    (
+        AgentEfficiencyProviderMetricKind::InputTokens,
+        "input_tokens",
+    ),
+    (
+        AgentEfficiencyProviderMetricKind::CachedInputTokens,
+        "cached_input_tokens",
+    ),
+    (
+        AgentEfficiencyProviderMetricKind::CacheWriteInputTokens,
+        "cache_write_input_tokens",
+    ),
+    (
+        AgentEfficiencyProviderMetricKind::OutputTokens,
+        "output_tokens",
+    ),
+    (
+        AgentEfficiencyProviderMetricKind::ReasoningOutputTokens,
+        "reasoning_output_tokens",
+    ),
+];
+
+/// Load an optional benchmark artifact under the captured project binding.
+pub(crate) fn load_agent_efficiency_comparison(
+    binding: &CapturedProjectBinding,
+    benchmark_results: Option<&Path>,
+) -> ServiceResult<AgentEfficiencyComparison> {
+    let Some(benchmark_results) = benchmark_results else {
+        return Ok(AgentEfficiencyComparison::default());
+    };
+    let bytes = match read_benchmark_bytes(binding, benchmark_results)? {
+        BenchmarkRead::Bytes(bytes) => bytes,
+        BenchmarkRead::Failed(reason) => return Ok(failed_comparison(reason)),
+    };
+    let artifact = match serde_json::from_slice::<BenchmarkArtifact>(&bytes) {
+        Ok(artifact) => artifact,
+        Err(error) => {
+            return Ok(failed_comparison(format!(
+                "benchmark artifact is malformed: {error}"
+            )));
+        }
+    };
+    match validate_and_project(artifact, &bytes) {
+        Ok(comparison) => Ok(comparison),
+        Err(reason) => Ok(incompatible_comparison(reason)),
+    }
+}
+
+/// Result of a boundary-checked benchmark read.
+enum BenchmarkRead {
+    /// Exact bounded artifact bytes.
+    Bytes(Vec<u8>),
+    /// Non-boundary filesystem failure represented in the typed report.
+    Failed(String),
+}
+
+/// Read one regular in-project artifact without following path indirection.
+fn read_benchmark_bytes(
+    binding: &CapturedProjectBinding,
+    requested: &Path,
+) -> ServiceResult<BenchmarkRead> {
+    let key = validated_repo_file_key(requested)
+        .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
+    let root = Path::new(&binding.project_root);
+    let relative = repo_path_to_native(&key);
+    let path = root.join(&relative);
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        current.push(component.as_os_str());
+        let metadata = match fs::symlink_metadata(&current) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(BenchmarkRead::Failed(
+                    "benchmark artifact was not found".to_string(),
+                ));
+            }
+            Err(error) => {
+                return Ok(BenchmarkRead::Failed(format!(
+                    "benchmark artifact metadata could not be read: {}",
+                    error.kind()
+                )));
+            }
+        };
+        if metadata_is_indirect(&metadata) {
+            return Err(ServiceError::InvalidInput(
+                "benchmark artifact path contains a symlink or reparse point".to_string(),
+            ));
+        }
+    }
+    let metadata = fs::symlink_metadata(&path).map_err(|source| ServiceError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(ServiceError::InvalidInput(
+            "benchmark artifact path must name a regular file".to_string(),
+        ));
+    }
+    if metadata.len() > BENCHMARK_MAX_BYTES as u64 {
+        return Ok(BenchmarkRead::Failed(format!(
+            "benchmark artifact exceeds the {BENCHMARK_MAX_BYTES}-byte limit"
+        )));
+    }
+    let canonical_root = match root.canonicalize() {
+        Ok(root) => root,
+        Err(error) => {
+            return Ok(BenchmarkRead::Failed(format!(
+                "selected project root could not be resolved: {}",
+                error.kind()
+            )));
+        }
+    };
+    let canonical_path = match path.canonicalize() {
+        Ok(path) => path,
+        Err(error) => {
+            return Ok(BenchmarkRead::Failed(format!(
+                "benchmark artifact could not be resolved: {}",
+                error.kind()
+            )));
+        }
+    };
+    if !canonical_path.starts_with(&canonical_root) {
+        return Err(ServiceError::InvalidInput(
+            "benchmark artifact resolves outside the selected project".to_string(),
+        ));
+    }
+    let file = match open_benchmark_file(&canonical_path) {
+        Ok(file) => file,
+        Err(error) => {
+            return Ok(BenchmarkRead::Failed(format!(
+                "benchmark artifact could not be opened: {}",
+                error.kind()
+            )));
+        }
+    };
+    let opened_canonical_path = match path.canonicalize() {
+        Ok(path) => path,
+        Err(error) => {
+            return Ok(BenchmarkRead::Failed(format!(
+                "benchmark artifact changed before the read: {}",
+                error.kind()
+            )));
+        }
+    };
+    if opened_canonical_path != canonical_path
+        || !opened_canonical_path.starts_with(&canonical_root)
+    {
+        return Ok(BenchmarkRead::Failed(
+            "benchmark artifact changed before the read".to_string(),
+        ));
+    }
+    let opened_metadata = match file.metadata() {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            return Ok(BenchmarkRead::Failed(format!(
+                "benchmark artifact metadata could not be read from its open handle: {}",
+                error.kind()
+            )));
+        }
+    };
+    if metadata_is_indirect(&opened_metadata)
+        || !opened_metadata.file_type().is_file()
+        || !benchmark_metadata_unchanged(&metadata, &opened_metadata)
+    {
+        return Ok(BenchmarkRead::Failed(
+            "benchmark artifact changed before the read".to_string(),
+        ));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    if let Err(error) = (&file)
+        .take(BENCHMARK_MAX_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+    {
+        return Ok(BenchmarkRead::Failed(format!(
+            "benchmark artifact could not be read: {}",
+            error.kind()
+        )));
+    }
+    if bytes.len() > BENCHMARK_MAX_BYTES {
+        return Ok(BenchmarkRead::Failed(format!(
+            "benchmark artifact exceeds the {BENCHMARK_MAX_BYTES}-byte limit"
+        )));
+    }
+    let final_metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            return Ok(BenchmarkRead::Failed(format!(
+                "benchmark artifact changed during the read: {}",
+                error.kind()
+            )));
+        }
+    };
+    let read_metadata = match file.metadata() {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            return Ok(BenchmarkRead::Failed(format!(
+                "benchmark artifact metadata changed during the read: {}",
+                error.kind()
+            )));
+        }
+    };
+    let final_canonical_path = match path.canonicalize() {
+        Ok(path) => path,
+        Err(error) => {
+            return Ok(BenchmarkRead::Failed(format!(
+                "benchmark artifact changed during the read: {}",
+                error.kind()
+            )));
+        }
+    };
+    if metadata_is_indirect(&final_metadata)
+        || !final_metadata.file_type().is_file()
+        || final_canonical_path != canonical_path
+        || !final_canonical_path.starts_with(&canonical_root)
+        || !benchmark_metadata_unchanged(&opened_metadata, &read_metadata)
+        || !benchmark_metadata_unchanged(&opened_metadata, &final_metadata)
+    {
+        return Ok(BenchmarkRead::Failed(
+            "benchmark artifact changed during the read".to_string(),
+        ));
+    }
+    Ok(BenchmarkRead::Bytes(bytes))
+}
+
+/// Open one benchmark file while denying concurrent replacement where the platform supports it.
+fn open_benchmark_file(path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        const FILE_SHARE_READ: u32 = 0x1;
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        options
+            .share_mode(FILE_SHARE_READ)
+            .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+    options.open(path)
+}
+
+/// Compare stable identity where available and modification metadata around one bounded read.
+fn benchmark_metadata_unchanged(before: &fs::Metadata, after: &fs::Metadata) -> bool {
+    if before.file_type().is_file() != after.file_type().is_file() || before.len() != after.len() {
+        return false;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        before.creation_time() == after.creation_time()
+            && before.last_write_time() == after.last_write_time()
+            && before.file_attributes() == after.file_attributes()
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        before.dev() == after.dev()
+            && before.ino() == after.ino()
+            && before.mtime() == after.mtime()
+            && before.mtime_nsec() == after.mtime_nsec()
+            && before.ctime() == after.ctime()
+            && before.ctime_nsec() == after.ctime_nsec()
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        before.modified().ok() == after.modified().ok()
+            && before.created().ok() == after.created().ok()
+            && before.permissions().readonly() == after.permissions().readonly()
+    }
+}
+
+/// Return whether metadata represents a symlink or Windows reparse point.
+fn metadata_is_indirect(metadata: &fs::Metadata) -> bool {
+    if metadata.file_type().is_symlink() {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+/// Validate the supported contract and project the bounded public report.
+fn validate_and_project(
+    artifact: BenchmarkArtifact,
+    source_bytes: &[u8],
+) -> Result<AgentEfficiencyComparison, String> {
+    validate_identity(&artifact)?;
+    let runs = validate_schedule_and_runs(&artifact)?;
+    validate_aggregate(&artifact, &runs)?;
+    let baselines = [
+        (AgentEfficiencyBaseline::FrozenProjectAtlasV0326, FROZEN_ARM),
+        (AgentEfficiencyBaseline::PlainCodex, PLAIN_ARM),
+    ]
+    .into_iter()
+    .map(|(baseline, arm)| project_baseline(&artifact, baseline, arm))
+    .collect::<Result<Vec<_>, _>>()?;
+    let capabilities = project_capabilities(&artifact.runs)?;
+    let state = if baselines
+        .iter()
+        .all(|row| row.state == AgentEfficiencyEvidenceState::Compatible)
+    {
+        AgentEfficiencyEvidenceState::Compatible
+    } else if baselines
+        .iter()
+        .any(|row| row.state == AgentEfficiencyEvidenceState::Compatible)
+        || baselines
+            .iter()
+            .any(|row| row.state == AgentEfficiencyEvidenceState::Partial)
+    {
+        AgentEfficiencyEvidenceState::Partial
+    } else {
+        AgentEfficiencyEvidenceState::Failed
+    };
+    let reason = (state != AgentEfficiencyEvidenceState::Compatible)
+        .then(|| "retained benchmark failures are excluded from matched denominators".to_string());
+    let candidate = artifact
+        .candidate_identities
+        .get(CANDIDATE_ARM)
+        .ok_or_else(|| "candidate identity is missing".to_string())?;
+    let frozen = artifact
+        .candidate_identities
+        .get(FROZEN_ARM)
+        .ok_or_else(|| "frozen identity is missing".to_string())?;
+    Ok(AgentEfficiencyComparison {
+        state,
+        reason,
+        artifact: Some(AgentEfficiencyArtifactIdentity {
+            schema_version: artifact.schema_version,
+            artifact_digest_kind: "blake3".to_string(),
+            artifact_digest: blake3::hash(source_bytes).to_hex().to_string(),
+            candidate_version: candidate
+                .version
+                .clone()
+                .ok_or_else(|| "candidate version is missing".to_string())?,
+            candidate_runtime_sha256: candidate
+                .runtime_sha256
+                .clone()
+                .ok_or_else(|| "candidate runtime digest is missing".to_string())?,
+            candidate_functional_head: artifact.candidate_source_identity.functional_head,
+            candidate_checklist_head: artifact.candidate_source_identity.checklist_head,
+            frozen_version: frozen
+                .version
+                .clone()
+                .ok_or_else(|| "frozen version is missing".to_string())?,
+            frozen_runtime_sha256: frozen
+                .runtime_sha256
+                .clone()
+                .ok_or_else(|| "frozen runtime digest is missing".to_string())?,
+        }),
+        baselines,
+        capabilities,
+        provider_counters_descriptive_only: true,
+    })
+}
+
+/// Validate schema, candidate, and source identities.
+fn validate_identity(artifact: &BenchmarkArtifact) -> Result<(), String> {
+    require(
+        artifact.schema_version == BENCHMARK_SCHEMA_VERSION,
+        "unsupported benchmark schema version",
+    )?;
+    require(
+        (BENCHMARK_MIN_REPEAT_COUNT..=BENCHMARK_MAX_REPEAT_COUNT).contains(&artifact.repeat_count),
+        "benchmark repeat count is outside the supported bounds",
+    )?;
+    require(
+        artifact.all_scheduled_runs_retained,
+        "benchmark does not retain every scheduled run",
+    )?;
+    require(
+        artifact.candidate_identities.len() == ARMS.len(),
+        "benchmark candidate inventory is incompatible",
+    )?;
+    for arm in ARMS {
+        require(
+            artifact.candidate_identities.contains_key(arm),
+            "benchmark candidate inventory is incomplete",
+        )?;
+    }
+    validate_projectatlas_identity(
+        artifact
+            .candidate_identities
+            .get(CANDIDATE_ARM)
+            .ok_or_else(|| "candidate identity is missing".to_string())?,
+        CANDIDATE_VERSION,
+    )?;
+    validate_projectatlas_identity(
+        artifact
+            .candidate_identities
+            .get(FROZEN_ARM)
+            .ok_or_else(|| "frozen identity is missing".to_string())?,
+        FROZEN_VERSION,
+    )?;
+    let plain = artifact
+        .candidate_identities
+        .get(PLAIN_ARM)
+        .ok_or_else(|| "plain identity is missing".to_string())?;
+    require(
+        !plain.projectatlas,
+        "plain control unexpectedly enables ProjectAtlas",
+    )?;
+    require(
+        is_lower_hex(&artifact.candidate_source_identity.functional_head, 40)
+            && is_lower_hex(&artifact.candidate_source_identity.checklist_head, 40),
+        "candidate source identity is malformed",
+    )?;
+    Ok(())
+}
+
+/// Validate one `ProjectAtlas` runtime and packaged-skill identity.
+fn validate_projectatlas_identity(
+    identity: &BenchmarkCandidateIdentity,
+    expected_version: &str,
+) -> Result<(), String> {
+    require(identity.projectatlas, "ProjectAtlas arm is disabled")?;
+    require(
+        identity.version.as_deref() == Some(expected_version),
+        "ProjectAtlas semantic identity is incompatible",
+    )?;
+    require(
+        identity
+            .runtime_sha256
+            .as_deref()
+            .is_some_and(|digest| is_lower_hex(digest, 64))
+            && identity
+                .skill_sha256
+                .as_deref()
+                .is_some_and(|digest| is_lower_hex(digest, 64)),
+        "ProjectAtlas runtime or skill digest is malformed",
+    )?;
+    require(
+        identity
+            .skill_bytes
+            .is_some_and(|value| (1..=BENCHMARK_MAX_EXACT_INTEGER).contains(&value))
+            && identity
+                .tool_discovery_bytes
+                .is_some_and(|value| (1..=BENCHMARK_MAX_EXACT_INTEGER).contains(&value)),
+        "ProjectAtlas skill or tool inventory is empty or exceeds the supported bound",
+    )
+}
+
+/// Validate exact schedule/run retention and return rows by run id.
+fn validate_schedule_and_runs(
+    artifact: &BenchmarkArtifact,
+) -> Result<HashMap<&str, &BenchmarkRun>, String> {
+    let expected_rows = WORKLOADS
+        .len()
+        .checked_mul(ARMS.len())
+        .and_then(|count| count.checked_mul(artifact.repeat_count))
+        .ok_or_else(|| "benchmark schedule size overflowed".to_string())?;
+    require(
+        expected_rows <= BENCHMARK_MAX_RUNS
+            && artifact.schedule.len() == expected_rows
+            && artifact.runs.len() == expected_rows,
+        "benchmark schedule or run count is incompatible",
+    )?;
+    let mut scheduled = HashMap::with_capacity(expected_rows);
+    let mut expected_cells = HashSet::with_capacity(expected_rows);
+    for row in &artifact.schedule {
+        validate_schedule_row(row, artifact.repeat_count)?;
+        require(
+            scheduled.insert(row.run_id.as_str(), row).is_none(),
+            "benchmark schedule contains duplicate run ids",
+        )?;
+        require(
+            expected_cells.insert((row.workload.as_str(), row.arm.as_str(), row.repeat)),
+            "benchmark schedule contains duplicate workload-arm-repeat cells",
+        )?;
+    }
+    for workload in WORKLOADS {
+        for arm in ARMS {
+            for repeat in 1..=artifact.repeat_count {
+                require(
+                    expected_cells.contains(&(workload, arm, repeat)),
+                    "benchmark schedule is missing a required workload-arm-repeat cell",
+                )?;
+            }
+        }
+    }
+    let mut runs = HashMap::with_capacity(expected_rows);
+    for run in &artifact.runs {
+        let schedule = scheduled
+            .get(run.run_id.as_str())
+            .ok_or_else(|| "benchmark run is not scheduled".to_string())?;
+        require(
+            run.repeat == schedule.repeat
+                && run.workload == schedule.workload
+                && run.arm == schedule.arm,
+            "benchmark run does not match its scheduled identity",
+        )?;
+        require(!run.excluded, "benchmark contains an excluded run")?;
+        require(
+            matches!(run.execution_status.as_str(), "completed" | "failed"),
+            "benchmark run has an unsupported execution status",
+        )?;
+        if let Some(trace) = run.trace.as_ref() {
+            require(
+                trace.mcp_calls.len() <= BENCHMARK_MAX_MCP_CALLS_PER_RUN,
+                "benchmark run exceeds the MCP-call bound",
+            )?;
+            for call in &trace.mcp_calls {
+                require(
+                    !call.server.is_empty()
+                        && call.server.len() <= 128
+                        && !call.tool.is_empty()
+                        && call.tool.len() <= 128
+                        && matches!(call.status.as_str(), "completed" | "failed" | "in_progress")
+                        && call.emitted_bytes <= BENCHMARK_MAX_EXACT_INTEGER,
+                    "benchmark MCP-call identity, status, or emitted-byte value is invalid",
+                )?;
+            }
+        }
+        require(
+            runs.insert(run.run_id.as_str(), run).is_none(),
+            "benchmark contains duplicate retained run ids",
+        )?;
+    }
+    require(
+        runs.len() == scheduled.len(),
+        "benchmark does not retain every scheduled run",
+    )?;
+    Ok(runs)
+}
+
+/// Validate one schedule row.
+fn validate_schedule_row(row: &BenchmarkSchedule, repeat_count: usize) -> Result<(), String> {
+    require(
+        !row.run_id.is_empty() && row.run_id.len() <= 128,
+        "benchmark run id is empty or too long",
+    )?;
+    require(
+        (1..=repeat_count).contains(&row.repeat),
+        "benchmark repeat number is outside the declared range",
+    )?;
+    require(
+        WORKLOADS.contains(&row.workload.as_str()),
+        "benchmark workload inventory is incompatible",
+    )?;
+    require(
+        ARMS.contains(&row.arm.as_str()),
+        "benchmark arm inventory is incompatible",
+    )
+}
+
+/// Validate aggregate counts, groups, distributions, comparisons, and provider truth.
+fn validate_aggregate(
+    artifact: &BenchmarkArtifact,
+    runs: &HashMap<&str, &BenchmarkRun>,
+) -> Result<(), String> {
+    let completed = artifact
+        .runs
+        .iter()
+        .filter(|run| run.execution_status == "completed")
+        .count();
+    let failed = artifact
+        .runs
+        .iter()
+        .filter(|run| run.execution_status == "failed")
+        .count();
+    require(
+        artifact.aggregate.scheduled == artifact.schedule.len()
+            && artifact.aggregate.completed == completed
+            && artifact.aggregate.failed == failed
+            && artifact.aggregate.excluded == 0
+            && completed + failed == artifact.schedule.len(),
+        "benchmark aggregate run totals do not reconcile",
+    )?;
+    require(
+        artifact.aggregate.all_run_ids.len() == artifact.runs.len(),
+        "benchmark aggregate run-id inventory is incomplete",
+    )?;
+    let aggregate_ids = artifact
+        .aggregate
+        .all_run_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    require(
+        aggregate_ids.len() == runs.len() && aggregate_ids.iter().all(|id| runs.contains_key(id)),
+        "benchmark aggregate run-id inventory does not match retained runs",
+    )?;
+    require(
+        artifact.aggregate.groups.len() == WORKLOADS.len() * ARMS.len()
+            && artifact.aggregate.groups.len() <= BENCHMARK_MAX_GROUPS,
+        "benchmark aggregate group inventory is incompatible",
+    )?;
+    for workload in WORKLOADS {
+        for arm in ARMS {
+            let key = group_key(workload, arm);
+            let group = artifact
+                .aggregate
+                .groups
+                .get(&key)
+                .ok_or_else(|| "benchmark aggregate group is missing".to_string())?;
+            validate_group(group, workload, arm, artifact.repeat_count, runs)?;
+        }
+    }
+    require(
+        artifact.aggregate.comparisons.len() == WORKLOADS.len() * 2
+            && artifact.aggregate.comparisons.len() <= BENCHMARK_MAX_COMPARISONS,
+        "benchmark comparison inventory is incompatible",
+    )?;
+    for workload in WORKLOADS {
+        for baseline in [FROZEN_ARM, PLAIN_ARM] {
+            let comparison_key = comparison_key(workload, baseline);
+            let comparison = artifact
+                .aggregate
+                .comparisons
+                .get(&comparison_key)
+                .ok_or_else(|| "benchmark comparison is missing".to_string())?;
+            let candidate = artifact
+                .aggregate
+                .groups
+                .get(&group_key(workload, CANDIDATE_ARM))
+                .ok_or_else(|| "candidate aggregate group is missing".to_string())?;
+            let baseline_group = artifact
+                .aggregate
+                .groups
+                .get(&group_key(workload, baseline))
+                .ok_or_else(|| "baseline aggregate group is missing".to_string())?;
+            validate_comparison(comparison, candidate, baseline_group)?;
+        }
+    }
+    require(
+        artifact.aggregate.provider_usage_note == PROVIDER_USAGE_NOTE,
+        "provider counters are not labeled descriptive-only",
+    )
+}
+
+/// Validate one workload/arm aggregate group.
+fn validate_group(
+    group: &BenchmarkGroup,
+    workload: &str,
+    arm: &str,
+    repeat_count: usize,
+    runs: &HashMap<&str, &BenchmarkRun>,
+) -> Result<(), String> {
+    require(
+        group.scheduled == repeat_count
+            && group.completed + group.failed + group.excluded == repeat_count
+            && group.excluded == 0,
+        "benchmark group totals do not reconcile",
+    )?;
+    require(
+        group.completed == 0 || group.completed == repeat_count,
+        "partially completed workload groups are unsupported",
+    )?;
+    require(
+        group.run_ids.len() == repeat_count,
+        "benchmark group run-id count is incompatible",
+    )?;
+    let mut group_run_ids = HashSet::with_capacity(repeat_count);
+    let mut completed = 0usize;
+    let mut failed = 0usize;
+    for run_id in &group.run_ids {
+        require(
+            group_run_ids.insert(run_id.as_str()),
+            "benchmark group contains duplicate run ids",
+        )?;
+        let run = runs
+            .get(run_id.as_str())
+            .ok_or_else(|| "benchmark group contains an unknown run id".to_string())?;
+        require(
+            run.workload == workload && run.arm == arm,
+            "benchmark group run belongs to another workload or arm",
+        )?;
+        match run.execution_status.as_str() {
+            "completed" => completed += 1,
+            "failed" => failed += 1,
+            _ => return Err("benchmark run has an unsupported execution status".to_string()),
+        }
+    }
+    require(
+        completed == group.completed && failed == group.failed,
+        "benchmark group status counts do not match retained runs",
+    )?;
+    if group.completed == 0 {
+        require(
+            group.distributions.is_empty() && group.provider_usage.is_empty(),
+            "failed benchmark group exposes fabricated distributions",
+        )?;
+        return Ok(());
+    }
+    require(
+        group.distributions.len() <= 64,
+        "benchmark group contains too many distributions",
+    )?;
+    require(
+        group.provider_usage.len() == PROVIDER_METRICS.len(),
+        "benchmark group provider-counter inventory is incompatible",
+    )?;
+    for (key, distribution) in &group.distributions {
+        validate_distribution(distribution, group.completed, key)?;
+    }
+    for (_, key) in METRICS {
+        if !group.distributions.contains_key(key) {
+            return Err(format!("benchmark group is missing required metric {key}"));
+        }
+    }
+    for (key, distribution) in &group.provider_usage {
+        validate_distribution(distribution, group.completed, key)?;
+    }
+    for (_, key) in PROVIDER_METRICS {
+        if !group.provider_usage.contains_key(key) {
+            return Err(format!("benchmark group is missing provider counter {key}"));
+        }
+    }
+    Ok(())
+}
+
+/// Validate one bounded numeric distribution.
+fn validate_distribution(
+    distribution: &BenchmarkDistribution,
+    expected_count: usize,
+    metric: &str,
+) -> Result<(), String> {
+    require(
+        distribution.count == expected_count
+            && distribution.values.len() == expected_count
+            && distribution.values.len() <= BENCHMARK_MAX_DISTRIBUTION_VALUES,
+        "benchmark distribution count does not reconcile",
+    )?;
+    let wall_seconds = metric.ends_with("_seconds");
+    let valid_number = |value: f64| {
+        finite_nonnegative(value)
+            && value
+                <= if wall_seconds {
+                    BENCHMARK_MAX_WALL_SECONDS
+                } else {
+                    BENCHMARK_MAX_EXACT_INTEGER as f64
+                }
+    };
+    let valid_sample = |value: f64| valid_number(value) && (wall_seconds || value.fract() == 0.0);
+    require(
+        !metric.is_empty()
+            && metric.len() <= 128
+            && distribution.observed_tail == "maximum"
+            && valid_number(distribution.median)
+            && valid_sample(distribution.maximum)
+            && distribution.values.iter().copied().all(valid_sample),
+        "benchmark distribution contains invalid numeric, integer, bound, or tail values",
+    )?;
+    let mut values = distribution.values.clone();
+    values.sort_by(f64::total_cmp);
+    let median =
+        median(&values).ok_or_else(|| "benchmark distribution has no median value".to_string())?;
+    let maximum = values
+        .last()
+        .copied()
+        .ok_or_else(|| "benchmark distribution has no maximum value".to_string())?;
+    require(
+        approximately_equal(distribution.median, median)
+            && approximately_equal(distribution.maximum, maximum),
+        "benchmark distribution summary does not match retained values",
+    )
+}
+
+/// Validate one candidate/baseline comparison against its owning groups.
+fn validate_comparison(
+    comparison: &BenchmarkComparison,
+    candidate: &BenchmarkGroup,
+    baseline: &BenchmarkGroup,
+) -> Result<(), String> {
+    if candidate.completed == 0 || baseline.completed == 0 {
+        return require(
+            comparison.lower_is_better_percent_savings.is_empty()
+                && comparison.provider_usage_descriptive_only.is_empty()
+                && comparison.wall_time_break_even_tasks.is_none(),
+            "unmatched comparison exposes fabricated values",
+        );
+    }
+    require(
+        (METRICS.len()..=64).contains(&comparison.lower_is_better_percent_savings.len()),
+        "matched comparison metric inventory is incomplete or too large",
+    )?;
+    for (key, row) in &comparison.lower_is_better_percent_savings {
+        require(
+            !key.is_empty() && key.len() <= 128,
+            "matched comparison metric identity is invalid",
+        )?;
+        validate_comparison_metric(
+            row,
+            candidate
+                .distributions
+                .get(key)
+                .ok_or_else(|| format!("candidate comparison distribution is missing for {key}"))?,
+            baseline
+                .distributions
+                .get(key)
+                .ok_or_else(|| format!("baseline comparison distribution is missing for {key}"))?,
+        )
+        .map_err(|reason| format!("{key}: {reason}"))?;
+    }
+    for (_, key) in METRICS {
+        if !comparison.lower_is_better_percent_savings.contains_key(key) {
+            return Err(format!("matched comparison is missing metric {key}"));
+        }
+    }
+    require(
+        comparison.provider_usage_descriptive_only.len() == PROVIDER_METRICS.len(),
+        "provider comparison inventory is incomplete",
+    )?;
+    for (_, key) in PROVIDER_METRICS {
+        let row = comparison
+            .provider_usage_descriptive_only
+            .get(key)
+            .ok_or_else(|| format!("provider comparison is missing counter {key}"))?;
+        require(
+            !row.causal_attribution,
+            "provider comparison claims causal attribution",
+        )?;
+        validate_provider_metric(
+            row,
+            candidate
+                .provider_usage
+                .get(key)
+                .ok_or_else(|| "candidate provider distribution is missing".to_string())?,
+            baseline
+                .provider_usage
+                .get(key)
+                .ok_or_else(|| "baseline provider distribution is missing".to_string())?,
+        )
+        .map_err(|reason| format!("{key}: {reason}"))?;
+    }
+    require(
+        comparison.wall_time_break_even_tasks == wall_time_break_even(candidate, baseline)?,
+        "wall-time break-even value does not match validated setup and runtime medians",
+    )
+}
+
+/// Validate one comparison metric against aggregate medians and maxima.
+fn validate_comparison_metric(
+    row: &BenchmarkComparisonMetric,
+    candidate: &BenchmarkDistribution,
+    baseline: &BenchmarkDistribution,
+) -> Result<(), String> {
+    let expected_saving = percent_saving(candidate.median, baseline.median);
+    require(
+        finite_nonnegative(row.candidate_median)
+            && finite_nonnegative(row.baseline_median)
+            && finite_nonnegative(row.candidate_tail)
+            && finite_nonnegative(row.baseline_tail)
+            && approximately_equal(row.candidate_median, candidate.median)
+            && approximately_equal(row.baseline_median, baseline.median)
+            && approximately_equal(row.candidate_tail, candidate.maximum)
+            && approximately_equal(row.baseline_tail, baseline.maximum)
+            && option_approximately_equal(row.median_percent_saving, expected_saving)
+            && row.tail_statistic == "observed maximum",
+        "comparison metric does not match its validated distributions",
+    )
+}
+
+/// Validate one descriptive provider counter against aggregate distributions.
+fn validate_provider_metric(
+    row: &BenchmarkProviderComparison,
+    candidate: &BenchmarkDistribution,
+    baseline: &BenchmarkDistribution,
+) -> Result<(), String> {
+    require(
+        finite_nonnegative(row.candidate_median)
+            && finite_nonnegative(row.baseline_median)
+            && finite_nonnegative(row.candidate_tail)
+            && finite_nonnegative(row.baseline_tail)
+            && approximately_equal(row.candidate_median, candidate.median)
+            && approximately_equal(row.baseline_median, baseline.median)
+            && approximately_equal(row.candidate_tail, candidate.maximum)
+            && approximately_equal(row.baseline_tail, baseline.maximum)
+            && !row.causal_attribution,
+        "provider counter does not match its validated distributions",
+    )
+}
+
+/// Project one baseline across workload groups that completed in both arms.
+fn project_baseline(
+    artifact: &BenchmarkArtifact,
+    baseline: AgentEfficiencyBaseline,
+    baseline_arm: &str,
+) -> Result<AgentEfficiencyBaselineRow, String> {
+    let mut candidate_values = METRICS
+        .iter()
+        .map(|(_, key)| (*key, Vec::<f64>::new()))
+        .collect::<BTreeMap<_, _>>();
+    let mut baseline_values = METRICS
+        .iter()
+        .map(|(_, key)| (*key, Vec::<f64>::new()))
+        .collect::<BTreeMap<_, _>>();
+    let mut candidate_provider = PROVIDER_METRICS
+        .iter()
+        .map(|(_, key)| (*key, Vec::<f64>::new()))
+        .collect::<BTreeMap<_, _>>();
+    let mut baseline_provider = PROVIDER_METRICS
+        .iter()
+        .map(|(_, key)| (*key, Vec::<f64>::new()))
+        .collect::<BTreeMap<_, _>>();
+    let mut matched_trials = 0usize;
+    let mut candidate_failed_trials = 0usize;
+    let mut baseline_failed_trials = 0usize;
+    let mut unmatched_trials = 0usize;
+    let mut break_even = Vec::with_capacity(WORKLOADS.len());
+    for workload in WORKLOADS {
+        let candidate = artifact
+            .aggregate
+            .groups
+            .get(&group_key(workload, CANDIDATE_ARM))
+            .ok_or_else(|| "candidate aggregate group is missing".to_string())?;
+        let baseline_group = artifact
+            .aggregate
+            .groups
+            .get(&group_key(workload, baseline_arm))
+            .ok_or_else(|| "baseline aggregate group is missing".to_string())?;
+        candidate_failed_trials = candidate_failed_trials.saturating_add(candidate.failed);
+        baseline_failed_trials = baseline_failed_trials.saturating_add(baseline_group.failed);
+        if candidate.completed > 0 && baseline_group.completed > 0 {
+            require(
+                candidate.completed == baseline_group.completed,
+                "matched benchmark groups have different completed-trial counts",
+            )?;
+            matched_trials = matched_trials.saturating_add(candidate.completed);
+            append_group_values(&mut candidate_values, &candidate.distributions, &METRICS)?;
+            append_group_values(
+                &mut baseline_values,
+                &baseline_group.distributions,
+                &METRICS,
+            )?;
+            append_provider_values(
+                &mut candidate_provider,
+                &candidate.provider_usage,
+                &PROVIDER_METRICS,
+            )?;
+            append_provider_values(
+                &mut baseline_provider,
+                &baseline_group.provider_usage,
+                &PROVIDER_METRICS,
+            )?;
+            break_even.push(AgentEfficiencyBreakEven {
+                workload: workload.to_string(),
+                wall_time_tasks: wall_time_break_even(candidate, baseline_group)?,
+            });
+        } else {
+            unmatched_trials = unmatched_trials
+                .saturating_add(candidate.completed)
+                .saturating_add(baseline_group.completed);
+        }
+    }
+    let state = if matched_trials == 0 {
+        AgentEfficiencyEvidenceState::Failed
+    } else if candidate_failed_trials > 0 || baseline_failed_trials > 0 || unmatched_trials > 0 {
+        AgentEfficiencyEvidenceState::Partial
+    } else {
+        AgentEfficiencyEvidenceState::Compatible
+    };
+    let metrics = if matched_trials == 0 {
+        Vec::new()
+    } else {
+        METRICS
+            .into_iter()
+            .map(|(metric, key)| {
+                metric_comparison(
+                    metric,
+                    candidate_values
+                        .get(key)
+                        .ok_or_else(|| "candidate metric values are missing".to_string())?,
+                    baseline_values
+                        .get(key)
+                        .ok_or_else(|| "baseline metric values are missing".to_string())?,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    let provider_usage_descriptive_only = if matched_trials == 0 {
+        Vec::new()
+    } else {
+        PROVIDER_METRICS
+            .into_iter()
+            .map(|(metric, key)| {
+                provider_metric(
+                    metric,
+                    candidate_provider
+                        .get(key)
+                        .ok_or_else(|| "candidate provider values are missing".to_string())?,
+                    baseline_provider
+                        .get(key)
+                        .ok_or_else(|| "baseline provider values are missing".to_string())?,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    Ok(AgentEfficiencyBaselineRow {
+        baseline,
+        state,
+        matched_trials,
+        candidate_failed_trials,
+        baseline_failed_trials,
+        unmatched_trials,
+        metrics,
+        break_even,
+        provider_usage_descriptive_only,
+    })
+}
+
+/// Derive tasks required to repay incremental setup time from validated medians.
+fn wall_time_break_even(
+    candidate: &BenchmarkGroup,
+    baseline: &BenchmarkGroup,
+) -> Result<Option<u64>, String> {
+    let median = |group: &BenchmarkGroup, metric: &str| {
+        group
+            .distributions
+            .get(metric)
+            .map(|distribution| distribution.median)
+            .ok_or_else(|| format!("benchmark group is missing required metric {metric}"))
+    };
+    let warm_saving = median(baseline, RUNTIME_WALL_SECONDS_METRIC)?
+        - median(candidate, RUNTIME_WALL_SECONDS_METRIC)?;
+    if warm_saving <= 0.0 {
+        return Ok(None);
+    }
+    let incremental_setup = median(candidate, SETUP_WALL_SECONDS_METRIC)?
+        - median(baseline, SETUP_WALL_SECONDS_METRIC)?;
+    if incremental_setup <= 0.0 {
+        return Ok(Some(0));
+    }
+    let tasks = (incremental_setup / warm_saving).ceil();
+    require(
+        tasks.is_finite() && tasks <= f64::from(u32::MAX),
+        "wall-time break-even value exceeds the supported bound",
+    )?;
+    Ok(Some(tasks as u64))
+}
+
+/// Append matched distribution values for public navigation metrics.
+fn append_group_values(
+    destination: &mut BTreeMap<&'static str, Vec<f64>>,
+    source: &BTreeMap<String, BenchmarkDistribution>,
+    metrics: &[(AgentEfficiencyMetricKind, &'static str)],
+) -> Result<(), String> {
+    for (_, key) in metrics {
+        destination
+            .get_mut(key)
+            .ok_or_else(|| "metric destination is missing".to_string())?
+            .extend_from_slice(
+                &source
+                    .get(*key)
+                    .ok_or_else(|| "metric distribution is missing".to_string())?
+                    .values,
+            );
+    }
+    Ok(())
+}
+
+/// Append matched distribution values for descriptive provider counters.
+fn append_provider_values(
+    destination: &mut BTreeMap<&'static str, Vec<f64>>,
+    source: &BTreeMap<String, BenchmarkDistribution>,
+    metrics: &[(AgentEfficiencyProviderMetricKind, &'static str)],
+) -> Result<(), String> {
+    for (_, key) in metrics {
+        destination
+            .get_mut(key)
+            .ok_or_else(|| "provider destination is missing".to_string())?
+            .extend_from_slice(
+                &source
+                    .get(*key)
+                    .ok_or_else(|| "provider distribution is missing".to_string())?
+                    .values,
+            );
+    }
+    Ok(())
+}
+
+/// Build one aggregate navigation metric from matched trial values.
+fn metric_comparison(
+    metric: AgentEfficiencyMetricKind,
+    candidate: &[f64],
+    baseline: &[f64],
+) -> Result<AgentEfficiencyMetricComparison, String> {
+    let (candidate_median, candidate_maximum) = summarize_values(candidate)?;
+    let (baseline_median, baseline_maximum) = summarize_values(baseline)?;
+    Ok(AgentEfficiencyMetricComparison {
+        metric,
+        candidate_median,
+        baseline_median,
+        candidate_maximum,
+        baseline_maximum,
+        median_percent_saving: percent_saving(candidate_median, baseline_median),
+    })
+}
+
+/// Build one aggregate descriptive provider counter.
+fn provider_metric(
+    metric: AgentEfficiencyProviderMetricKind,
+    candidate: &[f64],
+    baseline: &[f64],
+) -> Result<AgentEfficiencyProviderMetric, String> {
+    let (candidate_median, candidate_maximum) = summarize_values(candidate)?;
+    let (baseline_median, baseline_maximum) = summarize_values(baseline)?;
+    Ok(AgentEfficiencyProviderMetric {
+        metric,
+        candidate_median,
+        baseline_median,
+        candidate_maximum,
+        baseline_maximum,
+        causal_attribution: false,
+    })
+}
+
+/// Return median and observed maximum for non-empty validated values.
+fn summarize_values(values: &[f64]) -> Result<(f64, f64), String> {
+    let mut values = values.to_vec();
+    values.sort_by(f64::total_cmp);
+    let median = median(&values).ok_or_else(|| "matched benchmark values are empty".to_string())?;
+    let maximum = values
+        .last()
+        .copied()
+        .ok_or_else(|| "matched benchmark values are empty".to_string())?;
+    Ok((median, maximum))
+}
+
+/// Group trace-completed candidate MCP calls by navigation responsibility.
+fn project_capabilities(
+    runs: &[BenchmarkRun],
+) -> Result<Vec<AgentEfficiencyCapabilityContribution>, String> {
+    let mut counts = [0usize; 5];
+    let mut bytes = [0u64; 5];
+    let mut total_calls = 0usize;
+    for run in runs.iter().filter(|run| {
+        run.arm == CANDIDATE_ARM && run.execution_status == "completed" && !run.excluded
+    }) {
+        let trace = run
+            .trace
+            .as_ref()
+            .ok_or_else(|| "completed candidate run is missing its trace".to_string())?;
+        for call in &trace.mcp_calls {
+            require(
+                call.server == "projectatlas",
+                "candidate MCP call belongs to another server",
+            )?;
+            if call.status != "completed" {
+                continue;
+            }
+            total_calls = total_calls
+                .checked_add(1)
+                .ok_or_else(|| "candidate MCP-call count overflowed".to_string())?;
+            require(
+                total_calls <= BENCHMARK_MAX_TOTAL_MCP_CALLS,
+                "artifact exceeds the trace-completed MCP-call bound",
+            )?;
+            let index = capability_index(&call.tool);
+            counts[index] = counts[index]
+                .checked_add(1)
+                .ok_or_else(|| "capability call count overflowed".to_string())?;
+            bytes[index] = bytes[index]
+                .checked_add(call.emitted_bytes)
+                .ok_or_else(|| "capability emitted-byte count overflowed".to_string())?;
+        }
+    }
+    let capabilities = [
+        AgentEfficiencyCapability::Discovery,
+        AgentEfficiencyCapability::SummaryAndSlice,
+        AgentEfficiencyCapability::Search,
+        AgentEfficiencyCapability::SymbolsAndRelations,
+        AgentEfficiencyCapability::Other,
+    ];
+    Ok(capabilities
+        .into_iter()
+        .enumerate()
+        .filter(|(index, _)| counts[*index] > 0)
+        .map(
+            |(index, capability)| AgentEfficiencyCapabilityContribution {
+                capability,
+                calls: counts[index],
+                emitted_bytes: bytes[index],
+            },
+        )
+        .collect())
+}
+
+/// Return the stable capability bucket for one trace-completed MCP tool.
+fn capability_index(tool: &str) -> usize {
+    match tool {
+        "atlas_session_brief"
+        | "atlas_overview"
+        | "atlas_folders"
+        | "atlas_files"
+        | "atlas_next" => 0,
+        "atlas_file_summary" | "atlas_outline" | "atlas_slice" => 1,
+        "atlas_search" => 2,
+        "atlas_symbols" | "atlas_symbol_relations" => 3,
+        _ => 4,
+    }
+}
+
+/// Return a bounded failed evidence state.
+fn failed_comparison(reason: String) -> AgentEfficiencyComparison {
+    AgentEfficiencyComparison {
+        state: AgentEfficiencyEvidenceState::Failed,
+        reason: Some(bounded_reason(reason)),
+        artifact: None,
+        baselines: Vec::new(),
+        capabilities: Vec::new(),
+        provider_counters_descriptive_only: true,
+    }
+}
+
+/// Return a bounded incompatible evidence state.
+fn incompatible_comparison(reason: String) -> AgentEfficiencyComparison {
+    AgentEfficiencyComparison {
+        state: AgentEfficiencyEvidenceState::Incompatible,
+        reason: Some(bounded_reason(reason)),
+        artifact: None,
+        baselines: Vec::new(),
+        capabilities: Vec::new(),
+        provider_counters_descriptive_only: true,
+    }
+}
+
+/// Bound a caller-visible reason without splitting UTF-8.
+fn bounded_reason(reason: String) -> String {
+    if reason.len() <= BENCHMARK_REASON_MAX_BYTES {
+        return reason;
+    }
+    let mut end = BENCHMARK_REASON_MAX_BYTES;
+    while !reason.is_char_boundary(end) {
+        end = end.saturating_sub(1);
+    }
+    reason[..end].to_string()
+}
+
+/// Return a workload/arm aggregate key.
+fn group_key(workload: &str, arm: &str) -> String {
+    format!("{workload}/{arm}")
+}
+
+/// Return a workload candidate/baseline comparison key.
+fn comparison_key(workload: &str, baseline: &str) -> String {
+    format!("{workload}/{CANDIDATE_ARM}-vs-{baseline}")
+}
+
+/// Return a lower-is-better median saving or `None` for a zero denominator.
+fn percent_saving(candidate: f64, baseline: f64) -> Option<f64> {
+    (baseline > 0.0).then(|| (baseline - candidate) / baseline * 100.0)
+}
+
+/// Return the median of sorted values.
+fn median(sorted: &[f64]) -> Option<f64> {
+    if sorted.is_empty() {
+        return None;
+    }
+    let middle = sorted.len() / 2;
+    if sorted.len().is_multiple_of(2) {
+        Some(f64::midpoint(sorted[middle - 1], sorted[middle]))
+    } else {
+        Some(sorted[middle])
+    }
+}
+
+/// Return whether one numeric value is finite and nonnegative.
+fn finite_nonnegative(value: f64) -> bool {
+    value.is_finite() && value >= 0.0
+}
+
+/// Compare serialized floating summaries with a scale-aware tolerance.
+fn approximately_equal(left: f64, right: f64) -> bool {
+    let scale = left.abs().max(right.abs()).max(1.0);
+    (left - right).abs() <= scale * 1.0e-6
+}
+
+/// Compare optional floating summaries.
+fn option_approximately_equal(left: Option<f64>, right: Option<f64>) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => approximately_equal(left, right),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+/// Return whether a value is exact lowercase hexadecimal of the requested length.
+fn is_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+/// Convert a boolean invariant into a bounded validation error.
+fn require(condition: bool, reason: &str) -> Result<(), String> {
+    if condition {
+        Ok(())
+    } else {
+        Err(reason.to_string())
+    }
+}
+
+/// Private benchmark artifact projection; unrelated large fields are skipped by Serde.
+#[derive(Deserialize)]
+struct BenchmarkArtifact {
+    /// Artifact schema version.
+    schema_version: u32,
+    /// Preregistered repeat count per workload and arm.
+    repeat_count: usize,
+    /// Complete preregistered run schedule.
+    schedule: Vec<BenchmarkSchedule>,
+    /// Runtime and skill identity for each benchmark arm.
+    candidate_identities: BTreeMap<String, BenchmarkCandidateIdentity>,
+    /// Candidate source commits used by the campaign.
+    candidate_source_identity: BenchmarkSourceIdentity,
+    /// Every retained benchmark run.
+    runs: Vec<BenchmarkRun>,
+    /// Published aggregate groups and comparisons.
+    aggregate: BenchmarkAggregate,
+    /// Whether every scheduled run remains present.
+    all_scheduled_runs_retained: bool,
+}
+
+/// Candidate runtime and packaged-skill identity.
+#[derive(Deserialize)]
+struct BenchmarkCandidateIdentity {
+    /// Whether this arm enables `ProjectAtlas`.
+    projectatlas: bool,
+    /// Runtime semantic version when `ProjectAtlas` is enabled.
+    version: Option<String>,
+    /// Runtime binary digest when `ProjectAtlas` is enabled.
+    runtime_sha256: Option<String>,
+    /// Packaged skill digest when `ProjectAtlas` is enabled.
+    skill_sha256: Option<String>,
+    /// Packaged skill bytes charged to the arm.
+    skill_bytes: Option<u64>,
+    /// Tool-discovery bytes charged to the arm.
+    tool_discovery_bytes: Option<u64>,
+}
+
+/// Candidate source commits retained by the benchmark.
+#[derive(Deserialize)]
+struct BenchmarkSourceIdentity {
+    /// Functional release-candidate source commit.
+    functional_head: String,
+    /// Checklist reconciliation source commit.
+    checklist_head: String,
+}
+
+/// One preregistered workload/arm/repeat cell.
+#[derive(Deserialize)]
+struct BenchmarkSchedule {
+    /// Stable scheduled run identifier.
+    run_id: String,
+    /// One-based repeat number.
+    repeat: usize,
+    /// Preregistered workload name.
+    #[serde(rename = "case")]
+    workload: String,
+    /// Candidate or baseline arm identifier.
+    arm: String,
+}
+
+/// One retained benchmark run.
+#[derive(Deserialize)]
+struct BenchmarkRun {
+    /// Stable retained run identifier.
+    run_id: String,
+    /// One-based repeat number.
+    repeat: usize,
+    /// Retained workload name.
+    #[serde(rename = "case")]
+    workload: String,
+    /// Candidate or baseline arm identifier.
+    arm: String,
+    /// Whether the retained run was excluded.
+    excluded: bool,
+    /// Completed or failed execution state.
+    execution_status: String,
+    /// Optional detailed trace retained by the campaign.
+    trace: Option<BenchmarkTrace>,
+}
+
+/// Required trace subset for candidate capability reconciliation.
+#[derive(Deserialize)]
+struct BenchmarkTrace {
+    /// Bounded MCP calls retained for the run.
+    #[serde(default)]
+    mcp_calls: Vec<BenchmarkMcpCall>,
+}
+
+/// One retained MCP call.
+#[derive(Deserialize)]
+struct BenchmarkMcpCall {
+    /// MCP server identifier.
+    server: String,
+    /// MCP tool identifier.
+    tool: String,
+    /// Retained call completion state.
+    status: String,
+    /// Bytes emitted by the call.
+    emitted_bytes: u64,
+}
+
+/// Final aggregate report.
+#[derive(Deserialize)]
+struct BenchmarkAggregate {
+    /// Complete retained run-id inventory.
+    all_run_ids: Vec<String>,
+    /// Scheduled run count.
+    scheduled: usize,
+    /// Completed run count.
+    completed: usize,
+    /// Failed run count.
+    failed: usize,
+    /// Excluded run count.
+    excluded: usize,
+    /// Workload-and-arm aggregate groups.
+    groups: BTreeMap<String, BenchmarkGroup>,
+    /// Workload-specific candidate/baseline comparisons.
+    comparisons: BTreeMap<String, BenchmarkComparison>,
+    /// Required non-causal provider-counter label.
+    provider_usage_note: String,
+}
+
+/// One workload/arm aggregate.
+#[derive(Deserialize)]
+struct BenchmarkGroup {
+    /// Run identifiers owned by this group.
+    run_ids: Vec<String>,
+    /// Scheduled group count.
+    scheduled: usize,
+    /// Completed group count.
+    completed: usize,
+    /// Failed group count.
+    failed: usize,
+    /// Excluded group count.
+    excluded: usize,
+    /// Navigation and runtime metric distributions.
+    distributions: BTreeMap<String, BenchmarkDistribution>,
+    /// Descriptive provider-counter distributions.
+    provider_usage: BTreeMap<String, BenchmarkDistribution>,
+}
+
+/// Retained values plus median and observed maximum.
+#[derive(Clone, Deserialize)]
+struct BenchmarkDistribution {
+    /// Retained value count.
+    count: usize,
+    /// Retained per-run values.
+    values: Vec<f64>,
+    /// Published median.
+    median: f64,
+    /// Published tail-statistic label.
+    observed_tail: String,
+    /// Published observed maximum.
+    maximum: f64,
+}
+
+/// One workload-specific candidate/baseline comparison.
+#[derive(Deserialize)]
+struct BenchmarkComparison {
+    /// Lower-is-better navigation and runtime comparisons.
+    lower_is_better_percent_savings: BTreeMap<String, BenchmarkComparisonMetric>,
+    /// Descriptive-only provider-counter comparisons.
+    provider_usage_descriptive_only: BTreeMap<String, BenchmarkProviderComparison>,
+    /// Tasks required to repay setup wall time.
+    wall_time_break_even_tasks: Option<u64>,
+}
+
+/// One lower-is-better comparison row.
+#[derive(Deserialize)]
+struct BenchmarkComparisonMetric {
+    /// Candidate median.
+    candidate_median: f64,
+    /// Baseline median.
+    baseline_median: f64,
+    /// Lower-is-better median percentage saving.
+    median_percent_saving: Option<f64>,
+    /// Published tail-statistic label.
+    tail_statistic: String,
+    /// Candidate observed tail.
+    candidate_tail: f64,
+    /// Baseline observed tail.
+    baseline_tail: f64,
+}
+
+/// One provider comparison row that must remain non-causal.
+#[derive(Deserialize)]
+struct BenchmarkProviderComparison {
+    /// Candidate provider-counter median.
+    candidate_median: f64,
+    /// Baseline provider-counter median.
+    baseline_median: f64,
+    /// Candidate provider-counter tail.
+    candidate_tail: f64,
+    /// Baseline provider-counter tail.
+    baseline_tail: f64,
+    /// Whether the artifact claims unsupported causal attribution.
+    causal_attribution: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BenchmarkArtifact, require, validate_and_project};
+    use projectatlas_core::telemetry::{
+        AgentEfficiencyBaseline, AgentEfficiencyCapability, AgentEfficiencyEvidenceState,
+    };
+    use std::fs;
+    use std::io;
+    use std::path::PathBuf;
+
+    fn rejected_benchmark_reason(
+        value: &serde_json::Value,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let bytes = serde_json::to_vec(value)?;
+        let artifact: BenchmarkArtifact = serde_json::from_slice(&bytes)?;
+        validate_and_project(artifact, &bytes)
+            .err()
+            .ok_or_else(|| io::Error::other("modified benchmark unexpectedly validated").into())
+    }
+
+    #[test]
+    fn published_benchmark_projects_partial_and_capability_truth()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docs/benchmarks/v0.4-agent-navigation-results.json");
+        let bytes = fs::read(path)?;
+        let artifact: BenchmarkArtifact = serde_json::from_slice(&bytes)?;
+        let comparison = validate_and_project(artifact, &bytes)
+            .map_err(|reason| io::Error::other(format!("benchmark validation failed: {reason}")))?;
+
+        require(
+            comparison.state == AgentEfficiencyEvidenceState::Partial,
+            "published benchmark was not partial",
+        )
+        .map_err(io::Error::other)?;
+        require(
+            comparison.baselines.len() == 2,
+            "published benchmark baseline count changed",
+        )
+        .map_err(io::Error::other)?;
+        let frozen = comparison
+            .baselines
+            .iter()
+            .find(|row| row.baseline == AgentEfficiencyBaseline::FrozenProjectAtlasV0326)
+            .ok_or_else(|| io::Error::other("frozen baseline row missing"))?;
+        require(
+            frozen.state == AgentEfficiencyEvidenceState::Partial
+                && frozen.matched_trials == 12
+                && frozen.baseline_failed_trials == 3
+                && frozen.unmatched_trials == 3,
+            "published frozen baseline truth changed",
+        )
+        .map_err(io::Error::other)?;
+        let plain = comparison
+            .baselines
+            .iter()
+            .find(|row| row.baseline == AgentEfficiencyBaseline::PlainCodex)
+            .ok_or_else(|| io::Error::other("plain baseline row missing"))?;
+        require(
+            plain.state == AgentEfficiencyEvidenceState::Compatible
+                && plain.matched_trials == 15
+                && plain.baseline_failed_trials == 0,
+            "published plain baseline truth changed",
+        )
+        .map_err(io::Error::other)?;
+
+        let calls = comparison
+            .capabilities
+            .iter()
+            .map(|row| row.calls)
+            .sum::<usize>();
+        require(
+            calls == 159,
+            "trace-completed capability calls did not reconcile",
+        )
+        .map_err(io::Error::other)?;
+        for (capability, expected) in [
+            (AgentEfficiencyCapability::Discovery, 15),
+            (AgentEfficiencyCapability::SummaryAndSlice, 97),
+            (AgentEfficiencyCapability::Search, 23),
+            (AgentEfficiencyCapability::SymbolsAndRelations, 24),
+        ] {
+            require(
+                comparison
+                    .capabilities
+                    .iter()
+                    .find(|row| row.capability == capability)
+                    .map(|row| row.calls)
+                    == Some(expected),
+                "published capability call count changed",
+            )
+            .map_err(io::Error::other)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn fully_failed_baseline_remains_typed_without_fabricated_metrics()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docs/benchmarks/v0.4-agent-navigation-results.json");
+        let mut artifact: serde_json::Value = serde_json::from_slice(&fs::read(path)?)?;
+        for run in artifact
+            .get_mut("runs")
+            .and_then(serde_json::Value::as_array_mut)
+            .ok_or_else(|| io::Error::other("benchmark runs are missing"))?
+        {
+            if run.get("arm").and_then(serde_json::Value::as_str) == Some("v0.3.26") {
+                run.as_object_mut()
+                    .ok_or_else(|| io::Error::other("benchmark run is not an object"))?
+                    .insert(
+                        "execution_status".to_string(),
+                        serde_json::Value::String("failed".to_string()),
+                    );
+            }
+        }
+        let aggregate = artifact
+            .get_mut("aggregate")
+            .and_then(serde_json::Value::as_object_mut)
+            .ok_or_else(|| io::Error::other("benchmark aggregate is missing"))?;
+        aggregate.insert("completed".to_string(), serde_json::Value::from(30));
+        aggregate.insert("failed".to_string(), serde_json::Value::from(15));
+        for (key, group) in aggregate
+            .get_mut("groups")
+            .and_then(serde_json::Value::as_object_mut)
+            .ok_or_else(|| io::Error::other("benchmark groups are missing"))?
+        {
+            if key.ends_with("/v0.3.26") {
+                let group = group
+                    .as_object_mut()
+                    .ok_or_else(|| io::Error::other("benchmark group is not an object"))?;
+                group.insert("completed".to_string(), serde_json::Value::from(0));
+                group.insert("failed".to_string(), serde_json::Value::from(3));
+                group.insert(
+                    "distributions".to_string(),
+                    serde_json::Value::Object(serde_json::Map::new()),
+                );
+                group.insert(
+                    "provider_usage".to_string(),
+                    serde_json::Value::Object(serde_json::Map::new()),
+                );
+            }
+        }
+        for (key, comparison) in aggregate
+            .get_mut("comparisons")
+            .and_then(serde_json::Value::as_object_mut)
+            .ok_or_else(|| io::Error::other("benchmark comparisons are missing"))?
+        {
+            if key.ends_with("-vs-v0.3.26") {
+                let comparison = comparison
+                    .as_object_mut()
+                    .ok_or_else(|| io::Error::other("benchmark comparison is not an object"))?;
+                comparison.insert(
+                    "lower_is_better_percent_savings".to_string(),
+                    serde_json::Value::Object(serde_json::Map::new()),
+                );
+                comparison.insert(
+                    "provider_usage_descriptive_only".to_string(),
+                    serde_json::Value::Object(serde_json::Map::new()),
+                );
+                comparison.insert(
+                    "wall_time_break_even_tasks".to_string(),
+                    serde_json::Value::Null,
+                );
+            }
+        }
+        let bytes = serde_json::to_vec(&artifact)?;
+        let artifact: BenchmarkArtifact = serde_json::from_slice(&bytes)?;
+        let comparison = validate_and_project(artifact, &bytes).map_err(io::Error::other)?;
+        let frozen = comparison
+            .baselines
+            .iter()
+            .find(|row| row.baseline == AgentEfficiencyBaseline::FrozenProjectAtlasV0326)
+            .ok_or_else(|| io::Error::other("failed frozen baseline row is missing"))?;
+        require(
+            comparison.state == AgentEfficiencyEvidenceState::Partial
+                && frozen.state == AgentEfficiencyEvidenceState::Failed
+                && frozen.matched_trials == 0
+                && frozen.baseline_failed_trials == 15
+                && frozen.metrics.is_empty()
+                && frozen.provider_usage_descriptive_only.is_empty(),
+            "fully failed baseline was not preserved without fabricated metrics",
+        )
+        .map_err(io::Error::other)?;
+        Ok(())
+    }
+
+    #[test]
+    fn benchmark_validation_rejects_run_loss_invalid_numbers_and_provider_causality()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docs/benchmarks/v0.4-agent-navigation-results.json");
+        let published: serde_json::Value = serde_json::from_slice(&fs::read(path)?)?;
+
+        let mut missing_run = published.clone();
+        missing_run
+            .get_mut("runs")
+            .and_then(serde_json::Value::as_array_mut)
+            .ok_or_else(|| io::Error::other("benchmark runs are missing"))?
+            .pop();
+        require(
+            rejected_benchmark_reason(&missing_run)?.contains("schedule or run count"),
+            "missing run did not fail retention validation",
+        )
+        .map_err(io::Error::other)?;
+
+        let mut duplicate_group_run = published.clone();
+        let group_run_ids = duplicate_group_run
+            .get_mut("aggregate")
+            .and_then(|value| value.get_mut("groups"))
+            .and_then(|value| value.get_mut("small-clean/v0.4"))
+            .and_then(|value| value.get_mut("run_ids"))
+            .and_then(serde_json::Value::as_array_mut)
+            .ok_or_else(|| io::Error::other("benchmark group run ids are missing"))?;
+        group_run_ids[1] = group_run_ids[0].clone();
+        require(
+            rejected_benchmark_reason(&duplicate_group_run)?.contains("duplicate run ids"),
+            "duplicate group run id did not fail retention validation",
+        )
+        .map_err(io::Error::other)?;
+
+        let mut excessive_mcp_calls = published.clone();
+        let frozen_calls = excessive_mcp_calls
+            .get_mut("runs")
+            .and_then(serde_json::Value::as_array_mut)
+            .and_then(|runs| {
+                runs.iter_mut().find_map(|run| {
+                    (run.get("arm").and_then(serde_json::Value::as_str) == Some("v0.3.26"))
+                        .then(|| {
+                            run.get_mut("trace")
+                                .and_then(|value| value.get_mut("mcp_calls"))
+                                .and_then(serde_json::Value::as_array_mut)
+                        })
+                        .flatten()
+                        .filter(|calls| !calls.is_empty())
+                })
+            })
+            .ok_or_else(|| io::Error::other("frozen benchmark MCP calls are missing"))?;
+        let retained_call = frozen_calls
+            .first()
+            .cloned()
+            .ok_or_else(|| io::Error::other("frozen benchmark MCP call is missing"))?;
+        frozen_calls.resize(129, retained_call);
+        require(
+            rejected_benchmark_reason(&excessive_mcp_calls)?.contains("MCP-call bound"),
+            "non-candidate MCP-call overflow did not fail collection validation",
+        )
+        .map_err(io::Error::other)?;
+
+        let mut excessive_emitted_bytes = published.clone();
+        let emitted_bytes = excessive_emitted_bytes
+            .get_mut("runs")
+            .and_then(serde_json::Value::as_array_mut)
+            .and_then(|runs| {
+                runs.iter_mut().find_map(|run| {
+                    (run.get("arm").and_then(serde_json::Value::as_str) == Some("v0.4"))
+                        .then(|| {
+                            run.get_mut("trace")
+                                .and_then(|value| value.get_mut("mcp_calls"))
+                                .and_then(serde_json::Value::as_array_mut)
+                                .and_then(|calls| calls.first_mut())
+                                .and_then(|call| call.get_mut("emitted_bytes"))
+                        })
+                        .flatten()
+                })
+            })
+            .ok_or_else(|| io::Error::other("candidate MCP emitted bytes are missing"))?;
+        *emitted_bytes = serde_json::Value::from(9_007_199_254_740_992_u64);
+        require(
+            rejected_benchmark_reason(&excessive_emitted_bytes)?.contains("emitted-byte"),
+            "excessive MCP emitted bytes did not fail numeric validation",
+        )
+        .map_err(io::Error::other)?;
+
+        let mut invalid_numeric = published.clone();
+        let invalid_values = invalid_numeric
+            .get_mut("aggregate")
+            .and_then(|value| value.get_mut("groups"))
+            .and_then(|value| value.get_mut("small-clean/v0.4"))
+            .and_then(|value| value.get_mut("distributions"))
+            .and_then(|value| value.get_mut("tool_calls"))
+            .and_then(|value| value.get_mut("values"))
+            .and_then(serde_json::Value::as_array_mut)
+            .ok_or_else(|| io::Error::other("benchmark metric values are missing"))?;
+        invalid_values[0] = serde_json::Value::from(-1);
+        require(
+            rejected_benchmark_reason(&invalid_numeric)?.contains("invalid numeric"),
+            "negative metric did not fail numeric validation",
+        )
+        .map_err(io::Error::other)?;
+
+        let mut fractional_count = published.clone();
+        let fractional_values = fractional_count
+            .get_mut("aggregate")
+            .and_then(|value| value.get_mut("groups"))
+            .and_then(|value| value.get_mut("small-clean/v0.4"))
+            .and_then(|value| value.get_mut("distributions"))
+            .and_then(|value| value.get_mut("tool_calls"))
+            .and_then(|value| value.get_mut("values"))
+            .and_then(serde_json::Value::as_array_mut)
+            .ok_or_else(|| io::Error::other("benchmark metric values are missing"))?;
+        fractional_values[0] = serde_json::Value::from(1.5);
+        require(
+            rejected_benchmark_reason(&fractional_count)?.contains("integer"),
+            "fractional count did not fail numeric validation",
+        )
+        .map_err(io::Error::other)?;
+
+        let mut excessive_count = published.clone();
+        let excessive_values = excessive_count
+            .get_mut("aggregate")
+            .and_then(|value| value.get_mut("groups"))
+            .and_then(|value| value.get_mut("small-clean/v0.4"))
+            .and_then(|value| value.get_mut("distributions"))
+            .and_then(|value| value.get_mut("tool_calls"))
+            .and_then(|value| value.get_mut("values"))
+            .and_then(serde_json::Value::as_array_mut)
+            .ok_or_else(|| io::Error::other("benchmark metric values are missing"))?;
+        excessive_values[0] = serde_json::Value::from(9_007_199_254_740_992_u64);
+        require(
+            rejected_benchmark_reason(&excessive_count)?.contains("bound"),
+            "excessive count did not fail numeric validation",
+        )
+        .map_err(io::Error::other)?;
+
+        let mut false_break_even = published.clone();
+        let break_even = false_break_even
+            .get_mut("aggregate")
+            .and_then(|value| value.get_mut("comparisons"))
+            .and_then(|value| value.get_mut("small-clean/v0.4-vs-plain"))
+            .and_then(|value| value.get_mut("wall_time_break_even_tasks"))
+            .ok_or_else(|| io::Error::other("benchmark break-even value is missing"))?;
+        *break_even = serde_json::Value::from(123_456_u64);
+        require(
+            rejected_benchmark_reason(&false_break_even)?.contains("does not match"),
+            "fabricated break-even value did not fail derived validation",
+        )
+        .map_err(io::Error::other)?;
+
+        let mut excessive_comparison_metrics = published.clone();
+        let comparison_metrics = excessive_comparison_metrics
+            .get_mut("aggregate")
+            .and_then(|value| value.get_mut("comparisons"))
+            .and_then(|value| value.get_mut("small-clean/v0.4-vs-plain"))
+            .and_then(|value| value.get_mut("lower_is_better_percent_savings"))
+            .and_then(serde_json::Value::as_object_mut)
+            .ok_or_else(|| io::Error::other("benchmark comparison metrics are missing"))?;
+        let comparison_template = comparison_metrics
+            .values()
+            .next()
+            .cloned()
+            .ok_or_else(|| io::Error::other("benchmark comparison metric is missing"))?;
+        while comparison_metrics.len() <= 64 {
+            comparison_metrics.insert(
+                format!("extra_metric_{}", comparison_metrics.len()),
+                comparison_template.clone(),
+            );
+        }
+        require(
+            rejected_benchmark_reason(&excessive_comparison_metrics)?.contains("too large"),
+            "comparison metric overflow did not fail collection validation",
+        )
+        .map_err(io::Error::other)?;
+
+        let mut excessive_identity_bytes = published.clone();
+        let skill_bytes = excessive_identity_bytes
+            .get_mut("candidate_identities")
+            .and_then(|value| value.get_mut("v0.4"))
+            .and_then(|value| value.get_mut("skill_bytes"))
+            .ok_or_else(|| io::Error::other("candidate skill bytes are missing"))?;
+        *skill_bytes = serde_json::Value::from(9_007_199_254_740_992_u64);
+        require(
+            rejected_benchmark_reason(&excessive_identity_bytes)?.contains("supported bound"),
+            "excessive identity bytes did not fail numeric validation",
+        )
+        .map_err(io::Error::other)?;
+
+        let mut causal_provider = published;
+        let causal_attribution = causal_provider
+            .get_mut("aggregate")
+            .and_then(|value| value.get_mut("comparisons"))
+            .and_then(|value| value.get_mut("small-clean/v0.4-vs-plain"))
+            .and_then(|value| value.get_mut("provider_usage_descriptive_only"))
+            .and_then(|value| value.get_mut("input_tokens"))
+            .and_then(|value| value.get_mut("causal_attribution"))
+            .ok_or_else(|| io::Error::other("provider causality marker is missing"))?;
+        *causal_attribution = serde_json::Value::Bool(true);
+        require(
+            rejected_benchmark_reason(&causal_provider)?.contains("causal attribution"),
+            "causal provider counter did not fail validation",
+        )
+        .map_err(io::Error::other)?;
+        Ok(())
+    }
+}

--- a/crates/projectatlas-service/src/agent_efficiency.rs
+++ b/crates/projectatlas-service/src/agent_efficiency.rs
@@ -622,6 +622,8 @@ fn validate_schedule_and_runs(
             matches!(run.execution_status.as_str(), "completed" | "failed"),
             "benchmark run has an unsupported execution status",
         )?;
+        let mut projectatlas_calls = 0usize;
+        let mut completed_projectatlas_calls = 0usize;
         if let Some(trace) = run.trace.as_ref() {
             require(
                 trace.mcp_calls.len() <= BENCHMARK_MAX_MCP_CALLS_PER_RUN,
@@ -637,8 +639,22 @@ fn validate_schedule_and_runs(
                         && call.emitted_bytes <= BENCHMARK_MAX_EXACT_INTEGER,
                     "benchmark MCP-call identity, status, or emitted-byte value is invalid",
                 )?;
+                if call.server == "projectatlas" {
+                    projectatlas_calls += 1;
+                    completed_projectatlas_calls += usize::from(call.status == "completed");
+                }
             }
         }
+        require(
+            run.arm != PLAIN_ARM || projectatlas_calls == 0,
+            "plain benchmark run contains a ProjectAtlas MCP call",
+        )?;
+        require(
+            run.execution_status != "completed"
+                || run.arm == PLAIN_ARM
+                || completed_projectatlas_calls > 0,
+            "completed ProjectAtlas benchmark run has no completed ProjectAtlas MCP call",
+        )?;
         require(
             runs.insert(run.run_id.as_str(), run).is_none(),
             "benchmark contains duplicate retained run ids",
@@ -1252,13 +1268,13 @@ fn project_capabilities(
     let mut counts = [0usize; 5];
     let mut bytes = [0u64; 5];
     let mut total_calls = 0usize;
-    for run in runs.iter().filter(|run| {
-        run.arm == CANDIDATE_ARM && run.execution_status == "completed" && !run.excluded
-    }) {
-        let trace = run
-            .trace
-            .as_ref()
-            .ok_or_else(|| "completed candidate run is missing its trace".to_string())?;
+    for run in runs
+        .iter()
+        .filter(|run| run.arm == CANDIDATE_ARM && !run.excluded)
+    {
+        let Some(trace) = run.trace.as_ref() else {
+            continue;
+        };
         for call in &trace.mcp_calls {
             require(
                 call.server == "projectatlas",
@@ -1622,7 +1638,10 @@ struct BenchmarkProviderComparison {
 
 #[cfg(test)]
 mod tests {
-    use super::{BenchmarkArtifact, require, validate_and_project};
+    use super::{
+        BenchmarkArtifact, BenchmarkMcpCall, BenchmarkRun, BenchmarkTrace, CANDIDATE_ARM,
+        PLAIN_ARM, project_capabilities, require, validate_and_project,
+    };
     use projectatlas_core::telemetry::{
         AgentEfficiencyBaseline, AgentEfficiencyCapability, AgentEfficiencyEvidenceState,
     };
@@ -1638,6 +1657,27 @@ mod tests {
         validate_and_project(artifact, &bytes)
             .err()
             .ok_or_else(|| io::Error::other("modified benchmark unexpectedly validated").into())
+    }
+
+    fn mcp_calls_for_arm<'a>(
+        artifact: &'a mut serde_json::Value,
+        arm: &str,
+    ) -> Result<&'a mut Vec<serde_json::Value>, io::Error> {
+        artifact
+            .get_mut("runs")
+            .and_then(serde_json::Value::as_array_mut)
+            .and_then(|runs| {
+                runs.iter_mut().find_map(|run| {
+                    (run.get("arm").and_then(serde_json::Value::as_str) == Some(arm))
+                        .then(|| {
+                            run.get_mut("trace")
+                                .and_then(|value| value.get_mut("mcp_calls"))
+                                .and_then(serde_json::Value::as_array_mut)
+                        })
+                        .flatten()
+                })
+            })
+            .ok_or_else(|| io::Error::other(format!("{arm} benchmark MCP calls are missing")))
     }
 
     #[test]
@@ -1713,6 +1753,65 @@ mod tests {
             )
             .map_err(io::Error::other)?;
         }
+        Ok(())
+    }
+
+    #[test]
+    fn benchmark_validation_enforces_each_arm_mcp_contract()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docs/benchmarks/v0.4-agent-navigation-results.json");
+        let published: serde_json::Value = serde_json::from_slice(&fs::read(path)?)?;
+
+        let mut contaminated_plain = published.clone();
+        let candidate_call = mcp_calls_for_arm(&mut contaminated_plain, CANDIDATE_ARM)?
+            .first()
+            .cloned()
+            .ok_or_else(|| io::Error::other("candidate benchmark MCP call is missing"))?;
+        mcp_calls_for_arm(&mut contaminated_plain, PLAIN_ARM)?.push(candidate_call);
+        require(
+            rejected_benchmark_reason(&contaminated_plain)?.contains("plain benchmark run"),
+            "contaminated plain control did not fail MCP-contract validation",
+        )
+        .map_err(io::Error::other)?;
+
+        let mut call_free_candidate = published;
+        mcp_calls_for_arm(&mut call_free_candidate, CANDIDATE_ARM)?.clear();
+        require(
+            rejected_benchmark_reason(&call_free_candidate)?.contains("no completed ProjectAtlas"),
+            "call-free completed ProjectAtlas run did not fail MCP-contract validation",
+        )
+        .map_err(io::Error::other)?;
+        Ok(())
+    }
+
+    #[test]
+    fn failed_candidate_completed_calls_are_projected() -> Result<(), Box<dyn std::error::Error>> {
+        let capabilities = project_capabilities(&[BenchmarkRun {
+            run_id: "failed-candidate".to_string(),
+            repeat: 1,
+            workload: "small-clean".to_string(),
+            arm: CANDIDATE_ARM.to_string(),
+            excluded: false,
+            execution_status: "failed".to_string(),
+            trace: Some(BenchmarkTrace {
+                mcp_calls: vec![BenchmarkMcpCall {
+                    server: "projectatlas".to_string(),
+                    tool: "atlas_search".to_string(),
+                    status: "completed".to_string(),
+                    emitted_bytes: 42,
+                }],
+            }),
+        }])
+        .map_err(io::Error::other)?;
+        require(
+            capabilities.len() == 1
+                && capabilities[0].capability == AgentEfficiencyCapability::Search
+                && capabilities[0].calls == 1
+                && capabilities[0].emitted_bytes == 42,
+            "failed candidate trace-completed call was not projected",
+        )
+        .map_err(io::Error::other)?;
         Ok(())
     }
 

--- a/crates/projectatlas-service/src/lib.rs
+++ b/crates/projectatlas-service/src/lib.rs
@@ -1,5 +1,6 @@
 //! Purpose: Provide shared `ProjectAtlas` query services for CLI and MCP adapters.
 
+mod agent_efficiency;
 mod analysis;
 mod federation;
 mod import_aliases;
@@ -25,6 +26,7 @@ pub use relations::{
     parse_relation_confidence, parse_relation_direction, parse_relation_resolution,
 };
 
+use agent_efficiency::load_agent_efficiency_comparison;
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use import_aliases::{ImportAliasMap, load_import_alias_map};
 use projectatlas_core::graph::{
@@ -190,6 +192,8 @@ pub enum TokenReportRequest<'a> {
     Overview {
         /// Optional caller-visible label filter.
         caller_label: Option<&'a str>,
+        /// Optional repository-relative controlled benchmark artifact.
+        benchmark_results: Option<&'a Path>,
     },
     /// Load retained token trends for an optional caller label and window.
     Trends {
@@ -244,10 +248,18 @@ pub fn load_token_report(
     store: &AtlasStore,
     request: TokenReportRequest<'_>,
 ) -> ServiceResult<TokenReport> {
-    let _selected_project = selected_project_binding(store)?;
+    let selected_project = selected_project_binding(store)?;
     let report = match request {
-        TokenReportRequest::Overview { caller_label } => {
-            TokenReport::Overview(Box::new(store.token_overview(caller_label)?))
+        TokenReportRequest::Overview {
+            caller_label,
+            benchmark_results,
+        } => {
+            let mut overview = store.token_overview(caller_label)?;
+            overview.set_agent_efficiency(load_agent_efficiency_comparison(
+                &selected_project,
+                benchmark_results,
+            )?);
+            TokenReport::Overview(Box::new(overview))
         }
         TokenReportRequest::Trends {
             caller_label,
@@ -3370,7 +3382,9 @@ mod tests {
         CoverageRecord, GraphIdentityText, GraphLimitKind, RepositoryNodePath,
     };
     use projectatlas_core::symbols::{ParserKind, SymbolGraph};
-    use projectatlas_core::telemetry::UsageDetailAvailability;
+    use projectatlas_core::telemetry::{
+        AgentEfficiencyBaseline, AgentEfficiencyEvidenceState, UsageDetailAvailability,
+    };
     use projectatlas_core::{Node, Purpose, PurposeSource, PurposeStatus, normalized_parent};
     use std::error::Error;
     use std::io;
@@ -3384,8 +3398,13 @@ mod tests {
         fs::create_dir_all(&atlas_dir)?;
         let store = AtlasStore::open_for_project(&atlas_dir.join("projectatlas.db"), &root)?;
 
-        let overview =
-            load_token_report(&store, TokenReportRequest::Overview { caller_label: None })?;
+        let overview = load_token_report(
+            &store,
+            TokenReportRequest::Overview {
+                caller_label: None,
+                benchmark_results: None,
+            },
+        )?;
         match overview {
             TokenReport::Overview(overview) => {
                 require_eq(&overview.calls, &0, "empty overview calls")?;
@@ -3393,6 +3412,11 @@ mod tests {
                     &overview.detail_availability,
                     &UsageDetailAvailability::Retained,
                     "empty overview detail availability",
+                )?;
+                require_eq(
+                    &overview.agent_efficiency.state,
+                    &AgentEfficiencyEvidenceState::Unavailable,
+                    "empty overview agent-efficiency state",
                 )?;
             }
             TokenReport::Trends(_) => {
@@ -3425,11 +3449,149 @@ mod tests {
         if !matches!(
             load_token_report(
                 &unbound,
-                TokenReportRequest::Overview { caller_label: None }
+                TokenReportRequest::Overview {
+                    caller_label: None,
+                    benchmark_results: None,
+                }
             ),
             Err(ServiceError::SelectedProjectUnavailable)
         ) {
             return Err(io::Error::other("unbound token report did not fail closed").into());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn token_report_service_bounds_and_classifies_benchmark_evidence() -> Result<(), Box<dyn Error>>
+    {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("benchmark-service");
+        let atlas_dir = root.join(".projectatlas");
+        fs::create_dir_all(&atlas_dir)?;
+        let store = AtlasStore::open_for_project(&atlas_dir.join("projectatlas.db"), &root)?;
+        let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docs/benchmarks/v0.4-agent-navigation-results.json");
+        let published = root.join("published.json");
+        fs::copy(&source, &published)?;
+
+        let report = load_token_report(
+            &store,
+            TokenReportRequest::Overview {
+                caller_label: None,
+                benchmark_results: Some(Path::new("published.json")),
+            },
+        )?;
+        let TokenReport::Overview(report) = report else {
+            return Err(io::Error::other("benchmark request returned token trends").into());
+        };
+        require_eq(
+            &report.agent_efficiency.state,
+            &AgentEfficiencyEvidenceState::Partial,
+            "published benchmark state",
+        )?;
+        let frozen = report
+            .agent_efficiency
+            .baselines
+            .iter()
+            .find(|row| row.baseline == AgentEfficiencyBaseline::FrozenProjectAtlasV0326)
+            .ok_or_else(|| io::Error::other("frozen baseline row missing"))?;
+        require_eq(
+            &frozen.baseline_failed_trials,
+            &3,
+            "published frozen failed trials",
+        )?;
+
+        fs::write(root.join("malformed.json"), b"{")?;
+        let malformed = load_token_report(
+            &store,
+            TokenReportRequest::Overview {
+                caller_label: None,
+                benchmark_results: Some(Path::new("malformed.json")),
+            },
+        )?;
+        let TokenReport::Overview(malformed) = malformed else {
+            return Err(io::Error::other("malformed request returned token trends").into());
+        };
+        require_eq(
+            &malformed.agent_efficiency.state,
+            &AgentEfficiencyEvidenceState::Failed,
+            "malformed benchmark state",
+        )?;
+
+        let stale = String::from_utf8(fs::read(&source)?)?.replacen(
+            "\"schema_version\": 1",
+            "\"schema_version\": 2",
+            1,
+        );
+        fs::write(root.join("stale.json"), stale)?;
+        let stale = load_token_report(
+            &store,
+            TokenReportRequest::Overview {
+                caller_label: None,
+                benchmark_results: Some(Path::new("stale.json")),
+            },
+        )?;
+        let TokenReport::Overview(stale) = stale else {
+            return Err(io::Error::other("stale request returned token trends").into());
+        };
+        require_eq(
+            &stale.agent_efficiency.state,
+            &AgentEfficiencyEvidenceState::Incompatible,
+            "stale benchmark state",
+        )?;
+
+        let missing = load_token_report(
+            &store,
+            TokenReportRequest::Overview {
+                caller_label: None,
+                benchmark_results: Some(Path::new("missing.json")),
+            },
+        )?;
+        let TokenReport::Overview(missing) = missing else {
+            return Err(io::Error::other("missing request returned token trends").into());
+        };
+        require_eq(
+            &missing.agent_efficiency.state,
+            &AgentEfficiencyEvidenceState::Failed,
+            "missing benchmark state",
+        )?;
+
+        fs::write(
+            root.join("oversized.json"),
+            vec![b' '; super::agent_efficiency::BENCHMARK_MAX_BYTES + 1],
+        )?;
+        let oversized = load_token_report(
+            &store,
+            TokenReportRequest::Overview {
+                caller_label: None,
+                benchmark_results: Some(Path::new("oversized.json")),
+            },
+        )?;
+        let TokenReport::Overview(oversized) = oversized else {
+            return Err(io::Error::other("oversized request returned token trends").into());
+        };
+        require_eq(
+            &oversized.agent_efficiency.state,
+            &AgentEfficiencyEvidenceState::Failed,
+            "oversized benchmark state",
+        )?;
+
+        for escaped in [published.as_path(), Path::new("../outside.json")] {
+            if !matches!(
+                load_token_report(
+                    &store,
+                    TokenReportRequest::Overview {
+                        caller_label: None,
+                        benchmark_results: Some(escaped),
+                    },
+                ),
+                Err(ServiceError::InvalidInput(_))
+            ) {
+                return Err(io::Error::other(
+                    "escaping benchmark path did not fail at the service boundary",
+                )
+                .into());
+            }
         }
         Ok(())
     }

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -255,7 +255,7 @@ Prefer MCP tools when the harness exposes them. Use CLI fallbacks only when the 
 - `atlas_slice`: fetch exact line or symbol source only after selection.
 - `atlas_health`: find cleanup/refactor/DRY structure issues. Use `limit`, `start_index`, `category`, `severity`, `path_prefix`, `summary_only`, or `source_only` for large health surfaces.
 - `atlas_watch_once`: bounded refresh after local file changes when no continuous watcher is running.
-- `atlas_token_report`: report estimated token savings.
+- `atlas_token_report`: report estimated token savings; optionally pass one repository-relative `benchmark_results` artifact for validated publication evidence.
 - `atlas_settings` and `atlas_watch_status`: diagnose runtime/index/cache state.
 - `atlas_reset_index`: preview or clear local SQLite/cache files when the index is corrupt or intentionally being rebuilt.
 - `atlas_strip_legacy_purpose`: remove migrated `.purpose` files when explicitly requested.
@@ -304,6 +304,7 @@ This preserves normal atlas reads while preventing usage telemetry writes to `.p
 | Curating missing or generated purposes | `atlas_purpose_queue`, then `atlas_purpose_set` or `atlas_purpose_review` | `projectatlas purpose queue --limit <n>`, then `projectatlas purpose set ...` or `projectatlas purpose review --from-file <json> --apply` |
 | Intentional health conflict | `atlas_health_resolve` | `projectatlas health resolve ... --rationale <why>` |
 | User asks for saved tokens | `atlas_token_report` | `projectatlas token` |
+| Compare the controlled navigation benchmark with live token context | `atlas_token_report` with repository-relative `benchmark_results` | `projectatlas token --benchmark-results <path>` |
 | Human asks for a terminal token dashboard | `atlas_token_report` first for agent state | `projectatlas token --view tui` |
 | Runtime/index diagnostics | `atlas_settings`, `atlas_watch_status`, `atlas_runtime_info` | `projectatlas settings`, `projectatlas watch-status`, `projectatlas runtime-info` |
 | Generate harness MCP config | `atlas_mcp_config` | `projectatlas --format json --db .projectatlas/projectatlas.db mcp-config` |
@@ -332,6 +333,38 @@ The default token report is a fast offline heuristic, not provider billing telem
 ProjectAtlas payload text with `ceil(chars / 4)` and file-size baselines with `ceil(bytes / 4)`. Reports expose
 bucket, baseline kind, confidence, accounting layer, provider, model, tokenizer backend, and accuracy labels so agents can separate
 observed full-file compression from modeled navigation savings. Use `tokens_avoided` for the conservative headline because repeated modeled baselines are deduped there; `estimated_saved` remains the legacy gross compatibility value. Local tokenizer calibration is explicit with `projectatlas token --tokenizer o200k_base` or `projectatlas token --tokenizer cl100k_base`; normal orientation and `atlas_token_report` must stay local and fast.
+
+To attach the controlled v0.4 navigation benchmark to the existing overview,
+pass its repository-relative path:
+
+```bash
+projectatlas token --benchmark-results docs/benchmarks/v0.4-agent-navigation-results.json
+projectatlas --format json token --benchmark-results docs/benchmarks/v0.4-agent-navigation-results.json
+projectatlas token --view tui --benchmark-results docs/benchmarks/v0.4-agent-navigation-results.json
+```
+
+The equivalent MCP request adds:
+
+```json
+{
+  "benchmark_results": "docs/benchmarks/v0.4-agent-navigation-results.json"
+}
+```
+
+The path is optional and applies only to token overviews, not trend reports.
+ProjectAtlas accepts only a direct regular file below the selected project root
+and reads at most 8 MiB. No path yields `unavailable`; safe read/decode failures
+yield `failed`; a decoded but unsupported contract yields `incompatible`;
+retained unmatched failures yield `partial`; and fully matched evidence yields
+`compatible`. Absolute, parent-escaping, symlink, reparse-point, and non-file
+paths are rejected at the request boundary.
+
+The comparison is read-only publication evidence. It is attached once as
+`TokenOverview.agent_efficiency` and rendered identically by CLI JSON/TOON,
+`atlas_token_report`, and the Ratatui overview. The benchmark is never written
+to SQLite, added to live `tokens_avoided` or file-read estimates, or cached.
+Provider token counters remain descriptive-only; capability rows report calls
+and emitted bytes without claiming per-tool token causality.
 
 Read-avoidance counters are also local workflow estimates. Observed
 summary/outline/slice replacements are stronger evidence than search-modeled

--- a/docs/projectatlas-3-architecture.md
+++ b/docs/projectatlas-3-architecture.md
@@ -2371,6 +2371,115 @@ funnel usage. The goal is not perfect accounting; the goal is a useful,
 consistent local metric that shows whether ProjectAtlas is reducing context
 load.
 
+### Read-Only Agent-Efficiency Benchmark
+
+The optional agent-efficiency comparison is immutable publication evidence, not
+live telemetry. A caller may attach one repository-relative benchmark result to
+the existing token overview with CLI `--benchmark-results <path>` or MCP
+`benchmark_results`. The selected project's SQLite database remains
+authoritative only for observed and modeled live usage; ProjectAtlas never
+copies the benchmark into SQLite or creates a cache, sidecar, telemetry event,
+or background loader for it.
+
+```mermaid
+sequenceDiagram
+    participant Request as CLI or MCP overview request
+    participant Service as projectatlas-service
+    participant DB as projectatlas.db
+    participant Artifact as Benchmark JSON
+    participant Report as projectatlas-core TokenOverview
+    participant Adapters as JSON, TOON, MCP, and Ratatui
+
+    Request->>Service: Optional repository-relative benchmark path
+    Service->>DB: Read bounded live telemetry snapshot
+    DB-->>Service: Existing token overview
+    alt no benchmark path
+        Service->>Report: Attach unavailable comparison
+    else benchmark path supplied
+        Service->>Service: Gate direct regular file under captured root
+        alt boundary violation
+            Service-->>Request: Hard request error
+        else safe direct file
+            Service->>Artifact: Read through 8 MiB limit + 1
+            Artifact-->>Service: Exact bytes or I/O failure
+            alt I/O or typed decode failure
+                Service->>Report: Attach failed comparison
+            else decoded artifact
+                Service->>Service: Validate identities, runs, distributions, providers, capabilities
+                alt contract mismatch
+                    Service->>Report: Attach incompatible comparison
+                else retained failed or unmatched trials
+                    Service->>Report: Attach partial matched evidence
+                else all required trials matched
+                    Service->>Report: Attach compatible evidence
+                end
+            end
+        end
+    end
+    opt typed report completed
+        Service->>DB: Revalidate captured project binding
+        Service->>Report: Return one typed overview
+        Report-->>Adapters: Identical agent_efficiency values
+    end
+    Note over Artifact,DB: Benchmark evidence never enters SQLite
+    Note over Report,Adapters: Provider counters remain descriptive-only and non-causal
+```
+
+`projectatlas-service` owns the trust boundary. It resolves the requested path
+under the captured project root, rejects absolute paths, parent traversal,
+symlinks, Windows reparse points, non-regular files, and any canonical target
+outside that root, then preflights metadata, reads through an 8 MiB `limit + 1`,
+and rechecks the open handle plus canonical path, size, and modification
+metadata after the read. Windows opens deny write/delete sharing and open the
+final reparse point itself rather than following it; the share lock prevents
+replacement during the read, while metadata comparison is change detection
+rather than a stable file-index claim. Path-boundary violations remain hard
+request errors. Missing, unreadable, changed, oversized, or malformed artifacts
+produce a bounded `failed` comparison without exposing partial decoded values.
+
+The supported contract validates schema version 1; exact v0.4 and frozen
+v0.3.26 semantic identities and runtime/skill digests; a plain control with
+ProjectAtlas disabled; candidate source heads; the complete five-workload,
+three-arm, repeated schedule; a one-to-one retained schedule/run inventory;
+zero excluded trials; completed and failed run accounting; bounded group,
+comparison, distribution, and MCP-call collections; finite nonnegative values
+whose medians and observed maxima reconcile; descriptive-only provider
+counters; and reconciled capability call/byte rows. The comparison preserves
+failed trials outside matched denominators rather than turning them into zero.
+
+The closed states have one meaning across all adapters:
+
+| State | Meaning |
+| --- | --- |
+| `unavailable` | No benchmark path was supplied; the existing token overview is unchanged. |
+| `failed` | The requested file could not be read or decoded safely, or no matched evidence survives. |
+| `incompatible` | JSON decoded, but its schema, identities, schedule, run accounting, metrics, provider labels, or capability contract is unsupported. |
+| `partial` | Valid matched evidence is visible while retained failed or unmatched trials remain explicit. |
+| `compatible` | Every required candidate and baseline trial is matched and valid. |
+
+The final v0.4 benchmark therefore keeps the frozen-v0.3.26 huge-corpus setup
+failures visible: that baseline row and the overall comparison are `partial`,
+while the plain-control row remains `compatible`. The report retains a BLAKE3
+digest of the exact artifact bytes plus bounded release/runtime/source
+identities. It does not expose local paths, prompts, answers, or raw traces.
+
+`projectatlas-core` owns the closed comparison enums and the single
+backward-compatible defaulted `TokenOverview.agent_efficiency` field. CLI
+JSON/TOON, MCP, and Ratatui render that same typed overview and perform no
+independent parsing or arithmetic. Capability rows report trace-completed
+ProjectAtlas MCP calls and emitted bytes by discovery, summary/slice, search,
+symbols/relations, or bounded `other` responsibility. Provider input,
+cached-input, output, and reasoning counters remain descriptive-only and never
+contribute to navigation savings, `tokens_avoided`, file-read avoidance, or
+break-even arithmetic.
+
+The optional path costs one synchronous `O(file bytes + retained bounded rows)`
+read and validation pass, with file bytes capped at 8 MiB and every repeated
+collection capped before projection. There is no cache, worker pool, SQLite
+write, schema or migration, retention or WAL/checkpoint policy, query-plan
+change, or persistent-size growth. Omitting the path preserves the existing
+fast token overview.
+
 Token accounting model:
 
 - Estimate baseline tokens as the content and exploration the agent avoided:

--- a/openspec/changes/show-agent-efficiency-dashboard/.openspec.yaml
+++ b/openspec/changes/show-agent-efficiency-dashboard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/show-agent-efficiency-dashboard/design.md
+++ b/openspec/changes/show-agent-efficiency-dashboard/design.md
@@ -1,0 +1,81 @@
+## Context
+
+`TokenOverview` in `projectatlas-core` is the authoritative serialized token report. `projectatlas-db` supplies bounded observed and modeled telemetry, `projectatlas-service` selects the report through one captured project binding, and the CLI, MCP, TOON/JSON, and Ratatui paths only adapt that typed result. The final v0.4 navigation benchmark is a versioned JSON artifact with 45 retained scheduled trials, matched v0.4, frozen-v0.3.26, and plain arms, per-run navigation audits, aggregate distributions, explicit failed setup runs, and non-causal provider counters.
+
+The benchmark is publication evidence, not project data. Importing it into SQLite would create a second authority plus schema, migration, retention, and drift responsibilities without improving normal telemetry.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Validate one optional repository-relative benchmark artifact under fixed size, count, identity, schema, and numeric bounds.
+- Keep observed telemetry, modeled avoidance, and benchmark comparison as separate typed accounting layers.
+- Expose identical comparison values through existing CLI JSON/TOON, MCP, and Ratatui paths.
+- Preserve failed and unmatched trials and distinguish unavailable, failed, incompatible, partial, and compatible evidence.
+- Keep the existing dashboard readable at normal and compact widths.
+
+**Non-Goals:**
+
+- Persisting benchmark data, changing the SQLite schema, or recording comparison reads as telemetry.
+- Claiming provider-token causality or deriving benchmark-only navigation counters from live events.
+- Adding another MCP tool, dashboard framework, background loader, or dependency.
+- Re-running or rewriting the immutable task-7.6 result artifact.
+
+## Decisions
+
+### Attach a closed comparison state to the existing token overview
+
+`projectatlas-core` will own closed serializable comparison-state, baseline-row, metric, and capability-contribution types. `TokenOverview` gains one backward-compatible defaulted comparison field. Adapters continue to serialize the same authoritative report rather than maintaining separate arithmetic.
+
+A trait hierarchy or generic analytics model was rejected because the accepted artifact schema and report variants are closed for v0.4.
+
+### Validate read-only evidence in the service
+
+The overview request accepts an optional repository-relative benchmark path. The service resolves it beneath the already captured project root, rejects absolute, parent-escaping, non-file, and path-indirection inputs through the existing repository path boundary, then reads at most 8 MiB. Missing input produces `unavailable`; unreadable or malformed content produces `failed`; semantic mismatch produces `incompatible`; compatible evidence with retained failed or unmatched trials produces `partial`; fully matched evidence produces `compatible`. Path-boundary violations remain hard request errors.
+
+The loader deserializes only required fields with private typed structs and ignores unrelated answer text. It validates:
+
+- schema version `1`, exact v0.4 and frozen-v0.3.26 semantic identities, and a plain arm with ProjectAtlas disabled;
+- bounded run, schedule, comparison, distribution-value, and MCP-call counts;
+- unique and exactly retained scheduled run IDs, at least three repeats, and zero excluded trials;
+- finite, nonnegative counts/timings/bytes and required matched candidate/baseline distributions, with exact-integer samples for count/byte/token fields, lossless JSON-integer bounds, and a seven-day wall-time ceiling;
+- explicit failed-run accounting rather than converting failures to zero;
+- non-causal provider metadata when provider counters are present.
+
+The artifact digest and bounded public identities are retained; local filesystem paths, prompts, answers, and raw traces are not copied into the report.
+
+### Derive two matched baseline rows and bounded capability rows
+
+The service combines only workload groups that have completed trials in both compared arms. It reports medians and observed maxima for total/ProjectAtlas tool calls, productive and wrong folder/file/relation visits, broad/full reads, backtracks, gross and net navigation context, setup/runtime cost, persistent bytes, and wall-time break-even. Frozen-v0.3.26's failed huge-corpus setup remains an unmatched failure and makes that row partial; it is never treated as a successful zero.
+
+Capability rows classify trace-completed v0.4 MCP calls into the existing durable navigation responsibilities:
+
+- initial purpose and connection discovery;
+- summary and exact slice compression;
+- lexical search narrowing;
+- symbol and relation navigation.
+
+Rows report calls and emitted bytes and reconcile to the classified trace-completed MCP-call total. A completed trace status is not relabeled as semantic success, and the rows do not attribute token savings to individual tools because the artifact does not establish that causal split.
+
+### Keep comparison rendering subordinate to the accepted token dashboard
+
+The conservative token headline, file-read strip, observed/modeled composition, source table, calibration notes, and footer stay unchanged. A bounded agent-efficiency panel follows the existing accounting sections and shows comparison state plus two compact baseline rows. Normal width shows the principal call/read/navigation/context/runtime fields; compact width uses shorter labels and fewer columns without hiding state or failed trials. Provider counters remain in the typed payload under a descriptive-only label and are not added to the causal savings panel.
+
+## Risks / Trade-offs
+
+- **A large or hostile JSON artifact consumes excessive resources** → bound bytes and every repeated collection, reject non-finite or negative numeric values, and keep parsing synchronous and optional.
+- **Same-version evidence is mistaken for exact-binary proof** → retain the benchmark runtime digest and source identity in the typed result and label compatibility as release-contract compatibility, not current-executable identity.
+- **Failed frozen-baseline trials disappear from aggregates** → require scheduled/run retention and carry unmatched failures into row and top-level state.
+- **Dashboard density regresses readability** → use two bounded baseline rows, compact fallbacks, deterministic buffer tests, and real visual review.
+- **Adapters drift** → calculate and classify only in core/service types; CLI, MCP, JSON, TOON, and TUI render that result.
+
+## Migration Plan
+
+1. Add defaulted core report types so existing databases and serialized payload consumers remain compatible.
+2. Add the optional CLI/MCP path and read-only service loader.
+3. Add the dashboard panel, documentation, smoke/E2E coverage, and visual proof.
+4. Rollback removes the optional loader and panel; no database or authored state requires migration.
+
+## Open Questions
+
+None.

--- a/openspec/changes/show-agent-efficiency-dashboard/proposal.md
+++ b/openspec/changes/show-agent-efficiency-dashboard/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+ProjectAtlas v0.4 now has a reproducible three-arm navigation benchmark, but the existing token report cannot show that comparison without mixing controlled evidence into live telemetry. Users need one typed, honest view that keeps observed and modeled session accounting separate from a validated benchmark comparison.
+
+## What Changes
+
+- Add an optional, bounded, read-only benchmark-result input to the existing token overview request.
+- Validate the supported benchmark schema, candidate/runtime identity, run completeness, comparison arms, required metrics, and numeric bounds before exposing any comparison values.
+- Extend the authoritative typed token overview with explicit unavailable, incompatible, partial, failed, and compatible comparison states.
+- Render compatible tool-call, navigation-visit, broad/full-read, backtrack, context, setup/runtime, and break-even evidence through the existing CLI JSON/TOON, MCP, and Ratatui dashboard paths.
+- Keep provider token counters descriptive and separate from causal navigation savings.
+- Preserve the existing conservative token/file-read arithmetic, trend mode, semantic palette, compact layout, and backward-compatible output fields.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-efficiency-comparison`: Validate one versioned navigation benchmark artifact and project its matched candidate/baseline evidence into a bounded typed report without persisting it.
+
+### Modified Capabilities
+
+- `token-impact-reference-dashboard`: Add a distinct benchmark-comparison panel and compact fallback while preserving the accepted reference hierarchy and accounting semantics.
+
+## Impact
+
+The change affects the core token-report types, the transport-independent token service, existing CLI and MCP token parameters, TOON/JSON serialization, the Ratatui overview, focused smoke/E2E tests, and the owning telemetry architecture documentation. It adds no crate, dependency, MCP tool, SQLite schema, migration, write path, or background work and is ready for implementation in v0.4.0.
+
+## Non-Goals
+
+- Do not infer saved calls, wrong selections, or backtracks from ordinary telemetry.
+- Do not persist benchmark artifacts or copy their counters into SQLite.
+- Do not treat provider billing counters as causal navigation savings.
+- Do not add a second dashboard, analytics framework, or benchmark collector.
+- Do not alter the dedicated trend dashboard or the established conservative token headline.

--- a/openspec/changes/show-agent-efficiency-dashboard/specs/agent-efficiency-comparison/spec.md
+++ b/openspec/changes/show-agent-efficiency-dashboard/specs/agent-efficiency-comparison/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Optional Benchmark Evidence Is Bounded And Read-Only
+The token overview SHALL accept an optional repository-relative navigation benchmark artifact, SHALL validate it without persisting or mutating project state, and SHALL read it only within fixed byte and collection bounds.
+
+#### Scenario: No benchmark artifact is supplied
+- **WHEN** a caller requests the existing token overview without a benchmark path
+- **THEN** the report SHALL return comparison state `unavailable`
+- **AND** existing token accounting and trend behavior SHALL remain unchanged.
+
+#### Scenario: A valid in-project artifact is supplied
+- **WHEN** a caller supplies a regular benchmark-result file beneath the selected project root
+- **THEN** the service SHALL read and validate it through the captured project binding
+- **AND** the benchmark read SHALL create no SQLite row, telemetry event, benchmark-owned sidecar, or rewritten artifact beyond the existing read-only SQLite connection lifecycle.
+
+#### Scenario: The path escapes the selected project
+- **WHEN** an MCP or CLI caller supplies an absolute path, parent traversal, path indirection, or a file outside the selected project root
+- **THEN** the request SHALL fail at the repository path boundary
+- **AND** it SHALL NOT read the outside target or mutate either project.
+
+#### Scenario: The artifact exceeds a bound
+- **WHEN** the artifact exceeds the byte limit, any retained run, schedule, comparison, distribution, or MCP-call count exceeds its limit, a count/byte/token sample is fractional or exceeds the lossless JSON-integer bound, or a wall-time sample exceeds seven days
+- **THEN** the report SHALL return an explicit failed or incompatible comparison state
+- **AND** it SHALL NOT partially expose unvalidated comparison values.
+
+### Requirement: Comparison Compatibility Is Typed And Honest
+The report SHALL distinguish unavailable, failed, incompatible, partial, and compatible benchmark evidence and SHALL preserve candidate, baseline, schema, workload, failure, and digest identity needed to interpret the result.
+
+#### Scenario: The supported final benchmark is loaded
+- **WHEN** schema version, v0.4 candidate version, frozen-v0.3.26 version, plain control, schedule, repeat, run-retention, comparison, and metric contracts validate
+- **THEN** the report SHALL expose the artifact digest and bounded public identities
+- **AND** it SHALL classify each baseline row from its actual matched and failed trials.
+
+#### Scenario: A required identity or metric is stale
+- **WHEN** the schema, candidate/baseline semantic identity, arm contract, required workload, or required metric differs from the supported contract
+- **THEN** the report SHALL return `incompatible` with a bounded reason
+- **AND** it SHALL expose no fabricated comparison zero or savings percentage.
+
+#### Scenario: Retained setup failures prevent one complete match
+- **WHEN** a baseline has explicit failed trials for a workload while other workloads remain exactly matched
+- **THEN** that baseline row and the overall evidence SHALL be marked `partial`
+- **AND** matched metrics MAY remain visible with the unmatched failure count
+- **AND** failed trials SHALL NOT enter completed-trial denominators as zero.
+
+#### Scenario: Provider counters are present
+- **WHEN** the artifact contains provider input, cached-input, output, or reasoning counters
+- **THEN** those counters SHALL remain labeled descriptive-only and non-causal
+- **AND** they SHALL NOT contribute to navigation savings or break-even arithmetic.
+
+### Requirement: Matched Navigation Metrics Have One Typed Representation
+The token overview SHALL expose matched v0.4-versus-frozen-v0.3.26 and v0.4-versus-plain rows from the validated artifact, using the same typed values for CLI JSON/TOON, MCP, and TUI rendering.
+
+#### Scenario: Matched groups contain navigation evidence
+- **WHEN** both arms completed the same workload trials
+- **THEN** the row SHALL report matched and failed trial counts
+- **AND** it SHALL report total and ProjectAtlas tool calls, productive and wrong folder/file/relation visits, broad/full reads, backtracks, gross and net navigation context, setup/runtime cost, persistent bytes, and break-even state where available.
+
+#### Scenario: A ratio denominator is zero
+- **WHEN** a baseline metric is zero or a break-even saving is not positive
+- **THEN** the typed result SHALL report the percentage or break-even value as unavailable
+- **AND** it SHALL NOT emit infinity, NaN, or a fabricated percentage.
+
+#### Scenario: Adapters render the report
+- **WHEN** the same project, session, and benchmark path are requested through CLI JSON, CLI TOON, and `atlas_token_report`
+- **THEN** all adapters SHALL expose identical comparison state, identities, counts, values, and unavailable fields.
+
+### Requirement: Capability Contributions Are Bounded And Non-Causal
+The report SHALL group trace-completed v0.4 MCP calls into bounded navigation-capability rows and SHALL reconcile their calls and emitted bytes without relabeling trace status as semantic success or claiming per-capability token causality.
+
+#### Scenario: Supported v0.4 MCP calls are present
+- **WHEN** validated v0.4 traces contain discovery, summary/slice, search, and symbol/relation tools
+- **THEN** capability rows SHALL classify calls by those durable responsibilities
+- **AND** visible row calls SHALL sum to the classified trace-completed ProjectAtlas MCP-call total.
+
+#### Scenario: An unknown tool name is present
+- **WHEN** a compatible artifact contains a trace-completed ProjectAtlas MCP tool outside the supported classification
+- **THEN** the report SHALL place it in one bounded `other` contribution row or mark the evidence incompatible
+- **AND** it SHALL NOT silently drop the call or assign unsupported savings.

--- a/openspec/changes/show-agent-efficiency-dashboard/specs/token-impact-reference-dashboard/spec.md
+++ b/openspec/changes/show-agent-efficiency-dashboard/specs/token-impact-reference-dashboard/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Agent Efficiency Comparison Remains Visually Distinct
+The token overview TUI SHALL render validated benchmark evidence in a bounded agent-efficiency panel that is visually and semantically separate from observed and modeled live telemetry.
+
+#### Scenario: Compatible or partial evidence is available
+- **WHEN** `projectatlas token --view tui` receives validated benchmark comparison rows
+- **THEN** the dashboard SHALL show the comparison state and artifact identity
+- **AND** it SHALL show distinct frozen-v0.3.26 and plain-control rows with matched and failed trial counts
+- **AND** it SHALL NOT add benchmark values to `tokens_avoided` or `likely_file_reads_avoided`.
+
+#### Scenario: Evidence is unavailable or invalid
+- **WHEN** comparison state is unavailable, failed, or incompatible
+- **THEN** the dashboard SHALL show that explicit state and a bounded reason
+- **AND** it SHALL NOT render fabricated zero-valued efficiency rows or savings percentages.
+
+### Requirement: Comparison Layout Preserves The Accepted Dashboard
+The agent-efficiency panel SHALL preserve the accepted token-impact hierarchy, semantic palette, terminal-background behavior, trend mode, and compact-width contract.
+
+#### Scenario: Normal-width overview renders
+- **WHEN** the overview renders at the canonical normal width
+- **THEN** the existing headline, file-read, composition, signal, source, calibration, and footer sections SHALL retain their accounting and semantic roles
+- **AND** the agent-efficiency panel SHALL show the principal call, navigation, context, runtime, and break-even fields without hidden overflow.
+
+#### Scenario: Compact-width overview renders
+- **WHEN** the overview renders at 80 columns
+- **THEN** comparison state, both baseline identities, matched/failed trials, and the principal call/read/context result SHALL remain visible
+- **AND** the layout SHALL use bounded short labels rather than truncating into adjacent columns.
+
+#### Scenario: Trend mode is selected
+- **WHEN** a user requests the dedicated token trend dashboard
+- **THEN** trend mode SHALL remain unchanged
+- **AND** it SHALL NOT duplicate the agent-efficiency comparison panel.
+
+### Requirement: Dashboard Values Come From The Typed Report
+The Ratatui dashboard SHALL render comparison values and states from the authoritative typed token overview and SHALL NOT parse benchmark JSON or maintain independent comparison arithmetic.
+
+#### Scenario: Ratatui buffer tests render representative states
+- **WHEN** tests render compatible, partial, unavailable, failed, and incompatible comparison reports
+- **THEN** labels, semantic styles, clamped ratios, absent values, failed counts, normal layout, and compact layout SHALL match the typed values
+- **AND** existing conservative token and file-read equations SHALL continue to reconcile.
+
+#### Scenario: Real visual review is performed
+- **WHEN** the implementation is ready for acceptance
+- **THEN** a real normal-width dashboard render SHALL be compared to the approved token-impact reference
+- **AND** the new panel SHALL remain readable without weakening the existing visual hierarchy.

--- a/openspec/changes/show-agent-efficiency-dashboard/tasks.md
+++ b/openspec/changes/show-agent-efficiency-dashboard/tasks.md
@@ -1,0 +1,21 @@
+## 1. Typed Comparison Contract
+
+- [x] 1.1 Add backward-compatible core comparison states, identities, baseline metrics, and capability-contribution rows to the existing token overview, with serialization and unavailable/default coverage and no SQLite schema or write-path change.
+- [x] 1.2 Implement the bounded service-owned benchmark reader and typed schema, identity, schedule, run-retention, numeric, failure, and path-boundary validation, including malformed, oversized, stale, missing, escaping, and indirection cases.
+- [x] 1.3 Derive matched frozen-v0.3.26 and plain-control distributions, unmatched failure counts, unavailable percentages/break-even, and reconciled v0.4 capability call/byte rows without provider-token causality.
+
+## 2. Existing Adapter Integration
+
+- [x] 2.1 Add one optional repository-relative benchmark path to the existing token overview request and wire identical typed results through CLI JSON/TOON and `atlas_token_report`, preserving project isolation and no-implicit-mutation behavior.
+- [x] 2.2 Add representative real CLI and MCP smoke coverage for compatible, partial, unavailable, incompatible, malformed, wrong-root, and backward-compatible requests.
+
+## 3. Ratatui Dashboard
+
+- [x] 3.1 Add one bounded agent-efficiency comparison panel to the existing overview while preserving the accepted headline, file-read, composition, source, calibration, footer, palette, background, and separate trend dashboard.
+- [x] 3.2 Cover compatible, partial, unavailable, failed, and incompatible states plus normal/compact labels, styles, clamped ratios, failed trials, hidden-overflow prevention, and unchanged accounting equations in deterministic Ratatui buffer tests.
+
+## 4. Documentation And Release Proof
+
+- [x] 4.1 Update the owning telemetry architecture view and user documentation for read-only benchmark validation, typed report ownership, CLI/MCP/TUI flow, provenance, compatibility, limitations, and provider-counter separation; render every changed Mermaid block and inspect semantic and visual correctness.
+- [x] 4.2 Run focused core/service/DB-read-only/CLI/MCP/TUI tests, `cargo fmt --check`, workspace check, Clippy, full tests, doc tests, rustdoc, dependency policy, strict OpenSpec validation, ProjectAtlas lint, and IssueOps synchronization; capture and visually inspect a real normal-width dashboard render.
+- [ ] 4.3 Inspect and disposition all live PR review threads plus Codex and Dependabot feedback on the exact head, then synchronize the completed OpenSpec and GitHub issue checklists before merge and closure.

--- a/openspec/changes/show-agent-efficiency-dashboard/tasks.md
+++ b/openspec/changes/show-agent-efficiency-dashboard/tasks.md
@@ -18,4 +18,4 @@
 
 - [x] 4.1 Update the owning telemetry architecture view and user documentation for read-only benchmark validation, typed report ownership, CLI/MCP/TUI flow, provenance, compatibility, limitations, and provider-counter separation; render every changed Mermaid block and inspect semantic and visual correctness.
 - [x] 4.2 Run focused core/service/DB-read-only/CLI/MCP/TUI tests, `cargo fmt --check`, workspace check, Clippy, full tests, doc tests, rustdoc, dependency policy, strict OpenSpec validation, ProjectAtlas lint, and IssueOps synchronization; capture and visually inspect a real normal-width dashboard render.
-- [ ] 4.3 Inspect and disposition all live PR review threads plus Codex and Dependabot feedback on the exact head, then synchronize the completed OpenSpec and GitHub issue checklists before merge and closure.
+- [x] 4.3 Inspect and disposition all live PR review threads plus Codex and Dependabot feedback on the exact head, then synchronize the completed OpenSpec and GitHub issue checklists before merge and closure.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -30,6 +30,7 @@
     },
     "publish-rustdoc-readme-links": 300,
     "reuse-unchanged-ci-build-layers": 341,
+    "show-agent-efficiency-dashboard": 340,
     "simplify-token-tui-dashboard": 296
   }
 }


### PR DESCRIPTION
## Summary

- validate one bounded repository-local navigation benchmark as read-only publication evidence
- expose the same typed comparison through token JSON/TOON, `atlas_token_report`, and the existing Ratatui dashboard
- preserve live telemetry accounting, the v0.3.26 MCP description, SQLite state, and the seven-crate architecture

## Issue

Refs #340

## Checklist

- [x] `projectatlas scan` run when indexed context changed.
- [x] `projectatlas lint --report-untracked --purpose-level low` passes, and `projectatlas purpose queue` has been reviewed for touched high-value paths.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo check --workspace --all-targets --all-features --locked` clean.
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean.
- [x] `cargo test --workspace --all-features --locked` and stable workspace doctests clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked` clean.
- [x] Tests updated or added where behavior changed.
- [x] All active OpenSpec changes are mapped in `openspec/issue-map.json`, linked issue task sections exactly mirror local task text and state, and `.github/scripts/issue-checklists.py` passes. Full issue and milestone completion is required only when closing or releasing, not for every incremental `dev` slice.
- [x] README, Markdown docs, and GitHub Pages/rustdoc-facing content are updated or confirmed current for this change.
- [x] PR text contains no private or internal-only details (release notes are generated from PR text).

OpenSpec tasks 1.1 through 4.3 are complete. Both live Codex review findings were fixed, covered by regressions, replied to, and resolved; no Dependabot feedback is present.