### PR TITLE
fix(release): close final v0.4 review findings

### DIFF
--- a/.github/scripts/verify-optional-parser-release-assets.py
+++ b/.github/scripts/verify-optional-parser-release-assets.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Validate and stage an exact clean optional-parser release handoff."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+TARGETS = (
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+)
+PACK_ID = "broad-parser"
+PROOF_NAME = "optional-parser-pack-proof-aggregate.json"
+
+
+def digest(path: Path) -> str:
+    """Return one file's lowercase SHA-256."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    """Load one JSON object or fail closed."""
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path.name} must contain a JSON object")
+    return value
+
+
+def require(condition: bool, message: str) -> None:
+    """Raise one bounded validation error."""
+    if not condition:
+        raise ValueError(message)
+
+
+def stage_release_assets(
+    source: Path,
+    output: Path,
+    release_version: str,
+    revision: str,
+    cargo_lock: Path,
+) -> list[Path]:
+    """Validate a clean handoff and stage versioned release assets."""
+    require(
+        re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", release_version) is not None,
+        "release version must match vMAJOR.MINOR.PATCH",
+    )
+    require(re.fullmatch(r"[0-9a-f]{40}", revision) is not None, "invalid run revision")
+    expected_files = {PROOF_NAME}
+    for target in TARGETS:
+        expected_files.add(f"projectatlas-{PACK_ID}-{target}.tar.zst")
+        expected_files.add(f"cargo-layer-{target}.json")
+    source_entries = list(source.iterdir())
+    require(
+        all(path.is_file() and not path.is_symlink() for path in source_entries),
+        "clean handoff contains a non-regular file",
+    )
+    actual_files = {path.name for path in source_entries}
+    require(actual_files == expected_files, "clean handoff file inventory differs")
+
+    proof = load_object(source / PROOF_NAME)
+    version = release_version.removeprefix("v")
+    require(proof.get("schema_version") == 2, "unsupported aggregate proof schema")
+    require(proof.get("pack_id") == PACK_ID, "aggregate proof pack differs")
+    require(proof.get("projectatlas_version") == version, "aggregate proof version differs")
+    platforms = proof.get("platforms")
+    require(isinstance(platforms, list), "aggregate proof platforms must be a list")
+    require(
+        [platform.get("platform") for platform in platforms if isinstance(platform, dict)]
+        == list(TARGETS),
+        "aggregate proof supported target set or order differs",
+    )
+    cargo_lock_sha256 = digest(cargo_lock)
+    common_digests = (
+        "accepted_manifest_sha256",
+        "capability_set_digest",
+        "fixture_corpus_sha256",
+    )
+
+    staged: list[Path] = []
+    output.mkdir(parents=True, exist_ok=True)
+    require(not any(output.iterdir()), "release output directory must be empty")
+    for target, platform in zip(TARGETS, platforms, strict=True):
+        require(platform.get("schema_version") == 2, f"{target} proof schema differs")
+        require(platform.get("pack_id") == PACK_ID, f"{target} pack differs")
+        candidate = platform.get("candidate")
+        require(isinstance(candidate, dict), f"{target} candidate proof is missing")
+        require(
+            candidate.get("projectatlas_revision") == revision,
+            f"{target} candidate revision differs",
+        )
+        require(candidate.get("cargo_package_version") == version, f"{target} Cargo version differs")
+        require(
+            candidate.get("intended_release_version") == version,
+            f"{target} intended release differs",
+        )
+        require(candidate.get("source_state") == "clean", f"{target} source was not clean")
+        require(
+            candidate.get("cargo_lock_sha256") == cargo_lock_sha256,
+            f"{target} Cargo.lock digest differs",
+        )
+        for field in common_digests:
+            require(
+                platform.get(field) == proof.get(field),
+                f"{target} {field} differs from aggregate proof",
+            )
+
+        archive_name = f"projectatlas-{PACK_ID}-{target}.tar.zst"
+        archive = source / archive_name
+        require(platform.get("archive_name") == archive_name, f"{target} archive name differs")
+        require(platform.get("archive_bytes") == archive.stat().st_size, f"{target} archive size differs")
+        require(platform.get("archive_sha256") == digest(archive), f"{target} archive digest differs")
+
+        runner = platform.get("runner")
+        require(isinstance(runner, dict), f"{target} fresh-runner proof is missing")
+        for field in (
+            "fresh_host",
+            "repository_inputs_absent",
+            "build_tools_not_invoked",
+            "working_directory_outside_pack",
+            "ambient_library_paths_cleared",
+        ):
+            require(runner.get(field) == "verified", f"{target} runner {field} is not verified")
+        network = runner.get("network_denial")
+        require(isinstance(network, dict), f"{target} network-denial proof is missing")
+        require(
+            all(network.get(field) is True for field in ("dns_denied", "direct_tcp_denied", "https_denied")),
+            f"{target} network denial is incomplete",
+        )
+        grammars = platform.get("grammars")
+        require(
+            isinstance(grammars, list)
+            and grammars
+            and all(isinstance(grammar, dict) and grammar.get("worker_probe_passed") is True for grammar in grammars),
+            f"{target} grammar probe proof is incomplete",
+        )
+        memory = platform.get("memory")
+        require(
+            isinstance(memory, dict)
+            and memory.get("limit_enforced") == "verified"
+            and memory.get("process_tree_cleaned") == "verified",
+            f"{target} memory/process-tree proof is incomplete",
+        )
+
+        receipt = load_object(source / f"cargo-layer-{target}.json")
+        require(receipt.get("schema_version") == 1, f"{target} receipt schema differs")
+        require(receipt.get("target") == target, f"{target} receipt target differs")
+        require(receipt.get("revision") == revision, f"{target} receipt revision differs")
+        require(receipt.get("disposition") == "clean", f"{target} construction was not clean")
+        require(receipt.get("restore_attempted") is False, f"{target} attempted cache restore")
+        require(receipt.get("exact_hit") is False, f"{target} used an exact cache hit")
+        require(receipt.get("compatible_hit") is False, f"{target} used a compatible cache hit")
+        require(receipt.get("restored_entries") == 0, f"{target} restored cache entries")
+        require(receipt.get("restored_bytes") == 0, f"{target} restored cache bytes")
+        require(receipt.get("save_eligible") is False, f"{target} clean run became save eligible")
+
+        destination = output / f"projectatlas-{release_version}-{PACK_ID}-{target}.tar.zst"
+        shutil.copyfile(archive, destination)
+        staged.append(destination)
+
+    proof_destination = output / f"projectatlas-{release_version}-optional-parser-pack-proof.json"
+    shutil.copyfile(source / PROOF_NAME, proof_destination)
+    staged.append(proof_destination)
+    return staged
+
+
+def self_test() -> None:
+    """Exercise success and tamper rejection without external dependencies."""
+    with tempfile.TemporaryDirectory(prefix="projectatlas-parser-release-") as temporary:
+        root = Path(temporary)
+        source = root / "source"
+        output = root / "output"
+        source.mkdir()
+        cargo_lock = root / "Cargo.lock"
+        cargo_lock.write_bytes(b"locked\n")
+        revision = "a" * 40
+        common = {
+            "accepted_manifest_sha256": "b" * 64,
+            "capability_set_digest": "c" * 64,
+            "fixture_corpus_sha256": "d" * 64,
+        }
+        platforms = []
+        for target in TARGETS:
+            archive_name = f"projectatlas-{PACK_ID}-{target}.tar.zst"
+            archive = source / archive_name
+            archive.write_bytes(target.encode("utf-8"))
+            platforms.append(
+                {
+                    "schema_version": 2,
+                    "pack_id": PACK_ID,
+                    "platform": target,
+                    "candidate": {
+                        "projectatlas_revision": revision,
+                        "cargo_package_version": "0.4.0",
+                        "intended_release_version": "0.4.0",
+                        "cargo_lock_sha256": digest(cargo_lock),
+                        "source_state": "clean",
+                    },
+                    "archive_name": archive_name,
+                    "archive_sha256": digest(archive),
+                    "archive_bytes": archive.stat().st_size,
+                    **common,
+                    "runner": {
+                        "fresh_host": "verified",
+                        "repository_inputs_absent": "verified",
+                        "build_tools_not_invoked": "verified",
+                        "working_directory_outside_pack": "verified",
+                        "ambient_library_paths_cleared": "verified",
+                        "network_denial": {
+                            "dns_denied": True,
+                            "direct_tcp_denied": True,
+                            "https_denied": True,
+                        },
+                    },
+                    "grammars": [{"language_id": "fixture", "worker_probe_passed": True}],
+                    "memory": {
+                        "limit_enforced": "verified",
+                        "process_tree_cleaned": "verified",
+                    },
+                }
+            )
+            (source / f"cargo-layer-{target}.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "target": target,
+                        "revision": revision,
+                        "disposition": "clean",
+                        "restore_attempted": False,
+                        "exact_hit": False,
+                        "compatible_hit": False,
+                        "restored_entries": 0,
+                        "restored_bytes": 0,
+                        "save_eligible": False,
+                    }
+                ),
+                encoding="utf-8",
+            )
+        (source / PROOF_NAME).write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "pack_id": PACK_ID,
+                    "projectatlas_version": "0.4.0",
+                    **common,
+                    "platforms": platforms,
+                }
+            ),
+            encoding="utf-8",
+        )
+        staged = stage_release_assets(source, output, "v0.4.0", revision, cargo_lock)
+        require(len(staged) == 3 and all(path.is_file() for path in staged), "self-test staging failed")
+        (source / f"projectatlas-{PACK_ID}-{TARGETS[0]}.tar.zst").write_bytes(b"tampered")
+        try:
+            stage_release_assets(source, root / "tampered-output", "v0.4.0", revision, cargo_lock)
+        except ValueError:
+            return
+        raise RuntimeError("tampered archive passed validation")
+
+
+def main() -> None:
+    """Run validation or its bounded self-test."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--release-version")
+    parser.add_argument("--revision")
+    parser.add_argument("--cargo-lock", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        print("Optional-parser release-asset self-test passed")
+        return
+    if None in (args.source, args.output, args.release_version, args.revision, args.cargo_lock):
+        parser.error("validation requires source, output, release-version, revision, and cargo-lock")
+    staged = stage_release_assets(
+        args.source,
+        args.output,
+        args.release_version,
+        args.revision,
+        args.cargo_lock,
+    )
+    for path in staged:
+        print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/03-auto-release.yml
+++ b/.github/workflows/03-auto-release.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
 
       - name: Read version
         id: version
@@ -55,6 +57,41 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve clean optional-parser handoff
+        id: parser_pack
+        if: steps.release.outputs.eligible == 'true' && steps.tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          promotion_sha="$(git rev-parse HEAD^2)"
+          if [[ "$(git rev-parse 'HEAD^{tree}')" != "$(git rev-parse "$promotion_sha^{tree}")" ]]; then
+            echo "Main promotion tree differs from its verified dev parent" >&2
+            exit 1
+          fi
+          mapfile -t run_ids < <(
+            gh api \
+              "/repos/$GITHUB_REPOSITORY/actions/workflows/optional-parser-pack.yml/runs?event=workflow_dispatch&status=success&head_sha=$promotion_sha&per_page=100" \
+              --jq '.workflow_runs | sort_by(.run_number) | reverse | .[].id'
+          )
+          parser_pack_run_id=""
+          for run_id in "${run_ids[@]}"; do
+            mapfile -t artifacts < <(
+              gh api \
+                "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts" \
+                --jq '.artifacts[] | select(.name == "optional-parser-pack-release-assets" and (.expired | not)) | .id'
+            )
+            if [[ ${#artifacts[@]} -gt 0 ]]; then
+              parser_pack_run_id="$run_id"
+              break
+            fi
+          done
+          if [[ -z "$parser_pack_run_id" ]]; then
+            echo "No unexpired clean optional-parser handoff matches promotion $promotion_sha" >&2
+            exit 1
+          fi
+          echo "run_id=$parser_pack_run_id" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch release workflow
         if: steps.release.outputs.eligible == 'true' && steps.tag.outputs.exists == 'false'
         env:
@@ -62,4 +99,5 @@ jobs:
         run: |
           gh workflow run release.yml \
             --ref main \
-            --field version="v${{ steps.version.outputs.version }}"
+            --field version="v${{ steps.version.outputs.version }}" \
+            --field parser_pack_run_id="${{ steps.parser_pack.outputs.run_id }}"

--- a/.github/workflows/optional-parser-pack.yml
+++ b/.github/workflows/optional-parser-pack.yml
@@ -1225,3 +1225,49 @@ jobs:
           if-no-files-found: error
           compression-level: 0
           retention-days: 14
+
+      - name: Download clean release construction archives
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clean_construction && inputs.target == 'all' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: parser-pack-*-construction
+          path: ${{ runner.temp }}/parser-pack-release-source/construction
+          merge-multiple: true
+
+      - name: Download clean release construction receipts
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clean_construction && inputs.target == 'all' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: parser-pack-*-cargo-layer-receipt
+          path: ${{ runner.temp }}/parser-pack-release-source/receipts
+          merge-multiple: true
+
+      - name: Assemble clean release handoff
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clean_construction && inputs.target == 'all' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          source="$RUNNER_TEMP/parser-pack-release-source"
+          output="$RUNNER_TEMP/parser-pack-release-output"
+          mkdir -p "$output"
+          install -m 0644 \
+            "$RUNNER_TEMP/parser-pack-aggregate-output/optional-parser-pack-proof-aggregate.json" \
+            "$output/optional-parser-pack-proof-aggregate.json"
+          for target in x86_64-unknown-linux-gnu x86_64-pc-windows-msvc; do
+            install -m 0644 \
+              "$source/construction/projectatlas-broad-parser-$target.tar.zst" \
+              "$output/projectatlas-broad-parser-$target.tar.zst"
+            install -m 0644 \
+              "$source/receipts/cargo-layer-$target.json" \
+              "$output/cargo-layer-$target.json"
+          done
+
+      - name: Upload clean release handoff
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clean_construction && inputs.target == 'all' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: optional-parser-pack-release-assets
+          path: ${{ runner.temp }}/parser-pack-release-output/*
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ on:
         required: false
         default: false
         type: boolean
+      parser_pack_run_id:
+        description: "Successful clean optional-parser-pack workflow run for this release tree"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -78,6 +82,12 @@ jobs:
 
       - name: Issue checklist self-test
         run: python3 .github/scripts/issue-checklists.py --self-test
+
+      - name: Optional-parser release-asset self-test
+        run: python3 .github/scripts/verify-optional-parser-release-assets.py --self-test
+
+      - name: MCP composition integrity
+        run: python3 docs/benchmarks/harness/mcp_composition.py --self-test
 
       - name: Verify version
         run: |
@@ -440,10 +450,89 @@ jobs:
             throw "Packaged CLI behavior contract failed with exit code $LASTEXITCODE."
           }
 
+  parser-pack-assets:
+    name: optional-parser release assets
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PARSER_PACK_RUN_ID: ${{ inputs.parser_pack_run_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Bind clean handoff to this release tree
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$PARSER_PACK_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo "parser_pack_run_id must be a positive workflow run id" >&2
+            exit 1
+          fi
+          run_json="$RUNNER_TEMP/parser-pack-run.json"
+          gh api \
+            "/repos/$GITHUB_REPOSITORY/actions/runs/$PARSER_PACK_RUN_ID" \
+            > "$run_json"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            '
+              .repository.full_name == $repository
+              and .head_repository.full_name == $repository
+              and .path == ".github/workflows/optional-parser-pack.yml"
+              and .event == "workflow_dispatch"
+              and .status == "completed"
+              and .conclusion == "success"
+            ' \
+            "$run_json" \
+            > /dev/null
+          run_sha="$(jq -r '.head_sha' "$run_json")"
+          git fetch --no-tags origin "$run_sha"
+          if [[ "$(git rev-parse "$run_sha^{tree}")" != "$(git rev-parse 'HEAD^{tree}')" ]]; then
+            echo "Optional-parser handoff tree differs from the release tree" >&2
+            exit 1
+          fi
+          echo "PARSER_PACK_RUN_SHA=$run_sha" >> "$GITHUB_ENV"
+
+      - name: Download clean optional-parser handoff
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: optional-parser-pack-release-assets
+          path: ${{ runner.temp }}/optional-parser-release-source
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.parser_pack_run_id }}
+
+      - name: Validate and stage optional-parser release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/verify-optional-parser-release-assets.py \
+            --source "$RUNNER_TEMP/optional-parser-release-source" \
+            --output "$RUNNER_TEMP/optional-parser-release-assets" \
+            --release-version "$RELEASE_VERSION" \
+            --revision "$PARSER_PACK_RUN_SHA" \
+            --cargo-lock Cargo.lock
+
+      - name: Upload optional-parser release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: projectatlas-parser-packs
+          path: ${{ runner.temp }}/optional-parser-release-assets/*
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
   publish:
     name: publish
     if: ${{ !inputs.prepublish_only }}
-    needs: [prepublish-installer-smoke-unix, prepublish-installer-smoke-windows]
+    needs:
+      [prepublish-installer-smoke-unix, prepublish-installer-smoke-windows, parser-pack-assets]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -3663,6 +3663,8 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
     let workflow_dir = workspace_root.join(".github").join("workflows");
     let release_workflow = fs::read_to_string(workflow_dir.join("release.yml"))?;
     let auto_release_workflow = fs::read_to_string(workflow_dir.join("03-auto-release.yml"))?;
+    let optional_parser_workflow =
+        fs::read_to_string(workflow_dir.join("optional-parser-pack.yml"))?;
     let ci_workflow = fs::read_to_string(workflow_dir.join("ci.yml"))?;
     let dependabot = fs::read_to_string(workspace_root.join(".github").join("dependabot.yml"))?;
     let deny = fs::read_to_string(workspace_root.join("deny.toml"))?;
@@ -4043,6 +4045,49 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
             .into());
         }
     }
+    for required in [
+        "parser_pack_run_id:",
+        "parser-pack-assets:",
+        "optional-parser-pack-release-assets",
+        "github-token: ${{ github.token }}",
+        "run-id: ${{ inputs.parser_pack_run_id }}",
+        "verify-optional-parser-release-assets.py",
+        "projectatlas-parser-packs",
+        "MCP composition integrity",
+    ] {
+        if !release_workflow.contains(required) {
+            return Err(io::Error::other(format!(
+                "release workflow is missing optional-parser handoff guard {required:?}"
+            ))
+            .into());
+        }
+    }
+    for required in [
+        "github.event_name == 'workflow_dispatch' && inputs.clean_construction && inputs.target == 'all'",
+        "optional-parser-pack-release-assets",
+        "cargo-layer-$target.json",
+        "projectatlas-broad-parser-$target.tar.zst",
+    ] {
+        if !optional_parser_workflow.contains(required) {
+            return Err(io::Error::other(format!(
+                "optional-parser workflow is missing clean release handoff guard {required:?}"
+            ))
+            .into());
+        }
+    }
+    for required in [
+        "git rev-parse HEAD^2",
+        "optional-parser-pack-release-assets",
+        "head_sha=$promotion_sha",
+        "--field parser_pack_run_id=",
+    ] {
+        if !auto_release_workflow.contains(required) {
+            return Err(io::Error::other(format!(
+                "auto-release workflow is missing exact optional-parser handoff guard {required:?}"
+            ))
+            .into());
+        }
+    }
     if !auto_release_workflow.contains("permissions:\n  contents: read\n  actions: write") {
         return Err(io::Error::other(
             "auto-release workflow must narrow permissions to contents read and actions write",
@@ -4275,7 +4320,7 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
         "packaged-contract-runner-${{ matrix.suffix }}",
         "packaged-contract-runner-x86_64-pc-windows-msvc",
         "PROJECTATLAS_MCP_CONTRACT_EXECUTABLE",
-        "needs: [prepublish-installer-smoke-unix, prepublish-installer-smoke-windows]",
+        "[prepublish-installer-smoke-unix, prepublish-installer-smoke-windows, parser-pack-assets]",
         "pattern: projectatlas-*",
     ] {
         if !release.contains(required) {
@@ -4293,7 +4338,7 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
     let windows_prepublish = release
         .split("  prepublish-installer-smoke-windows:")
         .nth(1)
-        .and_then(|tail| tail.split("  publish:").next())
+        .and_then(|tail| tail.split("  parser-pack-assets:").next())
         .ok_or_else(|| io::Error::other("release omitted the Windows prepublish job"))?;
     for (job, body) in [("Unix", unix_prepublish), ("Windows", windows_prepublish)] {
         for contract in [

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -293,9 +293,11 @@ impl RelationAnalysisDraft {
         &self.report
     }
 
-    /// Exact external identities eligible for call-scoped rendezvous.
-    pub(super) const fn external_relation_identities(&self) -> &BTreeSet<ExternalRelationIdentity> {
-        &self.external_relation_identities
+    /// Move the call-scoped rendezvous identities out before output fitting.
+    pub(super) fn take_external_relation_identities(
+        &mut self,
+    ) -> BTreeSet<ExternalRelationIdentity> {
+        std::mem::take(&mut self.external_relation_identities)
     }
 
     /// Fit one complete adapter envelope by retaining the largest finding prefix.

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -663,7 +663,8 @@ fn load_relation_analysis_with_closure_deadline(
                 relations
                     .work
                     .intermediate_bytes
-                    .saturating_add(closure.decoded_bytes),
+                    .saturating_add(closure.decoded_bytes)
+                    .saturating_add(external_relation_identity_bytes),
             ),
             deadline,
             control,

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -2,11 +2,14 @@
 
 mod impact;
 
+use super::relations::{
+    ExternalRelationIdentity, external_relation_identities, load_detailed_relations,
+};
 use super::{
     DetailedRelationBudget, DetailedRelationNode, DetailedRelationQuery, DetailedRelationReport,
     DetailedRelationWork, RelationAnchor, RelationDirection, RelationNextCall, RelationPurpose,
     RelationResolutionFilter, RelationTotalState, ServiceError, ServiceResult,
-    load_detailed_relations, selected_project_binding,
+    selected_project_binding,
 };
 use impact::{LoadedVcs, digest_vcs_paths, impact_findings, load_vcs_paths};
 use projectatlas_core::graph::{
@@ -277,6 +280,8 @@ pub struct RelationAnalysisDraft {
     finding_offset: u32,
     /// Optional normalized VCS evidence identity.
     vcs_digest: Option<[u8; 32]>,
+    /// Exact external identities reached by the bounded detailed traversal.
+    external_relation_identities: BTreeSet<ExternalRelationIdentity>,
     /// Shared request cancellation and deadline retained through rendering.
     control: IndexWorkControl,
 }
@@ -286,6 +291,11 @@ impl RelationAnalysisDraft {
     #[must_use]
     pub const fn candidate_report(&self) -> &RelationAnalysisReport {
         &self.report
+    }
+
+    /// Exact external identities eligible for call-scoped rendezvous.
+    pub(super) const fn external_relation_identities(&self) -> &BTreeSet<ExternalRelationIdentity> {
+        &self.external_relation_identities
     }
 
     /// Fit one complete adapter envelope by retaining the largest finding prefix.
@@ -555,7 +565,16 @@ pub fn load_relation_analysis(
     query: &RelationAnalysisQuery,
     control: Option<&IndexWorkControl>,
 ) -> ServiceResult<RelationAnalysisDraft> {
-    load_relation_analysis_with_closure_deadline(store, query, control, None)
+    load_relation_analysis_with_closure_deadline(store, query, control, None, false)
+}
+
+/// Load analysis while retaining its bounded external traversal identities.
+pub(super) fn load_relation_analysis_for_federation(
+    store: &AtlasStore,
+    query: &RelationAnalysisQuery,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<RelationAnalysisDraft> {
+    load_relation_analysis_with_closure_deadline(store, query, control, None, true)
 }
 
 /// Load analysis with an optional earlier closure-stage deadline ceiling.
@@ -564,6 +583,7 @@ fn load_relation_analysis_with_closure_deadline(
     query: &RelationAnalysisQuery,
     control: Option<&IndexWorkControl>,
     closure_deadline_ceiling: Option<Instant>,
+    retain_external_relation_identities: bool,
 ) -> ServiceResult<RelationAnalysisDraft> {
     validate_analysis_query(query)?;
     let started = Instant::now();
@@ -599,6 +619,12 @@ fn load_relation_analysis_with_closure_deadline(
         .as_ref()
         .map_or(0, |cursor| cursor.finding_offset);
     let relations = load_detailed_relations(store, &relation_query, control)?;
+    let external_relation_identities = if retain_external_relation_identities {
+        external_relation_identities(&relations)
+    } else {
+        BTreeSet::new()
+    };
+    let external_relation_identity_bytes = serialized_bytes(&external_relation_identities)?;
     let cursor_snapshot = AnalysisCursorSnapshot {
         project: relations.anchor.entity.key().project(),
         generation: relations.generation,
@@ -665,7 +691,8 @@ fn load_relation_analysis_with_closure_deadline(
         relations
             .work
             .intermediate_bytes
-            .saturating_add(closure.decoded_bytes),
+            .saturating_add(closure.decoded_bytes)
+            .saturating_add(external_relation_identity_bytes),
     );
     let projection_allowance = analysis_allowance.saturating_sub(vcs_load.retained_bytes);
     let mut topology_bytes =
@@ -772,12 +799,14 @@ fn load_relation_analysis_with_closure_deadline(
         .saturating_add(vcs_load.retained_bytes)
         .saturating_add(topology_bytes)
         .saturating_add(initial_finding_bytes)
+        .saturating_add(external_relation_identity_bytes)
         .saturating_add(supplemental_work.hydrated_symbol_peak_bytes);
     let final_peak = relations
         .work
         .intermediate_bytes
         .saturating_add(closure.decoded_bytes)
-        .saturating_add(supplemental_work.retained_composition_bytes);
+        .saturating_add(supplemental_work.retained_composition_bytes)
+        .saturating_add(external_relation_identity_bytes);
     let peak_intermediate_bytes = hydration_peak.max(final_peak);
     let full_finding_count = u32::try_from(findings.len()).map_err(|_overflow| {
         ServiceError::InvalidInput("analysis finding count overflowed".to_string())
@@ -869,6 +898,7 @@ fn load_relation_analysis_with_closure_deadline(
         replay_relation_cursor,
         finding_offset,
         vcs_digest,
+        external_relation_identities,
         control: analysis_control,
     })
 }

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -414,6 +414,7 @@ fn analysis_modes_are_closed_and_partial_evidence_stays_inconclusive() -> Result
         &analysis_query(RelationAnalysisMode::Architecture)?,
         None,
         Some(Instant::now()),
+        false,
     )?;
     let (deadline_limited, _) = deadline_limited.fit_output::<_, ServiceError, _>(|report| {
         serde_json::to_vec(report).map_err(ServiceError::from)

--- a/crates/projectatlas-service/src/federation.rs
+++ b/crates/projectatlas-service/src/federation.rs
@@ -596,13 +596,13 @@ pub fn load_federated_relation_analysis(
     )?;
     let operation: ServiceResult<(RelationAnalysisDraft, RendezvousLoad)> = (|| {
         check_control(control)?;
-        let primary = super::analysis::load_relation_analysis_for_federation(
+        let mut primary = super::analysis::load_relation_analysis_for_federation(
             stores[0].store(),
             &primary_query,
             control,
         )?;
+        let rendezvous_identities = primary.take_external_relation_identities();
         let candidate = primary.candidate_report();
-        let rendezvous_identities = primary.external_relation_identities();
         let primary_edges = u64::from(candidate.work.relations.inspected_edges)
             .saturating_add(u64::from(candidate.work.closure_inspected_edges));
         let primary_rows = u64::from(candidate.work.relations.database_returned_rows)
@@ -611,7 +611,7 @@ pub fn load_federated_relation_analysis(
         let rendezvous = load_rendezvous(
             &stores,
             &query.relations,
-            rendezvous_identities,
+            &rendezvous_identities,
             remaining_edges,
             aggregate_row_limit(budget).saturating_sub(primary_rows),
             budget
@@ -1229,7 +1229,7 @@ mod tests {
             "read-only federation changed database bytes",
         )?;
 
-        let analysis = load_federated_relation_analysis(
+        let mut analysis = load_federated_relation_analysis(
             open_participants(&participants)?,
             &RelationAnalysisQuery {
                 relations: query,
@@ -1241,6 +1241,13 @@ mod tests {
                 include_dead_code: false,
             },
             None,
+        )?;
+        require(
+            analysis
+                .primary
+                .take_external_relation_identities()
+                .is_empty(),
+            "federated analysis retained temporary rendezvous identities through output fitting",
         )?;
         let (analysis, _) =
             analysis.fit_output(|report| serde_json::to_vec(report).map_err(ServiceError::from))?;

--- a/crates/projectatlas-service/src/federation.rs
+++ b/crates/projectatlas-service/src/federation.rs
@@ -3,7 +3,7 @@
 use super::analysis::{RelationAnalysisDraft, RelationAnalysisQuery, RelationAnalysisReport};
 use super::relations::{
     DetailedRelationBudget, DetailedRelationPageDraft, DetailedRelationQuery,
-    DetailedRelationReport,
+    DetailedRelationReport, ExternalRelationIdentity, external_relation_identities,
 };
 use super::{ServiceError, ServiceResult, selected_project_binding};
 use projectatlas_core::graph::{
@@ -358,6 +358,8 @@ struct FederatedContext {
     rendezvous_limits: Vec<GraphLimitKind>,
     /// Work completed before adapter output fitting.
     base_work: FederatedRelationWork,
+    /// Temporary exact identity-set bytes retained during rendezvous discovery.
+    rendezvous_identity_bytes: u64,
     /// Existing aggregate relation and output budget.
     budget: DetailedRelationBudget,
 }
@@ -380,7 +382,10 @@ impl FederatedContext {
         let mut work = self.base_work.clone();
         work.rendered_output_bytes = primary.work.rendered_output_bytes;
         work.intermediate_bytes = federated_intermediate_bytes(
-            primary.work.intermediate_bytes,
+            primary
+                .work
+                .intermediate_bytes
+                .saturating_add(self.rendezvous_identity_bytes),
             &self.participants,
             &self.rendezvous,
             primary.continuation.as_deref(),
@@ -413,7 +418,10 @@ impl FederatedContext {
         let mut work = self.base_work.clone();
         work.rendered_output_bytes = primary.work.rendered_output_bytes;
         work.intermediate_bytes = federated_intermediate_bytes(
-            primary.work.peak_intermediate_bytes,
+            primary
+                .work
+                .peak_intermediate_bytes
+                .saturating_add(self.rendezvous_identity_bytes),
             &self.participants,
             &self.rendezvous,
             primary.continuation.as_deref(),
@@ -512,7 +520,7 @@ pub fn load_federated_detailed_relations(
         &captured.cursor_participants,
         budget,
     )?;
-    let operation: ServiceResult<(DetailedRelationPageDraft, RendezvousLoad)> = (|| {
+    let operation: ServiceResult<(DetailedRelationPageDraft, RendezvousLoad, u64)> = (|| {
         check_control(control)?;
         let primary = super::relations::load_detailed_relation_page(
             stores[0].store(),
@@ -520,24 +528,33 @@ pub fn load_federated_detailed_relations(
             control,
         )?;
         let candidate = primary.report_for_prefix(primary.candidate_rows())?;
+        let rendezvous_identities = external_relation_identities(&candidate);
+        let rendezvous_identity_bytes = u64::try_from(
+            serde_json::to_vec(&rendezvous_identities)?.len(),
+        )
+        .map_err(|_overflow| {
+            ServiceError::InvalidInput("federated identity byte count overflowed".to_string())
+        })?;
         let primary_edges = u64::from(candidate.work.inspected_edges);
         let primary_rows = u64::from(candidate.work.database_returned_rows);
         let remaining_edges = u64::from(budget.edges()).saturating_sub(primary_edges);
         let rendezvous = load_rendezvous(
             &stores,
             query,
+            &rendezvous_identities,
             remaining_edges,
             aggregate_row_limit(budget).saturating_sub(primary_rows),
             budget
                 .intermediate_bytes()
-                .saturating_sub(candidate.work.intermediate_bytes),
+                .saturating_sub(candidate.work.intermediate_bytes)
+                .saturating_sub(rendezvous_identity_bytes),
             started,
             control,
         )?;
-        Ok((primary, rendezvous))
+        Ok((primary, rendezvous, rendezvous_identity_bytes))
     })();
     let (closed, close_ms, close_error) = close_participants(stores);
-    let (primary, rendezvous) = operation?;
+    let (primary, rendezvous, rendezvous_identity_bytes) = operation?;
     if let Some(error) = close_error {
         return Err(error);
     }
@@ -551,6 +568,7 @@ pub fn load_federated_detailed_relations(
             rendezvous: rendezvous.rows,
             rendezvous_limits: rendezvous.reached_limits,
             base_work,
+            rendezvous_identity_bytes,
             budget,
         },
     })
@@ -578,9 +596,13 @@ pub fn load_federated_relation_analysis(
     )?;
     let operation: ServiceResult<(RelationAnalysisDraft, RendezvousLoad)> = (|| {
         check_control(control)?;
-        let primary =
-            super::analysis::load_relation_analysis(stores[0].store(), &primary_query, control)?;
+        let primary = super::analysis::load_relation_analysis_for_federation(
+            stores[0].store(),
+            &primary_query,
+            control,
+        )?;
         let candidate = primary.candidate_report();
+        let rendezvous_identities = primary.external_relation_identities();
         let primary_edges = u64::from(candidate.work.relations.inspected_edges)
             .saturating_add(u64::from(candidate.work.closure_inspected_edges));
         let primary_rows = u64::from(candidate.work.relations.database_returned_rows)
@@ -589,6 +611,7 @@ pub fn load_federated_relation_analysis(
         let rendezvous = load_rendezvous(
             &stores,
             &query.relations,
+            rendezvous_identities,
             remaining_edges,
             aggregate_row_limit(budget).saturating_sub(primary_rows),
             budget
@@ -614,6 +637,7 @@ pub fn load_federated_relation_analysis(
             rendezvous: rendezvous.rows,
             rendezvous_limits: rendezvous.reached_limits,
             base_work,
+            rendezvous_identity_bytes: 0,
             budget,
         },
     })
@@ -699,17 +723,20 @@ fn capture_federation(
 fn load_rendezvous(
     stores: &[FederatedStore],
     query: &DetailedRelationQuery,
+    identities: &BTreeSet<ExternalRelationIdentity>,
     mut remaining_edges: u64,
     mut remaining_rows: u64,
     mut remaining_intermediate_bytes: u64,
     started: Instant,
     control: Option<&IndexWorkControl>,
 ) -> ServiceResult<RendezvousLoad> {
-    if !matches!(
-        query.resolution,
-        super::relations::RelationResolutionFilter::Any
-            | super::relations::RelationResolutionFilter::External
-    ) {
+    if identities.is_empty()
+        || !matches!(
+            query.resolution,
+            super::relations::RelationResolutionFilter::Any
+                | super::relations::RelationResolutionFilter::External
+        )
+    {
         return Ok(RendezvousLoad {
             rows: Vec::new(),
             database_rows: 0,
@@ -802,6 +829,9 @@ fn load_rendezvous(
                     external.system.as_str().to_string(),
                     external.identity.as_str().to_string(),
                 );
+                if !identities.contains(&key) {
+                    continue;
+                }
                 let project = row.relation.key().project();
                 let generation = row.relation.generation();
                 let group = groups.entry(key).or_insert_with(|| FederatedRendezvous {
@@ -1149,7 +1179,11 @@ mod tests {
             .iter()
             .map(|(_, database)| fs::read(database))
             .collect::<Result<Vec<_>, _>>()?;
-        let query = relation_query(None, RelationResolutionFilter::External)?;
+        let query = relation_query(
+            None,
+            RelationResolutionFilter::External,
+            RelationDirection::Outbound,
+        )?;
         let draft =
             load_federated_detailed_relations(open_participants(&participants)?, &query, None)?;
         let (report, encoded) = draft.fit_output(None, |report| {
@@ -1195,9 +1229,81 @@ mod tests {
             "read-only federation changed database bytes",
         )?;
 
+        let analysis = load_federated_relation_analysis(
+            open_participants(&participants)?,
+            &RelationAnalysisQuery {
+                relations: query,
+                mode: crate::analysis::RelationAnalysisMode::Architecture,
+                trace_target: None,
+                vcs: None,
+                include_communities: false,
+                include_cycles: false,
+                include_dead_code: false,
+            },
+            None,
+        )?;
+        let (analysis, _) =
+            analysis.fit_output(|report| serde_json::to_vec(report).map_err(ServiceError::from))?;
+        require(
+            analysis.rendezvous.len() == 2
+                && analysis
+                    .rendezvous
+                    .iter()
+                    .flat_map(|row| &row.evidence)
+                    .all(|evidence| {
+                        matches!(
+                            evidence.source.selector(),
+                            EntitySelector::File { path } if path.as_str() == "src/same.rs"
+                        )
+                    }),
+            "analysis rendezvous escaped the primary anchored traversal",
+        )?;
+
+        let inbound_query = relation_query(
+            None,
+            RelationResolutionFilter::External,
+            RelationDirection::Inbound,
+        )?;
+        let inbound = load_federated_detailed_relations(
+            open_participants(&participants)?,
+            &inbound_query,
+            None,
+        )?;
+        let (inbound, _) = inbound.fit_output(None, |report| {
+            serde_json::to_string(report).map_err(ServiceError::from)
+        })?;
+        require(
+            inbound.rendezvous.is_empty() && inbound.work.rendezvous_database_rows == 0,
+            "inbound traversal scanned or returned unrelated external rendezvous",
+        )?;
+        let inbound_analysis = load_federated_relation_analysis(
+            open_participants(&participants)?,
+            &RelationAnalysisQuery {
+                relations: inbound_query,
+                mode: crate::analysis::RelationAnalysisMode::Architecture,
+                trace_target: None,
+                vcs: None,
+                include_communities: false,
+                include_cycles: false,
+                include_dead_code: false,
+            },
+            None,
+        )?;
+        let (inbound_analysis, _) = inbound_analysis
+            .fit_output(|report| serde_json::to_vec(report).map_err(ServiceError::from))?;
+        require(
+            inbound_analysis.rendezvous.is_empty()
+                && inbound_analysis.work.rendezvous_database_rows == 0,
+            "inbound analysis scanned or returned unrelated external rendezvous",
+        )?;
+
         let resolved = load_federated_detailed_relations(
             open_participants(&participants)?,
-            &relation_query(None, RelationResolutionFilter::Resolved)?,
+            &relation_query(
+                None,
+                RelationResolutionFilter::Resolved,
+                RelationDirection::Outbound,
+            )?,
             None,
         )?;
         let (resolved, _) = resolved.fit_output(None, |report| {
@@ -1219,7 +1325,11 @@ mod tests {
         )?;
         let stale = load_federated_detailed_relations(
             open_participants(&participants)?,
-            &relation_query(Some(cursor), RelationResolutionFilter::External)?,
+            &relation_query(
+                Some(cursor),
+                RelationResolutionFilter::External,
+                RelationDirection::Outbound,
+            )?,
             None,
         );
         require(
@@ -1236,7 +1346,11 @@ mod tests {
         control.cancel();
         let canceled = load_federated_detailed_relations(
             open_participants(&participants)?,
-            &relation_query(None, RelationResolutionFilter::External)?,
+            &relation_query(
+                None,
+                RelationResolutionFilter::External,
+                RelationDirection::Outbound,
+            )?,
             Some(&control),
         );
         require(canceled.is_err(), "pre-canceled federation returned rows")?;
@@ -1248,7 +1362,7 @@ mod tests {
         Ok(())
     }
 
-    /// Publish two exact external imports for one same-named local source.
+    /// Publish three anchored imports plus one unrelated same-family import.
     fn publish_fixture(
         root: &Path,
         database: &Path,
@@ -1256,6 +1370,7 @@ mod tests {
     ) -> Result<(), Box<dyn Error>> {
         fs::create_dir_all(root.join("src"))?;
         fs::write(root.join("src/same.rs"), "pub fn same() {}\n")?;
+        fs::write(root.join("src/unrelated.rs"), "pub fn unrelated() {}\n")?;
         let mut store = AtlasStore::open_for_project(database, root)?;
         let project = store
             .project_instance_id()?
@@ -1267,9 +1382,16 @@ mod tests {
             },
             generation,
         )?;
-        let mut entities = vec![source.clone()];
+        let unrelated_source = GraphEntity::new(
+            project,
+            EntitySelector::File {
+                path: RepositoryFilePath::new(Path::new("src/unrelated.rs"))?,
+            },
+            generation,
+        )?;
+        let mut entities = vec![source.clone(), unrelated_source.clone()];
         let mut relations = Vec::new();
-        for identity in ["package/a", "package/b"] {
+        for identity in ["package/a", "package/b", "package/c"] {
             let external = GraphEntity::new(
                 project,
                 EntitySelector::External {
@@ -1290,11 +1412,31 @@ mod tests {
             )?);
             entities.push(external);
         }
+        let unrelated_external = GraphEntity::new(
+            project,
+            EntitySelector::External {
+                external: ExternalSelector {
+                    system: GraphIdentityText::new("registry.example")?,
+                    identity: GraphIdentityText::new("package/unrelated")?,
+                },
+            },
+            generation,
+        )?;
+        relations.push(LogicalRelation::new(
+            &unrelated_source,
+            GraphRelationKind::Legacy(RelationKind::Imports),
+            RelationResolution::external(&unrelated_external)?,
+            projectatlas_core::graph::ConfidenceClass::Exact,
+            Completeness::Complete,
+            generation,
+        )?);
+        entities.push(unrelated_external);
         let mut publication = store.begin_index_publication("federation-fixture")?;
         publication.begin_scan_replacement()?;
         publication.upsert_scan_node_batch(&[
             fixture_folder_node("src"),
             fixture_file_node("src/same.rs"),
+            fixture_file_node("src/unrelated.rs"),
         ])?;
         publication.finish_scan_replacement()?;
         publication.replace_repository_graph(project, &entities, &relations, &[], &[])?;
@@ -1323,18 +1465,19 @@ mod tests {
     fn relation_query(
         cursor: Option<String>,
         resolution: RelationResolutionFilter,
+        direction: RelationDirection,
     ) -> Result<DetailedRelationQuery, Box<dyn Error>> {
         Ok(DetailedRelationQuery {
             anchor: RelationAnchor::File {
                 file: RepositoryFilePath::new(Path::new("src/same.rs"))?,
             },
-            direction: RelationDirection::Outbound,
+            direction,
             relation: Some(GraphRelationKind::Legacy(RelationKind::Imports)),
             minimum_confidence: projectatlas_core::graph::ConfidenceClass::Low,
             resolution,
             include_occurrences: false,
             budget: DetailedRelationBudget::from_graph_limits(GraphLimits::new(
-                1,
+                2,
                 1,
                 1,
                 512 * 1_024,

--- a/crates/projectatlas-service/src/relations.rs
+++ b/crates/projectatlas-service/src/relations.rs
@@ -536,6 +536,9 @@ pub struct DetailedRelationReport {
     pub rows: Vec<DetailedRelationRow>,
 }
 
+/// Exact typed external identity eligible for call-scoped rendezvous.
+pub(super) type ExternalRelationIdentity = (String, String, String);
+
 /// Cursor algorithm responsible for traversal-state interpretation.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -1719,6 +1722,26 @@ pub(super) fn relation_matches(relation: &LogicalRelation, query: &DetailedRelat
                 matches!(relation.resolution(), RelationResolution::External { .. })
             }
         }
+}
+
+/// Retain exact external identities reached by one bounded traversal page.
+pub(super) fn external_relation_identities(
+    report: &DetailedRelationReport,
+) -> BTreeSet<ExternalRelationIdentity> {
+    report
+        .rows
+        .iter()
+        .filter_map(|row| {
+            let RelationResolution::External { external, .. } = row.relation.resolution() else {
+                return None;
+            };
+            Some((
+                row.relation.kind().as_str().to_string(),
+                external.system.as_str().to_string(),
+                external.identity.as_str().to_string(),
+            ))
+        })
+        .collect()
 }
 
 /// Convert confidence classes to their stable descending rank.

--- a/docs/benchmarks/harness/mcp_composition.py
+++ b/docs/benchmarks/harness/mcp_composition.py
@@ -31,6 +31,8 @@ FIXTURES = ROOT / "docs/benchmarks/fixtures/mcp-composition"
 REQUESTS = ROOT / "docs/benchmarks/v0.4-mcp-composition-requests.json"
 DEFAULT_WORK = ROOT / "target/benchmarks/mcp-composition/current"
 DEFAULT_OUTPUT = ROOT / "docs/benchmarks/v0.4-mcp-composition-raw.json"
+PUBLISHED_EVALUATION = ROOT / "docs/benchmarks/v0.4-mcp-composition-evaluation.json"
+PUBLISHED_EVALUATION_MARKDOWN = ROOT / "docs/benchmarks/v0.4-mcp-composition-evaluation.md"
 CONTINUATION = re.compile(r'^\s+(?:continuation|cursor): "(.*)"$', re.MULTILINE)
 PURPOSES = {
     "clean": {
@@ -587,6 +589,26 @@ def self_test_git_environment_isolation() -> None:
             raise RuntimeError("Git fixture isolation changed the sentinel repository")
 
 
+def validate_published_raw_digest() -> None:
+    evaluation = json.loads(PUBLISHED_EVALUATION.read_text(encoding="utf-8"))
+    provenance = evaluation.get("inputs")
+    if not isinstance(provenance, dict):
+        raise RuntimeError("MCP composition evaluation provenance is missing")
+    expected_path = str(DEFAULT_OUTPUT.relative_to(ROOT)).replace("\\", "/")
+    if provenance.get("raw") != expected_path:
+        raise RuntimeError("MCP composition evaluation names a different raw input")
+    expected_digest = hashlib.sha256(DEFAULT_OUTPUT.read_bytes()).hexdigest()
+    if provenance.get("raw_sha256") != expected_digest:
+        raise RuntimeError("MCP composition JSON raw-input digest is stale")
+    markdown = PUBLISHED_EVALUATION_MARKDOWN.read_text(encoding="utf-8")
+    match = re.search(
+        r"The raw formal result SHA-256 is\s*`([0-9a-f]{64})`\.",
+        markdown,
+    )
+    if match is None or match.group(1) != expected_digest:
+        raise RuntimeError("MCP composition Markdown raw-input digest is stale")
+
+
 def remove_tree(path: Path, *, allowed_parent: Path) -> None:
     absolute = Path(os.path.abspath(path))
     allowed = Path(os.path.abspath(allowed_parent))
@@ -1091,6 +1113,7 @@ def main() -> None:
     args = parser.parse_args()
     if args.self_test:
         self_test_git_environment_isolation()
+        validate_published_raw_digest()
         print("MCP composition harness self-test passed")
         return
     if args.runtime is None:

--- a/docs/benchmarks/v0.4-mcp-composition-evaluation.json
+++ b/docs/benchmarks/v0.4-mcp-composition-evaluation.json
@@ -14,7 +14,7 @@
     "requests": "docs/benchmarks/v0.4-mcp-composition-requests.json",
     "harness": "docs/benchmarks/harness/mcp_composition.py",
     "raw": "docs/benchmarks/v0.4-mcp-composition-raw.json",
-    "raw_sha256": "c033b1bea2446836699eeebf1f5fcfd2c1a2895e81fb563f993b5ae5122e46f7",
+    "raw_sha256": "d3e2eb5c6a4185f16e1be49a99aad1062562f1ddb3cb5623fb61b20acc16887f",
     "excluded_runs": "docs/benchmarks/v0.4-mcp-composition-excluded-runs.json",
     "agent_trials": "docs/benchmarks/v0.4-mcp-agent-trials.json"
   },

--- a/docs/benchmarks/v0.4-mcp-composition-evaluation.md
+++ b/docs/benchmarks/v0.4-mcp-composition-evaluation.md
@@ -86,7 +86,7 @@ The checked-in contract consists of:
 - [all excluded and superseded runs](v0.4-mcp-composition-excluded-runs.json).
 
 The raw formal result SHA-256 is
-`c033b1bea2446836699eeebf1f5fcfd2c1a2895e81fb563f993b5ae5122e46f7`.
+`d3e2eb5c6a4185f16e1be49a99aad1062562f1ddb3cb5623fb61b20acc16887f`.
 Rerun it from the repository root with:
 
 ```powershell

--- a/docs/projectatlas-3-architecture.md
+++ b/docs/projectatlas-3-architecture.md
@@ -2093,14 +2093,31 @@ flowchart TB
     CleanBefore --> Build[Contained offline candidate build<br/>batched owned targets]
     Build --> Assemble[Two concurrent independent<br/>audit, assembly, and archive lanes]
     Assemble --> Verify[Digest, license, native, containment, lifecycle, package, and fresh-runner proof]
-    Verify --> Publish[Immutable construction artifact]
+    Verify --> Publish[Immutable construction artifact<br/>and platform proof]
     Verify --> CleanAfter[Remove owned outputs and Windows broker]
     Publish --> Receipt[Bounded target disposition receipt<br/>including disabled]
+    Publish --> Aggregate[Exact Linux and Windows<br/>aggregate proof]
+    Aggregate --> CleanHandoff{Explicit clean all-platform dispatch?}
+    CleanHandoff -->|no| NoHandoff[No release handoff]
+    CleanHandoff -->|yes| Handoff[Supported archives, aggregate proof,<br/>and clean receipts]
+    Handoff --> Release[02-Release binds successful run<br/>and identical candidate tree]
+    Release --> Assets[Versioned Linux and Windows archives,<br/>proof, and SHA256SUMS]
     CleanAfter --> Receipt
     Receipt --> Trust{Cache-save eligible?<br/>trusted, non-clean, reuse-enabled}
     Trust -->|no| NoSave[Do not save cache state]
     Trust -->|yes| Save[Save exact dependency layer]
 ```
+
+Only an explicit `clean_construction=true`, `target=all` dispatch emits the
+release handoff. `02-Release` verifies the referenced run belongs to the same
+repository and workflow, completed successfully, and has a Git tree identical
+to the release checkout. It then checks the aggregate target set, candidate
+revision and version, clean no-restore receipts, Cargo lock digest, archive
+names, sizes, SHA-256 digests, fresh-host isolation, network denial, grammar
+probes, and memory/process cleanup before staging versioned Linux and Windows
+pack archives plus the aggregate proof. `03-Auto-Release` selects that handoff
+from the exact identical-tree `dev` promotion parent; stale, partial, reused,
+expired, or altered handoffs fail before publication.
 
 The retained policy is measurement-owned, not platform folklore:
 

--- a/openspec/changes/complete-v040-release-readiness/design.md
+++ b/openspec/changes/complete-v040-release-readiness/design.md
@@ -86,7 +86,7 @@ Until readiness is complete, `main`, tags, and releases remain untouched. If any
 - **A green older run is mistaken for final evidence** → Compare every required run's `headSha` with the locked candidate before closure.
 - **Supported optional-parser archives exist only as expiring workflow artifacts** → Require one explicit clean handoff, verify it against the exact release tree, and stage both supported archives plus aggregate proof as versioned release assets.
 - **Secondary federation rows escape the requested anchor or direction** → Derive the eligible typed external identities from the bounded primary traversal and reject every other secondary row.
-- **Published benchmark metadata names stale input** → Compute the raw input SHA-256 and compare both published representations in the release gate.
+- **Published MCP composition metadata names stale input** → Compute its raw input SHA-256 and compare both published representations in the release gate.
 - **The milestone gate becomes circular around post-release cleanup** → Keep #311 prepublication-only and create the non-milestone post-release owner before closure.
 - **A prepublish run is mistaken for publication** → Require `prepublish_only=true`, verify no tag or release was created, and leave publication to the existing main-triggered workflow.
 - **Installer or plugin state passes in source but fails when packaged** → Require real package/installer smoke and installed CLI/MCP behavior from the release workflow.

--- a/openspec/changes/complete-v040-release-readiness/design.md
+++ b/openspec/changes/complete-v040-release-readiness/design.md
@@ -1,13 +1,13 @@
 ## Context
 
-Issue #308 and its feature proof are closed, #340 is merged and closed, and #341 has only its final explicit empty-cache construction proof left. Issue #311 still contains an obsolete split of the pre-closure #308 program, is not mapped in `openspec/issue-map.json`, and includes a post-release cleanup checkbox that cannot truthfully be completed before publication.
+Issue #308 and its feature proof are closed, #340 and #341 are merged and closed, and the first #311 reconciliation reached `dev`. Fresh Codex review of the exact promotion head then found three blockers: `02-Release` did not publish the supported optional-parser archives, federated rendezvous discovery reapplied trust filters without preserving the primary anchor and direction, and the published MCP composition evaluation named a stale raw-input digest. The affected candidate and proof tasks must be reopened rather than inferred from the older green head.
 
 The existing release path already has the required mechanics:
 
 - `01-CI` owns Rust quality and source-built CLI/MCP E2E smoke on Linux, Windows, macOS x64, and macOS arm64.
-- `optional-parser-pack` owns explicit cache-free Linux and Windows optional-pack construction and full runtime proof.
-- `02-Release` owns version validation, package construction, installer smoke, release assets, and publication; `prepublish_only=true` exercises the package and installer path without publishing.
-- `03-Auto-Release` dispatches `02-Release` after an eligible version reaches `main`.
+- `optional-parser-pack` owns explicit cache-free Linux and Windows optional-pack construction, full runtime proof, and the clean all-platform handoff consumed by release.
+- `02-Release` owns version validation, package construction, installer smoke, release assets, and publication; `prepublish_only=true` exercises the package, optional-pack handoff, and installer path without publishing.
+- `03-Auto-Release` dispatches `02-Release` after an eligible version reaches `main` and supplies the exact successful clean optional-pack run for the identical promotion tree.
 - `02-Release` requires every issue in milestone `v0.4.0-00` to be mapped, checked, and closed before publication.
 
 The user also requires branch, worktree, and external ProjectAtlas checkout cleanup only after v0.4.0 is published and independently verified. Release readiness and post-release cleanup therefore need separate owners even though both remain part of the same active release goal.
@@ -18,30 +18,43 @@ The user also requires branch, worktree, and external ProjectAtlas checkout clea
 
 - Make #311 a concise, mapped, mechanically synchronized readiness owner.
 - Prove one exact final `dev` head through the existing local and hosted release surfaces.
+- Fix and prove every fresh exact-head Codex finding before candidate reconciliation.
+- Publish both supported optional-parser archives only after binding them to one clean all-platform run and the exact release tree.
+- Keep federated rendezvous evidence inside the primary anchor/direction result without changing SQLite schema or query ownership.
 - Keep `main`, tags, and GitHub releases untouched until all prepublication evidence is green.
 - Prepare an exact `dev`-to-`main` promotion that can pass the existing milestone gate.
 - Preserve a durable post-release owner for independent publication verification and safe workspace consolidation.
 
 **Non-Goals:**
 
-- Add or change product runtime behavior, Rust APIs, crate boundaries, SQLite state, CLI/MCP schemas, package formats, or dependencies.
+- Add a crate, dependency, SQLite schema, migration, write path, identity-specific database query, CLI/MCP schema, or second release path.
 - Create a second release workflow, test framework, evidence ledger, or task-specific receipt scheme.
 - Reopen completed #308 work, absorb #314 into v0.4.0, or claim hosted success from local tests.
 - Delete any branch, worktree, or checkout before publication verification and unique-work inventory.
 
 ## Decisions
 
-### Reuse the existing release workflows
+### Extend the existing release workflows
 
-The change records and executes the existing `01-CI`, `optional-parser-pack`, `02-Release`, and `03-Auto-Release` contracts. No workflow or release orchestrator is added.
+The change keeps `01-CI`, `optional-parser-pack`, `02-Release`, and `03-Auto-Release` as the only release path. `optional-parser-pack` emits one clean release handoff only for an explicit all-platform clean construction. `02-Release` requires the referenced successful run, verifies the same repository/workflow/event and identical candidate tree, then validates the aggregate proof, clean receipts, archive sizes, and archive digests before staging versioned release assets. `03-Auto-Release` discovers the successful clean handoff on the exact promotion parent and passes its run identifier.
 
 A new release driver was rejected because the current workflows already own the real package, installer, platform, and publication boundaries. Duplicating them would create drift without increasing proof.
+
+### Scope rendezvous to the primary traversal
+
+The primary project remains the only anchor and direction authority. Its already bounded detailed traversal yields the exact typed external identities eligible for cross-root rendezvous. Secondary projects may contribute evidence only for that bounded identity set. Analysis retains the same derived set from its existing detailed traversal so it does not repeat the database read. An empty set returns immediately.
+
+The existing indexed relation-family read remains the storage boundary. A bounded ordered set membership check fixes the correctness defect in `O(primary rows log primary rows + bounded secondary rows log primary rows)` time and bounded memory. A new SQLite query shape or index was rejected because this finding does not establish a schema or plan deficit; that change would require separate query-plan and representative-scale evidence.
+
+### Bind published benchmark metadata to its raw input
+
+Both the human-readable and machine-readable MCP composition evaluations name the SHA-256 of the same raw JSON input. The existing release gate computes and compares that digest directly; no benchmark receipt framework or task-specific identifier is added.
 
 ### Bind readiness to one exact promotion head
 
 First, lock one release-content head after #341 is closed and every v0.4.0 implementation and readiness artifact is merged. Run the complete local gates, ordinary CI, explicit clean optional-parser construction, prepublish release packaging, and review disposition on that head.
 
-Once those tasks are true, one bounded reconciliation commit may change only the #311 OpenSpec task checkbox state. Mirror that state to the GitHub issue. Because `dev` is protected, land the task-state commit through a merge commit whose parent is that commit and whose Git tree is identical; the resulting `dev` merge SHA is the exact promotion head. Clean optional-parser and prepublish proof carry forward because the verified tree change affects no runtime, workflow, package, installer, or documentation input. Ordinary exact-head CI, strict OpenSpec, IssueOps, ProjectAtlas low lint, and review checks then run as post-commit closure gates on that `dev` SHA outside the reconciled checklist; #311 remains open until they pass. Any other path change, non-identical protection merge, or later tree change invalidates the affected proof and restarts the boundary at the release-content lock.
+Once those tasks are true, one bounded reconciliation commit may change only the #311 OpenSpec task checkbox state. Mirror that state to the GitHub issue. Because `dev` is protected, land the task-state commit through a merge commit whose parent is that commit and whose Git tree is identical; the resulting `dev` merge SHA is the exact promotion head. Ordinary exact-head CI, strict OpenSpec, IssueOps, ProjectAtlas low lint, review checks, and a fresh clean optional-parser handoff then run on that promotion head; #311 remains open until they pass. Any other path change, non-identical protection merge, or later tree change invalidates the affected proof and restarts the boundary at the release-content lock.
 
 Promote only when `main` is an ancestor of the promotion head, and use a merge commit rather than squash or rebase. The resulting `main` commit must have the promotion head as a parent and the same Git tree. Its new SHA is therefore not a content change, and the actual `02-Release` run still repeats verification, packaging, and installer smoke on that `main` SHA before publication.
 
@@ -71,6 +84,9 @@ Until readiness is complete, `main`, tags, and releases remain untouched. If any
 - **Protected `dev` landing creates an unproven promotion SHA** → Require the protection merge to contain the task-state commit as a parent with an identical tree, then run closure gates on the resulting `dev` SHA.
 - **Promotion changes the verified tree or hides it behind squash/rebase** → Require `main` ancestry, a merge commit with the promotion head as a parent, identical Git trees, and actual release verification on the resulting `main` SHA.
 - **A green older run is mistaken for final evidence** → Compare every required run's `headSha` with the locked candidate before closure.
+- **Supported optional-parser archives exist only as expiring workflow artifacts** → Require one explicit clean handoff, verify it against the exact release tree, and stage both supported archives plus aggregate proof as versioned release assets.
+- **Secondary federation rows escape the requested anchor or direction** → Derive the eligible typed external identities from the bounded primary traversal and reject every other secondary row.
+- **Published benchmark metadata names stale input** → Compute the raw input SHA-256 and compare both published representations in the release gate.
 - **The milestone gate becomes circular around post-release cleanup** → Keep #311 prepublication-only and create the non-milestone post-release owner before closure.
 - **A prepublish run is mistaken for publication** → Require `prepublish_only=true`, verify no tag or release was created, and leave publication to the existing main-triggered workflow.
 - **Installer or plugin state passes in source but fails when packaged** → Require real package/installer smoke and installed CLI/MCP behavior from the release workflow.
@@ -81,12 +97,13 @@ Until readiness is complete, `main`, tags, and releases remain untouched. If any
 1. Land the bounded installer trust fix and reconcile all live review feedback.
 2. Add this change to `openspec/issue-map.json` and replace #311's obsolete body with the exact local checklist.
 3. Complete and close #341 after its Linux and Windows empty-cache proof and land its reconciled checklist state.
-4. Merge all remaining readiness artifacts into `dev`, then lock the release-content head.
-5. Run the complete local gates, exact-head `01-CI`, clean optional-parser proof, and `02-Release` with `prepublish_only=true` on that head.
-6. Reconcile #311 in one task-state-only commit and mirror the GitHub checklist; its resulting `dev` SHA is the exact promotion head.
-7. Run ordinary exact-head CI, strict OpenSpec, IssueOps, ProjectAtlas low lint, and review checks on the promotion head, close #311, and then pass milestone IssueOps.
-8. Promote with a merge commit after verifying `main` ancestry and identical promotion/main trees; let the existing release workflow verify the resulting `main` SHA and publish v0.4.0.
-9. Independently verify the published release and only then perform the post-release cleanup.
+4. Land the supported optional-parser release handoff, anchored federation filtering, benchmark digest correction, focused tests, specs, and architecture diagram.
+5. Merge all remaining readiness artifacts into `dev`, then lock the corrected release-content head.
+6. Run the complete local gates, exact-head `01-CI`, clean optional-parser proof, and `02-Release` with `prepublish_only=true` and the exact clean handoff on that head.
+7. Reconcile #311 in one task-state-only commit and mirror the GitHub checklist; its resulting `dev` SHA is the exact promotion head.
+8. Run ordinary exact-head CI, strict OpenSpec, IssueOps, ProjectAtlas low lint, review checks, and a clean optional-parser handoff on the promotion head, close #311, and then pass milestone IssueOps.
+9. Promote with a merge commit after verifying `main` ancestry and identical promotion/main trees; let the existing release workflow consume the promotion handoff, verify the resulting `main` tree, and publish v0.4.0.
+10. Independently verify the published release and only then perform the post-release cleanup.
 
 Rollback before promotion is ordinary correction followed by a new release-content lock and reconciliation. After promotion, retain all source lanes and release artifacts until the publishing failure is understood; never use workspace cleanup as rollback.
 

--- a/openspec/changes/complete-v040-release-readiness/proposal.md
+++ b/openspec/changes/complete-v040-release-readiness/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-ProjectAtlas v0.4.0 has completed its feature program, but release issue #311 still mirrors an obsolete pre-closure split of #308 and cannot serve as a truthful release gate. The final candidate needs one concise readiness contract that reconciles the remaining milestone work, proves packages and installed behavior without publishing, and hands publication verification plus workspace cleanup to a deliberately post-release owner.
+ProjectAtlas v0.4.0 has completed its feature program, but exact-head review of the promotion candidate found three release blockers after the first readiness reconciliation: supported optional-parser archives were not published, federated rendezvous evidence could escape the anchored traversal, and a published benchmark digest was stale. Release issue #311 must remain the truthful owner while those findings are fixed, the candidate is reproved, and publication verification plus workspace cleanup remain with the deliberately post-release owner.
 
 ## What Changes
 
@@ -9,6 +9,9 @@ ProjectAtlas v0.4.0 has completed its feature program, but release issue #311 st
 - Land the remaining installer trust-boundary correction and close every other v0.4.0 milestone issue against exact-head local, hosted, and review evidence.
 - Prove one exact release-content head, carry that proof only across one verified task-state-only reconciliation commit, and require ordinary exact-head gates on the resulting promotion head.
 - Run `02-Release` in `prepublish_only` mode so the real package and installer paths are proven without creating a tag or GitHub release.
+- Carry only an explicit clean, all-platform optional-parser handoff into `02-Release`, bind its run, candidate tree, aggregate proof, clean receipts, archive sizes, and archive digests, and publish both supported pack archives with the release.
+- Restrict cross-root rendezvous evidence to exact external identities reached by the primary anchored traversal in the requested direction.
+- Correct the MCP composition evaluation's raw-input digest in both published representations and verify the binding directly.
 - Prepare the exact `dev`-to-`main` promotion while keeping `main` and publication untouched until readiness is complete.
 - Create a separate non-milestone post-release issue that owns published-release verification and the user-requested safe branch, worktree, and external ProjectAtlas checkout cleanup.
 
@@ -20,15 +23,18 @@ ProjectAtlas v0.4.0 has completed its feature program, but release issue #311 st
 
 ### Modified Capabilities
 
-None.
+- `cross-repository-intelligence`: Require federated rendezvous evidence to remain inside the primary anchored and directed traversal.
+- `language-intelligence-registry`: Require supported optional-parser archives to ship only through an exact clean-run release handoff.
+- `repository-intelligence-benchmarks`: Require published evaluation digests to match their named raw input.
 
 ## Impact
 
-This change affects OpenSpec release artifacts, `openspec/issue-map.json`, GitHub issue #311, the final `dev` candidate proof, the existing `01-CI`, `optional-parser-pack`, `02-Release`, and `03-Auto-Release` workflows, and the later post-release cleanup issue. It changes no Rust API, crate boundary, SQLite schema, CLI/MCP contract, dependency, package format, or runtime behavior.
+This change affects OpenSpec release artifacts, GitHub issue #311, federated service filtering and focused tests, the MCP composition evaluation metadata, the optional-parser architecture diagram, the final `dev` candidate proof, and the existing `optional-parser-pack`, `02-Release`, and `03-Auto-Release` workflows. It adds no crate, dependency, SQLite schema or migration, SQLite write path, CLI/MCP schema, or second release workflow.
 
 ## Non-Goals
 
-- Do not add another release workflow, installer architecture, evidence framework, runtime feature, crate, dependency, database migration, or MCP tool.
+- Do not add another release workflow, installer architecture, generic evidence framework, runtime feature, crate, dependency, database migration, or MCP tool.
+- Do not add an identity-specific database query or index without measured evidence that the existing bounded family reads plus anchored identity filtering are insufficient.
 - Do not weaken the milestone checklist gate or mark publication, verification, or cleanup complete before it happens.
 - Do not reopen completed #308 feature work or move #314 into v0.4.0.
 - Do not delete branches, worktrees, or external ProjectAtlas checkouts before the release is published, independently verified, and their unique work is inventoried.

--- a/openspec/changes/complete-v040-release-readiness/specs/cross-repository-intelligence/spec.md
+++ b/openspec/changes/complete-v040-release-readiness/specs/cross-repository-intelligence/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Federated Rendezvous Respects The Anchored Traversal
+
+Federated detailed-relation and analysis responses SHALL derive the eligible typed external identities from the primary project's already bounded anchored traversal. Secondary roots SHALL contribute rendezvous evidence only for those identities, under the existing relation, confidence, resolution, row, edge, intermediate-byte, time, cancellation, and output limits.
+
+#### Scenario: An anchored outbound identity is shared
+- **WHEN** the primary outbound traversal reaches an exact external identity and at least one secondary root contains the same typed identity
+- **THEN** the federated response retains the project-qualified evidence from the participating roots
+
+#### Scenario: An unrelated relation shares the requested family
+- **WHEN** two or more roots contain another external relation of the requested family that the primary anchored traversal did not reach
+- **THEN** that identity and its evidence do not appear in detailed or analysis rendezvous output
+
+#### Scenario: Inbound traversal reaches no external identity
+- **WHEN** the requested inbound traversal contains no exact external identity
+- **THEN** rendezvous output is empty and no secondary family scan is needed

--- a/openspec/changes/complete-v040-release-readiness/specs/language-intelligence-registry/spec.md
+++ b/openspec/changes/complete-v040-release-readiness/specs/language-intelligence-registry/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Supported Optional-Parser Archives Ship Through An Exact Clean Handoff
+
+An explicit all-platform clean optional-parser run SHALL emit one bounded release handoff containing exactly the supported Linux and Windows archives, their clean construction receipts, and the aggregate proof. `02-Release` SHALL accept that handoff only from the same repository's successful `optional-parser-pack` workflow-dispatch run whose candidate tree matches the release tree. It SHALL validate the supported target set, version, revision, clean receipts, archive names, sizes, and SHA-256 digests before staging versioned release assets.
+
+#### Scenario: A supported clean candidate is released
+- **WHEN** the exact release tree has a successful clean all-platform handoff
+- **THEN** both supported optional-parser archives and the aggregate proof are included in the release assets and covered by the release checksum manifest
+
+#### Scenario: The handoff is stale, partial, reused, or altered
+- **WHEN** the run identity, tree, target set, proof, receipt, archive size, archive digest, or version does not match
+- **THEN** prepublish and publish fail before any optional-parser asset is staged
+
+#### Scenario: Automatic release follows an identical-tree promotion
+- **WHEN** `main` receives the verified `dev` promotion through an identical-tree merge commit
+- **THEN** `03-Auto-Release` supplies the successful clean handoff for that exact promotion parent to `02-Release`

--- a/openspec/changes/complete-v040-release-readiness/specs/repository-intelligence-benchmarks/spec.md
+++ b/openspec/changes/complete-v040-release-readiness/specs/repository-intelligence-benchmarks/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Published Evaluation Digests Match Their Named Inputs
+
+Every human-readable and machine-readable benchmark evaluation that names a raw input SHA-256 SHALL match the bytes of that exact repository file. The release gate SHALL compare all published representations with the computed digest.
+
+#### Scenario: Evaluation metadata is current
+- **WHEN** release readiness validates a published benchmark evaluation
+- **THEN** the Markdown and JSON digest fields equal the SHA-256 of the named raw input
+
+#### Scenario: One representation drifts
+- **WHEN** either published digest differs from the raw input or from the other representation
+- **THEN** release readiness fails before promotion

--- a/openspec/changes/complete-v040-release-readiness/specs/repository-intelligence-benchmarks/spec.md
+++ b/openspec/changes/complete-v040-release-readiness/specs/repository-intelligence-benchmarks/spec.md
@@ -1,11 +1,11 @@
 ## ADDED Requirements
 
-### Requirement: Published Evaluation Digests Match Their Named Inputs
+### Requirement: Published MCP Composition Digests Match Their Named Input
 
-Every human-readable and machine-readable benchmark evaluation that names a raw input SHA-256 SHALL match the bytes of that exact repository file. The release gate SHALL compare all published representations with the computed digest.
+The human-readable and machine-readable MCP composition evaluations SHALL name the SHA-256 of their exact raw input file. The release gate SHALL compare both MCP composition representations with the computed digest.
 
-#### Scenario: Evaluation metadata is current
-- **WHEN** release readiness validates a published benchmark evaluation
+#### Scenario: MCP composition metadata is current
+- **WHEN** release readiness validates the published MCP composition evaluation
 - **THEN** the Markdown and JSON digest fields equal the SHA-256 of the named raw input
 
 #### Scenario: One representation drifts

--- a/openspec/changes/complete-v040-release-readiness/specs/v040-release-readiness/spec.md
+++ b/openspec/changes/complete-v040-release-readiness/specs/v040-release-readiness/spec.md
@@ -31,15 +31,30 @@ ProjectAtlas SHALL first prove one locked release-content head after every v0.4.
 - **THEN** release readiness remains incomplete
 
 ### Requirement: Existing workflows prove the real release boundary
-Release readiness SHALL use the existing `01-CI`, `optional-parser-pack`, and `02-Release` workflows. It SHALL require cross-platform source-built CLI/MCP E2E, explicit empty-cache Linux and Windows optional-parser construction, and `02-Release` package and installer proof with `prepublish_only=true`.
+Release readiness SHALL use the existing `01-CI`, `optional-parser-pack`, and `02-Release` workflows. It SHALL require cross-platform source-built CLI/MCP E2E, explicit empty-cache Linux and Windows optional-parser construction, and `02-Release` package, optional-parser release-asset, and installer proof with `prepublish_only=true`.
 
 #### Scenario: Clean optional-parser proof succeeds
 - **WHEN** the exact release-content head is dispatched with `clean_construction=true` and `target=all`
 - **THEN** Linux and Windows bypass cache restore and save, complete construction plus fresh-runner and runtime proof, and produce the complete aggregate result
 
 #### Scenario: Prepublish release proof succeeds
-- **WHEN** `02-Release` runs on the exact release-content head with version `v0.4.0` and `prepublish_only=true`
-- **THEN** every required package and installer smoke job succeeds without creating a tag or GitHub release
+- **WHEN** `02-Release` runs on the exact release-content head with version `v0.4.0`, `prepublish_only=true`, and the exact clean optional-parser handoff
+- **THEN** every required package, optional-parser release-asset, and installer smoke job succeeds without creating a tag or GitHub release
+
+#### Scenario: Optional-parser handoff is stale or incomplete
+- **WHEN** the referenced run, repository, workflow, event, candidate tree, aggregate proof, clean receipt, archive size, archive digest, version, or supported target set differs
+- **THEN** `02-Release` fails before publication and does not stage the optional-parser archives
+
+### Requirement: Fresh review findings reopen affected release proof
+Any exact-head review finding that changes release content SHALL reopen the affected candidate, local, hosted, review, prepublish, and reconciliation tasks. Older success SHALL NOT be treated as proof of the corrected head.
+
+#### Scenario: Review finds a release blocker after reconciliation
+- **WHEN** an actionable finding requires a workflow, runtime, spec, test, or published documentation change
+- **THEN** #311 remains open, the finding receives an explicit local task owner, and all proof affected by the changed tree is rerun
+
+#### Scenario: Corrected head is ready to reconcile
+- **WHEN** every actionable Codex and Dependabot finding is fixed or explicitly dispositioned and the corrected exact head passes its required local and hosted gates
+- **THEN** the finite task-state-only reconciliation may begin
 
 #### Scenario: Ordinary candidate behavior succeeds
 - **WHEN** exact-head `01-CI` completes

--- a/openspec/changes/complete-v040-release-readiness/tasks.md
+++ b/openspec/changes/complete-v040-release-readiness/tasks.md
@@ -7,15 +7,22 @@
 ## 2. Final Candidate
 
 - [x] 2.1 Complete issue #341's explicit empty-cache Linux and Windows construction, reconcile and land its OpenSpec and GitHub checklist state, resolve live feedback, and close #341.
-- [x] 2.2 Merge every remaining v0.4.0 readiness change into `dev`, confirm #314 remains outside the release, and lock one release-content head with no uncommitted source changes or unresolved review feedback.
-- [x] 2.3 Run the complete pre-push gate, strict OpenSpec validation, ProjectAtlas candidate scan and low lint, and IssueOps synchronization on the locked release-content head; confirm this release-only change adds no Rust API, crate, dependency, schema, migration, SQLite write path, or runtime behavior.
+- [ ] 2.2 Merge every remaining v0.4.0 readiness change into `dev`, confirm #314 remains outside the release, and lock one corrected release-content head with no uncommitted source changes or unresolved review feedback.
+- [ ] 2.3 Run the complete pre-push gate, strict OpenSpec validation, ProjectAtlas candidate scan and low lint, and IssueOps synchronization on the locked release-content head; confirm the correction adds no crate, dependency, schema, migration, SQLite write path, CLI/MCP schema, or second release path.
 
 ## 3. Prepublication Proof
 
-- [x] 3.1 Run exact-head `01-CI` and require Rust verification plus source-built CLI/MCP E2E smoke on Linux, Windows, macOS x64, and macOS arm64; dispatch `optional-parser-pack` with `clean_construction=true` and `target=all` on the same locked release-content head and require complete Linux and Windows construction, fresh-runner, runtime, and aggregate proof.
-- [x] 3.2 Run `02-Release` for `v0.4.0` with `prepublish_only=true` and require every package and installer-smoke job to succeed on its supported platform.
-- [x] 3.3 Verify the prepublish run created no tag or GitHub release; reconcile package, installer, runtime, plugin, MCP, CLI, documentation, and release-note identities; leave published checksum verification to #346; prepare a merge-commit `dev`-to-`main` promotion without merging it, with `main` as an ancestor and squash/rebase refused; re-audit PR threads plus Codex and Dependabot feedback; and keep `main`, tags, releases, and post-release issue #346 unchanged.
+- [ ] 3.1 Run exact-head `01-CI` and require Rust verification plus source-built CLI/MCP E2E smoke on Linux, Windows, macOS x64, and macOS arm64; dispatch `optional-parser-pack` with `clean_construction=true` and `target=all` on the same locked release-content head and require complete Linux and Windows construction, fresh-runner, runtime, aggregate proof, clean receipts, and the release handoff.
+- [ ] 3.2 Run `02-Release` for `v0.4.0` with `prepublish_only=true` and the exact clean optional-parser run; require every package, optional-parser release-asset, and installer-smoke job to succeed on its supported platform.
+- [ ] 3.3 Verify the prepublish run created no tag or GitHub release; reconcile package, optional-parser archive, installer, runtime, plugin, MCP, CLI, documentation, benchmark-input digest, and release-note identities; leave published checksum verification to #346; prepare a merge-commit `dev`-to-`main` promotion without merging it, with `main` as an ancestor and squash/rebase refused; re-audit PR threads plus Codex and Dependabot feedback; and keep `main`, tags, releases, and post-release issue #346 unchanged.
 
-## 4. Finite Reconciliation
+## 4. Exact-Head Review Corrections
 
-- [x] 4.1 After tasks 1.1 through 3.3 are true, create one commit whose only repository change is checking those completed tasks and this reconciliation task, mirror #311 exactly, verify the diff is task-state-only, and carry clean-construction and prepublish proof forward only across that verified diff.
+- [ ] 4.1 Make explicit clean all-platform optional-parser construction emit one bounded release handoff; require `02-Release` and `03-Auto-Release` to bind the successful run and identical candidate tree, validate aggregate proof, clean receipts, versions, archive sizes and digests, and stage both supported archives plus aggregate proof as versioned release assets; update and render the owning architecture flow.
+- [ ] 4.2 Restrict detailed and analysis federated rendezvous to exact typed external identities reached by the primary anchored traversal in the requested direction; cover retained outbound matches, unrelated outbound exclusion, empty inbound rendezvous, both public routes, bounded work, cancellation, freshness, and compatibility without a schema, index, migration, transaction, or SQLite write change.
+- [ ] 4.3 Replace the stale MCP composition raw-input SHA-256 in both published evaluation representations and make the existing release gate compare them with the actual raw file.
+- [ ] 4.4 Run the focused workflow validator, benchmark-integrity, federated unit/integration, direction, negative, analysis, and architecture-render checks; then disposition every live PR #351 Codex and Dependabot thread against the corrected head before relocking the candidate.
+
+## 5. Finite Reconciliation
+
+- [ ] 5.1 After tasks 1.1 through 4.4 are true, create one commit whose only repository change is checking those completed tasks and this reconciliation task, mirror #311 exactly, verify the diff is task-state-only, and require ordinary exact-head closure gates plus a fresh clean optional-parser handoff on the resulting promotion head.


### PR DESCRIPTION
## Summary

- Bind both supported optional-parser archives and their aggregate proof to one successful clean-construction run with an identical release tree.
- Restrict federated rendezvous to exact external identities reached by the requested anchored traversal and direction.
- Correct and continuously verify the published MCP composition input digest.

## Issue

Refs #311

## Checklist

- [x] `projectatlas scan` run when indexed context changed.
- [x] `projectatlas lint --report-untracked --purpose-level low` passes, and `projectatlas purpose queue` has been reviewed for touched high-value paths.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo check --workspace --all-targets --all-features --locked` clean.
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean.
- [x] `cargo test --workspace --all-features --locked` and stable workspace doctests clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked` clean.
- [x] Tests updated or added where behavior changed.
- [x] All active OpenSpec changes are mapped in `openspec/issue-map.json`, linked issue task sections exactly mirror local task text and state, and `.github/scripts/issue-checklists.py` passes. Full issue and milestone completion is required only when closing or releasing, not for every incremental `dev` slice.
- [x] README, Markdown docs, and GitHub Pages/rustdoc-facing content are updated or confirmed current for this change.
- [x] PR text contains no private or internal-only details.
