### PR TITLE
fix(service): bound federated rendezvous resources

### DIFF
--- a/crates/projectatlas-db/Cargo.toml
+++ b/crates/projectatlas-db/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 
+[features]
+sqlite-progress-test-observer = []
+
 [dependencies]
 blake3.workspace = true
 getrandom.workspace = true

--- a/crates/projectatlas-db/src/lib.rs
+++ b/crates/projectatlas-db/src/lib.rs
@@ -6227,6 +6227,75 @@ fn validate_indexed_file_text(text: &IndexedFileText) -> DbResult<()> {
 /// Virtual-machine operations between bounded database-read progress checks.
 const SQLITE_READ_PROGRESS_OPS: i32 = 1_000;
 
+/// Deterministic observation of production `SQLite` progress boundaries for downstream tests.
+#[cfg(feature = "sqlite-progress-test-observer")]
+pub mod sqlite_progress_test_observer {
+    use projectatlas_core::IndexWorkStage;
+    use std::cell::RefCell;
+
+    /// One observable event emitted by the production `SQLite` read-progress boundary.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum SqliteReadProgressEvent {
+        /// A repository relation-family query entered after its live-control precheck.
+        RepositoryRelationFamilyQueryEntered,
+        /// A repository relation-family query returned from `SQLite`.
+        RepositoryRelationFamilyQueryExited,
+        /// `SQLite` invoked the production progress callback.
+        CallbackEntered {
+            /// Typed work stage owned by the guarded query.
+            stage: IndexWorkStage,
+        },
+        /// The production progress callback evaluated its control.
+        CallbackEvaluated {
+            /// Typed work stage owned by the guarded query.
+            stage: IndexWorkStage,
+            /// Whether the callback requested `SQLite` interruption.
+            interrupted: bool,
+        },
+    }
+
+    /// Thread-local callback used only while a downstream test owns observation.
+    type Observer = Box<dyn FnMut(SqliteReadProgressEvent)>;
+
+    thread_local! {
+        /// Observer scoped to the synchronous test thread running the SQLite connection.
+        static OBSERVER: RefCell<Option<Observer>> = RefCell::new(None);
+    }
+
+    /// Restores a prior nested observer on every return or unwind path.
+    struct ObserverGuard {
+        /// Observer replaced for the current scope.
+        previous: Option<Observer>,
+    }
+
+    impl Drop for ObserverGuard {
+        fn drop(&mut self) {
+            OBSERVER.with(|slot| {
+                drop(slot.replace(self.previous.take()));
+            });
+        }
+    }
+
+    /// Run one operation while observing its synchronous `SQLite` progress events.
+    pub fn observe_sqlite_read_progress<T>(
+        observer: impl FnMut(SqliteReadProgressEvent) + 'static,
+        operation: impl FnOnce() -> T,
+    ) -> T {
+        let previous = OBSERVER.with(|slot| slot.replace(Some(Box::new(observer))));
+        let _guard = ObserverGuard { previous };
+        operation()
+    }
+
+    /// Notify the current thread-local observer when one is installed.
+    pub(crate) fn notify(event: SqliteReadProgressEvent) {
+        OBSERVER.with(|slot| {
+            if let Some(observer) = slot.borrow_mut().as_mut() {
+                observer(event);
+            }
+        });
+    }
+}
+
 /// Clears a connection-local `SQLite` progress handler on every exit path.
 pub(crate) struct SqliteReadProgressGuard<'connection> {
     /// Connection whose temporary progress callback is armed.
@@ -6247,7 +6316,23 @@ impl<'connection> SqliteReadProgressGuard<'connection> {
             let progress_control = control.clone();
             connection.progress_handler(
                 SQLITE_READ_PROGRESS_OPS,
-                Some(move || progress_control.check(stage).is_err()),
+                Some(move || {
+                    #[cfg(feature = "sqlite-progress-test-observer")]
+                    sqlite_progress_test_observer::notify(
+                        sqlite_progress_test_observer::SqliteReadProgressEvent::CallbackEntered {
+                            stage,
+                        },
+                    );
+                    let interrupted = progress_control.check(stage).is_err();
+                    #[cfg(feature = "sqlite-progress-test-observer")]
+                    sqlite_progress_test_observer::notify(
+                        sqlite_progress_test_observer::SqliteReadProgressEvent::CallbackEvaluated {
+                            stage,
+                            interrupted,
+                        },
+                    );
+                    interrupted
+                }),
             );
             true
         } else {

--- a/crates/projectatlas-db/src/repository_graph.rs
+++ b/crates/projectatlas-db/src/repository_graph.rs
@@ -1762,23 +1762,34 @@ impl AtlasStore {
                     control,
                     IndexWorkStage::RepositoryTraversal,
                     || {
-                        let mut statement = self.connection.prepare_cached(
-                            "SELECT relation_key, project_instance_id, canonical_identity,
-                                source_entity_key, relation_scope, relation_kind,
-                                resolution_status, target_entity_key, reference_text,
-                                candidate_count, confidence, completeness
-                           FROM graph_relations
-                          WHERE project_instance_id = ?1
-                            AND relation_scope = ?2 AND relation_kind = ?3
-                          ORDER BY relation_key
-                          LIMIT ?4",
-                        )?;
-                        collect_relation_rows(statement.query(params![
-                            &project.as_bytes()[..],
-                            scope,
-                            kind,
-                            limit_plus_one
-                        ])?)
+                        #[cfg(feature = "sqlite-progress-test-observer")]
+                        crate::sqlite_progress_test_observer::notify(
+                            crate::sqlite_progress_test_observer::SqliteReadProgressEvent::RepositoryRelationFamilyQueryEntered,
+                        );
+                        let result = (|| {
+                            let mut statement = self.connection.prepare_cached(
+                                "SELECT relation_key, project_instance_id, canonical_identity,
+                                    source_entity_key, relation_scope, relation_kind,
+                                    resolution_status, target_entity_key, reference_text,
+                                    candidate_count, confidence, completeness
+                               FROM graph_relations
+                              WHERE project_instance_id = ?1
+                                AND relation_scope = ?2 AND relation_kind = ?3
+                              ORDER BY relation_key
+                              LIMIT ?4",
+                            )?;
+                            collect_relation_rows(statement.query(params![
+                                &project.as_bytes()[..],
+                                scope,
+                                kind,
+                                limit_plus_one
+                            ])?)
+                        })();
+                        #[cfg(feature = "sqlite-progress-test-observer")]
+                        crate::sqlite_progress_test_observer::notify(
+                            crate::sqlite_progress_test_observer::SqliteReadProgressEvent::RepositoryRelationFamilyQueryExited,
+                        );
+                        result
                     },
                 )?;
                 (project, raw)

--- a/crates/projectatlas-service/Cargo.toml
+++ b/crates/projectatlas-service/Cargo.toml
@@ -18,6 +18,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+projectatlas-db = { workspace = true, features = ["sqlite-progress-test-observer"] }
 tempfile.workspace = true
 
 [lints]

--- a/crates/projectatlas-service/src/federation.rs
+++ b/crates/projectatlas-service/src/federation.rs
@@ -1167,7 +1167,7 @@ mod tests {
         for index in 0..4 {
             let root = temp.path().join(format!("project-{index}"));
             let database = root.join("projectatlas.db");
-            publish_fixture(&root, &database, IndexGeneration::new(1))?;
+            publish_fixture(&root, &database, IndexGeneration::new(1), 1)?;
             participants.push((root, database));
         }
         let before = participants
@@ -1332,6 +1332,7 @@ mod tests {
             &participants[3].0,
             &participants[3].1,
             IndexGeneration::new(2),
+            1,
         )?;
         let stale = load_federated_detailed_relations(
             open_participants(&participants)?,
@@ -1372,11 +1373,66 @@ mod tests {
         Ok(())
     }
 
-    /// Publish three anchored imports plus one unrelated same-family import.
+    #[test]
+    fn federation_deadline_interrupts_active_rendezvous_and_releases_snapshots()
+    -> Result<(), Box<dyn Error>> {
+        let temp = tempfile::tempdir()?;
+        let primary_root = temp.path().join("primary");
+        let primary_database = primary_root.join("projectatlas.db");
+        publish_fixture(&primary_root, &primary_database, IndexGeneration::new(1), 1)?;
+        let secondary_root = temp.path().join("secondary");
+        let secondary_database = secondary_root.join("projectatlas.db");
+        publish_fixture(
+            &secondary_root,
+            &secondary_database,
+            IndexGeneration::new(1),
+            usize::try_from(GraphLimits::MAX_ROWS)?,
+        )?;
+        let participants = vec![
+            (primary_root, primary_database),
+            (secondary_root, secondary_database),
+        ];
+        let mut query = relation_query(
+            None,
+            RelationResolutionFilter::External,
+            RelationDirection::Outbound,
+        )?;
+        query.budget = query.budget.with_aggregate_limits(
+            Some(GraphLimits::MAX_ROWS),
+            None,
+            None,
+            None,
+            Some(DetailedRelationBudget::MAX_INTERMEDIATE_BYTES),
+            Some(50),
+        )?;
+
+        let deadline =
+            load_federated_detailed_relations(open_participants(&participants)?, &query, None);
+        require(
+            matches!(
+                deadline,
+                Err(ServiceError::Db(DbError::IndexWork(
+                    projectatlas_core::IndexWorkFailure::DeadlineExceeded {
+                        stage: IndexWorkStage::RepositoryTraversal
+                    }
+                )))
+            ),
+            "active rendezvous query was not interrupted with its typed deadline",
+        )?;
+        for (index, (_, database)) in participants.iter().enumerate() {
+            let moved = database.with_extension(format!("deadline-closed-{index}"));
+            fs::rename(database, &moved)?;
+            fs::rename(moved, database)?;
+        }
+        Ok(())
+    }
+
+    /// Publish three anchored imports plus the requested unrelated same-family imports.
     fn publish_fixture(
         root: &Path,
         database: &Path,
         generation: IndexGeneration,
+        unrelated_relations: usize,
     ) -> Result<(), Box<dyn Error>> {
         fs::create_dir_all(root.join("src"))?;
         fs::write(root.join("src/same.rs"), "pub fn same() {}\n")?;
@@ -1422,25 +1478,32 @@ mod tests {
             )?);
             entities.push(external);
         }
-        let unrelated_external = GraphEntity::new(
-            project,
-            EntitySelector::External {
-                external: ExternalSelector {
-                    system: GraphIdentityText::new("registry.example")?,
-                    identity: GraphIdentityText::new("package/unrelated")?,
+        for index in 0..unrelated_relations {
+            let identity = if unrelated_relations == 1 {
+                "package/unrelated".to_string()
+            } else {
+                format!("package/unrelated/{index:05}/{}", "x".repeat(4_000))
+            };
+            let unrelated_external = GraphEntity::new(
+                project,
+                EntitySelector::External {
+                    external: ExternalSelector {
+                        system: GraphIdentityText::new("registry.example")?,
+                        identity: GraphIdentityText::new(identity)?,
+                    },
                 },
-            },
-            generation,
-        )?;
-        relations.push(LogicalRelation::new(
-            &unrelated_source,
-            GraphRelationKind::Legacy(RelationKind::Imports),
-            RelationResolution::external(&unrelated_external)?,
-            projectatlas_core::graph::ConfidenceClass::Exact,
-            Completeness::Complete,
-            generation,
-        )?);
-        entities.push(unrelated_external);
+                generation,
+            )?;
+            relations.push(LogicalRelation::new(
+                &unrelated_source,
+                GraphRelationKind::Legacy(RelationKind::Imports),
+                RelationResolution::external(&unrelated_external)?,
+                projectatlas_core::graph::ConfidenceClass::Exact,
+                Completeness::Complete,
+                generation,
+            )?);
+            entities.push(unrelated_external);
+        }
         let mut publication = store.begin_index_publication("federation-fixture")?;
         publication.begin_scan_replacement()?;
         publication.upsert_scan_node_batch(&[

--- a/crates/projectatlas-service/src/federation.rs
+++ b/crates/projectatlas-service/src/federation.rs
@@ -4,6 +4,7 @@ use super::analysis::{RelationAnalysisDraft, RelationAnalysisQuery, RelationAnal
 use super::relations::{
     DetailedRelationBudget, DetailedRelationPageDraft, DetailedRelationQuery,
     DetailedRelationReport, ExternalRelationIdentity, external_relation_identities,
+    relation_request_control, serialized_equivalent_bytes,
 };
 use super::{ServiceError, ServiceResult, selected_project_binding};
 use projectatlas_core::graph::{
@@ -19,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::PathBuf;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// Minimum number of explicit roots that constitutes a federated call.
 const MIN_FEDERATED_ROOTS: usize = 2;
@@ -529,12 +530,7 @@ pub fn load_federated_detailed_relations(
         )?;
         let candidate = primary.report_for_prefix(primary.candidate_rows())?;
         let rendezvous_identities = external_relation_identities(&candidate);
-        let rendezvous_identity_bytes = u64::try_from(
-            serde_json::to_vec(&rendezvous_identities)?.len(),
-        )
-        .map_err(|_overflow| {
-            ServiceError::InvalidInput("federated identity byte count overflowed".to_string())
-        })?;
+        let rendezvous_identity_bytes = serialized_equivalent_bytes(&rendezvous_identities)?;
         let primary_edges = u64::from(candidate.work.inspected_edges);
         let primary_rows = u64::from(candidate.work.database_returned_rows);
         let remaining_edges = u64::from(budget.edges()).saturating_sub(primary_edges);
@@ -745,6 +741,11 @@ fn load_rendezvous(
             reached_limits: Vec::new(),
         });
     }
+    let deadline = started
+        .checked_add(Duration::from_millis(query.budget.deadline_ms()))
+        .unwrap_or(started);
+    let request_control = relation_request_control(control, deadline);
+    let control = Some(&request_control);
     let families = query.relation.map_or_else(
         || FEDERATED_RENDEZVOUS_RELATIONS.to_vec(),
         |relation| vec![relation],
@@ -802,13 +803,7 @@ fn load_rendezvous(
                 push_limit(&mut reached_limits, GraphLimitKind::Edges);
             }
             for row in page.rows {
-                let encoded_bytes =
-                    u64::try_from(serde_json::to_vec(&(&row.source, &row.relation))?.len())
-                        .map_err(|_overflow| {
-                            ServiceError::InvalidInput(
-                                "federated decoded-byte count overflowed".to_string(),
-                            )
-                        })?;
+                let encoded_bytes = serialized_equivalent_bytes(&(&row.source, &row.relation))?;
                 if encoded_bytes > remaining_intermediate_bytes {
                     push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
                     break 'queries;
@@ -1084,14 +1079,14 @@ fn federated_intermediate_bytes(
     cursor: Option<&str>,
     budget: DetailedRelationBudget,
 ) -> ServiceResult<u64> {
-    let federation_bytes = u64::try_from(
-        serde_json::to_vec(&(participants, rendezvous))?
-            .len()
-            .saturating_add(cursor.map_or(0, str::len)),
-    )
-    .map_err(|_overflow| {
-        ServiceError::InvalidInput("federated intermediate-byte count overflowed".to_string())
+    let cursor_bytes = u64::try_from(cursor.map_or(0, str::len)).map_err(|_overflow| {
+        ServiceError::InvalidInput("federated cursor byte count overflowed".to_string())
     })?;
+    let federation_bytes = checked_sum(
+        serialized_equivalent_bytes(&(participants, rendezvous))?,
+        cursor_bytes,
+        "federated intermediate bytes",
+    )?;
     let total = checked_sum(
         primary_bytes,
         federation_bytes,
@@ -1219,6 +1214,14 @@ mod tests {
             encoded.len() <= query.budget.output_bytes() as usize
                 && report.work.intermediate_bytes <= query.budget.intermediate_bytes(),
             "federated output escaped its aggregate byte budgets",
+        )?;
+        let rendezvous_identities = external_relation_identities(&report.primary);
+        let encoded_identity_bytes =
+            u64::try_from(serde_json::to_vec(&rendezvous_identities)?.len())?;
+        require(
+            !rendezvous_identities.is_empty()
+                && serialized_equivalent_bytes(&rendezvous_identities)? == encoded_identity_bytes,
+            "streamed federation identity accounting diverged from exact JSON bytes",
         )?;
         let after = participants
             .iter()

--- a/crates/projectatlas-service/src/federation.rs
+++ b/crates/projectatlas-service/src/federation.rs
@@ -1155,9 +1155,14 @@ mod tests {
     };
     use projectatlas_core::symbols::RelationKind;
     use projectatlas_core::{IndexCancellation, Node, NodeKind};
+    use projectatlas_db::sqlite_progress_test_observer::{
+        SqliteReadProgressEvent, observe_sqlite_read_progress,
+    };
+    use std::cell::Cell;
     use std::error::Error;
     use std::io;
     use std::path::Path;
+    use std::rc::Rc;
 
     #[test]
     fn federation_is_project_qualified_fresh_bounded_and_handle_free() -> Result<(), Box<dyn Error>>
@@ -1402,12 +1407,58 @@ mod tests {
             None,
             None,
             None,
-            Some(DetailedRelationBudget::MAX_INTERMEDIATE_BYTES),
-            Some(50),
+            None,
+            None,
         )?;
-
-        let deadline =
-            load_federated_detailed_relations(open_participants(&participants)?, &query, None);
+        let control = IndexWorkControl::with_deadline(
+            IndexCancellation::new(),
+            Instant::now() + Duration::from_secs(1),
+        );
+        let family_query_active = Rc::new(Cell::new(false));
+        let family_query_entered_live = Rc::new(Cell::new(false));
+        let callback_entered_live = Rc::new(Cell::new(false));
+        let callback_interrupted = Rc::new(Cell::new(false));
+        let stores = open_participants(&participants)?;
+        let deadline = observe_sqlite_read_progress(
+            {
+                let observer_control = control.clone();
+                let family_query_active = Rc::clone(&family_query_active);
+                let family_query_entered_live = Rc::clone(&family_query_entered_live);
+                let callback_entered_live = Rc::clone(&callback_entered_live);
+                let callback_interrupted = Rc::clone(&callback_interrupted);
+                move |event| match event {
+                    SqliteReadProgressEvent::RepositoryRelationFamilyQueryEntered => {
+                        family_query_active.set(true);
+                        if observer_control
+                            .check(IndexWorkStage::RepositoryTraversal)
+                            .is_ok()
+                        {
+                            family_query_entered_live.set(true);
+                        }
+                    }
+                    SqliteReadProgressEvent::RepositoryRelationFamilyQueryExited => {
+                        family_query_active.set(false);
+                    }
+                    SqliteReadProgressEvent::CallbackEntered { stage }
+                        if family_query_active.get() && !callback_entered_live.get() =>
+                    {
+                        if observer_control.check(stage).is_ok() {
+                            callback_entered_live.set(true);
+                            while observer_control.check(stage).is_ok() {
+                                std::thread::sleep(Duration::from_millis(1));
+                            }
+                        }
+                    }
+                    SqliteReadProgressEvent::CallbackEvaluated {
+                        interrupted: true, ..
+                    } if family_query_active.get() && callback_entered_live.get() => {
+                        callback_interrupted.set(true);
+                    }
+                    _ => {}
+                }
+            },
+            || load_federated_detailed_relations(stores, &query, Some(&control)),
+        );
         require(
             matches!(
                 deadline,
@@ -1418,6 +1469,13 @@ mod tests {
                 )))
             ),
             "active rendezvous query was not interrupted with its typed deadline",
+        )?;
+        require(
+            family_query_entered_live.get()
+                && callback_entered_live.get()
+                && callback_interrupted.get()
+                && !family_query_active.get(),
+            "rendezvous deadline did not enter a live family query and interrupt it through SQLite",
         )?;
         for (index, (_, database)) in participants.iter().enumerate() {
             let moved = database.with_extension(format!("deadline-closed-{index}"));
@@ -1482,7 +1540,7 @@ mod tests {
             let identity = if unrelated_relations == 1 {
                 "package/unrelated".to_string()
             } else {
-                format!("package/unrelated/{index:05}/{}", "x".repeat(4_000))
+                format!("package/unrelated/{index:05}")
             };
             let unrelated_external = GraphEntity::new(
                 project,

--- a/crates/projectatlas-service/src/relations.rs
+++ b/crates/projectatlas-service/src/relations.rs
@@ -2260,7 +2260,7 @@ fn relation_database_budget(
 }
 
 /// Measure deterministic serialized-equivalent bytes without retaining an encoding.
-fn serialized_equivalent_bytes<T>(value: &T) -> ServiceResult<u64>
+pub(super) fn serialized_equivalent_bytes<T>(value: &T) -> ServiceResult<u64>
 where
     T: Serialize + ?Sized,
 {
@@ -2350,7 +2350,7 @@ fn relation_work_overflow() -> ServiceError {
 }
 
 /// Bind every database call to the earlier caller or service deadline.
-fn relation_request_control(
+pub(super) fn relation_request_control(
     caller: Option<&IndexWorkControl>,
     service_deadline: Instant,
 ) -> IndexWorkControl {

--- a/openspec/changes/complete-v040-release-readiness/design.md
+++ b/openspec/changes/complete-v040-release-readiness/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-Issue #308 and its feature proof are closed, #340 and #341 are merged and closed, and the first #311 reconciliation reached `dev`. Fresh Codex review of the exact promotion head then found three blockers: `02-Release` did not publish the supported optional-parser archives, federated rendezvous discovery reapplied trust filters without preserving the primary anchor and direction, and the published MCP composition evaluation named a stale raw-input digest. The affected candidate and proof tasks must be reopened rather than inferred from the older green head.
+Issue #308 and its feature proof are closed, #340 and #341 are merged and closed, and the first #311 reconciliation reached `dev`. Fresh Codex review of successive exact promotion heads then found five blockers: `02-Release` did not publish the supported optional-parser archives, federated rendezvous discovery reapplied trust filters without preserving the primary anchor and direction, the published MCP composition evaluation named a stale raw-input digest, rendezvous database reads lacked the service-owned deadline, and exact federation byte accounting allocated avoidable duplicate encodings. The affected candidate and proof tasks must be reopened rather than inferred from older green heads.
 
 The existing release path already has the required mechanics:
 
@@ -21,6 +21,7 @@ The user also requires branch, worktree, and external ProjectAtlas checkout clea
 - Fix and prove every fresh exact-head Codex finding before candidate reconciliation.
 - Publish both supported optional-parser archives only after binding them to one clean all-platform run and the exact release tree.
 - Keep federated rendezvous evidence inside the primary anchor/direction result without changing SQLite schema or query ownership.
+- Carry the same caller-or-service deadline into rendezvous SQLite reads and measure retained federation state without an additional encoded buffer.
 - Keep `main`, tags, and GitHub releases untouched until all prepublication evidence is green.
 - Prepare an exact `dev`-to-`main` promotion that can pass the existing milestone gate.
 - Preserve a durable post-release owner for independent publication verification and safe workspace consolidation.
@@ -45,6 +46,8 @@ A new release driver was rejected because the current workflows already own the 
 The primary project remains the only anchor and direction authority. Its already bounded detailed traversal yields the exact typed external identities eligible for cross-root rendezvous. Secondary projects may contribute evidence only for that bounded identity set. Analysis retains the same derived set from its existing detailed traversal so it does not repeat the database read. An empty set returns immediately.
 
 The existing indexed relation-family read remains the storage boundary. A bounded ordered set membership check fixes the correctness defect in `O(primary rows log primary rows + bounded secondary rows log primary rows)` time and bounded memory. A new SQLite query shape or index was rejected because this finding does not establish a schema or plan deficit; that change would require separate query-plan and representative-scale evidence.
+
+The existing relation request control remains the cancellation and deadline owner. Rendezvous derives one control whose deadline is the earlier of the caller deadline and the federation service deadline, then passes it through every family read so the existing SQLite progress handler can stop late work. Exact serialized-equivalent byte counts reuse the service's streaming counter instead of allocating a second JSON buffer. This preserves query shape, indexes, read-only snapshot ownership, transaction behavior, output compatibility, and `O(serialized bytes)` counting work while removing the duplicate `O(serialized bytes)` allocation.
 
 ### Bind published benchmark metadata to its raw input
 
@@ -86,6 +89,8 @@ Until readiness is complete, `main`, tags, and releases remain untouched. If any
 - **A green older run is mistaken for final evidence** → Compare every required run's `headSha` with the locked candidate before closure.
 - **Supported optional-parser archives exist only as expiring workflow artifacts** → Require one explicit clean handoff, verify it against the exact release tree, and stage both supported archives plus aggregate proof as versioned release assets.
 - **Secondary federation rows escape the requested anchor or direction** → Derive the eligible typed external identities from the bounded primary traversal and reject every other secondary row.
+- **A rendezvous family query runs past the service deadline** → Bind every database call to the existing caller-or-service request control.
+- **Exact federation accounting doubles retained memory while measuring it** → Stream serialized-equivalent bytes into the existing counter without retaining another encoding.
 - **Published MCP composition metadata names stale input** → Compute its raw input SHA-256 and compare both published representations in the release gate.
 - **The milestone gate becomes circular around post-release cleanup** → Keep #311 prepublication-only and create the non-milestone post-release owner before closure.
 - **A prepublish run is mistaken for publication** → Require `prepublish_only=true`, verify no tag or release was created, and leave publication to the existing main-triggered workflow.
@@ -97,7 +102,7 @@ Until readiness is complete, `main`, tags, and releases remain untouched. If any
 1. Land the bounded installer trust fix and reconcile all live review feedback.
 2. Add this change to `openspec/issue-map.json` and replace #311's obsolete body with the exact local checklist.
 3. Complete and close #341 after its Linux and Windows empty-cache proof and land its reconciled checklist state.
-4. Land the supported optional-parser release handoff, anchored federation filtering, benchmark digest correction, focused tests, specs, and architecture diagram.
+4. Land the supported optional-parser release handoff, anchored and deadline-bound federation filtering with allocation-free byte accounting, benchmark digest correction, focused tests, specs, and architecture diagram.
 5. Merge all remaining readiness artifacts into `dev`, then lock the corrected release-content head.
 6. Run the complete local gates, exact-head `01-CI`, clean optional-parser proof, and `02-Release` with `prepublish_only=true` and the exact clean handoff on that head.
 7. Reconcile #311 in one task-state-only commit and mirror the GitHub checklist; its resulting `dev` SHA is the exact promotion head.

--- a/openspec/changes/complete-v040-release-readiness/proposal.md
+++ b/openspec/changes/complete-v040-release-readiness/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-ProjectAtlas v0.4.0 has completed its feature program, but exact-head review of the promotion candidate found three release blockers after the first readiness reconciliation: supported optional-parser archives were not published, federated rendezvous evidence could escape the anchored traversal, and a published benchmark digest was stale. Release issue #311 must remain the truthful owner while those findings are fixed, the candidate is reproved, and publication verification plus workspace cleanup remain with the deliberately post-release owner.
+ProjectAtlas v0.4.0 has completed its feature program, but exact-head review of the promotion candidate found release blockers after the first readiness reconciliation: supported optional-parser archives were not published, federated rendezvous evidence could escape the anchored traversal, a published benchmark digest was stale, rendezvous database reads lacked the service deadline, and exact byte accounting allocated avoidable duplicate encodings. Release issue #311 must remain the truthful owner while those findings are fixed, the candidate is reproved, and publication verification plus workspace cleanup remain with the deliberately post-release owner.
 
 ## What Changes
 
@@ -11,6 +11,7 @@ ProjectAtlas v0.4.0 has completed its feature program, but exact-head review of 
 - Run `02-Release` in `prepublish_only` mode so the real package and installer paths are proven without creating a tag or GitHub release.
 - Carry only an explicit clean, all-platform optional-parser handoff into `02-Release`, bind its run, candidate tree, aggregate proof, clean receipts, archive sizes, and archive digests, and publish both supported pack archives with the release.
 - Restrict cross-root rendezvous evidence to exact external identities reached by the primary anchored traversal in the requested direction.
+- Bind every rendezvous database read to the earlier caller or service deadline and count serialized-equivalent federation state without retaining another encoded copy.
 - Correct the MCP composition evaluation's raw-input digest in both published representations and verify the binding directly.
 - Prepare the exact `dev`-to-`main` promotion while keeping `main` and publication untouched until readiness is complete.
 - Create a separate non-milestone post-release issue that owns published-release verification and the user-requested safe branch, worktree, and external ProjectAtlas checkout cleanup.
@@ -23,13 +24,13 @@ ProjectAtlas v0.4.0 has completed its feature program, but exact-head review of 
 
 ### Modified Capabilities
 
-- `cross-repository-intelligence`: Require federated rendezvous evidence to remain inside the primary anchored and directed traversal.
+- `cross-repository-intelligence`: Require federated rendezvous evidence to remain inside the primary anchored and directed traversal, the request deadline, and the aggregate intermediate-state ceiling.
 - `language-intelligence-registry`: Require supported optional-parser archives to ship only through an exact clean-run release handoff.
 - `repository-intelligence-benchmarks`: Require published evaluation digests to match their named raw input.
 
 ## Impact
 
-This change affects OpenSpec release artifacts, GitHub issue #311, federated service filtering and focused tests, the MCP composition evaluation metadata, the optional-parser architecture diagram, the final `dev` candidate proof, and the existing `optional-parser-pack`, `02-Release`, and `03-Auto-Release` workflows. It adds no crate, dependency, SQLite schema or migration, SQLite write path, CLI/MCP schema, or second release workflow.
+This change affects OpenSpec release artifacts, GitHub issue #311, federated service filtering, deadline propagation, byte accounting and focused tests, the MCP composition evaluation metadata, the optional-parser architecture diagram, the final `dev` candidate proof, and the existing `optional-parser-pack`, `02-Release`, and `03-Auto-Release` workflows. It adds no crate, dependency, SQLite schema or migration, SQLite write path, CLI/MCP schema, or second release workflow.
 
 ## Non-Goals
 

--- a/openspec/changes/complete-v040-release-readiness/specs/cross-repository-intelligence/spec.md
+++ b/openspec/changes/complete-v040-release-readiness/specs/cross-repository-intelligence/spec.md
@@ -15,3 +15,15 @@ Federated detailed-relation and analysis responses SHALL derive the eligible typ
 #### Scenario: Inbound traversal reaches no external identity
 - **WHEN** the requested inbound traversal contains no exact external identity
 - **THEN** rendezvous output is empty and no secondary family scan is needed
+
+### Requirement: Federated Rendezvous Preserves Request Resource Bounds
+
+Federated rendezvous SHALL bind every SQLite family read to the earlier caller or service deadline through the existing request control. It SHALL measure exact serialized-equivalent identity, row, participant, rendezvous, and cursor bytes without retaining another encoded copy solely for counting.
+
+#### Scenario: A family read reaches the federation deadline
+- **WHEN** a rendezvous SQLite query begins before the service deadline but continues until the deadline expires
+- **THEN** the existing SQLite progress handler observes the request control and stops the read before federation exceeds its advertised wall-clock budget
+
+#### Scenario: A large identity set approaches the intermediate ceiling
+- **WHEN** exact federation state is counted near the intermediate-byte limit
+- **THEN** accounting uses a streaming byte counter, preserves exact JSON-equivalent totals, and does not allocate a second full encoding

--- a/openspec/changes/complete-v040-release-readiness/tasks.md
+++ b/openspec/changes/complete-v040-release-readiness/tasks.md
@@ -19,9 +19,9 @@
 ## 4. Exact-Head Review Corrections
 
 - [ ] 4.1 Make explicit clean all-platform optional-parser construction emit one bounded release handoff; require `02-Release` and `03-Auto-Release` to bind the successful run and identical candidate tree, validate aggregate proof, clean receipts, versions, archive sizes and digests, and stage both supported archives plus aggregate proof as versioned release assets; update and render the owning architecture flow.
-- [ ] 4.2 Restrict detailed and analysis federated rendezvous to exact typed external identities reached by the primary anchored traversal in the requested direction; cover retained outbound matches, unrelated outbound exclusion, empty inbound rendezvous, both public routes, bounded work, cancellation, freshness, and compatibility without a schema, index, migration, transaction, or SQLite write change.
+- [ ] 4.2 Restrict detailed and analysis federated rendezvous to exact typed external identities reached by the primary anchored traversal in the requested direction; bind every family read to the earlier caller or service deadline; use allocation-free exact serialized-byte accounting; and cover retained outbound matches, unrelated outbound exclusion, empty inbound rendezvous, both public routes, bounded work, deadline, cancellation, freshness, and compatibility without a schema, index, migration, transaction, or SQLite write change.
 - [ ] 4.3 Replace the stale MCP composition raw-input SHA-256 in both published evaluation representations and make the existing release gate compare them with the actual raw file.
-- [ ] 4.4 Run the focused workflow validator, benchmark-integrity, federated unit/integration, direction, negative, analysis, and architecture-render checks; then disposition every live PR #351 Codex and Dependabot thread against the corrected head before relocking the candidate.
+- [ ] 4.4 Run the focused workflow validator, benchmark-integrity, federated unit/integration, direction, negative, deadline, byte-accounting, analysis, and architecture-render checks; then disposition every live PR #351 Codex and Dependabot thread against the corrected head before relocking the candidate.
 
 ## 5. Finite Reconciliation
 


### PR DESCRIPTION
## Summary

- bind every federated rendezvous family read to the earlier caller or service deadline
- reuse the existing streaming serialized-byte counter for identity, row, and envelope accounting
- deterministically observe live relation-family query entry and SQLite callback interruption through an opt-in downstream-test feature; default builds remain unchanged
- synchronize the exact-head review scope across OpenSpec and issue #311
- retain the required two-parent merge promotion and disposition the unsupported one-parent topology as fail-closed

## Verification

- complete repository pre-push gate
- 55 projectatlas-service tests
- deterministic deadline regression repeated three times
- all-feature database progress-handler regression
- strict projectatlas-service Clippy
- strict OpenSpec validation and live IssueOps synchronization
- optional-parser release-asset, release-note, MCP composition, and Codex gate self-tests
- ProjectAtlas candidate refresh and low lint

Refs #311