### PR TITLE
fix(installer): preserve project trust boundaries (#311)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,11 @@ jobs:
         timeout-minutes: 5
         run: cargo test --locked -p projectatlas-cli windows_release_binary_installer_repairs_stale_mirror_without_registering_it --test e2e
 
+      - name: Windows installer trust boundaries
+        if: matrix.label == 'windows'
+        timeout-minutes: 10
+        run: cargo test --locked -p projectatlas-cli --all-features --test installer_trust_boundaries
+
       - name: macOS unsupported parser-pack boundary E2E
         if: runner.os == 'macOS'
         timeout-minutes: 5

--- a/crates/projectatlas-cli/tests/installer_trust_boundaries.rs
+++ b/crates/projectatlas-cli/tests/installer_trust_boundaries.rs
@@ -1,0 +1,356 @@
+//! Verify release bootstraps never execute source discovered in a target project.
+
+use assert_cmd::Command;
+use std::env;
+use std::error::Error;
+use std::ffi::OsString;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Maximum runtime for one installer subprocess.
+const INSTALL_TIMEOUT: Duration = Duration::from_secs(30);
+/// Unreachable release endpoint that makes any remaining source fallback observable.
+const UNREACHABLE_RELEASE_BASE_URL: &str = "http://127.0.0.1:9/projectatlas-test";
+
+#[test]
+fn bootstraps_never_derive_executable_source_from_the_target_project() -> Result<(), Box<dyn Error>>
+{
+    let root = workspace_root()?;
+    let sources = [
+        (
+            "PowerShell",
+            fs::read_to_string(root.join("plugins/projectatlas/scripts/install-runtime.ps1"))?,
+        ),
+        (
+            "POSIX",
+            fs::read_to_string(root.join("plugins/projectatlas/scripts/install-runtime.sh"))?,
+        ),
+    ];
+
+    for (host, source) in sources {
+        require(
+            !source.contains("cargo install --path")
+                && !source.contains("\"install\", \"--path\"")
+                && !source.contains("$project_root/crates/projectatlas-cli/Cargo.toml")
+                && !source.contains("Join-Path $ProjectRoot \"crates\\projectatlas-cli"),
+            format!("{host} bootstrap can execute source inferred from its target project"),
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+#[test]
+fn powershell_bootstrap_treats_hostile_target_source_as_data() -> Result<(), Box<dyn Error>> {
+    let fixture = HostileTarget::create()?;
+    let fake_bin = fixture.root.path().join("fake-bin");
+    fs::create_dir(&fake_bin)?;
+    fs::write(
+        fake_bin.join("cargo.cmd"),
+        "@echo off\r\necho %* > \"%PROJECTATLAS_FAKE_CARGO_LOG%\"\r\nexit /b 23\r\n",
+    )?;
+
+    let installer = workspace_root()?.join("plugins/projectatlas/scripts/install-runtime.ps1");
+    let mut command = Command::new("powershell");
+    configure_hostile_install(&mut command, &fixture, &fake_bin)?;
+    let output = command
+        .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+        .arg(installer)
+        .arg("-ProjectRoot")
+        .arg(&fixture.target)
+        .arg("-ProjectAtlasVersion")
+        .arg(release_version())
+        .arg("-ReleaseBaseUrl")
+        .arg(UNREACHABLE_RELEASE_BASE_URL)
+        .output()?;
+
+    fixture.verify_target_source_remained_inert(output.status)
+}
+
+#[cfg(windows)]
+#[test]
+fn powershell_bootstrap_rejects_project_state_reparse_points_before_writing()
+-> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let target = root.path().join("target");
+    let outside = root.path().join("outside");
+    fs::create_dir(&target)?;
+    fs::create_dir(&outside)?;
+    let sentinel = outside.join("sentinel.txt");
+    fs::write(&sentinel, "unchanged\n")?;
+    let stable_runtime = root
+        .path()
+        .join("local-app-data/ProjectAtlas/bin/projectatlas.exe");
+
+    let junction = target.join(".projectatlas");
+    let junction_output = Command::new("cmd")
+        .timeout(INSTALL_TIMEOUT)
+        .args(["/D", "/C", "mklink", "/J"])
+        .arg(&junction)
+        .arg(&outside)
+        .output()?;
+    require(
+        junction_output.status.success(),
+        format!(
+            "failed to create junction fixture: {}",
+            String::from_utf8_lossy(&junction_output.stderr)
+        ),
+    )?;
+
+    let output = run_powershell_runtime_install(&target, root.path())?;
+    require(
+        !output.status.success(),
+        "PowerShell bootstrap accepted a project-state reparse point",
+    )?;
+    require(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("must not be a symlink, junction, or reparse point"),
+        format!(
+            "PowerShell bootstrap did not explain the rejected reparse point: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ),
+    )?;
+    require(
+        fs::read_to_string(sentinel)? == "unchanged\n"
+            && !outside.join("projectatlas.mcp.json").exists()
+            && !stable_runtime.exists(),
+        "PowerShell bootstrap mutated state before rejecting the project-state reparse point",
+    )
+}
+
+#[cfg(unix)]
+#[test]
+fn posix_bootstrap_treats_hostile_target_source_as_data() -> Result<(), Box<dyn Error>> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let fixture = HostileTarget::create()?;
+    let fake_bin = fixture.root.path().join("fake-bin");
+    fs::create_dir(&fake_bin)?;
+    let fake_cargo = fake_bin.join("cargo");
+    fs::write(
+        &fake_cargo,
+        "#!/usr/bin/env sh\nprintf '%s\\n' \"$*\" > \"$PROJECTATLAS_FAKE_CARGO_LOG\"\nexit 23\n",
+    )?;
+    fs::set_permissions(&fake_cargo, fs::Permissions::from_mode(0o755))?;
+
+    let installer = workspace_root()?.join("plugins/projectatlas/scripts/install-runtime.sh");
+    let mut command = Command::new("bash");
+    configure_hostile_install(&mut command, &fixture, &fake_bin)?;
+    let output = command.arg(installer).arg(&fixture.target).output()?;
+
+    fixture.verify_target_source_remained_inert(output.status)
+}
+
+#[cfg(unix)]
+#[test]
+fn posix_bootstrap_rejects_project_state_symlinks_before_writing() -> Result<(), Box<dyn Error>> {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir()?;
+    let target = root.path().join("target");
+    let outside = root.path().join("outside");
+    fs::create_dir(&target)?;
+    fs::create_dir(&outside)?;
+    let sentinel = outside.join("sentinel.txt");
+    fs::write(&sentinel, "unchanged\n")?;
+    let installed_runtime = root.path().join(".local/bin/projectatlas");
+    symlink(&outside, target.join(".projectatlas"))?;
+
+    let installer = workspace_root()?.join("plugins/projectatlas/scripts/install-runtime.sh");
+    let output = isolated_command("bash", root.path())?
+        .arg(installer)
+        .arg(&target)
+        .env(
+            "PROJECTATLAS_RUNTIME_PATH",
+            assert_cmd::cargo::cargo_bin("projectatlas"),
+        )
+        .env("PROJECTATLAS_VERSION", release_version())
+        .output()?;
+    require(
+        !output.status.success(),
+        "POSIX bootstrap accepted a project-state symlink",
+    )?;
+    require(
+        String::from_utf8_lossy(&output.stderr).contains("must not be a symlink"),
+        format!(
+            "POSIX bootstrap did not explain the rejected symlink: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ),
+    )?;
+    require(
+        fs::read_to_string(sentinel)? == "unchanged\n"
+            && !outside.join("projectatlas.mcp.json").exists()
+            && !installed_runtime.exists(),
+        "POSIX bootstrap mutated state before rejecting the project-state symlink",
+    )
+}
+
+/// A target project whose apparent CLI package would execute a marker-writing build script.
+struct HostileTarget {
+    /// Isolated fixture root.
+    root: tempfile::TempDir,
+    /// Installer target project.
+    target: PathBuf,
+    /// Marker written only if target-controlled Rust executes.
+    execution_marker: PathBuf,
+    /// Captured arguments from the fake Cargo fallback.
+    cargo_log: PathBuf,
+}
+
+impl HostileTarget {
+    /// Create a target-controlled package that must remain inert installer input.
+    fn create() -> Result<Self, Box<dyn Error>> {
+        let root = tempfile::tempdir()?;
+        let target = root.path().join("hostile-target");
+        let package = target.join("crates/projectatlas-cli");
+        let execution_marker = root.path().join("target-source-executed");
+        let cargo_log = root.path().join("cargo-arguments.log");
+        fs::create_dir_all(package.join("src"))?;
+        fs::write(
+            package.join("Cargo.toml"),
+            "[package]\nname = \"projectatlas-cli\"\nversion = \"0.0.0\"\nedition = \"2024\"\nbuild = \"build.rs\"\n\n[[bin]]\nname = \"projectatlas\"\npath = \"src/main.rs\"\n",
+        )?;
+        let marker_literal = serde_json::to_string(execution_marker.to_string_lossy().as_ref())?;
+        fs::write(
+            package.join("build.rs"),
+            format!("fn main() {{ std::fs::write({marker_literal}, \"executed\").unwrap(); }}\n"),
+        )?;
+        fs::write(package.join("src/main.rs"), "fn main() {}\n")?;
+        fs::write(
+            target.join("Cargo.lock"),
+            "version = 4\n\n[[package]]\nname = \"projectatlas-cli\"\nversion = \"0.0.0\"\n",
+        )?;
+        Ok(Self {
+            root,
+            target,
+            execution_marker,
+            cargo_log,
+        })
+    }
+
+    /// Verify target-controlled Rust remains inert under every supported fallback choice.
+    fn verify_target_source_remained_inert(
+        &self,
+        status: std::process::ExitStatus,
+    ) -> Result<(), Box<dyn Error>> {
+        require(
+            !status.success(),
+            "fake Cargo failure must stop installation",
+        )?;
+        require(
+            !self.execution_marker.exists(),
+            "installer executed the target project's build script",
+        )?;
+        if self.cargo_log.is_file() {
+            let arguments = fs::read_to_string(&self.cargo_log)?;
+            require(
+                !arguments.contains("--path")
+                    && !arguments.contains(self.target.to_string_lossy().as_ref()),
+                format!("installer passed target-controlled source to Cargo: {arguments}"),
+            )?;
+        }
+        Ok(())
+    }
+}
+
+/// Configure an installer process that reaches a logged, failing Cargo fallback.
+fn configure_hostile_install(
+    command: &mut Command,
+    fixture: &HostileTarget,
+    fake_bin: &Path,
+) -> Result<(), Box<dyn Error>> {
+    configure_isolated_environment(command, fixture.root.path())?;
+    command
+        .env("PATH", prepend_path(fake_bin)?)
+        .env("PROJECTATLAS_FAKE_CARGO_LOG", &fixture.cargo_log)
+        .env("PROJECTATLAS_VERSION", release_version())
+        .env(
+            "PROJECTATLAS_RELEASE_BASE_URL",
+            UNREACHABLE_RELEASE_BASE_URL,
+        )
+        .env_remove("PROJECTATLAS_RUNTIME_PATH")
+        .env_remove("PROJECTATLAS_RELEASE_BINARY_ONLY");
+    Ok(())
+}
+
+#[cfg(windows)]
+/// Run the `PowerShell` bootstrap with an already-built runtime and isolated host state.
+fn run_powershell_runtime_install(
+    project_root: &Path,
+    isolated_root: &Path,
+) -> Result<std::process::Output, Box<dyn Error>> {
+    let installer = workspace_root()?.join("plugins/projectatlas/scripts/install-runtime.ps1");
+    let mut command = isolated_command("powershell", isolated_root)?;
+    command
+        .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+        .arg(installer)
+        .arg("-ProjectRoot")
+        .arg(project_root)
+        .arg("-RuntimePath")
+        .arg(assert_cmd::cargo::cargo_bin("projectatlas"))
+        .arg("-ProjectAtlasVersion")
+        .arg(release_version());
+    Ok(command.output()?)
+}
+
+/// Create a subprocess with all installer-owned host state redirected into a fixture root.
+fn isolated_command(program: &str, root: &Path) -> Result<Command, Box<dyn Error>> {
+    let mut command = Command::new(program);
+    configure_isolated_environment(&mut command, root)?;
+    Ok(command)
+}
+
+/// Redirect installer-owned host paths and disable unrelated registry updates.
+fn configure_isolated_environment(
+    command: &mut Command,
+    root: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let app_data = root.join("app-data");
+    let local_app_data = root.join("local-app-data");
+    let codex_home = root.join(".codex");
+    fs::create_dir_all(&app_data)?;
+    fs::create_dir_all(&local_app_data)?;
+    fs::create_dir_all(&codex_home)?;
+    command
+        .timeout(INSTALL_TIMEOUT)
+        .env("HOME", root)
+        .env("USERPROFILE", root)
+        .env("APPDATA", app_data)
+        .env("LOCALAPPDATA", local_app_data)
+        .env("CODEX_HOME", codex_home)
+        .env("PROJECTATLAS_SKIP_USER_PATH_UPDATE", "1")
+        .env("PROJECTATLAS_SKIP_CODEX_PLUGIN_UPDATE", "1")
+        .env("PROJECTATLAS_SKIP_CODEX_MCP_REGISTRY_UPDATE", "1")
+        .env("PROJECTATLAS_NO_TELEMETRY", "1");
+    Ok(())
+}
+
+/// Prepend one fixture executable directory to the inherited process path.
+fn prepend_path(path: &Path) -> Result<OsString, env::JoinPathsError> {
+    let mut paths = vec![path.to_path_buf()];
+    paths.extend(env::split_paths(&env::var_os("PATH").unwrap_or_default()));
+    env::join_paths(paths)
+}
+
+/// Return the release version expected by the checked-in bootstraps.
+fn release_version() -> String {
+    format!("v{}", env!("CARGO_PKG_VERSION"))
+}
+
+/// Convert a failed invariant into a test error without panicking.
+fn require(condition: bool, message: impl Into<String>) -> Result<(), Box<dyn Error>> {
+    if condition {
+        Ok(())
+    } else {
+        Err(io::Error::other(message.into()).into())
+    }
+}
+
+/// Resolve the Cargo workspace containing this integration test.
+fn workspace_root() -> Result<PathBuf, Box<dyn Error>> {
+    Ok(PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()?)
+}

--- a/crates/projectatlas-cli/tests/installer_trust_boundaries.rs
+++ b/crates/projectatlas-cli/tests/installer_trust_boundaries.rs
@@ -1,4 +1,4 @@
-//! Verify release bootstraps never execute source discovered in a target project.
+//! Verify release bootstraps treat target projects as untrusted installer input.
 
 use assert_cmd::Command;
 use std::env;
@@ -13,6 +13,12 @@ use std::time::Duration;
 const INSTALL_TIMEOUT: Duration = Duration::from_secs(30);
 /// Unreachable release endpoint that makes any remaining source fallback observable.
 const UNREACHABLE_RELEASE_BASE_URL: &str = "http://127.0.0.1:9/projectatlas-test";
+/// Project-local MCP config files written by both release bootstraps.
+const GENERATED_MCP_CONFIG_FILES: [&str; 3] = [
+    "projectatlas.mcp.json",
+    "projectatlas.claude.mcp.json",
+    "projectatlas.opencode.json",
+];
 
 #[test]
 fn bootstraps_never_derive_executable_source_from_the_target_project() -> Result<(), Box<dyn Error>>
@@ -120,6 +126,55 @@ fn powershell_bootstrap_rejects_project_state_reparse_points_before_writing()
     )
 }
 
+#[cfg(windows)]
+#[test]
+fn powershell_bootstrap_rejects_redirected_config_outputs() -> Result<(), Box<dyn Error>> {
+    for config_name in GENERATED_MCP_CONFIG_FILES {
+        let root = tempfile::tempdir()?;
+        let target = root.path().join("target");
+        let atlas_dir = target.join(".projectatlas");
+        let outside = root.path().join("outside");
+        fs::create_dir_all(&atlas_dir)?;
+        fs::create_dir(&outside)?;
+        let sentinel = outside.join("sentinel.txt");
+        fs::write(&sentinel, "unchanged\n")?;
+        let redirected_output = atlas_dir.join(config_name);
+
+        let link_output = Command::new("cmd")
+            .timeout(INSTALL_TIMEOUT)
+            .args(["/D", "/C", "mklink", "/J"])
+            .arg(&redirected_output)
+            .arg(&outside)
+            .output()?;
+        require(
+            link_output.status.success(),
+            format!(
+                "failed to create config reparse-point fixture for {config_name}: {}",
+                String::from_utf8_lossy(&link_output.stderr)
+            ),
+        )?;
+
+        let output = run_powershell_runtime_install(&target, root.path())?;
+        require(
+            !output.status.success(),
+            format!("PowerShell bootstrap accepted redirected output {config_name}"),
+        )?;
+        require(
+            String::from_utf8_lossy(&output.stderr)
+                .contains("must not be a symlink, junction, or reparse point"),
+            format!(
+                "PowerShell bootstrap did not explain redirected output {config_name}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ),
+        )?;
+        require(
+            fs::read_to_string(&sentinel)? == "unchanged\n",
+            format!("PowerShell bootstrap overwrote redirected output {config_name}"),
+        )?;
+    }
+    Ok(())
+}
+
 #[cfg(unix)]
 #[test]
 fn posix_bootstrap_treats_hostile_target_source_as_data() -> Result<(), Box<dyn Error>> {
@@ -158,16 +213,7 @@ fn posix_bootstrap_rejects_project_state_symlinks_before_writing() -> Result<(),
     let installed_runtime = root.path().join(".local/bin/projectatlas");
     symlink(&outside, target.join(".projectatlas"))?;
 
-    let installer = workspace_root()?.join("plugins/projectatlas/scripts/install-runtime.sh");
-    let output = isolated_command("bash", root.path())?
-        .arg(installer)
-        .arg(&target)
-        .env(
-            "PROJECTATLAS_RUNTIME_PATH",
-            assert_cmd::cargo::cargo_bin("projectatlas"),
-        )
-        .env("PROJECTATLAS_VERSION", release_version())
-        .output()?;
+    let output = run_posix_runtime_install(&target, root.path())?;
     require(
         !output.status.success(),
         "POSIX bootstrap accepted a project-state symlink",
@@ -185,6 +231,42 @@ fn posix_bootstrap_rejects_project_state_symlinks_before_writing() -> Result<(),
             && !installed_runtime.exists(),
         "POSIX bootstrap mutated state before rejecting the project-state symlink",
     )
+}
+
+#[cfg(unix)]
+#[test]
+fn posix_bootstrap_rejects_redirected_config_outputs() -> Result<(), Box<dyn Error>> {
+    use std::os::unix::fs::symlink;
+
+    for config_name in GENERATED_MCP_CONFIG_FILES {
+        let root = tempfile::tempdir()?;
+        let target = root.path().join("target");
+        let atlas_dir = target.join(".projectatlas");
+        let outside = root.path().join("outside");
+        fs::create_dir_all(&atlas_dir)?;
+        fs::create_dir(&outside)?;
+        let sentinel = outside.join("sentinel.txt");
+        fs::write(&sentinel, "unchanged\n")?;
+        symlink(&sentinel, atlas_dir.join(config_name))?;
+
+        let output = run_posix_runtime_install(&target, root.path())?;
+        require(
+            !output.status.success(),
+            format!("POSIX bootstrap accepted redirected output {config_name}"),
+        )?;
+        require(
+            String::from_utf8_lossy(&output.stderr).contains("must not be a symlink"),
+            format!(
+                "POSIX bootstrap did not explain redirected output {config_name}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ),
+        )?;
+        require(
+            fs::read_to_string(&sentinel)? == "unchanged\n",
+            format!("POSIX bootstrap overwrote redirected output {config_name}"),
+        )?;
+    }
+    Ok(())
 }
 
 /// A target project whose apparent CLI package would execute a marker-writing build script.
@@ -292,6 +374,25 @@ fn run_powershell_runtime_install(
         .arg(assert_cmd::cargo::cargo_bin("projectatlas"))
         .arg("-ProjectAtlasVersion")
         .arg(release_version());
+    Ok(command.output()?)
+}
+
+#[cfg(unix)]
+/// Run the POSIX bootstrap with an already-built runtime and isolated host state.
+fn run_posix_runtime_install(
+    project_root: &Path,
+    isolated_root: &Path,
+) -> Result<std::process::Output, Box<dyn Error>> {
+    let installer = workspace_root()?.join("plugins/projectatlas/scripts/install-runtime.sh");
+    let mut command = isolated_command("bash", isolated_root)?;
+    command
+        .arg(installer)
+        .arg(project_root)
+        .env(
+            "PROJECTATLAS_RUNTIME_PATH",
+            assert_cmd::cargo::cargo_bin("projectatlas"),
+        )
+        .env("PROJECTATLAS_VERSION", release_version());
     Ok(command.output()?)
 }
 

--- a/crates/projectatlas-cli/tests/installer_trust_boundaries.rs
+++ b/crates/projectatlas-cli/tests/installer_trust_boundaries.rs
@@ -175,6 +175,16 @@ fn powershell_bootstrap_rejects_redirected_config_outputs() -> Result<(), Box<dy
     Ok(())
 }
 
+#[cfg(windows)]
+#[test]
+fn powershell_bootstrap_atomically_replaces_hard_linked_config_outputs()
+-> Result<(), Box<dyn Error>> {
+    installer_atomically_replaces_hard_linked_config_outputs(
+        "PowerShell",
+        run_powershell_runtime_install,
+    )
+}
+
 #[cfg(unix)]
 #[test]
 fn posix_bootstrap_treats_hostile_target_source_as_data() -> Result<(), Box<dyn Error>> {
@@ -264,6 +274,51 @@ fn posix_bootstrap_rejects_redirected_config_outputs() -> Result<(), Box<dyn Err
         require(
             fs::read_to_string(&sentinel)? == "unchanged\n",
             format!("POSIX bootstrap overwrote redirected output {config_name}"),
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn posix_bootstrap_atomically_replaces_hard_linked_config_outputs() -> Result<(), Box<dyn Error>> {
+    installer_atomically_replaces_hard_linked_config_outputs("POSIX", run_posix_runtime_install)
+}
+
+/// Verify publication replaces hostile hard links without changing their external inodes.
+fn installer_atomically_replaces_hard_linked_config_outputs(
+    host: &str,
+    run_installer: fn(&Path, &Path) -> Result<std::process::Output, Box<dyn Error>>,
+) -> Result<(), Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let target = root.path().join("target");
+    let atlas_dir = target.join(".projectatlas");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(&atlas_dir)?;
+    fs::create_dir(&outside)?;
+
+    let mut sentinels = Vec::with_capacity(GENERATED_MCP_CONFIG_FILES.len());
+    for config_name in GENERATED_MCP_CONFIG_FILES {
+        let sentinel = outside.join(format!("{config_name}.sentinel"));
+        fs::write(&sentinel, "unchanged\n")?;
+        fs::hard_link(&sentinel, atlas_dir.join(config_name))?;
+        sentinels.push((config_name, sentinel));
+    }
+
+    let output = run_installer(&target, root.path())?;
+    require(
+        output.status.success(),
+        format!(
+            "{host} bootstrap failed to replace hard-linked config outputs: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ),
+    )?;
+    for (config_name, sentinel) in sentinels {
+        require(
+            fs::read_to_string(&sentinel)? == "unchanged\n"
+                && fs::read_to_string(atlas_dir.join(config_name))? != "unchanged\n",
+            format!("{host} bootstrap did not safely replace hard-linked output {config_name}"),
         )?;
     }
     Ok(())

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -36,6 +36,18 @@ function Assert-ProjectAtlasDirectPath {
     }
 }
 
+function Assert-ProjectAtlasDirectFilePath {
+    param(
+        [string]$Path,
+        [string]$Label
+    )
+    Assert-ProjectAtlasDirectPath $Path $Label
+    $item = Get-Item -Force -LiteralPath $Path -ErrorAction SilentlyContinue
+    if ($item -and -not ($item -is [System.IO.FileInfo])) {
+        throw "$Label must be a regular file: $Path"
+    }
+}
+
 function Resolve-PluginReleaseVersion {
     $scriptDirectory = Split-Path -Parent $PSCommandPath
     $pluginRoot = Split-Path -Parent $scriptDirectory
@@ -1207,6 +1219,7 @@ function Write-ProjectAtlasMcpConfig {
     }
     $utf8NoBom = New-Object System.Text.UTF8Encoding -ArgumentList $false
     $mcpConfigText = ($mcpConfig -join [Environment]::NewLine) + [Environment]::NewLine
+    Assert-ProjectAtlasDirectFilePath $OutputPath "ProjectAtlas MCP config output"
     [System.IO.File]::WriteAllText($OutputPath, $mcpConfigText, $utf8NoBom)
 }
 

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -1220,7 +1220,17 @@ function Write-ProjectAtlasMcpConfig {
     $utf8NoBom = New-Object System.Text.UTF8Encoding -ArgumentList $false
     $mcpConfigText = ($mcpConfig -join [Environment]::NewLine) + [Environment]::NewLine
     Assert-ProjectAtlasDirectFilePath $OutputPath "ProjectAtlas MCP config output"
-    [System.IO.File]::WriteAllText($OutputPath, $mcpConfigText, $utf8NoBom)
+    $temporaryOutputPath = Join-Path $atlasDir (".projectatlas-mcp-config-" + [guid]::NewGuid().ToString("N") + ".tmp")
+    try {
+        [System.IO.File]::WriteAllText($temporaryOutputPath, $mcpConfigText, $utf8NoBom)
+        Assert-ProjectAtlasDirectFilePath $OutputPath "ProjectAtlas MCP config output"
+        Move-Item -LiteralPath $temporaryOutputPath -Destination $OutputPath -Force
+    }
+    finally {
+        if ([System.IO.File]::Exists($temporaryOutputPath)) {
+            [System.IO.File]::Delete($temporaryOutputPath)
+        }
+    }
 }
 
 Write-ProjectAtlasMcpConfig $mcpConfigPath $null

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -25,6 +25,17 @@ function Test-Truthy {
     return @("1", "true", "yes", "on") -contains $Value.ToLowerInvariant()
 }
 
+function Assert-ProjectAtlasDirectPath {
+    param(
+        [string]$Path,
+        [string]$Label
+    )
+    $item = Get-Item -Force -LiteralPath $Path -ErrorAction SilentlyContinue
+    if ($item -and (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+        throw "$Label must not be a symlink, junction, or reparse point: $Path"
+    }
+}
+
 function Resolve-PluginReleaseVersion {
     $scriptDirectory = Split-Path -Parent $PSCommandPath
     $pluginRoot = Split-Path -Parent $scriptDirectory
@@ -1112,6 +1123,8 @@ if (-not $RuntimePath -and $env:PROJECTATLAS_RUNTIME_PATH) {
 
 $releaseBinaryOnly = $ReleaseBinaryOnly -or (Test-Truthy $env:PROJECTATLAS_RELEASE_BINARY_ONLY)
 $ProjectRoot = (Resolve-Path $ProjectRoot).Path
+$atlasDir = Join-Path $ProjectRoot ".projectatlas"
+Assert-ProjectAtlasDirectPath $atlasDir "ProjectAtlas project state directory"
 
 if ($RuntimePath) {
     $projectAtlas = (Resolve-Path $RuntimePath).Path
@@ -1123,7 +1136,6 @@ if ($RuntimePath) {
 }
 else {
     $cargo = Find-Cargo
-    $sourceManifest = Join-Path $ProjectRoot "crates\projectatlas-cli\Cargo.toml"
     $installedBinary = $null
 
     if ($releaseBinaryOnly) {
@@ -1133,15 +1145,6 @@ else {
         }
         if (-not (Test-ProjectAtlasRuntime $installedBinary $ProjectAtlasVersion)) {
             throw "ProjectAtlas release-binary install produced an invalid runtime for ${ProjectAtlasVersion}: $installedBinary"
-        }
-    }
-    elseif ($cargo -and (Test-Path -LiteralPath $sourceManifest)) {
-        Push-Location $ProjectRoot
-        try {
-            Invoke-Checked $cargo @("install", "--path", "crates/projectatlas-cli", "--locked", "--force")
-        }
-        finally {
-            Pop-Location
         }
     }
     else {
@@ -1172,8 +1175,9 @@ Confirm-ProjectAtlasBareCommandResolution $projectAtlas $ProjectAtlasVersion
 Quarantine-ProjectAtlasStaleShims $projectAtlas $ProjectAtlasVersion
 Write-ProjectAtlasPathShadowReport $projectAtlas $ProjectAtlasVersion
 
-$atlasDir = Join-Path $ProjectRoot ".projectatlas"
+Assert-ProjectAtlasDirectPath $atlasDir "ProjectAtlas project state directory"
 New-Item -ItemType Directory -Force -Path $atlasDir | Out-Null
+Assert-ProjectAtlasDirectPath $atlasDir "ProjectAtlas project state directory"
 $dbPath = Join-Path $atlasDir "projectatlas.db"
 $projectConfigPath = Join-Path $atlasDir "config.toml"
 $flatConfigPath = Join-Path $ProjectRoot "projectatlas.toml"

--- a/plugins/projectatlas/scripts/install-runtime.sh
+++ b/plugins/projectatlas/scripts/install-runtime.sh
@@ -822,7 +822,19 @@ write_mcp_config() {
     set -- "$@" --harness "$harness"
   fi
   assert_config_output_path "$output_path"
-  "$projectatlas_bin" "$@" > "$output_path"
+  temporary_output=$(mktemp "$atlas_dir/.projectatlas-mcp-config.XXXXXX")
+  if ! "$projectatlas_bin" "$@" > "$temporary_output"; then
+    rm -f "$temporary_output"
+    return 1
+  fi
+  if ! assert_config_output_path "$output_path"; then
+    rm -f "$temporary_output"
+    return 1
+  fi
+  if ! mv -f "$temporary_output" "$output_path"; then
+    rm -f "$temporary_output"
+    return 1
+  fi
 }
 
 canonical_path() {

--- a/plugins/projectatlas/scripts/install-runtime.sh
+++ b/plugins/projectatlas/scripts/install-runtime.sh
@@ -796,6 +796,18 @@ opencode_config_path="$atlas_dir/projectatlas.opencode.json"
 flat_config="$project_root/projectatlas.toml"
 project_config="$atlas_dir/config.toml"
 
+assert_config_output_path() {
+  output_path=$1
+  if [ -L "$output_path" ] || [ -h "$output_path" ]; then
+    printf '%s\n' "ProjectAtlas MCP config output must not be a symlink: $output_path" >&2
+    return 1
+  fi
+  if [ -e "$output_path" ] && [ ! -f "$output_path" ]; then
+    printf '%s\n' "ProjectAtlas MCP config output must be a regular file: $output_path" >&2
+    return 1
+  fi
+}
+
 write_mcp_config() {
   output_path=$1
   harness=${2:-}
@@ -809,6 +821,7 @@ write_mcp_config() {
   if [ -n "$harness" ]; then
     set -- "$@" --harness "$harness"
   fi
+  assert_config_output_path "$output_path"
   "$projectatlas_bin" "$@" > "$output_path"
 }
 

--- a/plugins/projectatlas/scripts/install-runtime.sh
+++ b/plugins/projectatlas/scripts/install-runtime.sh
@@ -23,6 +23,22 @@ if [ "${1:-}" ]; then
 else
   project_root=$(pwd -P)
 fi
+atlas_dir="$project_root/.projectatlas"
+if [ -L "$atlas_dir" ] || [ -h "$atlas_dir" ]; then
+  printf '%s\n' "ProjectAtlas project state directory must not be a symlink: $atlas_dir" >&2
+  exit 1
+fi
+if [ -e "$atlas_dir" ] && [ ! -d "$atlas_dir" ]; then
+  printf '%s\n' "ProjectAtlas project state path must be a directory: $atlas_dir" >&2
+  exit 1
+fi
+if [ -d "$atlas_dir" ]; then
+  atlas_dir_canonical=$(CDPATH= cd -- "$atlas_dir" && pwd -P)
+  if [ "$atlas_dir_canonical" != "$atlas_dir" ]; then
+    printf '%s\n' "ProjectAtlas project state directory escaped the canonical project root: $atlas_dir" >&2
+    exit 1
+  fi
+fi
 if [ -n "$runtime_override" ]; then
   runtime_dir=$(CDPATH= cd -- "$(dirname -- "$runtime_override")" && pwd -P)
   runtime_override="$runtime_dir/$(basename -- "$runtime_override")"
@@ -729,8 +745,6 @@ else
       exit 1
     }
     installed_bin="$HOME/.local/bin/projectatlas"
-  elif command -v cargo >/dev/null 2>&1 && [ -f "$project_root/crates/projectatlas-cli/Cargo.toml" ]; then
-    (cd "$project_root" && cargo install --path crates/projectatlas-cli --locked --force)
   elif install_release_binary; then
     installed_bin="$HOME/.local/bin/projectatlas"
   elif command -v cargo >/dev/null 2>&1; then
@@ -762,8 +776,20 @@ confirm_bare_projectatlas_resolution "$projectatlas_bin"
 quarantine_known_stale_projectatlas_shims "$projectatlas_bin"
 warn_path_shadow "$projectatlas_bin"
 
-atlas_dir="$project_root/.projectatlas"
+if [ -L "$atlas_dir" ] || [ -h "$atlas_dir" ]; then
+  printf '%s\n' "ProjectAtlas project state directory must not be a symlink: $atlas_dir" >&2
+  exit 1
+fi
+if [ -e "$atlas_dir" ] && [ ! -d "$atlas_dir" ]; then
+  printf '%s\n' "ProjectAtlas project state path must be a directory: $atlas_dir" >&2
+  exit 1
+fi
 mkdir -p "$atlas_dir"
+atlas_dir_canonical=$(CDPATH= cd -- "$atlas_dir" && pwd -P)
+if [ "$atlas_dir_canonical" != "$atlas_dir" ]; then
+  printf '%s\n' "ProjectAtlas project state directory escaped the canonical project root: $atlas_dir" >&2
+  exit 1
+fi
 mcp_config_path="$atlas_dir/projectatlas.mcp.json"
 claude_mcp_config_path="$atlas_dir/projectatlas.claude.mcp.json"
 opencode_config_path="$atlas_dir/projectatlas.opencode.json"


### PR DESCRIPTION
## Summary

- never compile executable source inferred from the target project during runtime installation
- reject project-state symlink, junction, and reparse-point redirection before installer writes
- cover hostile target source plus Windows and POSIX project-state indirection with real subprocess tests

## Issue

Refs #311

## Verification

- complete repository pre-push gate
- focused installer trust integration tests
- normal installer configuration and clean-host E2E tests
- PowerShell parser and POSIX shell syntax checks