### PR TITLE
fix(release): close exact-head review gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,14 +254,21 @@ projectatlas --format json --db .projectatlas/projectatlas.db mcp-config --harne
 projectatlas --format json --db .projectatlas/projectatlas.db mcp-config --harness opencode > .projectatlas/projectatlas.opencode.json
 ```
 
-Or run the installer from the target project root:
+For normal setup, point your agent to
+[https://github.com/styler-ai/ProjectAtlas](https://github.com/styler-ai/ProjectAtlas)
+and ask it to install and set up ProjectAtlas through its plugin store or the
+supported method best suited to that agent harness.
+
+For manual setup, resolve the version-matched installer from an installed
+ProjectAtlas plugin or source checkout, then pass the target project root
+separately:
 
 ```powershell
-plugins/projectatlas/scripts/install-runtime.ps1
+& "<ProjectAtlas checkout>\plugins\projectatlas\scripts\install-runtime.ps1" -ProjectRoot "<target project root>"
 ```
 
 ```bash
-bash plugins/projectatlas/scripts/install-runtime.sh
+bash "<ProjectAtlas checkout>/plugins/projectatlas/scripts/install-runtime.sh" "<target project root>"
 ```
 
 The generated configs pin the runtime version, project database, config path, and working directory where the host supports it.

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -916,7 +916,7 @@ fn read_one_frame(input: &mut impl Read) -> Result<Option<Vec<u8>>, ParserIoThre
     Ok(Some(frame))
 }
 
-/// Own worker stdout and fence every complete frame through the diagnostic pipe.
+/// Own worker stdout and fence every complete or failed frame through the diagnostic pipe.
 fn frame_reader_loop(
     mut stdout: ChildStdout,
     mut diagnostic_fence_writer: impl Write,
@@ -925,18 +925,23 @@ fn frame_reader_loop(
 ) {
     loop {
         let event = match read_one_frame(&mut stdout) {
-            Ok(Some(frame)) => match diagnostic_fence_writer
+            Ok(Some(frame)) => FrameReaderEvent::Frame(frame),
+            Ok(None) => FrameReaderEvent::EndOfStream,
+            Err(error) => FrameReaderEvent::Failure(error),
+        };
+        let event = if matches!(event, FrameReaderEvent::EndOfStream) {
+            event
+        } else {
+            match diagnostic_fence_writer
                 .write_all(&diagnostic_fence.0)
                 .and_then(|()| diagnostic_fence_writer.flush())
             {
-                Ok(()) => FrameReaderEvent::Frame(frame),
+                Ok(()) => event,
                 Err(source) => FrameReaderEvent::Failure(ParserIoThreadError::Stream {
                     operation: "write diagnostic fence",
                     source,
                 }),
-            },
-            Ok(None) => FrameReaderEvent::EndOfStream,
-            Err(error) => FrameReaderEvent::Failure(error),
+            }
         };
         let terminal = !matches!(event, FrameReaderEvent::Frame(_));
         if events.send(event).is_err() || terminal {
@@ -2235,8 +2240,8 @@ impl ResidentParserSession {
         no_progress_timeout: Duration,
         cancellation: &IndexCancellation,
     ) -> Result<(), ParserSupervisorError> {
-        if matches!(event, FrameReaderEvent::Frame(_)) {
-            self.wait_for_diagnostic_fence(
+        if matches!(event, FrameReaderEvent::EndOfStream) {
+            self.wait_for_diagnostic_termination(
                 phase,
                 absolute_deadline,
                 last_progress,
@@ -2244,7 +2249,7 @@ impl ResidentParserSession {
                 cancellation,
             )
         } else {
-            self.wait_for_diagnostic_termination(
+            self.wait_for_diagnostic_fence(
                 phase,
                 absolute_deadline,
                 last_progress,
@@ -2254,7 +2259,7 @@ impl ResidentParserSession {
         }
     }
 
-    /// Drain the diagnostic boundary before accepting terminal stdout state.
+    /// Drain the diagnostic boundary before accepting clean stdout termination.
     fn wait_for_diagnostic_termination(
         &mut self,
         phase: &'static str,
@@ -2319,8 +2324,7 @@ impl ResidentParserSession {
                     self.termination_requested = true;
                     return Err(io_thread_error(phase, &error));
                 }
-                Ok(DiagnosticReaderEvent::AdmissionAccepted) => {}
-                Err(RecvTimeoutError::Timeout) => self.require_child_running(phase)?,
+                Ok(DiagnosticReaderEvent::AdmissionAccepted) | Err(RecvTimeoutError::Timeout) => {}
                 Err(RecvTimeoutError::Disconnected) => {
                     return Err(ParserSupervisorError::IoThread {
                         phase,
@@ -3564,6 +3568,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         Response(&'static str),
         Limit(&'static str),
         InvalidControl(ParserFrameKind),
+        Worker(ParserFailureCode),
     }
 
     struct Case {
@@ -3624,6 +3629,9 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
                 },
                 ExpectedFailure::Limit(expected),
             ) => field == &expected,
+            (ParserSupervisorError::WorkerFailure { code }, ExpectedFailure::Worker(expected)) => {
+                code == &expected
+            }
             (
                 ParserSupervisorError::Protocol {
                     source: ParserProtocolError::InvalidControlJson { kind, .. },
@@ -3803,6 +3811,10 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         )?,
         case("completion-truncated", ExpectedFailure::Io)?,
         case("completion-oversized", ExpectedFailure::Io)?,
+        case(
+            "failure-exit",
+            ExpectedFailure::Worker(ParserFailureCode::ParseRejected),
+        )?,
         case("stderr-flood", ExpectedFailure::Io)?,
         case("stderr-completion", ExpectedFailure::Io)?,
         case(

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -392,8 +392,27 @@ struct PayloadObservation {
     path: PathBuf,
     /// Exact manifest-bound byte count.
     bytes: u64,
+    /// Exact manifest-bound SHA-256.
+    sha256: String,
     /// Modification timestamp when the host filesystem exposes one.
     modified: Option<SystemTime>,
+}
+
+impl PayloadObservation {
+    /// Rehash one payload before it can contribute to fresh launch authority.
+    fn is_current(&self) -> Result<bool, ParserSupervisorError> {
+        let Ok(metadata) = fs::metadata(&self.path) else {
+            return Ok(false);
+        };
+        if !metadata.is_file()
+            || metadata.len() != self.bytes
+            || metadata.modified().ok() != self.modified
+        {
+            return Ok(false);
+        }
+        let bytes = read_bounded_file(&self.path, self.bytes)?;
+        Ok(sha256_hex(&bytes) == self.sha256)
+    }
 }
 
 /// Complete private launch authority derived from one exact immutable artifact.
@@ -473,6 +492,7 @@ impl VerifiedParserPackLaunch {
             payloads.push(PayloadObservation {
                 path: path.clone(),
                 bytes: payload.bytes,
+                sha256: payload.sha256.as_str().to_owned(),
                 modified: metadata.modified().ok(),
             });
             match &payload.role {
@@ -560,7 +580,7 @@ impl VerifiedParserPackLaunch {
         })
     }
 
-    /// Return whether all cheap immutable-artifact observations still match.
+    /// Return whether every manifest and payload digest still matches.
     fn is_current(&self) -> Result<bool, ParserSupervisorError> {
         let artifact_bytes = read_bounded_file(
             &self.pack_root.join(ARTIFACT_MANIFEST_FILE_NAME),
@@ -577,13 +597,7 @@ impl VerifiedParserPackLaunch {
             return Ok(false);
         }
         for payload in &self.payloads {
-            let Ok(metadata) = fs::metadata(&payload.path) else {
-                return Ok(false);
-            };
-            if !metadata.is_file()
-                || metadata.len() != payload.bytes
-                || metadata.modified().ok() != payload.modified
-            {
+            if !payload.is_current()? {
                 return Ok(false);
             }
         }
@@ -825,6 +839,12 @@ enum ParserIoThreadError {
         /// Inclusive byte ceiling.
         maximum: usize,
     },
+    /// A worker or broker wrote bytes outside the framed protocol.
+    #[error("unexpected diagnostic bytes: {diagnostic}")]
+    UnexpectedDiagnostic {
+        /// Bounded lossy rendering of the first observed bytes.
+        diagnostic: String,
+    },
 }
 
 /// One bounded stdout-reader event.
@@ -996,6 +1016,19 @@ fn diagnostic_reader_loop(
             };
         }
         diagnostics.extend_from_slice(&chunk[..count]);
+        let diagnostic = bounded_diagnostic(&diagnostics);
+        return if events
+            .send(DiagnosticReaderEvent::Failure(
+                ParserIoThreadError::UnexpectedDiagnostic {
+                    diagnostic: diagnostic.clone(),
+                },
+            ))
+            .is_ok()
+        {
+            Ok(diagnostics)
+        } else {
+            Err(ParserIoThreadError::UnexpectedDiagnostic { diagnostic })
+        };
     }
 }
 
@@ -2113,16 +2146,20 @@ impl ResidentParserSession {
             )?;
             #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
             self.enforce_memory_bound(phase, false)?;
+            self.check_diagnostic_reader(phase)?;
             if let Some(event) = try_frame_event(&self.frame_reader.events)? {
+                self.check_diagnostic_reader(phase)?;
                 return self.finish_frame_event(event, phase);
             }
-            self.check_diagnostic_reader(phase)?;
             match self.frame_reader.events.recv_timeout(next_poll_wait(
                 absolute_deadline,
                 last_progress,
                 no_progress_timeout,
             )) {
-                Ok(event) => return self.finish_frame_event(event, phase),
+                Ok(event) => {
+                    self.check_diagnostic_reader(phase)?;
+                    return self.finish_frame_event(event, phase);
+                }
                 Err(RecvTimeoutError::Timeout) => {}
                 Err(RecvTimeoutError::Disconnected) => {
                     return Err(ParserSupervisorError::IoThread {
@@ -2157,7 +2194,10 @@ impl ResidentParserSession {
         phase: &'static str,
     ) -> Result<(), ParserSupervisorError> {
         match self.diagnostic_reader.events.try_recv() {
-            Ok(DiagnosticReaderEvent::Failure(error)) => Err(io_thread_error(phase, &error)),
+            Ok(DiagnosticReaderEvent::Failure(error)) => {
+                self.termination_requested = true;
+                Err(io_thread_error(phase, &error))
+            }
             Ok(DiagnosticReaderEvent::AdmissionAccepted)
             | Err(TryRecvError::Empty | TryRecvError::Disconnected) => Ok(()),
         }
@@ -3041,17 +3081,19 @@ impl OptionalParserSupervisor {
             no_progress_timeout,
             cancellation,
         )?;
-        self.refresh_changed_artifact()?;
-        let grammar = self.launch.require_grammar(language_id)?;
         let source_identity = ParserSourceIdentity::for_bytes(source)?;
-        if self
-            .resident
-            .as_ref()
-            .is_some_and(|resident| resident.grammar != grammar)
-        {
-            self.shutdown_resident()?;
+        if let Some(resident) = self.resident.as_ref() {
+            let grammar_changed = self
+                .launch
+                .require_grammar(language_id)
+                .map_or(true, |grammar| resident.grammar != grammar);
+            if grammar_changed {
+                self.shutdown_resident()?;
+            }
         }
         if self.resident.is_none() {
+            self.refresh_changed_artifact()?;
+            let grammar = self.launch.require_grammar(language_id)?;
             self.resident = Some(ResidentParserSession::launch(
                 &self.launch,
                 grammar,
@@ -3584,6 +3626,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         case("completion-truncated", ExpectedFailure::Io)?,
         case("completion-oversized", ExpectedFailure::Io)?,
         case("stderr-flood", ExpectedFailure::Io)?,
+        case("stderr-completion", ExpectedFailure::Io)?,
         case(
             "limit-output",
             ExpectedFailure::Limit("completion.output_bytes"),
@@ -3686,6 +3729,38 @@ mod tests {
         assert!(supervisor.accepts_language("zeta"));
         assert!(!supervisor.accepts_language("missing"));
         assert!(!supervisor.accepts_language("INVALID"));
+    }
+
+    #[test]
+    fn payload_observation_rehashes_same_size_same_mtime_content()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let path = temp.path().join("worker");
+        fs::write(&path, b"trusted")?;
+        let modified = fs::metadata(&path)?.modified()?;
+        let observation = PayloadObservation {
+            path: path.clone(),
+            bytes: 7,
+            sha256: sha256_hex(b"trusted"),
+            modified: Some(modified),
+        };
+        require_test(observation.is_current()?, "initial payload was rejected")?;
+
+        fs::write(&path, b"mutated")?;
+        File::options()
+            .write(true)
+            .open(&path)?
+            .set_times(fs::FileTimes::new().set_modified(modified))?;
+        require_test(
+            fs::metadata(&path)?.len() == observation.bytes
+                && fs::metadata(&path)?.modified()? == modified,
+            "test mutation did not preserve size and modification time",
+        )?;
+        require_test(
+            !observation.is_current()?,
+            "same-size same-mtime payload mutation retained launch authority",
+        )?;
+        Ok(())
     }
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -4050,7 +4125,7 @@ mod tests {
     -> Result<(), Box<dyn std::error::Error>> {
         let mut bytes = PARSER_WINDOWS_BROKER_ADMISSION_RECORD.to_vec();
         bytes.extend_from_slice(b"bounded diagnostic");
-        let (events, receiver) = mpsc::sync_channel(1);
+        let (events, receiver) = mpsc::sync_channel(2);
         let diagnostics = diagnostic_reader_loop(Cursor::new(bytes), true, &events)?;
         require_test(
             matches!(
@@ -4058,6 +4133,13 @@ mod tests {
                 DiagnosticReaderEvent::AdmissionAccepted
             ),
             "diagnostics became visible before admission",
+        )?;
+        require_test(
+            matches!(
+                receiver.recv_timeout(Duration::from_secs(1))?,
+                DiagnosticReaderEvent::Failure(ParserIoThreadError::UnexpectedDiagnostic { .. })
+            ),
+            "bounded diagnostic bytes did not fail closed",
         )?;
         require_test(
             diagnostics == b"bounded diagnostic",

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -392,6 +392,8 @@ impl From<OptionalParserPackManifestError> for ParserSupervisorError {
 struct PayloadObservation {
     /// Canonical payload path.
     path: PathBuf,
+    /// Manifest-owned payload responsibility.
+    role: ParserPackPayloadRole,
     /// Exact manifest-bound byte count.
     bytes: u64,
     /// Exact manifest-bound SHA-256.
@@ -401,6 +403,19 @@ struct PayloadObservation {
 }
 
 impl PayloadObservation {
+    /// Return whether this payload can affect one grammar-affined worker launch.
+    fn contributes_to_launch(&self, language_id: &str) -> bool {
+        matches!(
+            &self.role,
+            ParserPackPayloadRole::Worker | ParserPackPayloadRole::ContainmentBroker
+        ) || matches!(
+            &self.role,
+            ParserPackPayloadRole::GrammarLibrary {
+                language_id: payload_language
+            } if payload_language == language_id
+        )
+    }
+
     /// Rehash one payload before it can contribute to fresh launch authority.
     fn is_current(&self) -> Result<bool, ParserSupervisorError> {
         let Ok(metadata) = fs::metadata(&self.path) else {
@@ -493,6 +508,7 @@ impl VerifiedParserPackLaunch {
             let metadata = file_metadata(&path)?;
             payloads.push(PayloadObservation {
                 path: path.clone(),
+                role: payload.role.clone(),
                 bytes: payload.bytes,
                 sha256: payload.sha256.as_str().to_owned(),
                 modified: metadata.modified().ok(),
@@ -582,8 +598,8 @@ impl VerifiedParserPackLaunch {
         })
     }
 
-    /// Return whether every manifest and payload digest still matches.
-    fn is_current(&self) -> Result<bool, ParserSupervisorError> {
+    /// Return whether the manifests and payloads used by one launch still match.
+    fn is_current_for(&self, language_id: &str) -> Result<bool, ParserSupervisorError> {
         let artifact_bytes = read_bounded_file(
             &self.pack_root.join(ARTIFACT_MANIFEST_FILE_NAME),
             u64::try_from(OPTIONAL_PARSER_PACK_MANIFEST_MAX_BYTES).unwrap_or(u64::MAX),
@@ -598,7 +614,11 @@ impl VerifiedParserPackLaunch {
         if sha256_hex(&accepted_bytes) != self.accepted_manifest_sha256 {
             return Ok(false);
         }
-        for payload in &self.payloads {
+        for payload in self
+            .payloads
+            .iter()
+            .filter(|payload| payload.contributes_to_launch(language_id))
+        {
             if !payload.is_current()? {
                 return Ok(false);
             }
@@ -3280,7 +3300,7 @@ impl OptionalParserSupervisor {
             }
         }
         if self.resident.is_none() {
-            self.refresh_changed_artifact()?;
+            self.refresh_changed_artifact(language_id)?;
             let grammar = self.launch.require_grammar(language_id)?;
             self.resident = Some(ResidentParserSession::launch(
                 &self.launch,
@@ -3329,8 +3349,8 @@ impl OptionalParserSupervisor {
     }
 
     /// Replace launch authority only after observed artifact mutation.
-    fn refresh_changed_artifact(&mut self) -> Result<(), ParserSupervisorError> {
-        if let Ok(true) = self.launch.is_current() {
+    fn refresh_changed_artifact(&mut self, language_id: &str) -> Result<(), ParserSupervisorError> {
+        if let Ok(true) = self.launch.is_current_for(language_id) {
             return Ok(());
         }
         self.shutdown_resident()?;
@@ -3936,6 +3956,7 @@ mod tests {
         let modified = fs::metadata(&path)?.modified()?;
         let observation = PayloadObservation {
             path: path.clone(),
+            role: ParserPackPayloadRole::Worker,
             bytes: 7,
             sha256: sha256_hex(b"trusted"),
             modified: Some(modified),
@@ -3957,6 +3978,37 @@ mod tests {
             "same-size same-mtime payload mutation retained launch authority",
         )?;
         Ok(())
+    }
+
+    #[test]
+    fn payload_observation_revalidates_only_launch_inputs() {
+        let observation = |role| PayloadObservation {
+            path: PathBuf::new(),
+            role,
+            bytes: 0,
+            sha256: String::new(),
+            modified: None,
+        };
+
+        assert!(observation(ParserPackPayloadRole::Worker).contributes_to_launch("rust"));
+        assert!(
+            observation(ParserPackPayloadRole::ContainmentBroker).contributes_to_launch("rust")
+        );
+        assert!(
+            observation(ParserPackPayloadRole::GrammarLibrary {
+                language_id: "rust".to_owned(),
+            })
+            .contributes_to_launch("rust")
+        );
+        assert!(
+            !observation(ParserPackPayloadRole::GrammarLibrary {
+                language_id: "python".to_owned(),
+            })
+            .contributes_to_launch("rust")
+        );
+        assert!(
+            !observation(ParserPackPayloadRole::NativeAuditReport).contributes_to_launch("rust")
+        );
     }
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -2192,9 +2192,6 @@ impl ResidentParserSession {
                 no_progress_timeout,
                 cancellation,
             )?;
-            #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-            self.enforce_memory_bound(phase, false)?;
-            self.check_diagnostic_reader(phase)?;
             if let Some(event) = try_frame_event(&self.frame_reader.events)? {
                 self.synchronize_frame_event(
                     &event,
@@ -2206,6 +2203,9 @@ impl ResidentParserSession {
                 )?;
                 return self.finish_frame_event(event, phase);
             }
+            #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+            self.enforce_memory_bound(phase, false)?;
+            self.check_diagnostic_reader(phase)?;
             match self.frame_reader.events.recv_timeout(next_poll_wait(
                 absolute_deadline,
                 last_progress,
@@ -2316,7 +2316,10 @@ impl ResidentParserSession {
                 cancellation,
             )?;
             #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-            self.enforce_memory_bound(phase, false)?;
+            match self.enforce_memory_bound(phase, false) {
+                Ok(()) | Err(ParserSupervisorError::ChildExited { code: Some(0), .. }) => {}
+                Err(error) => return Err(error),
+            }
             match self.diagnostic_reader.events.recv_timeout(next_poll_wait(
                 absolute_deadline,
                 last_progress,

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -3,12 +3,7 @@
 use std::fs::{self, File, Metadata};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-#[cfg(any(
-    all(target_os = "linux", target_arch = "x86_64"),
-    all(target_os = "windows", target_arch = "x86_64")
-))]
-use std::process::Stdio;
-use std::process::{Child, ChildStdout, Command, ExitStatus};
+use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TryRecvError, TrySendError};

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -60,6 +60,8 @@ const WORKER_SERVE_ARGUMENT: &str = "--serve";
 const BROKER_SERVE_ARGUMENT: &str = "serve-worker";
 /// Poll interval for cancellation and bounded child state.
 const SUPERVISOR_POLL_INTERVAL: Duration = Duration::from_millis(20);
+/// Parent-only random record that orders each stdout frame against stderr.
+const PARSER_DIAGNOSTIC_FENCE_BYTES: usize = 32;
 /// Grace period for a healthy worker to close after its input pipe closes.
 const SUPERVISOR_GRACEFUL_CLOSE: Duration = Duration::from_millis(500);
 /// Hard cleanup ceiling after a child session becomes terminal.
@@ -833,12 +835,6 @@ enum ParserIoThreadError {
     /// The Windows broker admission record differed from the fixed contract.
     #[error("Windows admission record mismatch")]
     AdmissionMismatch,
-    /// The bounded diagnostic stream exceeded its fixed byte ceiling.
-    #[error("diagnostic stream exceeded {maximum} bytes")]
-    DiagnosticOverflow {
-        /// Inclusive byte ceiling.
-        maximum: usize,
-    },
     /// A worker or broker wrote bytes outside the framed protocol.
     #[error("unexpected diagnostic bytes: {diagnostic}")]
     UnexpectedDiagnostic {
@@ -863,9 +859,15 @@ enum FrameReaderEvent {
 enum DiagnosticReaderEvent {
     /// Platform admission completed and protocol input may begin.
     AdmissionAccepted,
+    /// The parent-authored fence after one complete stdout frame was observed.
+    FenceObserved,
     /// Terminal bounded reader failure.
     Failure(ParserIoThreadError),
 }
+
+/// One random parent-only record used to order independent standard pipes.
+#[derive(Clone, Copy)]
+struct DiagnosticFence([u8; PARSER_DIAGNOSTIC_FENCE_BYTES]);
 
 /// One exact write owned by the fixed worker-input thread.
 struct WriterCommand {
@@ -914,11 +916,25 @@ fn read_one_frame(input: &mut impl Read) -> Result<Option<Vec<u8>>, ParserIoThre
     Ok(Some(frame))
 }
 
-/// Own worker stdout until EOF or the first bounded framing failure.
-fn frame_reader_loop(mut stdout: ChildStdout, events: &SyncSender<FrameReaderEvent>) {
+/// Own worker stdout and fence every complete frame through the diagnostic pipe.
+fn frame_reader_loop(
+    mut stdout: ChildStdout,
+    mut diagnostic_fence_writer: impl Write,
+    diagnostic_fence: DiagnosticFence,
+    events: &SyncSender<FrameReaderEvent>,
+) {
     loop {
         let event = match read_one_frame(&mut stdout) {
-            Ok(Some(frame)) => FrameReaderEvent::Frame(frame),
+            Ok(Some(frame)) => match diagnostic_fence_writer
+                .write_all(&diagnostic_fence.0)
+                .and_then(|()| diagnostic_fence_writer.flush())
+            {
+                Ok(()) => FrameReaderEvent::Frame(frame),
+                Err(source) => FrameReaderEvent::Failure(ParserIoThreadError::Stream {
+                    operation: "write diagnostic fence",
+                    source,
+                }),
+            },
             Ok(None) => FrameReaderEvent::EndOfStream,
             Err(error) => FrameReaderEvent::Failure(error),
         };
@@ -933,6 +949,7 @@ fn frame_reader_loop(mut stdout: ChildStdout, events: &SyncSender<FrameReaderEve
 fn diagnostic_reader_loop(
     mut stderr: impl Read,
     expect_windows_admission: bool,
+    diagnostic_fence: DiagnosticFence,
     events: &SyncSender<DiagnosticReaderEvent>,
 ) -> Result<Vec<u8>, ParserIoThreadError> {
     if expect_windows_admission {
@@ -972,50 +989,43 @@ fn diagnostic_reader_loop(
         return Ok(Vec::new());
     }
 
-    let mut diagnostics = Vec::new();
-    let mut chunk = [0_u8; 4 * 1024];
     loop {
-        let count = match stderr.read(&mut chunk) {
-            Ok(0) => return Ok(diagnostics),
-            Ok(count) => count,
-            Err(source) if source.kind() == io::ErrorKind::Interrupted => continue,
-            Err(source) => {
-                let message = source.to_string();
-                return if events
-                    .send(DiagnosticReaderEvent::Failure(
-                        ParserIoThreadError::Stream {
+        let mut observed = [0_u8; PARSER_DIAGNOSTIC_FENCE_BYTES];
+        let mut observed_len = 0_usize;
+        while observed_len < observed.len() {
+            match stderr.read(&mut observed[observed_len..]) {
+                Ok(0) if observed_len == 0 => return Ok(Vec::new()),
+                Ok(0) => break,
+                Ok(count) => observed_len = observed_len.saturating_add(count),
+                Err(source) if source.kind() == io::ErrorKind::Interrupted => {}
+                Err(source) => {
+                    let message = source.to_string();
+                    return if events
+                        .send(DiagnosticReaderEvent::Failure(
+                            ParserIoThreadError::Stream {
+                                operation: "read diagnostic stream",
+                                source,
+                            },
+                        ))
+                        .is_ok()
+                    {
+                        Ok(observed[..observed_len].to_vec())
+                    } else {
+                        Err(ParserIoThreadError::Stream {
                             operation: "read diagnostic stream",
-                            source,
-                        },
-                    ))
-                    .is_ok()
-                {
-                    Ok(diagnostics)
-                } else {
-                    Err(ParserIoThreadError::Stream {
-                        operation: "read diagnostic stream",
-                        source: io::Error::other(message),
-                    })
-                };
+                            source: io::Error::other(message),
+                        })
+                    };
+                }
             }
-        };
-        if count > PARSER_MAX_STDERR_BYTES.saturating_sub(diagnostics.len()) {
-            return if events
-                .send(DiagnosticReaderEvent::Failure(
-                    ParserIoThreadError::DiagnosticOverflow {
-                        maximum: PARSER_MAX_STDERR_BYTES,
-                    },
-                ))
-                .is_ok()
-            {
-                Ok(diagnostics)
-            } else {
-                Err(ParserIoThreadError::DiagnosticOverflow {
-                    maximum: PARSER_MAX_STDERR_BYTES,
-                })
-            };
         }
-        diagnostics.extend_from_slice(&chunk[..count]);
+        if observed_len == observed.len() && observed == diagnostic_fence.0 {
+            if events.send(DiagnosticReaderEvent::FenceObserved).is_err() {
+                return Ok(Vec::new());
+            }
+            continue;
+        }
+        let diagnostics = observed[..observed_len].to_vec();
         let diagnostic = bounded_diagnostic(&diagnostics);
         return if events
             .send(DiagnosticReaderEvent::Failure(
@@ -1676,6 +1686,8 @@ struct ResidentParserSession {
     frame_reader: FrameReader,
     /// Owned bounded diagnostic/admission reader.
     diagnostic_reader: DiagnosticReader,
+    /// Parent-authored diagnostic fences already observed ahead of their frame event.
+    pending_diagnostic_fences: usize,
     /// Bounded Linux resident-memory accounting retained through cleanup.
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     memory_observer: Arc<Mutex<LinuxMemoryObserver>>,
@@ -1720,10 +1732,24 @@ impl ResidentParserSession {
         let _ = memory_limits;
         let session = fresh_session_identity()?;
         let containment = containment_for_platform(launch.platform);
+        let diagnostic_fence = fresh_diagnostic_fence()?;
+        let (diagnostic_pipe, child_diagnostic_writer) =
+            io::pipe().map_err(|source| ParserSupervisorError::IoThread {
+                phase: "diagnostic pipe startup",
+                message: source.to_string(),
+            })?;
+        let diagnostic_fence_writer = child_diagnostic_writer.try_clone().map_err(|source| {
+            ParserSupervisorError::IoThread {
+                phase: "diagnostic pipe startup",
+                message: source.to_string(),
+            }
+        })?;
+        command.stderr(Stdio::from(child_diagnostic_writer));
         let program = PathBuf::from(command.get_program());
         let mut child = command
             .spawn()
             .map_err(|source| ParserSupervisorError::Spawn { program, source })?;
+        drop(command);
         let stdin = child
             .stdin
             .take()
@@ -1732,17 +1758,12 @@ impl ResidentParserSession {
             .stdout
             .take()
             .ok_or(ParserSupervisorError::MissingPipe { stream: "stdout" });
-        let stderr = child
-            .stderr
-            .take()
-            .ok_or(ParserSupervisorError::MissingPipe { stream: "stderr" });
-        let (stdin, stdout, stderr) = match (stdin, stdout, stderr) {
-            (Ok(stdin), Ok(stdout), Ok(stderr)) => (stdin, stdout, stderr),
-            (stdin, stdout, stderr) => {
+        let (stdin, stdout) = match (stdin, stdout) {
+            (Ok(stdin), Ok(stdout)) => (stdin, stdout),
+            (stdin, stdout) => {
                 let operation = stdin
                     .err()
                     .or_else(|| stdout.err())
-                    .or_else(|| stderr.err())
                     .unwrap_or(ParserSupervisorError::MissingPipe { stream: "unknown" });
                 return Err(attach_cleanup(
                     operation,
@@ -1771,7 +1792,14 @@ impl ResidentParserSession {
         let (frame_sender, frame_events) = mpsc::sync_channel(1);
         let frame_handle = thread::Builder::new()
             .name("parser-supervisor-stdout".to_owned())
-            .spawn(move || frame_reader_loop(stdout, &frame_sender))
+            .spawn(move || {
+                frame_reader_loop(
+                    stdout,
+                    diagnostic_fence_writer,
+                    diagnostic_fence,
+                    &frame_sender,
+                );
+            })
             .map_err(|source| ParserSupervisorError::IoThread {
                 phase: "stdout reader startup",
                 message: source.to_string(),
@@ -1791,7 +1819,12 @@ impl ResidentParserSession {
         let diagnostic_handle = thread::Builder::new()
             .name("parser-supervisor-stderr".to_owned())
             .spawn(move || {
-                diagnostic_reader_loop(stderr, expect_windows_admission, &diagnostic_sender)
+                diagnostic_reader_loop(
+                    diagnostic_pipe,
+                    expect_windows_admission,
+                    diagnostic_fence,
+                    &diagnostic_sender,
+                )
             })
             .map_err(|source| ParserSupervisorError::IoThread {
                 phase: "diagnostic reader startup",
@@ -1838,6 +1871,7 @@ impl ResidentParserSession {
                 events: diagnostic_events,
                 handle: Some(diagnostic_handle),
             },
+            pending_diagnostic_fences: 0,
             #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
             memory_observer,
             #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -2032,6 +2066,12 @@ impl ResidentParserSession {
                 no_progress_timeout,
             )) {
                 Ok(DiagnosticReaderEvent::AdmissionAccepted) => return Ok(()),
+                Ok(DiagnosticReaderEvent::FenceObserved) => {
+                    return Err(ParserSupervisorError::IoThread {
+                        phase: "containment admission",
+                        message: "diagnostic fence arrived before admission".to_owned(),
+                    });
+                }
                 Ok(DiagnosticReaderEvent::Failure(ParserIoThreadError::AdmissionMismatch)) => {
                     return Err(ParserSupervisorError::InvalidAdmission);
                 }
@@ -2148,7 +2188,14 @@ impl ResidentParserSession {
             self.enforce_memory_bound(phase, false)?;
             self.check_diagnostic_reader(phase)?;
             if let Some(event) = try_frame_event(&self.frame_reader.events)? {
-                self.check_diagnostic_reader(phase)?;
+                self.synchronize_frame_event(
+                    &event,
+                    phase,
+                    absolute_deadline,
+                    last_progress,
+                    no_progress_timeout,
+                    cancellation,
+                )?;
                 return self.finish_frame_event(event, phase);
             }
             match self.frame_reader.events.recv_timeout(next_poll_wait(
@@ -2157,7 +2204,14 @@ impl ResidentParserSession {
                 no_progress_timeout,
             )) {
                 Ok(event) => {
-                    self.check_diagnostic_reader(phase)?;
+                    self.synchronize_frame_event(
+                        &event,
+                        phase,
+                        absolute_deadline,
+                        last_progress,
+                        no_progress_timeout,
+                        cancellation,
+                    )?;
                     return self.finish_frame_event(event, phase);
                 }
                 Err(RecvTimeoutError::Timeout) => {}
@@ -2165,6 +2219,112 @@ impl ResidentParserSession {
                     return Err(ParserSupervisorError::IoThread {
                         phase,
                         message: "stdout reader closed".to_owned(),
+                    });
+                }
+            }
+        }
+    }
+
+    /// Order one stdout event against every earlier diagnostic-pipe write.
+    fn synchronize_frame_event(
+        &mut self,
+        event: &FrameReaderEvent,
+        phase: &'static str,
+        absolute_deadline: Instant,
+        last_progress: Instant,
+        no_progress_timeout: Duration,
+        cancellation: &IndexCancellation,
+    ) -> Result<(), ParserSupervisorError> {
+        if matches!(event, FrameReaderEvent::Frame(_)) {
+            self.wait_for_diagnostic_fence(
+                phase,
+                absolute_deadline,
+                last_progress,
+                no_progress_timeout,
+                cancellation,
+            )
+        } else {
+            self.wait_for_diagnostic_termination(
+                phase,
+                absolute_deadline,
+                last_progress,
+                no_progress_timeout,
+                cancellation,
+            )
+        }
+    }
+
+    /// Drain the diagnostic boundary before accepting terminal stdout state.
+    fn wait_for_diagnostic_termination(
+        &mut self,
+        phase: &'static str,
+        absolute_deadline: Instant,
+        last_progress: Instant,
+        no_progress_timeout: Duration,
+        cancellation: &IndexCancellation,
+    ) -> Result<(), ParserSupervisorError> {
+        loop {
+            poll_stop(
+                phase,
+                absolute_deadline,
+                last_progress,
+                no_progress_timeout,
+                cancellation,
+            )?;
+            #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+            self.enforce_memory_bound(phase, false)?;
+            self.check_diagnostic_reader(phase)?;
+            if thread_finished(self.diagnostic_reader.handle.as_ref()) {
+                self.check_diagnostic_reader(phase)?;
+                return Ok(());
+            }
+            thread::sleep(next_poll_wait(
+                absolute_deadline,
+                last_progress,
+                no_progress_timeout,
+            ));
+        }
+    }
+
+    /// Require the parent-authored stderr fence for one complete stdout frame.
+    fn wait_for_diagnostic_fence(
+        &mut self,
+        phase: &'static str,
+        absolute_deadline: Instant,
+        last_progress: Instant,
+        no_progress_timeout: Duration,
+        cancellation: &IndexCancellation,
+    ) -> Result<(), ParserSupervisorError> {
+        if self.pending_diagnostic_fences > 0 {
+            self.pending_diagnostic_fences = self.pending_diagnostic_fences.saturating_sub(1);
+            return Ok(());
+        }
+        loop {
+            poll_stop(
+                phase,
+                absolute_deadline,
+                last_progress,
+                no_progress_timeout,
+                cancellation,
+            )?;
+            #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+            self.enforce_memory_bound(phase, false)?;
+            match self.diagnostic_reader.events.recv_timeout(next_poll_wait(
+                absolute_deadline,
+                last_progress,
+                no_progress_timeout,
+            )) {
+                Ok(DiagnosticReaderEvent::FenceObserved) => return Ok(()),
+                Ok(DiagnosticReaderEvent::Failure(error)) => {
+                    self.termination_requested = true;
+                    return Err(io_thread_error(phase, &error));
+                }
+                Ok(DiagnosticReaderEvent::AdmissionAccepted) => {}
+                Err(RecvTimeoutError::Timeout) => self.require_child_running(phase)?,
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(ParserSupervisorError::IoThread {
+                        phase,
+                        message: "diagnostic reader closed before frame fence".to_owned(),
                     });
                 }
             }
@@ -2188,18 +2348,29 @@ impl ResidentParserSession {
         result
     }
 
-    /// Surface diagnostic overflow or premature diagnostic-stream closure.
+    /// Surface diagnostic bytes and retain frame fences observed ahead of stdout.
     fn check_diagnostic_reader(
         &mut self,
         phase: &'static str,
     ) -> Result<(), ParserSupervisorError> {
-        match self.diagnostic_reader.events.try_recv() {
-            Ok(DiagnosticReaderEvent::Failure(error)) => {
-                self.termination_requested = true;
-                Err(io_thread_error(phase, &error))
+        loop {
+            match self.diagnostic_reader.events.try_recv() {
+                Ok(DiagnosticReaderEvent::Failure(error)) => {
+                    self.termination_requested = true;
+                    return Err(io_thread_error(phase, &error));
+                }
+                Ok(DiagnosticReaderEvent::FenceObserved) => {
+                    self.pending_diagnostic_fences = self
+                        .pending_diagnostic_fences
+                        .checked_add(1)
+                        .ok_or_else(|| ParserSupervisorError::IoThread {
+                            phase,
+                            message: "diagnostic fence count overflowed".to_owned(),
+                        })?;
+                }
+                Ok(DiagnosticReaderEvent::AdmissionAccepted) => {}
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => return Ok(()),
             }
-            Ok(DiagnosticReaderEvent::AdmissionAccepted)
-            | Err(TryRecvError::Empty | TryRecvError::Disconnected) => Ok(()),
         }
     }
 
@@ -2682,6 +2853,13 @@ fn fresh_session_identity() -> Result<ParserSessionIdentity, ParserSupervisorErr
     let mut entropy = [0_u8; PARSER_SESSION_ENTROPY_BYTES];
     getrandom::fill(&mut entropy).map_err(|_source| ParserSupervisorError::EntropyUnavailable)?;
     Ok(ParserSessionIdentity::for_entropy(&entropy))
+}
+
+/// Generate one parent-only marker that a worker cannot forge before a frame.
+fn fresh_diagnostic_fence() -> Result<DiagnosticFence, ParserSupervisorError> {
+    let mut entropy = [0_u8; PARSER_DIAGNOSTIC_FENCE_BYTES];
+    getrandom::fill(&mut entropy).map_err(|_source| ParserSupervisorError::EntropyUnavailable)?;
+    Ok(DiagnosticFence(entropy))
 }
 
 /// Convert a private I/O thread failure at the public typed boundary.
@@ -4126,7 +4304,12 @@ mod tests {
         let mut bytes = PARSER_WINDOWS_BROKER_ADMISSION_RECORD.to_vec();
         bytes.extend_from_slice(b"bounded diagnostic");
         let (events, receiver) = mpsc::sync_channel(2);
-        let diagnostics = diagnostic_reader_loop(Cursor::new(bytes), true, &events)?;
+        let diagnostics = diagnostic_reader_loop(
+            Cursor::new(bytes),
+            true,
+            DiagnosticFence([0xA5; PARSER_DIAGNOSTIC_FENCE_BYTES]),
+            &events,
+        )?;
         require_test(
             matches!(
                 receiver.recv_timeout(Duration::from_secs(1))?,

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -2035,7 +2035,10 @@ impl ResidentParserSession {
                 ParserFrameKind::Failure => {
                     let failure = decode_parser_failure_for_request(frame, &request)?;
                     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-                    self.enforce_memory_bound("request failure", true)?;
+                    match self.enforce_memory_bound("request failure", true) {
+                        Ok(()) | Err(ParserSupervisorError::ChildExited { code: Some(0), .. }) => {}
+                        Err(error) => return Err(error),
+                    }
                     return Err(ParserSupervisorError::WorkerFailure {
                         code: failure.code(),
                     });

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -3163,6 +3163,11 @@ fn packaged_skill_routes_task_startup_through_session_brief() -> Result<(), Box<
     )?;
     for required in [
         "For task-directed work in an existing indexed repository",
+        "On first use in each distinct project root",
+        "Every project root owns its own `.projectatlas/projectatlas.db`",
+        "**Fresh existing index:** make no indexing call",
+        "**Changed files:** use `atlas_watch_once`",
+        "**Deep symbol/graph rebuild:** use `atlas_symbols_build` only when",
         "`atlas_session_brief` once at task-oriented startup",
         "`atlas_session_brief` once at task-oriented startup with `query`, `project_path` when needed, and `compact: true`",
         "start with `file_limit: 3`, `folder_limit: 3`, `blocker_limit: 1`, and `purpose_limit: 1`",
@@ -3177,6 +3182,13 @@ fn packaged_skill_routes_task_startup_through_session_brief() -> Result<(), Box<
         "`connections_truncated` describes the compact sample",
         "Do not guess a symbol line or other disambiguator",
         "Fall back to `atlas_overview` only when the session-brief MCP tool is unavailable",
+        "partition a large queue into bounded, non-overlapping batches",
+        "becomes `approved`, `source: agent`, and `agent_reviewed: true` immediately",
+        "add one durable pointer to the nearest harness instruction file",
+        "a runtime `version` matching the selected plugin release",
+        "resolve the installer from the installed, version-matched ProjectAtlas plugin root",
+        "-ProjectRoot \"<target-project-root>\"",
+        "Do not assume an unrelated target repository contains `plugins/projectatlas/scripts`",
     ] {
         if !skill.contains(required) {
             return Err(io::Error::other(format!(

--- a/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
+++ b/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
@@ -221,7 +221,6 @@ fn hostile_peer(scenario: &str) -> Result<(), Box<dyn std::error::Error>> {
         "stderr-completion" => {
             diagnostic.write_all(b"bounded diagnostic")?;
             diagnostic.flush()?;
-            thread::sleep(Duration::from_millis(50));
             write_completion(
                 &mut output,
                 &request,

--- a/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
+++ b/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
@@ -218,6 +218,19 @@ fn hostile_peer(scenario: &str) -> Result<(), Box<dyn std::error::Error>> {
             diagnostic.flush()?;
             thread::sleep(Duration::from_secs(5));
         }
+        "stderr-completion" => {
+            diagnostic.write_all(b"bounded diagnostic")?;
+            diagnostic.flush()?;
+            thread::sleep(Duration::from_millis(50));
+            write_completion(
+                &mut output,
+                &request,
+                request.source().byte_len(),
+                1,
+                1,
+                "source_file",
+            )?;
+        }
         "limit-source" => write_completion(
             &mut output,
             &request,

--- a/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
+++ b/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
@@ -10,10 +10,11 @@ use projectatlas_core::optional_parser_protocol::PARSER_WINDOWS_BROKER_ADMISSION
 use projectatlas_core::optional_parser_protocol::{
     PARSER_FRAME_HEADER_BYTES, PARSER_MAX_STDERR_BYTES, PARSER_PROTOCOL_VERSION,
     ParserArtifactIdentity, ParserCompletion, ParserCompletionEvidence, ParserContainmentKind,
-    ParserControl, ParserFrame, ParserFrameHeader, ParserFrameKind, ParserLanguageIdentity,
-    ParserProgress, ParserProgressStage, ParserReady, ParserRequest, ParserRequestIdentity,
-    ParserResponseIdentity, ParserSessionIdentity, ParserSyntaxKind,
-    decode_parser_request_for_session, decode_parser_session_open, encode_parser_control,
+    ParserControl, ParserFailure, ParserFailureCode, ParserFrame, ParserFrameHeader,
+    ParserFrameKind, ParserLanguageIdentity, ParserProgress, ParserProgressStage, ParserReady,
+    ParserRequest, ParserRequestIdentity, ParserResponseIdentity, ParserSessionIdentity,
+    ParserSyntaxKind, decode_parser_request_for_session, decode_parser_session_open,
+    encode_parser_control,
 };
 
 #[allow(dead_code, unused_imports)]
@@ -212,6 +213,16 @@ fn hostile_peer(scenario: &str) -> Result<(), Box<dyn std::error::Error>> {
         }
         "completion-oversized" => {
             write_oversized_header(&mut output, ParserFrameKind::Completion)?;
+            thread::sleep(Duration::from_secs(5));
+        }
+        "failure-exit" => {
+            write_control(
+                &mut output,
+                &ParserControl::Failure(ParserFailure::new(
+                    ParserResponseIdentity::for_request(&request),
+                    ParserFailureCode::ParseRejected,
+                )),
+            )?;
         }
         "stderr-flood" => {
             diagnostic.write_all(&vec![b'x'; PARSER_MAX_STDERR_BYTES + 1])?;

--- a/crates/projectatlas-db/src/repository_graph.rs
+++ b/crates/projectatlas-db/src/repository_graph.rs
@@ -4295,19 +4295,21 @@ fn external_candidate_batch_sql(key_count: usize) -> String {
         "WITH affected(entity_key) AS (VALUES {values})
          SELECT relation.target_entity_key
            FROM affected
-           JOIN graph_relations AS relation INDEXED BY idx_graph_relations_source_kind
-             ON relation.source_entity_key = affected.entity_key
+           CROSS JOIN graph_relations AS relation
+                      INDEXED BY idx_graph_relations_source_kind
            JOIN graph_entities AS external
              ON external.entity_key = relation.target_entity_key
-          WHERE external.entity_kind = 'external'
+          WHERE relation.source_entity_key = affected.entity_key
+            AND external.entity_kind = 'external'
          UNION ALL
          SELECT relation.source_entity_key
            FROM affected
-           JOIN graph_relations AS relation INDEXED BY idx_graph_relations_target_kind
-             ON relation.target_entity_key = affected.entity_key
+           CROSS JOIN graph_relations AS relation
+                      INDEXED BY idx_graph_relations_target_kind
            JOIN graph_entities AS external
              ON external.entity_key = relation.source_entity_key
-          WHERE external.entity_kind = 'external'"
+          WHERE relation.target_entity_key = affected.entity_key
+            AND external.entity_kind = 'external'"
     )
 }
 
@@ -7282,26 +7284,37 @@ mod tests {
             )?;
         }
 
-        let sql = format!("EXPLAIN QUERY PLAN {}", external_candidate_batch_sql(2));
-        let bindings = [Value::Blob(vec![0_u8; 32]), Value::Blob(vec![1_u8; 32])];
-        let mut statement = store.connection.prepare(&sql)?;
-        let details = statement
-            .query_map(params_from_iter(bindings.iter()), |row| {
-                row.get::<_, String>(3)
-            })?
-            .collect::<Result<Vec<_>, _>>()?;
-        require(
-            [
-                "idx_graph_relations_source_kind",
-                "idx_graph_relations_target_kind",
-            ]
-            .iter()
-            .all(|index| details.iter().any(|detail| detail.contains(index)))
-                && details
-                    .iter()
-                    .all(|detail| !detail.contains("SCAN graph_relations")),
-            &format!("batched external cleanup was not index-bounded: {details:?}"),
-        )?;
+        for key_count in [2, EXTERNAL_CANDIDATE_KEYS_PER_QUERY] {
+            let sql = format!(
+                "EXPLAIN QUERY PLAN {}",
+                external_candidate_batch_sql(key_count)
+            );
+            let bindings = (0..key_count)
+                .map(|_| Value::Blob(vec![0_u8; 32]))
+                .collect::<Vec<_>>();
+            let mut statement = store.connection.prepare(&sql)?;
+            let details = statement
+                .query_map(params_from_iter(bindings.iter()), |row| {
+                    row.get::<_, String>(3)
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            require(
+                [
+                    "SEARCH relation USING INDEX idx_graph_relations_source_kind (source_entity_key=?)",
+                    "SEARCH relation USING INDEX idx_graph_relations_target_kind (target_entity_key=?)",
+                ]
+                .iter()
+                .all(|seek| details.iter().any(|detail| detail.contains(seek)))
+                    && details.iter().all(|detail| {
+                        !detail.contains("SCAN relation")
+                            && !detail.contains("SCAN graph_relations")
+                            && !detail.contains("USE TEMP B-TREE")
+                    }),
+                &format!(
+                    "{key_count}-key external cleanup batch was not driven by indexed point seeks: {details:?}"
+                ),
+            )?;
+        }
         Ok(())
     }
 

--- a/crates/projectatlas-db/src/repository_graph.rs
+++ b/crates/projectatlas-db/src/repository_graph.rs
@@ -1492,7 +1492,7 @@ impl AtlasStore {
             if chunk.is_empty() {
                 continue;
             }
-            let values_clause = resolution_values_clause(chunk.len(), 4);
+            let values_clause = anonymous_values_clause(chunk.len(), 4);
             let sql = format!(
                 "WITH requested(project_instance_id, resolution_domain, key_digest, canonical_identity)
                       AS (VALUES {values_clause})
@@ -3537,6 +3537,8 @@ impl IndexPublicationGuard<'_> {
 const RESOLUTION_KEYS_PER_QUERY: usize = 200;
 /// Conservative path count that stays below `SQLite`'s legacy bind ceiling.
 const RESOLUTION_PATHS_PER_QUERY: usize = 400;
+/// Conservative affected-entity count for one external-candidate adjacency batch.
+const EXTERNAL_CANDIDATE_KEYS_PER_QUERY: usize = 400;
 
 /// Closed owner projections that retain canonical resolution keys.
 #[derive(Clone, Copy)]
@@ -3723,7 +3725,7 @@ fn validate_persisted_resolution_keys(
         if chunk.is_empty() {
             continue;
         }
-        let values_clause = resolution_values_clause(chunk.len(), 4);
+        let values_clause = anonymous_values_clause(chunk.len(), 4);
         let sql = format!(
             "WITH requested(project_instance_id, resolution_domain, key_digest, canonical_identity)
                   AS (VALUES {values_clause})
@@ -3770,7 +3772,7 @@ fn affected_source_paths(
         if chunk.is_empty() {
             continue;
         }
-        let values_clause = resolution_values_clause(chunk.len(), 4);
+        let values_clause = anonymous_values_clause(chunk.len(), 4);
         let sql = format!(
             "WITH requested(project_instance_id, resolution_domain, key_digest, canonical_identity)
                   AS (VALUES {values_clause})
@@ -4046,7 +4048,7 @@ fn affected_source_footprint_sql(path_count: usize) -> String {
 }
 
 /// Build an anonymous `VALUES` clause with fixed columns per row.
-fn resolution_values_clause(rows: usize, columns: usize) -> String {
+fn anonymous_values_clause(rows: usize, columns: usize) -> String {
     let row = format!("({})", vec!["?"; columns].join(","));
     vec![row; rows].join(",")
 }
@@ -4209,7 +4211,7 @@ fn remove_touched_orphan_resolution_keys(
         if chunk.is_empty() {
             continue;
         }
-        let values_clause = resolution_values_clause(chunk.len(), 3);
+        let values_clause = anonymous_values_clause(chunk.len(), 3);
         let sql = format!(
             "WITH touched(project_instance_id, resolution_domain, key_digest)
                   AS (VALUES {values_clause})
@@ -4270,33 +4272,43 @@ fn affected_external_candidates(
         }
     }
 
-    let mut outgoing = connection.prepare_cached(
-        "SELECT relation.target_entity_key
-           FROM graph_relations AS relation INDEXED BY idx_graph_relations_source_kind
-           JOIN graph_entities AS external
-             ON external.entity_key = relation.target_entity_key
-          WHERE relation.source_entity_key = ?1 AND external.entity_kind = 'external'",
-    )?;
-    let mut incoming = connection.prepare_cached(
-        "SELECT relation.source_entity_key
-           FROM graph_relations AS relation INDEXED BY idx_graph_relations_target_kind
-           JOIN graph_entities AS external
-             ON external.entity_key = relation.source_entity_key
-          WHERE relation.target_entity_key = ?1 AND external.entity_kind = 'external'",
-    )?;
     let mut candidates = HashSet::new();
-    for local_key in local_keys {
-        for statement in [&mut outgoing, &mut incoming] {
-            let mut rows = statement.query([&local_key[..]])?;
-            while let Some(row) = rows.next()? {
-                candidates.insert(fixed_bytes::<32>(
-                    "graph_entities.entity_key",
-                    row.get::<_, Vec<u8>>(0)?,
-                )?);
-            }
+    let local_keys = local_keys.into_iter().collect::<Vec<_>>();
+    for chunk in local_keys.chunks(EXTERNAL_CANDIDATE_KEYS_PER_QUERY) {
+        let sql = external_candidate_batch_sql(chunk.len());
+        let mut statement = connection.prepare_cached(&sql)?;
+        let mut rows = statement.query(params_from_iter(chunk.iter().map(|key| &key[..])))?;
+        while let Some(row) = rows.next()? {
+            candidates.insert(fixed_bytes::<32>(
+                "graph_entities.entity_key",
+                row.get::<_, Vec<u8>>(0)?,
+            )?);
         }
     }
     Ok(candidates)
+}
+
+/// Build one two-direction indexed adjacency query for a bounded affected-key batch.
+fn external_candidate_batch_sql(key_count: usize) -> String {
+    let values = anonymous_values_clause(key_count, 1);
+    format!(
+        "WITH affected(entity_key) AS (VALUES {values})
+         SELECT relation.target_entity_key
+           FROM affected
+           JOIN graph_relations AS relation INDEXED BY idx_graph_relations_source_kind
+             ON relation.source_entity_key = affected.entity_key
+           JOIN graph_entities AS external
+             ON external.entity_key = relation.target_entity_key
+          WHERE external.entity_kind = 'external'
+         UNION ALL
+         SELECT relation.source_entity_key
+           FROM affected
+           JOIN graph_relations AS relation INDEXED BY idx_graph_relations_target_kind
+             ON relation.target_entity_key = affected.entity_key
+           JOIN graph_entities AS external
+             ON external.entity_key = relation.source_entity_key
+          WHERE external.entity_kind = 'external'"
+    )
 }
 
 /// Delete one affected local closure through statements prepared once per batch.
@@ -7269,6 +7281,27 @@ mod tests {
                 &format!("{context} was not bounded by index order: {details:?}"),
             )?;
         }
+
+        let sql = format!("EXPLAIN QUERY PLAN {}", external_candidate_batch_sql(2));
+        let bindings = [Value::Blob(vec![0_u8; 32]), Value::Blob(vec![1_u8; 32])];
+        let mut statement = store.connection.prepare(&sql)?;
+        let details = statement
+            .query_map(params_from_iter(bindings.iter()), |row| {
+                row.get::<_, String>(3)
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        require(
+            [
+                "idx_graph_relations_source_kind",
+                "idx_graph_relations_target_kind",
+            ]
+            .iter()
+            .all(|index| details.iter().any(|detail| detail.contains(index)))
+                && details
+                    .iter()
+                    .all(|detail| !detail.contains("SCAN graph_relations")),
+            &format!("batched external cleanup was not index-bounded: {details:?}"),
+        )?;
         Ok(())
     }
 
@@ -8370,6 +8403,30 @@ mod tests {
             )?;
             publication.complete()?;
         }
+
+        let affected_paths = [
+            RepositoryNodePath::new(Path::new("src/a"))?,
+            RepositoryNodePath::new(Path::new("packages/api/Cargo.toml"))?,
+        ];
+        let (candidates, statements) = trace_statements(&mut store, |store| {
+            affected_external_candidates(&store.connection, &affected_paths)
+        })?;
+        require(
+            candidates.contains(&orphan_external.key().digest_bytes()?),
+            "batched external cleanup omitted an affected candidate",
+        )?;
+        require_eq(
+            &statements
+                .iter()
+                .filter(|statement| {
+                    statement.contains("WITH affected(entity_key)")
+                        && statement.contains("idx_graph_relations_source_kind")
+                        && statement.contains("idx_graph_relations_target_kind")
+                })
+                .count(),
+            &1,
+            "bounded external candidate adjacency batches",
+        )?;
 
         let generation_two = IndexGeneration::new(2);
         let replacement_folder = GraphEntity::new(

--- a/openspec/changes/complete-v040-release-readiness/tasks.md
+++ b/openspec/changes/complete-v040-release-readiness/tasks.md
@@ -7,15 +7,15 @@
 ## 2. Final Candidate
 
 - [x] 2.1 Complete issue #341's explicit empty-cache Linux and Windows construction, reconcile and land its OpenSpec and GitHub checklist state, resolve live feedback, and close #341.
-- [x] 2.2 Merge every remaining v0.4.0 readiness change into `dev`, confirm #314 remains outside the release, and lock one release-content head with no uncommitted source changes or unresolved review feedback.
-- [x] 2.3 Run the complete pre-push gate, strict OpenSpec validation, ProjectAtlas candidate scan and low lint, and IssueOps synchronization on the locked release-content head; confirm this release-only change adds no Rust API, crate, dependency, schema, migration, SQLite write path, or runtime behavior.
+- [ ] 2.2 Merge every remaining v0.4.0 readiness change into `dev`, confirm #314 remains outside the release, and lock one release-content head with no uncommitted source changes or unresolved review feedback.
+- [ ] 2.3 Run the complete pre-push gate, strict OpenSpec validation, ProjectAtlas candidate scan and low lint, and IssueOps synchronization on the locked release-content head; confirm this release-only change adds no Rust API, crate, dependency, schema, migration, SQLite write path, or runtime behavior.
 
 ## 3. Prepublication Proof
 
-- [x] 3.1 Run exact-head `01-CI` and require Rust verification plus source-built CLI/MCP E2E smoke on Linux, Windows, macOS x64, and macOS arm64; dispatch `optional-parser-pack` with `clean_construction=true` and `target=all` on the same locked release-content head and require complete Linux and Windows construction, fresh-runner, runtime, and aggregate proof.
-- [x] 3.2 Run `02-Release` for `v0.4.0` with `prepublish_only=true` and require every package and installer-smoke job to succeed on its supported platform.
-- [x] 3.3 Verify the prepublish run created no tag or GitHub release; reconcile package, installer, runtime, plugin, MCP, CLI, documentation, and release-note identities; leave published checksum verification to #346; prepare a merge-commit `dev`-to-`main` promotion without merging it, with `main` as an ancestor and squash/rebase refused; re-audit PR threads plus Codex and Dependabot feedback; and keep `main`, tags, releases, and post-release issue #346 unchanged.
+- [ ] 3.1 Run exact-head `01-CI` and require Rust verification plus source-built CLI/MCP E2E smoke on Linux, Windows, macOS x64, and macOS arm64; dispatch `optional-parser-pack` with `clean_construction=true` and `target=all` on the same locked release-content head and require complete Linux and Windows construction, fresh-runner, runtime, and aggregate proof.
+- [ ] 3.2 Run `02-Release` for `v0.4.0` with `prepublish_only=true` and require every package and installer-smoke job to succeed on its supported platform.
+- [ ] 3.3 Verify the prepublish run created no tag or GitHub release; reconcile package, installer, runtime, plugin, MCP, CLI, documentation, and release-note identities; leave published checksum verification to #346; prepare a merge-commit `dev`-to-`main` promotion without merging it, with `main` as an ancestor and squash/rebase refused; re-audit PR threads plus Codex and Dependabot feedback; and keep `main`, tags, releases, and post-release issue #346 unchanged.
 
 ## 4. Finite Reconciliation
 
-- [x] 4.1 After tasks 1.1 through 3.3 are true, create one commit whose only repository change is checking those completed tasks and this reconciliation task, mirror #311 exactly, verify the diff is task-state-only, and carry clean-construction and prepublish proof forward only across that verified diff.
+- [ ] 4.1 After tasks 1.1 through 3.3 are true, create one commit whose only repository change is checking those completed tasks and this reconciliation task, mirror #311 exactly, verify the diff is task-state-only, and carry clean-construction and prepublish proof forward only across that verified diff.

--- a/plugins/projectatlas/skills/projectatlas/SKILL.md
+++ b/plugins/projectatlas/skills/projectatlas/SKILL.md
@@ -15,22 +15,38 @@ ProjectAtlas is an agent orientation layer. It combines reviewed folder/file res
 
 ## Task Startup
 
-1. Bind the intended project. In shared or concurrent MCP hosts, pass `project_path` on every call; use `atlas_set_project_path` only as a single-client process default.
-2. If the index may be stale, call `atlas_watch_once` or `atlas_scan`. Do not scan merely because a session started.
-3. Call `atlas_session_brief` once at task-oriented startup with `query`, `project_path` when needed, and `compact: true`. For a focused code question, start with `file_limit: 3`, `folder_limit: 3`, `blocker_limit: 1`, and `purpose_limit: 1`; widen only when no actionable candidate is returned. Follow its typed next call directly; do not restart the brief or repeat folder/file discovery for a later caller, source, or public-boundary check.
-4. Call a returned `atlas_file_summary` recommendation with `compact: true`. Use legacy/default summary output or an explicit `limit` only when full totals, empty sections, and complete coverage state are needed.
-5. Use the compact summary's crisp connections for an ordinary direct caller or dependency already shown there. Do not add a relation call merely to reconfirm a trusted `called_by` or call row, and do not inspect a plausible sibling once another ranked summary contains the exact requested behavior. Use `atlas_outline` or `atlas_symbols` only when summary context is insufficient. Use `atlas_symbol_relations` with `view: "detailed"` and `compact: true` when resolution/completeness matters, a connection sample is truncated, ambiguity or external/unresolved state matters, or a required path is not explicit in the summaries. Request occurrences only when the call-site span itself is needed. When the compact result returns a top-level `next_call`, submit its tool and arguments unchanged; do not reconstruct the cursor or rediscover the file first.
-6. Use `atlas_slice` for the smallest exact line or symbol range that answers the task. Do not guess a symbol line or other disambiguator; copy the returned selector fields.
-7. Stop once exact evidence answers the task. For external reachability, verify the owning module, re-export, package, or route boundary once; a public nested declaration alone is not proof, but do not repeat a boundary already established by a trusted export or exact declaration. Public exposure is not an inbound-caller question: use the trusted export or a bounded module/re-export declaration, not a relation query on the entrypoint.
-8. Fall back to `atlas_overview` only when the session-brief MCP tool is unavailable, the brief has no actionable candidate, or broader repository structure is itself the task. Then use `atlas_folders` before `atlas_files`.
+1. On first use in each distinct project root, call `atlas_init` when exposed or run `projectatlas init` from that root. Every project root owns its own `.projectatlas/projectatlas.db`, config, generated host configs, and initial index. Do not treat initialization of another repository as setup for the current one, and do not substitute a scan, symbol build, or hand-written MCP config for init.
+2. Bind the intended project. In shared or concurrent MCP hosts, pass `project_path` on every call; use `atlas_set_project_path` only as a single-client process default.
+3. Refresh only when needed. Prefer `atlas_watch_once` for ordinary changed-file updates. Use `atlas_scan` only when the index is absent or typed ProjectAtlas guidance requires a full refresh; never scan merely because a session started.
+4. Call `atlas_session_brief` once at task-oriented startup with `query`, `project_path` when needed, and `compact: true`. For a focused code question, start with `file_limit: 3`, `folder_limit: 3`, `blocker_limit: 1`, and `purpose_limit: 1`; widen only when no actionable candidate is returned. Follow its typed next call directly; do not restart the brief or repeat folder/file discovery for a later caller, source, or public-boundary check.
+5. Call a returned `atlas_file_summary` recommendation with `compact: true`. Use legacy/default summary output or an explicit `limit` only when full totals, empty sections, and complete coverage state are needed.
+6. Use the compact summary's crisp connections for an ordinary direct caller or dependency already shown there. Do not add a relation call merely to reconfirm a trusted `called_by` or call row, and do not inspect a plausible sibling once another ranked summary contains the exact requested behavior. Use `atlas_outline` or `atlas_symbols` only when summary context is insufficient. Use `atlas_symbol_relations` with `view: "detailed"` and `compact: true` when resolution/completeness matters, a connection sample is truncated, ambiguity or external/unresolved state matters, or a required path is not explicit in the summaries. Request occurrences only when the call-site span itself is needed. When the compact result returns a top-level `next_call`, submit its tool and arguments unchanged; do not reconstruct the cursor or rediscover the file first.
+7. Use `atlas_slice` for the smallest exact line or symbol range that answers the task. Do not guess a symbol line or other disambiguator; copy the returned selector fields.
+8. Stop once exact evidence answers the task. For external reachability, verify the owning module, re-export, package, or route boundary once; a public nested declaration alone is not proof, but do not repeat a boundary already established by a trusted export or exact declaration. Public exposure is not an inbound-caller question: use the trusted export or a bounded module/re-export declaration, not a relation query on the entrypoint.
+9. Fall back to `atlas_overview` only when the session-brief MCP tool is unavailable, the brief has no actionable candidate, or broader repository structure is itself the task. Then use `atlas_folders` before `atlas_files`.
 
 `connections_truncated` describes the compact sample. It means more relationships exist, not that the selected next call is wrong. Use the returned detailed-relations call only when those additional relationships matter.
+
+## Indexing Strategy
+
+- **First use for each project root:** `atlas_init` or `projectatlas init`. This is the normal per-project setup and initial-index path.
+- **Fresh existing index:** make no indexing call. Start with `atlas_session_brief`.
+- **Changed files:** use `atlas_watch_once`; it incrementally refreshes affected source, summaries, symbols, graph facts, and freshness state.
+- **Full refresh:** use `atlas_scan` only for a missing index, an intentional repository-wide rebuild, or typed full-refresh guidance after continuity, root, policy, or index uncertainty.
+- **Deep symbol/graph rebuild:** use `atlas_symbols_build` only when ProjectAtlas reports the symbol/graph projection missing, stale, or incomplete, or when the user explicitly requests that rebuild. Do not run it at ordinary startup or before every relation query.
+- **Continuous editing:** a human may keep `projectatlas watch` running; agents use `atlas_watch_once` for bounded refreshes.
+
+Never reset or replace an incompatible database as an orientation shortcut. Follow its typed recovery guidance and preserve authored purpose state.
 
 ## Task-to-Tool Routing
 
 | Task | Primary route | Follow-up |
 | --- | --- | --- |
 | Startup, project state, ranked candidates | `atlas_session_brief` with `compact: true` | Execute the returned summary, search, relations, slice, health, or scan request |
+| First use in a project | `atlas_init` | Honor the returned initial-index and purpose-curation handoff |
+| Changed files since the last verified index | `atlas_watch_once` | Continue only from the new complete generation |
+| Missing index or typed full-refresh requirement | `atlas_scan` | Do not use for routine session startup |
+| Missing, stale, or explicitly requested deep symbol/graph projection | `atlas_symbols_build` | Then use `atlas_symbols` or `atlas_symbol_relations`; do not rebuild repeatedly |
 | Broad work-area selection | `atlas_overview`, `atlas_folders`, `atlas_files` | Summary for the selected file |
 | One-file intelligence or direct impact already shown by crisp connections | `atlas_file_summary` with `compact: true` | Follow the selected connection to another compact summary or exact slice; use relations only when its stronger trust/path facts are material |
 | Declaration lookup | `atlas_symbols` | Slice the returned exact selector |
@@ -39,8 +55,12 @@ ProjectAtlas is an agent orientation layer. It combines reviewed folder/file res
 | Architecture, impact, dead-code, cycle, or static path review | `atlas_symbol_relations` with its closed analysis view/mode | Treat candidate/inconclusive output as review evidence, then inspect returned source selectors |
 | Indexed text discovery | `atlas_search` with a bounded `file_pattern` when possible | Slice the returned range; narrow before paging when truncated |
 | Exact source | `atlas_slice` | Stop when sufficient |
+| Missing, suggested, stale, or wrong purposes | `atlas_purpose_queue`, then `atlas_purpose_review` or `atlas_purpose_set` | Delegate one bounded `low` batch to a low-reasoning subagent when supported; never edit SQLite |
 | Cleanup, coverage, or purpose diagnostics | `atlas_health` / `atlas_purpose_queue` | Resolve a confirmed conflict or curate through purpose APIs |
+| Manual ProjectAtlas ignore policy | `atlas_ignore_list`, then `atlas_ignore_add` / `atlas_ignore_remove` | Keep `.gitignore` authoritative and add only stricter atlas-specific rules |
 | Runtime/config/index diagnostics | `atlas_runtime_info`, `atlas_root`, `atlas_config`, `atlas_settings`, `atlas_watch_status` | Use typed recovery guidance |
+| CLI/MCP compatibility audit | `atlas_parity_report` | Use for explicit diagnostics or release/CI proof, not normal navigation |
+| Legacy manual next-step ranking | `atlas_next` | Use only when session brief is unavailable or the manual overview/folders/files route is intentional |
 
 Search is lexical by default. Literal/token acceleration must preserve exact results; regex, fuzzy, short, punctuation-sensitive, or Unicode-unsafe queries may use bounded persisted-text fallback. Inspect searched files/bytes, completeness, and truncation before widening. Semantic or hybrid retrieval is explicit and may return typed unavailable/stale lifecycle state.
 
@@ -57,14 +77,14 @@ Search is lexical by default. Literal/token acceleration must preserve exact res
 
 ## Purpose Curation
 
-`folder_purpose` and `file_purpose` explain why a path exists; `content_summary` explains what is currently in it. Generated purposes remain `suggested` until an agent approves them. Accepted purposes are durable authored responsibility: source, summary, symbol, graph, scan, and watcher changes do not demote them. Deleted/excluded paths leave purposes dormant; renames do not transfer approval.
+`folder_purpose` and `file_purpose` explain why a path exists; `content_summary` explains what is currently in it. Generated purposes remain `suggested` until an agent approves them. A purpose written through `atlas_purpose_set` or successfully applied through `atlas_purpose_review` becomes `approved`, `source: agent`, and `agent_reviewed: true` immediately; it is no longer a generated suggestion and needs no second approval pass. Approved purposes are durable authored responsibility: source, summary, symbol, graph, scan, and watcher changes do not demote them. Deleted/excluded paths leave purposes dormant; renames do not transfer approval.
 
 When init, session brief, or `atlas_purpose_queue` returns an actionable `low`-scope handoff:
 
 1. Keep the main task moving.
-2. If the host supports bounded isolated subagents, delegate exactly that batch at the lowest reasoning tier the host can enforce; otherwise process it in the main agent.
-3. Give the curator only queue rows and bounded summary/graph/outline/slice context.
-4. Copy `task`, `work_key`, and `state_token` into `atlas_purpose_review`. Write only through `atlas_purpose_set` / `atlas_purpose_review` or their CLI equivalents; never edit SQLite.
+2. If the host supports bounded isolated subagents, partition a large queue into bounded, non-overlapping batches and delegate them to one or more agents at the lowest reasoning tier the host can enforce. Respect the host's subagent and ProjectAtlas worker budget, assign each path to exactly one curator, and curate folders before files whose responsibility depends on them. Otherwise process the queue in the main agent.
+3. Give each curator only its queue rows and bounded summary/graph/outline/slice context.
+4. Copy each batch's `task`, `work_key`, and `state_token` into `atlas_purpose_review`. Write only through `atlas_purpose_set` / `atlas_purpose_review` or their CLI equivalents; never edit SQLite. A successful agent write is already approved and agent-reviewed.
 5. Skip accepted purposes unless an agent or user explicitly assigns a correction.
 6. Keep successful maintenance out of normal conversation. ProjectAtlas exposes the handoff; the Rust server does not spawn an agent.
 7. Never expand automatic work to `medium` or `strict`.
@@ -87,16 +107,20 @@ For a single known wrong or genuinely repurposed accepted purpose, inspect enoug
 
 ## Setup and Runtime Repair
 
-For a new project, run `atlas_init` when exposed or `projectatlas init`. It creates/verifies project-local config, DB, host configs, and the initial index. Honor any returned purpose handoff.
+For every new project root, run `atlas_init` when exposed or `projectatlas init` from that root. It creates or verifies that project's local config, DB, host configs, and initial index. Initialization does not carry across roots. Honor any returned purpose handoff.
+
+After installing ProjectAtlas, read and follow this shipped skill before broad source reads. If the harness does not load plugin skills automatically, preserve the repository's existing guidance and add one durable pointer to the nearest harness instruction file: `AGENTS.md` for Codex, `CLAUDE.md` for Claude Code, or the host's equivalent. The pointer should tell future agents to use the installed/version-matched ProjectAtlas skill and MCP tools, run init only when project-local state is absent, and follow the skill's incremental freshness policy. Do not replace unrelated project instructions or paste a duplicate copy of the full skill.
 
 Use `atlas_runtime_info` first. CLI fallback:
 
 `projectatlas --format json runtime-info`
 
-The runtime must report ProjectAtlas major version 3+, MCP, SQLite, TOON, and the installed plugin version. If missing or stale, run the repository plugin installer from the target root:
+The runtime must report ProjectAtlas major version 3+, MCP, SQLite, TOON, and a runtime `version` matching the selected plugin release. Verify the installed plugin version and shipped skill artifact separately through the installer and harness plugin inventory. If the runtime is missing or stale, resolve the installer from the installed, version-matched ProjectAtlas plugin root or a checked-out matching ProjectAtlas release, then pass the target project root separately:
 
-- Windows: `plugins/projectatlas/scripts/install-runtime.ps1`
-- Linux/macOS: `bash plugins/projectatlas/scripts/install-runtime.sh`
+- Windows: `& "<projectatlas-plugin-root>\scripts\install-runtime.ps1" -ProjectRoot "<target-project-root>"`
+- Linux/macOS: `bash "<projectatlas-plugin-root>/scripts/install-runtime.sh" "<target-project-root>"`
+
+The command path belongs to the ProjectAtlas plugin/release artifact; the working/project-root argument belongs to the repository being initialized. Do not assume an unrelated target repository contains `plugins/projectatlas/scripts`.
 
 Prefer installer-generated absolute host configs:
 
@@ -114,10 +138,11 @@ MCP stdio uses newline-delimited JSON-RPC, not `Content-Length` framing.
 
 Use MCP for normal ProjectAtlas command families. Use CLI for installer/release/CI work, MCP startup/debugging, continuous watch, terminal TUI, or when a tool is unavailable.
 
-- Refresh: `atlas_scan`, `atlas_watch_once`
-- Navigate: `atlas_session_brief`, `atlas_overview`, `atlas_folders`, `atlas_files`, `atlas_file_summary`, `atlas_outline`, `atlas_symbols`, `atlas_symbol_relations`, `atlas_search`, `atlas_slice`
+- Select/setup: `atlas_set_project_path`, `atlas_init`
+- Refresh: `atlas_scan`, `atlas_watch_once`, `atlas_symbols_build`
+- Navigate: `atlas_session_brief`, `atlas_overview`, `atlas_folders`, `atlas_files`, `atlas_next`, `atlas_file_summary`, `atlas_outline`, `atlas_symbols`, `atlas_symbol_relations`, `atlas_search`, `atlas_slice`
 - Maintain: `atlas_health`, `atlas_health_resolve`, `atlas_purpose_queue`, `atlas_purpose_set`, `atlas_purpose_review`, `atlas_lint`
-- Diagnose/admin: `atlas_root`, `atlas_root_set`, `atlas_config`, `atlas_settings`, `atlas_watch_status`, `atlas_runtime_info`, `atlas_ignore_*`, `atlas_mcp_config`, `atlas_reset_index`, `atlas_strip_legacy_purpose`
+- Diagnose/admin: `atlas_root`, `atlas_root_set`, `atlas_config`, `atlas_settings`, `atlas_watch_status`, `atlas_runtime_info`, `atlas_ignore_list`, `atlas_ignore_init_gitignore`, `atlas_ignore_add`, `atlas_ignore_remove`, `atlas_mcp_config`, `atlas_reset_index`, `atlas_strip_legacy_purpose`, `atlas_parity_report`
 - Bounded task model: `atlas_task_status`, `atlas_task_cancel`
 - Telemetry: `atlas_token_report`
 - Compatibility export only: `atlas_map`


### PR DESCRIPTION
## Summary

- fail closed when an optional parser emits bounded diagnostics before a valid completion
- rehash manifest-bound native payloads before every fresh resident launch
- replace per-entity external graph endpoint lookups with bounded, indexed set queries
- make the shipped agent skill explicit about per-root init, adaptive indexing, parallel low-reasoning purpose curation, immediate agent-reviewed state, and executable runtime repair

## Verification

- full repository pre-push gate passed on 8f3cd4 (format, check, Clippy, deny, workspace tests, doctests, rustdoc, IssueOps, ProjectAtlas scan/lint)
- hostile parser stderr-plus-completion and same-size/same-mtime mutation coverage passed
- graph correctness, query-plan, and single-batch statement-shape coverage passed
- shipped-skill and external-target installer E2E passed

Closes #356