### PR TITLE
docs(openspec): complete v0.4.0 release readiness (#311)

### DIFF
--- a/openspec/changes/complete-v040-release-readiness/tasks.md
+++ b/openspec/changes/complete-v040-release-readiness/tasks.md
@@ -7,15 +7,15 @@
 ## 2. Final Candidate
 
 - [x] 2.1 Complete issue #341's explicit empty-cache Linux and Windows construction, reconcile and land its OpenSpec and GitHub checklist state, resolve live feedback, and close #341.
-- [ ] 2.2 Merge every remaining v0.4.0 readiness change into `dev`, confirm #314 remains outside the release, and lock one release-content head with no uncommitted source changes or unresolved review feedback.
-- [ ] 2.3 Run the complete pre-push gate, strict OpenSpec validation, ProjectAtlas candidate scan and low lint, and IssueOps synchronization on the locked release-content head; confirm this release-only change adds no Rust API, crate, dependency, schema, migration, SQLite write path, or runtime behavior.
+- [x] 2.2 Merge every remaining v0.4.0 readiness change into `dev`, confirm #314 remains outside the release, and lock one release-content head with no uncommitted source changes or unresolved review feedback.
+- [x] 2.3 Run the complete pre-push gate, strict OpenSpec validation, ProjectAtlas candidate scan and low lint, and IssueOps synchronization on the locked release-content head; confirm this release-only change adds no Rust API, crate, dependency, schema, migration, SQLite write path, or runtime behavior.
 
 ## 3. Prepublication Proof
 
-- [ ] 3.1 Run exact-head `01-CI` and require Rust verification plus source-built CLI/MCP E2E smoke on Linux, Windows, macOS x64, and macOS arm64; dispatch `optional-parser-pack` with `clean_construction=true` and `target=all` on the same locked release-content head and require complete Linux and Windows construction, fresh-runner, runtime, and aggregate proof.
-- [ ] 3.2 Run `02-Release` for `v0.4.0` with `prepublish_only=true` and require every package and installer-smoke job to succeed on its supported platform.
-- [ ] 3.3 Verify the prepublish run created no tag or GitHub release; reconcile package, installer, runtime, plugin, MCP, CLI, documentation, and release-note identities; leave published checksum verification to #346; prepare a merge-commit `dev`-to-`main` promotion without merging it, with `main` as an ancestor and squash/rebase refused; re-audit PR threads plus Codex and Dependabot feedback; and keep `main`, tags, releases, and post-release issue #346 unchanged.
+- [x] 3.1 Run exact-head `01-CI` and require Rust verification plus source-built CLI/MCP E2E smoke on Linux, Windows, macOS x64, and macOS arm64; dispatch `optional-parser-pack` with `clean_construction=true` and `target=all` on the same locked release-content head and require complete Linux and Windows construction, fresh-runner, runtime, and aggregate proof.
+- [x] 3.2 Run `02-Release` for `v0.4.0` with `prepublish_only=true` and require every package and installer-smoke job to succeed on its supported platform.
+- [x] 3.3 Verify the prepublish run created no tag or GitHub release; reconcile package, installer, runtime, plugin, MCP, CLI, documentation, and release-note identities; leave published checksum verification to #346; prepare a merge-commit `dev`-to-`main` promotion without merging it, with `main` as an ancestor and squash/rebase refused; re-audit PR threads plus Codex and Dependabot feedback; and keep `main`, tags, releases, and post-release issue #346 unchanged.
 
 ## 4. Finite Reconciliation
 
-- [ ] 4.1 After tasks 1.1 through 3.3 are true, create one commit whose only repository change is checking those completed tasks and this reconciliation task, mirror #311 exactly, verify the diff is task-state-only, and carry clean-construction and prepublish proof forward only across that verified diff.
+- [x] 4.1 After tasks 1.1 through 3.3 are true, create one commit whose only repository change is checking those completed tasks and this reconciliation task, mirror #311 exactly, verify the diff is task-state-only, and carry clean-construction and prepublish proof forward only across that verified diff.


### PR DESCRIPTION
## Summary

- reconcile the final six release-readiness task checkboxes after exact locked-head proof completed
- keep implementation, workflows, packaging, release notes, and public documentation unchanged
- preserve the proven content tree while making OpenSpec and issue #311 report the same 10/10 state

## Exact-head proof

The locked release-content head c54f9743fd3ca43d804a8667c414e7a80f628abf passed the complete local pre-push gate, ordinary 01-CI, clean Linux/Windows optional-parser construction and lifecycle proof, and the non-publishing 02-Release workflow for v0.4.0. This PR has that head as its direct parent and changes only six checkbox markers in openspec/changes/complete-v040-release-readiness/tasks.md, so it does not alter any tested runtime, workflow, packaging, or documentation input.

## Validation

- strict OpenSpec validation: 10/10 tasks complete
- issue checklist synchronization: #311 local 10 / remote 10 / checked 10
- complete pre-push gate
- fresh ProjectAtlas candidate scan and low purpose-level lint
- clean worktree and exact local/remote head f35a6a0fd492b59a304746910d2ea4a742c2b75f

Refs #311