### PR TITLE
fix(mcp): expose concrete Codex input schemas

### DIFF
--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -676,6 +676,7 @@ enum PurposeLintLevelArg {
     ValueEnum,
     schemars::JsonSchema,
 )]
+#[schemars(inline)]
 #[serde(rename_all = "lowercase")]
 enum SearchRetrievalModeArg {
     /// Correctness-authoritative lexical search.
@@ -720,6 +721,7 @@ enum IgnoreKind {
 #[derive(
     Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, ValueEnum, schemars::JsonSchema,
 )]
+#[schemars(inline)]
 #[serde(rename_all = "snake_case")]
 enum RootTransition {
     /// Initialize a missing binding or verify an identical existing binding.

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -1226,6 +1226,7 @@ struct AtlasPurposeSetParams {
 
 /// MCP payload for one batch purpose review item.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[schemars(inline)]
 struct AtlasPurposeReviewItem {
     /// Indexed repository-relative path.
     path: String,

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -19236,7 +19236,7 @@ fn assert_codex_bridge_compatible_input_schemas(tools: &[Value]) -> Result<(), B
         let schema = tool
             .get("inputSchema")
             .ok_or_else(|| io::Error::other(format!("{name} omitted inputSchema")))?;
-        assert_no_local_schema_references(&format!("{name}.inputSchema"), schema)?;
+        assert_self_contained_input_schema(&format!("{name}.inputSchema"), schema)?;
     }
 
     let item_schema = tools_by_name
@@ -19298,33 +19298,41 @@ fn assert_codex_bridge_compatible_input_schemas(tools: &[Value]) -> Result<(), B
     Ok(())
 }
 
-/// Reject bridge-sensitive local definitions or references anywhere in an input schema.
-fn assert_no_local_schema_references(path: &str, value: &Value) -> Result<(), Box<dyn Error>> {
+/// Reject definitions or references anywhere in a self-contained input schema.
+fn assert_self_contained_input_schema(path: &str, value: &Value) -> Result<(), Box<dyn Error>> {
     match value {
         Value::Object(object) => {
             for (key, child) in object {
-                if key == "$defs"
-                    || key == "$ref"
-                        && child
-                            .as_str()
-                            .is_some_and(|reference| reference.starts_with("#/$defs/"))
-                {
+                if matches!(key.as_str(), "$defs" | "definitions" | "$ref") {
                     return Err(io::Error::other(format!(
-                        "Codex-facing schema retained local reference member {path}.{key}"
+                        "Codex-facing schema retained reference member {path}.{key}"
                     ))
                     .into());
                 }
-                assert_no_local_schema_references(&format!("{path}.{key}"), child)?;
+                assert_self_contained_input_schema(&format!("{path}.{key}"), child)?;
             }
         }
         Value::Array(values) => {
             for (index, child) in values.iter().enumerate() {
-                assert_no_local_schema_references(&format!("{path}[{index}]"), child)?;
+                assert_self_contained_input_schema(&format!("{path}[{index}]"), child)?;
             }
         }
         _ => {}
     }
     Ok(())
+}
+
+#[test]
+fn codex_schema_audit_rejects_every_definition_and_reference_form() {
+    for schema in [
+        serde_json::json!({"$ref": "#/properties/value"}),
+        serde_json::json!({"items": {"$ref": "#/definitions/Value"}}),
+        serde_json::json!({"$ref": "https://example.invalid/schema.json"}),
+        serde_json::json!({"$defs": {"Value": {"type": "string"}}}),
+        serde_json::json!({"definitions": {"Value": {"type": "string"}}}),
+    ] {
+        assert!(assert_self_contained_input_schema("fixture", &schema).is_err());
+    }
 }
 
 /// Return whether one field schema admits the expected JSON primitive type.

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -137,8 +137,8 @@ const SKILL_FILE_NAME: &str = "SKILL.md";
 const MCP_CONTRACT_EXECUTABLE_ENV: &str = "PROJECTATLAS_MCP_CONTRACT_EXECUTABLE";
 const MCP_CONTRACT_PLUGIN_ROOT_ENV: &str = "PROJECTATLAS_MCP_CONTRACT_PLUGIN_ROOT";
 const MCP_CONTRACT_METADATA_CANARY: &str = "mcp_contract_metadata_canary";
-const MCP_V040_TOOLS_SHA256: &str =
-    "0c21ea673bdb9cdff48203a274db04fbaccb888bd362407d46fc1bcc0e506b28";
+const MCP_V041_TOOLS_SHA256: &str =
+    "26674d7134973a8f5abdb870a29db6d11e19d4287ec20add04f08653e50dec73";
 const AGENT_EFFICIENCY_BENCHMARK_PATH: &str =
     "../../docs/benchmarks/v0.4-agent-navigation-results.json";
 const AGENT_EFFICIENCY_PARTIAL_FILE: &str = "partial.json";
@@ -8146,6 +8146,34 @@ fn json_values_equivalent(left: &Value, right: &Value) -> bool {
 }
 
 #[test]
+fn mcp_tools_list_exposes_self_contained_codex_input_schemas_without_index_state()
+-> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join(TEST_REPO_DIR);
+    let atlas_dir = repo.join(ATLAS_DIR_NAME);
+    fs::create_dir_all(&atlas_dir)?;
+    let database = atlas_dir.join("projectatlas.db");
+    let executable = mcp_contract_executable();
+
+    let inventory = run_mcp_contract_inventory(&executable, &repo, &database)?;
+    let response = mcp_response(&inventory, 2)?;
+    let tools = response
+        .get("result")
+        .and_then(|result| result.get("tools"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| io::Error::other("MCP tools/list response omitted tools"))?;
+    assert_codex_bridge_compatible_input_schemas(tools)?;
+
+    if database.exists() || fs::read_dir(&atlas_dir)?.next().is_some() {
+        return Err(io::Error::other(
+            "tools/list created project index state while advertising schemas",
+        )
+        .into());
+    }
+    Ok(())
+}
+
+#[test]
 fn agent_efficiency_cli_mcp_contract_is_typed_read_only_and_isolated() -> Result<(), Box<dyn Error>>
 {
     let temp = tempfile::tempdir()?;
@@ -10006,6 +10034,7 @@ fn mcp_advertised_tools_own_their_real_sqlite_effects() -> Result<(), Box<dyn Er
         .and_then(|result| result.get("tools"))
         .and_then(Value::as_array)
         .ok_or_else(|| io::Error::other("MCP contract tools/list omitted tools"))?;
+    assert_codex_bridge_compatible_input_schemas(tools)?;
     let tools_by_name = mcp_tools_by_name(tools)?;
     let advertised_names = tools_by_name.keys().copied().collect::<BTreeSet<_>>();
     let case_names = cases.iter().map(|case| case.name).collect::<BTreeSet<_>>();
@@ -10016,9 +10045,9 @@ fn mcp_advertised_tools_own_their_real_sqlite_effects() -> Result<(), Box<dyn Er
         .into());
     }
     let tools_digest = sha256_hex(&serde_json::to_vec(tools)?);
-    if tools_digest != MCP_V040_TOOLS_SHA256 {
+    if tools_digest != MCP_V041_TOOLS_SHA256 {
         return Err(io::Error::other(format!(
-            "frozen v0.4.0 MCP inventory/schema digest drifted: expected {MCP_V040_TOOLS_SHA256}, found {tools_digest}"
+            "frozen v0.4.1 MCP inventory/schema digest drifted: expected {MCP_V041_TOOLS_SHA256}, found {tools_digest}"
         ))
         .into());
     }
@@ -10181,6 +10210,11 @@ fn mcp_advertised_tools_own_their_real_sqlite_effects() -> Result<(), Box<dyn Er
             "atlas_purpose_set",
             serde_json::json!({"project_path": repo_argument, "path": "../parent-canary.txt", "purpose": "Must not escape."}),
             "project",
+        ),
+        (
+            "atlas_purpose_review",
+            serde_json::json!({"project_path": repo_argument, "apply": false, "items": [{}]}),
+            "missing field `path`",
         ),
     ] {
         assert_mcp_contract_failure_no_mutation(
@@ -19084,11 +19118,15 @@ fn assert_legacy_mcp_surface_compatible(stdout: &str) -> Result<(), Box<dyn Erro
             ))
             .into());
         }
+        let baseline_schema = baseline_tool
+            .get("inputSchema")
+            .ok_or_else(|| io::Error::other(format!("baseline schema missing for {name}")))?;
+        let normalized_schema = (name == "atlas_purpose_review")
+            .then(|| inline_legacy_purpose_review_item_schema(baseline_schema))
+            .transpose()?;
         assert_json_contract_subset(
             &format!("{name}.inputSchema"),
-            baseline_tool
-                .get("inputSchema")
-                .ok_or_else(|| io::Error::other(format!("baseline schema missing for {name}")))?,
+            normalized_schema.as_ref().unwrap_or(baseline_schema),
             current_tool
                 .get("inputSchema")
                 .ok_or_else(|| io::Error::other(format!("current schema missing for {name}")))?,
@@ -19127,6 +19165,148 @@ fn mcp_tools_by_name(tools: &[Value]) -> Result<BTreeMap<&str, &Value>, Box<dyn 
         }
     }
     Ok(indexed)
+}
+
+/// Require the concrete JSON Schema subset consumed by the supported Codex bridge.
+fn assert_codex_bridge_compatible_input_schemas(tools: &[Value]) -> Result<(), Box<dyn Error>> {
+    let tools_by_name = mcp_tools_by_name(tools)?;
+    for (name, tool) in &tools_by_name {
+        let schema = tool
+            .get("inputSchema")
+            .ok_or_else(|| io::Error::other(format!("{name} omitted inputSchema")))?;
+        assert_no_local_schema_references(&format!("{name}.inputSchema"), schema)?;
+    }
+
+    let item_schema = tools_by_name
+        .get("atlas_purpose_review")
+        .and_then(|tool| tool.get("inputSchema"))
+        .and_then(|schema| schema.pointer("/properties/items/items"))
+        .ok_or_else(|| io::Error::other("atlas_purpose_review omitted its item schema"))?;
+    if item_schema.get("type").and_then(Value::as_str) != Some("object") {
+        return Err(io::Error::other(format!(
+            "atlas_purpose_review item schema is not a concrete object: {item_schema}"
+        ))
+        .into());
+    }
+    let required = item_schema
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect::<BTreeSet<_>>();
+    if required != BTreeSet::from(["path"]) {
+        return Err(io::Error::other(format!(
+            "atlas_purpose_review item required fields drifted: {required:?}"
+        ))
+        .into());
+    }
+    let properties = item_schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .ok_or_else(|| io::Error::other("atlas_purpose_review item omitted properties"))?;
+    for (name, expected_type) in [
+        ("path", "string"),
+        ("purpose", "string"),
+        ("confirm_existing", "boolean"),
+        ("task", "string"),
+        ("work_key", "string"),
+        ("state_token", "string"),
+    ] {
+        let property = properties.get(name).ok_or_else(|| {
+            io::Error::other(format!(
+                "atlas_purpose_review item omitted property {name:?}"
+            ))
+        })?;
+        if !schema_declares_type(property, expected_type) {
+            return Err(io::Error::other(format!(
+                "atlas_purpose_review item property {name:?} omitted type {expected_type:?}: {property}"
+            ))
+            .into());
+        }
+    }
+    if required_members_present(item_schema, &serde_json::json!({}))
+        || !required_members_present(item_schema, &serde_json::json!({"path": "src/lib.rs"}))
+    {
+        return Err(io::Error::other(
+            "atlas_purpose_review item schema does not make missing path host-rejectable",
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Reject bridge-sensitive local definitions or references anywhere in an input schema.
+fn assert_no_local_schema_references(path: &str, value: &Value) -> Result<(), Box<dyn Error>> {
+    match value {
+        Value::Object(object) => {
+            for (key, child) in object {
+                if key == "$defs"
+                    || key == "$ref"
+                        && child
+                            .as_str()
+                            .is_some_and(|reference| reference.starts_with("#/$defs/"))
+                {
+                    return Err(io::Error::other(format!(
+                        "Codex-facing schema retained local reference member {path}.{key}"
+                    ))
+                    .into());
+                }
+                assert_no_local_schema_references(&format!("{path}.{key}"), child)?;
+            }
+        }
+        Value::Array(values) => {
+            for (index, child) in values.iter().enumerate() {
+                assert_no_local_schema_references(&format!("{path}[{index}]"), child)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Return whether one field schema admits the expected JSON primitive type.
+fn schema_declares_type(schema: &Value, expected: &str) -> bool {
+    schema.get("type").is_some_and(|value| match value {
+        Value::String(value) => value == expected,
+        Value::Array(values) => values.iter().any(|value| value.as_str() == Some(expected)),
+        _ => false,
+    })
+}
+
+/// Apply the advertised required-object members to one host-side candidate.
+fn required_members_present(schema: &Value, candidate: &Value) -> bool {
+    let Some(candidate) = candidate.as_object() else {
+        return false;
+    };
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .all(|required| candidate.contains_key(required))
+}
+
+/// Normalize the one frozen v0.3.26 nested schema whose representation is now inline.
+fn inline_legacy_purpose_review_item_schema(schema: &Value) -> Result<Value, Box<dyn Error>> {
+    let mut schema = schema.clone();
+    let object = schema
+        .as_object_mut()
+        .ok_or_else(|| io::Error::other("legacy purpose-review schema is not an object"))?;
+    let definitions = object
+        .remove("$defs")
+        .and_then(|value| value.as_object().cloned())
+        .ok_or_else(|| io::Error::other("legacy purpose-review schema omitted $defs"))?;
+    let item = definitions
+        .get("AtlasPurposeReviewItem")
+        .cloned()
+        .ok_or_else(|| io::Error::other("legacy purpose-review item definition is missing"))?;
+    let item_schema = schema
+        .pointer_mut("/properties/items/items")
+        .ok_or_else(|| io::Error::other("legacy purpose-review item reference is missing"))?;
+    *item_schema = item;
+    Ok(schema)
 }
 
 /// Capture bounded logical rows so WAL/page-layout changes do not masquerade as product state.

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -10195,6 +10195,8 @@ fn mcp_advertised_tools_own_their_real_sqlite_effects() -> Result<(), Box<dyn Er
         }
     }
 
+    let missing_index_root = temp.path().join("missing-index");
+    fs::create_dir(&missing_index_root)?;
     for (name, arguments, expected_error) in [
         (
             "atlas_slice",
@@ -10216,6 +10218,21 @@ fn mcp_advertised_tools_own_their_real_sqlite_effects() -> Result<(), Box<dyn Er
             serde_json::json!({"project_path": repo_argument, "apply": false, "items": [{}]}),
             "missing field `path`",
         ),
+        (
+            "atlas_purpose_review",
+            serde_json::json!({"project_path": repo_argument, "apply": true, "items": [{"path": "src/scanned.rs", "purpose": "Must not apply.", "task": "mcp-contract", "work_key": "incomplete"}]}),
+            "entirely conditional",
+        ),
+        (
+            "atlas_purpose_review",
+            serde_json::json!({"project_path": parent_canary, "apply": true, "items": [{"path": "src/scanned.rs", "purpose": "Must not apply."}]}),
+            "not a directory",
+        ),
+        (
+            "atlas_purpose_review",
+            serde_json::json!({"project_path": missing_index_root, "apply": true, "items": [{"path": "src/scanned.rs", "purpose": "Must not apply."}]}),
+            "is missing",
+        ),
     ] {
         assert_mcp_contract_failure_no_mutation(
             &executable,
@@ -10225,6 +10242,51 @@ fn mcp_advertised_tools_own_their_real_sqlite_effects() -> Result<(), Box<dyn Er
             &arguments,
             expected_error,
         )?;
+    }
+    if missing_index_root.join(ATLAS_DIR_NAME).exists() {
+        return Err(io::Error::other("missing-index MCP review created project state").into());
+    }
+
+    let stale_before = mcp_database_snapshot(&db)?;
+    let (stale_response, stale_stdout) = run_mcp_contract_raw_call(
+        &executable,
+        &repo,
+        &db,
+        "atlas_purpose_review",
+        &serde_json::json!({
+            "project_path": repo_argument,
+            "apply": true,
+            "items": [{
+                "path": "src/scanned.rs",
+                "purpose": "Must not apply.",
+                "task": "mcp-contract",
+                "work_key": "0".repeat(64),
+                "state_token": "0".repeat(64)
+            }]
+        }),
+        false,
+    )?;
+    if stale_response
+        .get("result")
+        .and_then(|result| result.get("isError"))
+        .and_then(Value::as_bool)
+        == Some(true)
+    {
+        return Err(io::Error::other(format!(
+            "stale conditional MCP review returned an adapter error: {stale_response}"
+        ))
+        .into());
+    }
+    let stale_review: Value = toon_format::decode_default(&mcp_tool_text(&stale_stdout, 2)?)?;
+    require_json_usize(&stale_review, &["purpose_review", "changed"], 0)?;
+    require_json_usize(&stale_review, &["purpose_review", "conflicts"], 1)?;
+    require_json_string(
+        &stale_review,
+        &["purpose_review_items", "0", "action"],
+        "stale",
+    )?;
+    if mcp_database_snapshot(&db)? != stale_before {
+        return Err(io::Error::other("stale conditional MCP review changed SQLite state").into());
     }
     assert_mcp_non_git_freshness(&executable)?;
     assert_mcp_active_cancellation_preserves_generation(&executable)?;

--- a/openspec/changes/expose-concrete-codex-tool-schemas/.openspec.yaml
+++ b/openspec/changes/expose-concrete-codex-tool-schemas/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/expose-concrete-codex-tool-schemas/design.md
+++ b/openspec/changes/expose-concrete-codex-tool-schemas/design.md
@@ -1,0 +1,54 @@
+## Context
+
+RMCP derives each tool's JSON Schema from its typed `Parameters<T>`. Schemars emits reusable nested types under local `$defs` and points fields to them with `$ref`. ProjectAtlas v0.4.0 has three such inputs: the `atlas_purpose_review` item object, the `atlas_root_set` transition enum, and the `atlas_search` retrieval-mode enum.
+
+Those schemas are standards-valid, but the supported Codex plugin/tool-schema bridge does not reliably retain local references. This is an adapter representation mismatch: Serde deserialization, MCP request routing, and the service/storage layers are already typed and correct.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make every current ProjectAtlas MCP input schema self-contained at the field where a connected host needs its shape.
+- Keep purpose-review `path` required and all five optional fields discoverable.
+- Detect any future local input-schema reference through packaged raw-stdio contract coverage.
+- Preserve runtime validation, project-root isolation, CLI behavior, tool inventory, and request types.
+
+**Non-Goals:**
+
+- A generic JSON Schema resolver or rewriter.
+- Untyped `serde_json::Value` request models.
+- Changes to database, service, or conditional-write semantics.
+- General Codex support for local JSON Schema references or the broader #310 tool-surface redesign.
+
+## Decisions
+
+### Inline at the nested typed-schema boundary
+
+Apply Schemars' type-level `#[schemars(inline)]` attribute to the three affected nested request types. Schemars owns schema generation and those types own the reusable schema representation consumed by the MCP parameter structs, so this is the narrowest responsibility-coherent boundary supported by the pinned Schemars release. The attribute does not alter Serde deserialization.
+
+The simpler alternative of changing only `atlas_purpose_review` is insufficient because the released raw-schema audit found the same bridge-sensitive shape in `atlas_root_set` and `atlas_search`. A post-generation schema walker is rejected because it would duplicate standards-library behavior, add failure modes, and create a generic framework for three closed compile-time types.
+
+### Gate the complete advertised input inventory
+
+Packaged stdio coverage will inspect every `tools/list` input schema and fail if a local `$defs` or `$ref` remains. Focused assertions will also verify that `atlas_purpose_review.items.items` is an object, requires `path`, exposes the five optional fields without making them required, and contains types that allow host-side rejection of an empty item.
+
+The test is bridge-facing to the locally observable boundary: it enforces the self-contained schema subset consumed by Codex without claiming to control or test Codex's upstream renderer inside ProjectAtlas CI.
+
+### Preserve runtime admission as independent defense
+
+Runtime deserialization and purpose-review admission remain unchanged. Existing raw MCP behavior continues to reject a missing `path`, stale or incomplete conditional-write identities, oversized requests, wrong roots, and missing indexes independently of host validation.
+
+## Risks / Trade-offs
+
+- [Codex later adds complete local-reference support] → Keep the standards-valid typed models and treat inline schemas as a compatible representation; removing the attributes later is optional, not required.
+- [A future nested tool type reintroduces a local reference] → Audit all advertised input schemas in the packaged contract test rather than maintaining a hand-written affected-tool list.
+- [Inlining increases `tools/list` output] → Only three small, single-use nested definitions are affected. Generation remains startup/metadata work with constant CPU and memory; tool-call serialization, database I/O, locks, WAL behavior, and persistent bytes are unchanged.
+- [Structural tests overstate host integration] → Report Codex's general reference handling as an upstream dependency and describe the local regression as compatibility-shape evidence, not hosted Codex proof.
+
+## Migration Plan
+
+No data migration is required. Ship the schema-generation change with the next ProjectAtlas runtime/plugin build. Rollback is the ordinary code rollback; runtime request compatibility is unchanged in either direction.
+
+## Open Questions
+
+General local `$defs`/`$ref` support remains owned by the Codex plugin/tool-schema bridge. ProjectAtlas cannot close that upstream capability from this repository; it can only emit the smallest compatible self-contained shape for its own tools.

--- a/openspec/changes/expose-concrete-codex-tool-schemas/proposal.md
+++ b/openspec/changes/expose-concrete-codex-tool-schemas/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+ProjectAtlas v0.4.0 emits valid typed MCP input schemas, but its local `$defs` references are not reliably retained by the supported Codex tool-schema bridge. Agents can therefore see nested inputs such as `atlas_purpose_review.items` as unknown even though runtime deserialization remains strict.
+
+## What Changes
+
+- Publish self-contained MCP input schemas for every current ProjectAtlas tool whose nested request type otherwise produces a local `$ref`.
+- Keep `atlas_purpose_review.items` concrete, including required `path` and the optional purpose and conditional-write fields.
+- Add raw-stdio and bridge-facing regression coverage for reference-free schemas, required-field rejectability, and unchanged optional fields.
+- Preserve typed Rust request models and existing CLI, raw MCP, runtime validation, and conditional-write behavior.
+- Record that Codex still owns general support for valid local JSON Schema references; ProjectAtlas supplies a narrow compatibility representation for its current affected tools.
+
+This change is ready for implementation.
+
+## Capabilities
+
+### New Capabilities
+
+- `codex-tool-schema-compatibility`: MCP tool inputs remain concrete and agent-readable through the supported Codex plugin bridge.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The MCP adapter schema annotations and packaged MCP contract tests are affected. No database schema, storage behavior, CLI contract, dependency, or tool inventory changes are required.
+
+## Non-Goals
+
+- Replacing typed request structs with untyped JSON values.
+- Building a generic JSON Schema rewriting framework.
+- Redesigning or rationalizing the broader MCP tool surface tracked by #310.
+- Weakening runtime validation in reliance on host-side validation.

--- a/openspec/changes/expose-concrete-codex-tool-schemas/specs/codex-tool-schema-compatibility/spec.md
+++ b/openspec/changes/expose-concrete-codex-tool-schemas/specs/codex-tool-schema-compatibility/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Connected MCP input schemas are self-contained
+
+ProjectAtlas SHALL advertise every MCP tool input as a concrete self-contained JSON Schema that does not require the connected Codex bridge to resolve a local `$defs` or `$ref`.
+
+#### Scenario: Complete input-schema audit
+
+- **WHEN** a packaged ProjectAtlas server returns `tools/list`
+- **THEN** every advertised input schema contains no local definition or reference
+- **AND** nested request structs and enums remain concrete at their owning fields
+
+#### Scenario: Missing project index
+
+- **WHEN** a host lists MCP tools before the selected project index exists
+- **THEN** ProjectAtlas returns the same concrete input schemas without creating or migrating the index
+
+### Requirement: Purpose-review items remain discoverable and rejectable
+
+The connected `atlas_purpose_review` schema SHALL expose each `items` element as an object with required string `path` and optional `purpose`, `confirm_existing`, `task`, `work_key`, and `state_token` fields.
+
+#### Scenario: Missing required path
+
+- **WHEN** a host validates `{"apply":false,"items":[{}]}` against the advertised schema
+- **THEN** validation rejects the item for missing required `path` before runtime invocation
+
+#### Scenario: Optional review fields
+
+- **WHEN** a host inspects the concrete item object
+- **THEN** `purpose`, `confirm_existing`, `task`, `work_key`, and `state_token` are discoverable
+- **AND** none of those five fields is required
+
+### Requirement: Runtime and adapter compatibility are preserved
+
+ProjectAtlas SHALL retain typed Rust request models, Serde deserialization, MCP routing, CLI behavior, project-root isolation, and purpose-review admission checks independently of host-side schema validation.
+
+#### Scenario: Runtime defense for invalid purpose review
+
+- **WHEN** a raw MCP caller bypasses host validation and submits an item without `path`
+- **THEN** typed runtime deserialization rejects the request
+- **AND** no purpose metadata is changed
+
+#### Scenario: Conditional-write validation
+
+- **WHEN** a raw MCP caller submits stale or incomplete `task`, `work_key`, and `state_token` identity
+- **THEN** the existing purpose-review admission behavior rejects the request without mutation
+
+#### Scenario: Wrong root or missing index
+
+- **WHEN** a connected or raw MCP request addresses a wrong root or a missing index
+- **THEN** the existing typed error and no-implicit-mutation behavior is unchanged
+
+### Requirement: Upstream ownership is explicit
+
+ProjectAtlas SHALL describe general Codex support for standards-valid local JSON Schema references as an upstream host dependency while providing a narrow self-contained compatibility representation for its own affected tools.
+
+#### Scenario: Local compatibility proof
+
+- **WHEN** ProjectAtlas validates its packaged MCP contract
+- **THEN** it reports reference-free schema evidence as local compatibility proof
+- **AND** it does not claim that ProjectAtlas tests or fixes Codex's general schema renderer

--- a/openspec/changes/expose-concrete-codex-tool-schemas/tasks.md
+++ b/openspec/changes/expose-concrete-codex-tool-schemas/tasks.md
@@ -13,4 +13,4 @@
 
 - [x] 3.1 Run focused MCP schema and purpose-review tests, including the missing-`path` negative case and compatibility inventory.
 - [x] 3.2 Run formatting, workspace check, Clippy, rustdoc, OpenSpec, issue-map/checklist diagnostics, and diff-quality gates proportionate to the change.
-- [ ] 3.3 Synchronize the GitHub checklist and obtain final integrated, packaged-Codex/hosted, and live review proof.
+- [x] 3.3 Synchronize the GitHub checklist and obtain final integrated, packaged-Codex/hosted, and live review proof.

--- a/openspec/changes/expose-concrete-codex-tool-schemas/tasks.md
+++ b/openspec/changes/expose-concrete-codex-tool-schemas/tasks.md
@@ -1,0 +1,16 @@
+## 1. Reproduction and Contract
+
+- [x] 1.1 Reproduce the v0.4.0 raw-stdio local-reference schema and identify the Codex bridge compatibility boundary.
+- [x] 1.2 Audit all advertised MCP inputs for local `$defs` and `$ref` use and record the complete affected set.
+
+## 2. Concrete MCP Schemas
+
+- [x] 2.1 Inline the affected schemas at their nested typed-schema boundary without changing Serde or runtime request types.
+- [x] 2.2 Add packaged raw-stdio coverage that rejects any advertised local input reference and verifies concrete purpose-review required and optional fields.
+- [x] 2.3 Preserve and verify runtime rejection, conditional-write admission, wrong-root, missing-index, and no-implicit-mutation behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run focused MCP schema and purpose-review tests, including the missing-`path` negative case and compatibility inventory.
+- [x] 3.2 Run formatting, workspace check, Clippy, rustdoc, OpenSpec, issue-map/checklist diagnostics, and diff-quality gates proportionate to the change.
+- [ ] 3.3 Synchronize the GitHub checklist and obtain final integrated, packaged-Codex/hosted, and live review proof.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -12,6 +12,7 @@
     "converge-opencode-installer": 279,
     "delegate-bulk-purpose-curation": 301,
     "enforce-rust-test-quality-gates": 309,
+    "expose-concrete-codex-tool-schemas": 386,
     "expose-mcp-capabilities-settings": 293,
     "gate-codex-pr-review-threads": 299,
     "harden-parser-runtime-and-graph-invalidation": 356,


### PR DESCRIPTION
## Summary

- emit self-contained input schemas for every currently affected MCP nested type
- keep purpose-review path required and its optional fields concrete without changing typed runtime admission
- audit all advertised schemas through the packaged raw-stdio contract and preserve no-mutation behavior

Closes #386

## Verification

- focused raw MCP tools/list and missing-path regressions
- full ordinary workspace, CLI E2E, installer, parser, documentation, dependency, OpenSpec, and IssueOps gates
- long benchmark campaigns remain manual-only and were not run