### PR TITLE
chore(ci): record clean parser construction

### DIFF
--- a/openspec/changes/reuse-unchanged-ci-build-layers/tasks.md
+++ b/openspec/changes/reuse-unchanged-ci-build-layers/tasks.md
@@ -20,4 +20,4 @@
 - [x] 4.1 Add the CI dependency-layer and clean-release flow to the owning Mermaid architecture views, render it with Mermaid CLI, and inspect semantic and visual correctness.
 - [x] 4.2 Run the construction diagnostics, workflow syntax/policy checks, Rust formatting/check/Clippy/tests affected by the Linux launch fix, strict OpenSpec validation, and IssueOps synchronization.
 - [x] 4.3 Run trusted cold and unchanged-input Linux/Windows constructions, publish the cache receipts and timing comparison, and keep reuse only where contained construction improves by at least 30 percent and 30 seconds.
-- [ ] 4.4 Record one successful explicit empty-cache Linux and Windows construction on the final v0.4.0 candidate before release acceptance.
+- [x] 4.4 Record one successful explicit empty-cache Linux and Windows construction on the final v0.4.0 candidate before release acceptance.


### PR DESCRIPTION
## Summary
- mark the completed explicit empty-cache Linux and Windows construction gate for #341
- keep the reconciliation task-state-only with no runtime, workflow, package, or documentation change

## Verification
- strict OpenSpec validation
- local and GitHub IssueOps synchronization
- exact-candidate Linux and Windows clean construction plus fresh-runner package verification