### PR TITLE
fix(graph): resolve configured module aliases

### DIFF
--- a/crates/projectatlas-cli/src/runtime.rs
+++ b/crates/projectatlas-cli/src/runtime.rs
@@ -2,6 +2,7 @@
 //! Shared runtime orchestration for the `ProjectAtlas` CLI and MCP adapters.
 
 mod graph_projection;
+mod module_resolution;
 #[cfg(feature = "optional-parser-supervisor")]
 mod optional_parser_runtime;
 mod source_observation;
@@ -6470,6 +6471,10 @@ pub(crate) fn watch_path_requires_full_scan(root: &Path, path: &Path) -> bool {
         || relative.ends_with("/.git")
         || relative == ".git/info/exclude"
         || relative.ends_with("/.git/info/exclude")
+        || matches!(
+            relative.rsplit('/').next(),
+            Some("tsconfig.json" | "jsconfig.json")
+        )
         || index_policy_path(relative.as_str())
 }
 

--- a/crates/projectatlas-cli/src/runtime/graph_projection.rs
+++ b/crates/projectatlas-cli/src/runtime/graph_projection.rs
@@ -23,8 +23,9 @@ use projectatlas_db::{
     RepositoryResolutionCandidate,
 };
 use projectatlas_symbols::{
-    MAX_RESOLUTION_KEYS_PER_FACT, ResolutionKeyProjection, ResolutionProjectionError,
-    derive_resolution_keys, parse_import_references,
+    ConfiguredModuleResolution, MAX_RESOLUTION_KEYS_PER_FACT, ResolutionKeyProjection,
+    ResolutionProjectionContext, ResolutionProjectionError, derive_resolution_keys_with_context,
+    parse_import_references,
 };
 use std::borrow::{Borrow, Cow};
 use std::cmp::Reverse;
@@ -246,9 +247,18 @@ pub(super) fn stage_full_repository_graph(
         .collect::<BTreeSet<_>>();
     let graphs = complete_symbol_graphs(store, &paths, symbols, control)?;
     control.check(IndexWorkStage::SymbolParsing)?;
+    let configured_modules =
+        super::module_resolution::load_configured_module_resolution(root, nodes, control)?;
     let packages = PackageIndex::from_graphs(&graphs)?;
-    let entity_projection = build_entity_projection(
-        project, generation, nodes, &graphs, &packages, true, control,
+    let entity_projection = build_entity_projection_with_config(
+        project,
+        generation,
+        nodes,
+        &graphs,
+        &packages,
+        &configured_modules,
+        true,
+        control,
     )?;
     let candidates = resolution_registry_from_exports(&entity_projection, control)?;
     enforce_resolution_staging_budget(&entity_projection, &candidates)?;
@@ -292,6 +302,8 @@ pub(super) fn stage_incremental_repository_graph(
 ) -> Result<StagedRepositoryGraph, CliError> {
     let project = selected_project(store)?;
     let generation = next_generation(base_generation)?;
+    let configured_modules =
+        super::module_resolution::load_configured_module_resolution(root, expected_nodes, control)?;
     let direct_paths = direct_paths.iter().cloned().collect::<BTreeSet<_>>();
     enforce_incremental_count(
         root,
@@ -340,7 +352,12 @@ pub(super) fn stage_incremental_repository_graph(
     let mut changed_keys = old_exports.rows.into_iter().collect::<BTreeSet<_>>();
     for graph in &direct_graphs {
         control.check(IndexWorkStage::SymbolParsing)?;
-        let projection = resolution_projection(project, packages.package_name(&graph.path), graph)?;
+        let projection = resolution_projection_with_config(
+            project,
+            packages.package_name(&graph.path),
+            graph,
+            &configured_modules,
+        )?;
         changed_keys.extend(projection.source_keys().iter().cloned());
         for symbol in projection.symbol_keys() {
             changed_keys.extend(symbol.keys().iter().cloned());
@@ -387,12 +404,13 @@ pub(super) fn stage_incremental_repository_graph(
         .filter(|node| affected_paths.contains(&node.path))
         .cloned()
         .collect::<Vec<_>>();
-    let entity_projection = build_entity_projection(
+    let entity_projection = build_entity_projection_with_config(
         project,
         generation,
         &affected_nodes,
         &affected_graphs,
         &packages,
+        &configured_modules,
         false,
         control,
     )?;
@@ -637,12 +655,37 @@ fn qualified_symbol_parents(graph: &SymbolGraph) -> Vec<Option<String>> {
 }
 
 /// Project file, symbol, package, and canonical export facts from parser graphs.
+#[cfg(test)]
 fn build_entity_projection(
     project: ProjectInstanceId,
     generation: IndexGeneration,
     nodes: &[Node],
     graphs: &[impl Borrow<SymbolGraph>],
     packages: &PackageIndex,
+    include_project: bool,
+    control: &IndexWorkControl,
+) -> Result<EntityProjection, CliError> {
+    build_entity_projection_with_config(
+        project,
+        generation,
+        nodes,
+        graphs,
+        packages,
+        &ConfiguredModuleResolution::default(),
+        include_project,
+        control,
+    )
+}
+
+/// Project entity/key facts with one shared configured-module snapshot.
+#[allow(clippy::too_many_arguments)]
+fn build_entity_projection_with_config(
+    project: ProjectInstanceId,
+    generation: IndexGeneration,
+    nodes: &[Node],
+    graphs: &[impl Borrow<SymbolGraph>],
+    packages: &PackageIndex,
+    configured_modules: &ConfiguredModuleResolution,
     include_project: bool,
     control: &IndexWorkControl,
 ) -> Result<EntityProjection, CliError> {
@@ -750,7 +793,12 @@ fn build_entity_projection(
             }
             symbol_digests.push(entity_digest);
         }
-        let resolution = resolution_projection(project, packages.package_name(&graph.path), graph)?;
+        let resolution = resolution_projection_with_config(
+            project,
+            packages.package_name(&graph.path),
+            graph,
+            configured_modules,
+        )?;
         let file = entity_by_digest
             .get(&file_digest)
             .ok_or_else(|| CliError::InvalidInput("graph file owner was not staged".to_string()))?;
@@ -2628,13 +2676,15 @@ fn complete_symbol_graphs<'a>(
     Ok(graphs.into_values().collect())
 }
 
-/// Derive canonical resolution keys with typed resource-limit translation.
-fn resolution_projection(
+/// Derive canonical resolution keys with repository compiler configuration.
+fn resolution_projection_with_config(
     project: ProjectInstanceId,
     package: Option<&str>,
     graph: &SymbolGraph,
+    configured_modules: &ConfiguredModuleResolution,
 ) -> Result<ResolutionKeyProjection, CliError> {
-    match derive_resolution_keys(project, package, graph) {
+    let context = ResolutionProjectionContext::with_configured_modules(configured_modules);
+    match derive_resolution_keys_with_context(project, package, graph, context) {
         Ok(projection) => Ok(projection),
         Err(ResolutionProjectionError::KeyLimit { requested, .. }) => {
             Err(IndexWorkFailure::resource_limit(
@@ -2881,12 +2931,12 @@ mod tests {
         CliError, GRAPH_STAGE_DATABASE_FILE_NAME, GRAPH_STAGE_DIRECTORY_PREFIX, GraphOwners,
         GraphSymbolIndex, MAX_INCREMENTAL_GRAPH_BYTES, MAX_INCREMENTAL_GRAPH_ROWS, PackageIndex,
         ProjectResolutionRegistry, RepositoryGraphMutation, StagedRepositoryGraph,
-        build_entity_projection, cleanup_abandoned_graph_staging,
-        enforce_incremental_projection_budget, enforce_incremental_projection_limits,
-        explicit_external_selector, finish_projection, finish_projection_in_database,
-        insert_relation, is_cargo_manifest_path, registry_resolution_matches, relation_resolution,
-        remove_owned_graph_stage_payload, repository_path_belongs_to,
-        resolution_registry_from_exports, rust_toolchain_identity,
+        build_entity_projection, build_entity_projection_with_config,
+        cleanup_abandoned_graph_staging, enforce_incremental_projection_budget,
+        enforce_incremental_projection_limits, explicit_external_selector, finish_projection,
+        finish_projection_in_database, insert_relation, is_cargo_manifest_path,
+        registry_resolution_matches, relation_resolution, remove_owned_graph_stage_payload,
+        repository_path_belongs_to, resolution_registry_from_exports, rust_toolchain_identity,
         stage_incremental_repository_graph, try_graph_stage_lease,
     };
     use crate::runtime::{
@@ -2914,6 +2964,10 @@ mod tests {
         AtlasStore, RepositoryAffectedSourceFootprint, RepositoryGraphRelationQuery,
     };
     use projectatlas_symbols::extract_symbol_graph;
+    use projectatlas_symbols::{
+        ConfiguredModuleResolution, EcmaScriptConfigKind, EcmaScriptModuleConfig,
+        EcmaScriptPathMapping,
+    };
     use std::collections::{BTreeMap, BTreeSet};
     use std::error::Error;
     use std::fmt::Debug;
@@ -4131,6 +4185,74 @@ mod tests {
             }),
             "duplicate same-file declarations did not remain ambiguous",
         )?;
+        Ok(())
+    }
+
+    #[test]
+    fn configured_module_targets_reuse_graph_ambiguity_ownership() -> Result<(), Box<dyn Error>> {
+        let project = ProjectInstanceId::from_bytes([19; 16])?;
+        let generation = IndexGeneration::new(1);
+        let control = IndexWorkControl::new(IndexCancellation::new(), None);
+        let graphs = vec![
+            extract_symbol_graph(
+                "src/first/controller.ts",
+                Some("typescript"),
+                "export function useController() { return 'first'; }\n",
+            ),
+            extract_symbol_graph(
+                "src/second/controller.ts",
+                Some("typescript"),
+                "export function useController() { return 'second'; }\n",
+            ),
+            extract_symbol_graph(
+                "src/page.ts",
+                Some("typescript"),
+                "import { useController } from '@/controller';\nexport const value = useController();\n",
+            ),
+        ];
+        let packages = PackageIndex::from_graphs(&graphs)?;
+        let configured = ConfiguredModuleResolution::new(vec![EcmaScriptModuleConfig::new(
+            "tsconfig.json",
+            EcmaScriptConfigKind::TypeScript,
+            None,
+            vec![EcmaScriptPathMapping::new(
+                "@/*",
+                vec!["src/first/*".to_string(), "src/second/*".to_string()],
+            )?],
+        )?])?;
+        let projection = build_entity_projection_with_config(
+            project,
+            generation,
+            &[],
+            &graphs,
+            &packages,
+            &configured,
+            true,
+            &control,
+        )?;
+        let candidates = resolution_registry_from_exports(&projection, &control)?;
+        let staged = finish_projection(
+            project,
+            generation,
+            RepositoryGraphMutation::Full,
+            &graphs,
+            projection,
+            &candidates,
+            &control,
+        )?;
+        for kind in [RelationKind::Imports, RelationKind::Calls] {
+            require(
+                staged.relations.iter().any(|relation| {
+                    relation.kind() == GraphRelationKind::from_legacy(kind)
+                        && matches!(
+                            relation.resolution(),
+                            RelationResolution::Ambiguous { candidates, .. }
+                                if candidates.get() == 2
+                        )
+                }),
+                "configured mapping did not retain all ambiguity candidates",
+            )?;
+        }
         Ok(())
     }
 

--- a/crates/projectatlas-cli/src/runtime/module_resolution.rs
+++ b/crates/projectatlas-cli/src/runtime/module_resolution.rs
@@ -1,0 +1,345 @@
+//! Bounded repository compiler-configuration loading for semantic graph projection.
+
+use super::{
+    CliError, IndexWorkControl, IndexWorkFailure, IndexWorkResource, IndexWorkStage, Node,
+    NodeKind, SourceReadFailure, read_source_bytes_controlled, repo_path_to_native,
+    source_changed_during_derivation,
+};
+use jsonc_parser::{ParseOptions as JsoncParseOptions, parse_to_serde_value};
+use projectatlas_symbols::{
+    ConfiguredModuleResolution, EcmaScriptConfigKind, EcmaScriptModuleConfig,
+    EcmaScriptPathMapping, MAX_CONFIGURED_MODULE_CONFIGS, MAX_CONFIGURED_MODULE_MAPPINGS,
+    MAX_CONFIGURED_MODULE_TARGETS,
+};
+use serde_json::Value;
+use std::path::Path;
+
+/// Maximum complete bytes admitted from one compiler configuration.
+const MAX_MODULE_CONFIG_FILE_BYTES: u64 = 1024 * 1024;
+/// Maximum aggregate compiler-configuration bytes retained by one graph stage.
+const MAX_MODULE_CONFIG_TOTAL_BYTES: u64 = 16 * 1024 * 1024;
+/// Work interval between cancellation/deadline checks while decoding mappings.
+const MODULE_CONFIG_CONTROL_INTERVAL: usize = 64;
+
+/// Load one deterministic compiler-configuration snapshot from indexed nodes.
+pub(super) fn load_configured_module_resolution(
+    root: &Path,
+    nodes: &[Node],
+    control: &IndexWorkControl,
+) -> Result<ConfiguredModuleResolution, CliError> {
+    let mut config_nodes = nodes
+        .iter()
+        .filter(|node| node.kind == NodeKind::File)
+        .filter_map(|node| config_kind(&node.path).map(|kind| (node, kind)))
+        .collect::<Vec<_>>();
+    config_nodes.sort_by(|(left, _), (right, _)| left.path.cmp(&right.path));
+    if config_nodes.len() > MAX_CONFIGURED_MODULE_CONFIGS {
+        return Err(module_config_resource_limit(
+            IndexWorkResource::Entries,
+            MAX_CONFIGURED_MODULE_CONFIGS,
+            config_nodes.len(),
+        ));
+    }
+
+    let mut total_bytes = 0_u64;
+    let mut total_mappings = 0_usize;
+    let mut configs = Vec::with_capacity(config_nodes.len());
+    for (index, (node, kind)) in config_nodes.into_iter().enumerate() {
+        check_config_work(control, index)?;
+        let size = node.size_bytes.unwrap_or_default();
+        if size > MAX_MODULE_CONFIG_FILE_BYTES {
+            return Err(module_config_resource_limit(
+                IndexWorkResource::SourceBytes,
+                MAX_MODULE_CONFIG_FILE_BYTES,
+                size,
+            ));
+        }
+        total_bytes = total_bytes.saturating_add(size);
+        if total_bytes > MAX_MODULE_CONFIG_TOTAL_BYTES {
+            return Err(module_config_resource_limit(
+                IndexWorkResource::SourceBytes,
+                MAX_MODULE_CONFIG_TOTAL_BYTES,
+                total_bytes,
+            ));
+        }
+        let native_path = root.join(repo_path_to_native(&node.path));
+        let bytes = match read_source_bytes_controlled(
+            &native_path,
+            MAX_MODULE_CONFIG_FILE_BYTES,
+            IndexWorkStage::SymbolParsing,
+            control,
+        ) {
+            Ok(bytes) => bytes,
+            Err(SourceReadFailure::Io(source)) => {
+                return Err(CliError::Io {
+                    path: native_path,
+                    source,
+                });
+            }
+            Err(SourceReadFailure::IndexWork(failure)) => return Err(failure.into()),
+            Err(SourceReadFailure::LimitExceeded { observed }) => {
+                return Err(module_config_resource_limit(
+                    IndexWorkResource::SourceBytes,
+                    MAX_MODULE_CONFIG_FILE_BYTES,
+                    observed,
+                ));
+            }
+        };
+        let current_hash = blake3::hash(&bytes).to_hex().to_string();
+        if node.content_hash.as_deref() != Some(current_hash.as_str()) {
+            return Err(source_changed_during_derivation(root, &node.path));
+        }
+        let content = String::from_utf8(bytes).map_err(|_utf8_error| {
+            CliError::InvalidInput(format!(
+                "compiler configuration '{}' is not valid UTF-8",
+                node.path
+            ))
+        })?;
+        let value: Value =
+            parse_to_serde_value(&content, &JsoncParseOptions::default()).map_err(|error| {
+                CliError::InvalidInput(format!(
+                    "failed to parse compiler configuration '{}': {error}",
+                    node.path
+                ))
+            })?;
+        let config = decode_config(node.path.as_str(), kind, &value, control)?;
+        total_mappings = total_mappings.saturating_add(config.1);
+        if total_mappings > MAX_CONFIGURED_MODULE_MAPPINGS {
+            return Err(module_config_resource_limit(
+                IndexWorkResource::RelationRows,
+                MAX_CONFIGURED_MODULE_MAPPINGS,
+                total_mappings,
+            ));
+        }
+        configs.push(config.0);
+    }
+    ConfiguredModuleResolution::new(configs)
+        .map_err(|error| CliError::InvalidInput(error.to_string()))
+}
+
+/// Decode direct `compilerOptions.baseUrl` and `compilerOptions.paths`.
+fn decode_config(
+    config_path: &str,
+    kind: EcmaScriptConfigKind,
+    value: &Value,
+    control: &IndexWorkControl,
+) -> Result<(EcmaScriptModuleConfig, usize), CliError> {
+    let root = value.as_object().ok_or_else(|| {
+        CliError::InvalidInput(format!(
+            "compiler configuration '{config_path}' must contain a JSON object"
+        ))
+    })?;
+    let Some(compiler_options) = root.get("compilerOptions") else {
+        return EcmaScriptModuleConfig::new(config_path, kind, None, Vec::new())
+            .map(|config| (config, 0))
+            .map_err(|error| CliError::InvalidInput(error.to_string()));
+    };
+    let compiler_options = compiler_options.as_object().ok_or_else(|| {
+        CliError::InvalidInput(format!(
+            "compiler configuration '{config_path}' field 'compilerOptions' must be an object"
+        ))
+    })?;
+    let config_directory = config_path
+        .rsplit_once('/')
+        .map_or("", |(directory, _)| directory);
+    let base_url = compiler_options
+        .get("baseUrl")
+        .map(|value| {
+            value.as_str().ok_or_else(|| {
+                CliError::InvalidInput(format!(
+                    "compiler configuration '{config_path}' field 'baseUrl' must be a string"
+                ))
+            })
+        })
+        .transpose()?
+        .map(|base_url| normalize_repository_target(config_directory, base_url, false))
+        .transpose()?;
+    let mapping_base = base_url.as_deref().unwrap_or(config_directory);
+    let mut mappings = Vec::new();
+    if let Some(paths) = compiler_options.get("paths") {
+        let paths = paths.as_object().ok_or_else(|| {
+            CliError::InvalidInput(format!(
+                "compiler configuration '{config_path}' field 'paths' must be an object"
+            ))
+        })?;
+        for (index, (pattern, targets)) in paths.iter().enumerate() {
+            check_config_work(control, index)?;
+            let targets = targets.as_array().ok_or_else(|| {
+                CliError::InvalidInput(format!(
+                    "compiler configuration '{config_path}' path mapping '{pattern}' must be an array"
+                ))
+            })?;
+            if targets.is_empty() || targets.len() > MAX_CONFIGURED_MODULE_TARGETS {
+                return Err(module_config_resource_limit(
+                    IndexWorkResource::RelationRows,
+                    MAX_CONFIGURED_MODULE_TARGETS,
+                    targets.len(),
+                ));
+            }
+            let targets = targets
+                .iter()
+                .map(|target| {
+                    let target = target.as_str().ok_or_else(|| {
+                        CliError::InvalidInput(format!(
+                            "compiler configuration '{config_path}' path mapping '{pattern}' contains a non-string target"
+                        ))
+                    })?;
+                    normalize_repository_target(mapping_base, target, true)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            mappings.push(
+                EcmaScriptPathMapping::new(pattern, targets)
+                    .map_err(|error| CliError::InvalidInput(error.to_string()))?,
+            );
+        }
+    }
+    let mapping_count = mappings.len();
+    EcmaScriptModuleConfig::new(config_path, kind, base_url, mappings)
+        .map(|config| (config, mapping_count))
+        .map_err(|error| CliError::InvalidInput(error.to_string()))
+}
+
+/// Normalize one config-relative target into a repository-contained lexical path.
+fn normalize_repository_target(
+    base: &str,
+    target: &str,
+    allow_wildcard: bool,
+) -> Result<String, CliError> {
+    let target = target.replace('\\', "/");
+    if target.starts_with('/') || target.contains(':') || target.contains('\0') {
+        return Err(CliError::InvalidInput(format!(
+            "configured module target {target:?} is absolute or invalid"
+        )));
+    }
+    if !allow_wildcard && target.contains('*') || target.matches('*').count() > 1 {
+        return Err(CliError::InvalidInput(format!(
+            "configured module target {target:?} contains an invalid wildcard"
+        )));
+    }
+    let mut components = base
+        .split('/')
+        .filter(|component| !component.is_empty())
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    for component in target.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                if components.pop().is_none() {
+                    return Err(CliError::InvalidInput(format!(
+                        "configured module target {target:?} escapes the repository"
+                    )));
+                }
+            }
+            component => components.push(component.to_string()),
+        }
+    }
+    Ok(components.join("/"))
+}
+
+/// Classify exact compiler-configuration basenames.
+fn config_kind(path: &str) -> Option<EcmaScriptConfigKind> {
+    match path.rsplit('/').next() {
+        Some("tsconfig.json") => Some(EcmaScriptConfigKind::TypeScript),
+        Some("jsconfig.json") => Some(EcmaScriptConfigKind::JavaScript),
+        _ => None,
+    }
+}
+
+/// Observe cancellation and deadline ownership at a bounded work interval.
+fn check_config_work(control: &IndexWorkControl, index: usize) -> Result<(), CliError> {
+    if index.is_multiple_of(MODULE_CONFIG_CONTROL_INTERVAL) {
+        control.check(IndexWorkStage::SymbolParsing)?;
+    }
+    Ok(())
+}
+
+/// Translate configured-module bounds into the runtime's typed limit failure.
+fn module_config_resource_limit(
+    resource: IndexWorkResource,
+    limit: impl TryInto<u64>,
+    observed: impl TryInto<u64>,
+) -> CliError {
+    IndexWorkFailure::resource_limit(
+        IndexWorkStage::SymbolParsing,
+        resource,
+        limit.try_into().unwrap_or(u64::MAX),
+        observed.try_into().unwrap_or(u64::MAX),
+    )
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CliError, decode_config, normalize_repository_target};
+    use projectatlas_core::{
+        IndexCancellation, IndexWorkControl, IndexWorkFailure, IndexWorkStage,
+    };
+    use projectatlas_symbols::EcmaScriptConfigKind;
+    use serde_json::json;
+    use std::error::Error;
+
+    #[test]
+    fn direct_json_config_is_normalized_without_leaving_the_repository()
+    -> Result<(), Box<dyn Error>> {
+        let control = IndexWorkControl::new(IndexCancellation::new(), None);
+        let (config, mappings) = decode_config(
+            "packages/app/tsconfig.json",
+            EcmaScriptConfigKind::TypeScript,
+            &json!({
+                "compilerOptions": {
+                    "baseUrl": "src",
+                    "paths": {
+                        "@/*": ["*"],
+                        "@shared/*": ["../../shared/*"]
+                    }
+                }
+            }),
+            &control,
+        )?;
+        if mappings != 2 {
+            return Err(std::io::Error::other("expected both configured path mappings").into());
+        }
+        let _configured = projectatlas_symbols::ConfiguredModuleResolution::new(vec![config])?;
+        Ok(())
+    }
+
+    #[test]
+    fn lexical_target_normalization_rejects_root_escape() {
+        let contained = normalize_repository_target("packages/app", "../shared/*", true);
+        assert!(contained.is_ok());
+        assert_eq!(contained.ok().as_deref(), Some("packages/shared/*"));
+        assert_eq!(
+            normalize_repository_target("src", "shared folder/*", true)
+                .ok()
+                .as_deref(),
+            Some("src/shared folder/*")
+        );
+        assert!(normalize_repository_target("", "../outside/*", true).is_err());
+        assert!(normalize_repository_target("src", "C:/outside/*", true).is_err());
+    }
+
+    #[test]
+    fn config_decode_observes_typed_cancellation_before_mapping_work() {
+        let control = IndexWorkControl::new(IndexCancellation::new(), None);
+        control.cancel();
+        let result = decode_config(
+            "tsconfig.json",
+            EcmaScriptConfigKind::TypeScript,
+            &json!({
+                "compilerOptions": {
+                    "paths": {
+                        "@/*": ["src/*"]
+                    }
+                }
+            }),
+            &control,
+        );
+        assert!(matches!(
+            result,
+            Err(CliError::IndexWork(IndexWorkFailure::Cancelled {
+                stage: IndexWorkStage::SymbolParsing
+            }))
+        ));
+    }
+}

--- a/crates/projectatlas-cli/src/runtime/module_resolution.rs
+++ b/crates/projectatlas-cli/src/runtime/module_resolution.rs
@@ -42,7 +42,7 @@ pub(super) fn load_configured_module_resolution(
     }
 
     let mut total_bytes = 0_u64;
-    let mut total_mappings = 0_usize;
+    let mut total_mappings = 0_u64;
     let mut configs = Vec::with_capacity(config_nodes.len());
     for (index, (node, kind)) in config_nodes.into_iter().enumerate() {
         check_config_work(control, index)?;
@@ -54,14 +54,12 @@ pub(super) fn load_configured_module_resolution(
                 size,
             ));
         }
-        total_bytes = total_bytes.saturating_add(size);
-        if total_bytes > MAX_MODULE_CONFIG_TOTAL_BYTES {
-            return Err(module_config_resource_limit(
-                IndexWorkResource::SourceBytes,
-                MAX_MODULE_CONFIG_TOTAL_BYTES,
-                total_bytes,
-            ));
-        }
+        claim_module_config_total(
+            &mut total_bytes,
+            size,
+            MAX_MODULE_CONFIG_TOTAL_BYTES,
+            IndexWorkResource::SourceBytes,
+        )?;
         let native_path = root.join(repo_path_to_native(&node.path));
         let bytes = match read_source_bytes_controlled(
             &native_path,
@@ -103,14 +101,12 @@ pub(super) fn load_configured_module_resolution(
                 ))
             })?;
         let config = decode_config(node.path.as_str(), kind, &value, control)?;
-        total_mappings = total_mappings.saturating_add(config.1);
-        if total_mappings > MAX_CONFIGURED_MODULE_MAPPINGS {
-            return Err(module_config_resource_limit(
-                IndexWorkResource::RelationRows,
-                MAX_CONFIGURED_MODULE_MAPPINGS,
-                total_mappings,
-            ));
-        }
+        claim_module_config_total(
+            &mut total_mappings,
+            u64::try_from(config.1).unwrap_or(u64::MAX),
+            u64::try_from(MAX_CONFIGURED_MODULE_MAPPINGS).unwrap_or(u64::MAX),
+            IndexWorkResource::RelationRows,
+        )?;
         configs.push(config.0);
     }
     ConfiguredModuleResolution::new(configs)
@@ -254,6 +250,21 @@ fn check_config_work(control: &IndexWorkControl, index: usize) -> Result<(), Cli
     Ok(())
 }
 
+/// Admit aggregate compiler-configuration work without saturating past its bound.
+fn claim_module_config_total(
+    total: &mut u64,
+    added: u64,
+    limit: u64,
+    resource: IndexWorkResource,
+) -> Result<(), CliError> {
+    let observed = total.saturating_add(added);
+    if observed > limit {
+        return Err(module_config_resource_limit(resource, limit, observed));
+    }
+    *total = observed;
+    Ok(())
+}
+
 /// Translate configured-module bounds into the runtime's typed limit failure.
 fn module_config_resource_limit(
     resource: IndexWorkResource,
@@ -271,13 +282,41 @@ fn module_config_resource_limit(
 
 #[cfg(test)]
 mod tests {
-    use super::{CliError, decode_config, normalize_repository_target};
-    use projectatlas_core::{
-        IndexCancellation, IndexWorkControl, IndexWorkFailure, IndexWorkStage,
+    use super::{
+        CliError, MAX_MODULE_CONFIG_FILE_BYTES, MAX_MODULE_CONFIG_TOTAL_BYTES,
+        claim_module_config_total, decode_config, load_configured_module_resolution,
+        normalize_repository_target,
     };
-    use projectatlas_symbols::EcmaScriptConfigKind;
+    use projectatlas_core::{
+        IndexCancellation, IndexWorkControl, IndexWorkFailure, IndexWorkResource, IndexWorkStage,
+        Node, NodeKind,
+    };
+    use projectatlas_symbols::{
+        EcmaScriptConfigKind, MAX_CONFIGURED_MODULE_CONFIGS, MAX_CONFIGURED_MODULE_MAPPINGS,
+        MAX_CONFIGURED_MODULE_TARGETS,
+    };
     use serde_json::json;
     use std::error::Error;
+    use std::fs;
+    use std::path::Path;
+    use std::time::Instant;
+
+    fn config_node(path: &str, content: &[u8]) -> Node {
+        Node {
+            path: path.to_string(),
+            kind: NodeKind::File,
+            parent_path: Path::new(path)
+                .parent()
+                .and_then(Path::to_str)
+                .filter(|parent| !parent.is_empty())
+                .map(ToString::to_string),
+            extension: Some(".json".to_string()),
+            language: Some("json".to_string()),
+            size_bytes: Some(u64::try_from(content.len()).unwrap_or(u64::MAX)),
+            mtime_ns: Some(1),
+            content_hash: Some(blake3::hash(content).to_hex().to_string()),
+        }
+    }
 
     #[test]
     fn direct_json_config_is_normalized_without_leaving_the_repository()
@@ -341,5 +380,118 @@ mod tests {
                 stage: IndexWorkStage::SymbolParsing
             }))
         ));
+    }
+
+    #[test]
+    #[allow(clippy::panic_in_result_fn)]
+    fn configured_module_loader_enforces_deadline_currentness_and_bounds()
+    -> Result<(), Box<dyn Error>> {
+        let temp = tempfile::tempdir()?;
+        let content = br#"{"compilerOptions":{"paths":{"@/*":["src/*"]}}}"#;
+        fs::write(temp.path().join("tsconfig.json"), content)?;
+        let node = config_node("tsconfig.json", content);
+
+        let expired = IndexWorkControl::with_deadline(IndexCancellation::new(), Instant::now());
+        assert!(matches!(
+            load_configured_module_resolution(temp.path(), std::slice::from_ref(&node), &expired),
+            Err(CliError::IndexWork(IndexWorkFailure::DeadlineExceeded {
+                stage: IndexWorkStage::SymbolParsing
+            }))
+        ));
+
+        let mut changed = node.clone();
+        changed.content_hash = Some(blake3::hash(b"other").to_hex().to_string());
+        assert!(
+            load_configured_module_resolution(
+                temp.path(),
+                &[changed],
+                &IndexWorkControl::new(IndexCancellation::new(), None),
+            )
+            .is_err()
+        );
+
+        let mut oversized = node;
+        oversized.size_bytes = Some(MAX_MODULE_CONFIG_FILE_BYTES + 1);
+        assert!(matches!(
+            load_configured_module_resolution(
+                temp.path(),
+                &[oversized],
+                &IndexWorkControl::new(IndexCancellation::new(), None),
+            ),
+            Err(CliError::IndexWork(
+                IndexWorkFailure::ResourceLimitExceeded {
+                    resource: IndexWorkResource::SourceBytes,
+                    ..
+                }
+            ))
+        ));
+
+        let excessive_configs = (0..=MAX_CONFIGURED_MODULE_CONFIGS)
+            .map(|index| config_node(&format!("config-{index}/tsconfig.json"), content))
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            load_configured_module_resolution(
+                temp.path(),
+                &excessive_configs,
+                &IndexWorkControl::new(IndexCancellation::new(), None),
+            ),
+            Err(CliError::IndexWork(
+                IndexWorkFailure::ResourceLimitExceeded {
+                    resource: IndexWorkResource::Entries,
+                    ..
+                }
+            ))
+        ));
+
+        let mut total = MAX_MODULE_CONFIG_TOTAL_BYTES;
+        assert!(matches!(
+            claim_module_config_total(
+                &mut total,
+                1,
+                MAX_MODULE_CONFIG_TOTAL_BYTES,
+                IndexWorkResource::SourceBytes,
+            ),
+            Err(CliError::IndexWork(
+                IndexWorkFailure::ResourceLimitExceeded {
+                    resource: IndexWorkResource::SourceBytes,
+                    ..
+                }
+            ))
+        ));
+        let mut mappings = u64::try_from(MAX_CONFIGURED_MODULE_MAPPINGS).unwrap_or(u64::MAX);
+        assert!(matches!(
+            claim_module_config_total(
+                &mut mappings,
+                1,
+                u64::try_from(MAX_CONFIGURED_MODULE_MAPPINGS).unwrap_or(u64::MAX),
+                IndexWorkResource::RelationRows,
+            ),
+            Err(CliError::IndexWork(
+                IndexWorkFailure::ResourceLimitExceeded {
+                    resource: IndexWorkResource::RelationRows,
+                    ..
+                }
+            ))
+        ));
+
+        let excessive_targets = (0..=MAX_CONFIGURED_MODULE_TARGETS)
+            .map(|index| format!("src/{index}/*"))
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            decode_config(
+                "tsconfig.json",
+                EcmaScriptConfigKind::TypeScript,
+                &json!({"compilerOptions":{"paths":{"@/*": excessive_targets}}}),
+                &IndexWorkControl::new(IndexCancellation::new(), None),
+            ),
+            Err(CliError::IndexWork(
+                IndexWorkFailure::ResourceLimitExceeded {
+                    resource: IndexWorkResource::RelationRows,
+                    ..
+                }
+            ))
+        ));
+
+        Ok(())
     }
 }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -12861,7 +12861,7 @@ fn configured_module_aliases_resolve_across_adapters_and_refresh_atomically()
 "#;
     const JS_CONFIG: &str = r#"{
   "compilerOptions": {
-    "baseUrl": "src",
+    "baseUrl": "../src",
     "paths": {
       "@/*": ["*"]
     }
@@ -12880,6 +12880,14 @@ fn configured_module_aliases_resolve_across_adapters_and_refresh_atomically()
     fs::write(&ts_config, TS_CONFIG)?;
     fs::write(&js_config, JS_CONFIG)?;
     fs::write(
+        repo.join("Cargo.toml"),
+        "[package]\nname = \"configured-shared\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    fs::write(
+        repo.join(JS_DIR_NAME).join("Cargo.toml"),
+        "[package]\nname = \"configured-app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )?;
+    fs::write(
         source.join(CONTROLLER_TS_FILE),
         "export function useController(): string { return \"ok\"; }\n",
     )?;
@@ -12888,7 +12896,7 @@ fn configured_module_aliases_resolve_across_adapters_and_refresh_atomically()
         "<script setup lang=\"ts\">\nimport { useController } from \"@/controller\";\nconst value = useController();\n</script>\n<template><div>{{ value }}</div></template>\n",
     )?;
     fs::write(
-        js_source.join("js-controller.js"),
+        source.join("js-controller.js"),
         "export function useJsController() { return \"ok\"; }\n",
     )?;
     fs::write(
@@ -12907,17 +12915,19 @@ fn configured_module_aliases_resolve_across_adapters_and_refresh_atomically()
         "inbound",
     )?;
     assert_detailed_resolution(&ts_symbol, 1, "resolved")?;
-    let js_file =
-        detailed_relation_payload(&repo, &db, "js/src/js-controller.js", None, "inbound")?;
+    let js_file = detailed_relation_payload(&repo, &db, "src/js-controller.js", None, "inbound")?;
     assert_detailed_resolution(&js_file, 1, "resolved")?;
     let js_symbol = detailed_relation_payload(
         &repo,
         &db,
-        "js/src/js-controller.js",
+        "src/js-controller.js",
         Some("useJsController"),
         "inbound",
     )?;
     assert_detailed_resolution(&js_symbol, 1, "resolved")?;
+    let js_outbound =
+        detailed_relation_payload(&repo, &db, "js/src/js-page.js", Some("value"), "outbound")?;
+    assert_detailed_resolution(&js_outbound, 1, "resolved")?;
 
     let impact = Command::cargo_bin("projectatlas")?
         .current_dir(&repo)
@@ -13050,6 +13060,24 @@ fn configured_module_aliases_resolve_across_adapters_and_refresh_atomically()
     let unresolved = detailed_relation_payload(&repo, &db, "src/Page.vue", None, "outbound")?;
     assert_detailed_resolution(&unresolved, 2, "unresolved")?;
 
+    let pending_ts_config = repo.join("tsconfig.pending.json");
+    fs::write(&pending_ts_config, TS_CONFIG)?;
+    fs::rename(&pending_ts_config, &ts_config)?;
+    run_watch_once(&repo, &db)?;
+    assert_detailed_resolution(
+        &detailed_relation_payload(&repo, &db, "src/controller.ts", None, "inbound")?,
+        1,
+        "resolved",
+    )?;
+    fs::rename(&ts_config, &pending_ts_config)?;
+    run_watch_once(&repo, &db)?;
+    assert_detailed_resolution(
+        &detailed_relation_payload(&repo, &db, "src/controller.ts", None, "inbound")?,
+        0,
+        "resolved",
+    )?;
+    fs::remove_file(&pending_ts_config)?;
+
     let generation_before_failure = AtlasStore::open(&db)?
         .index_publication()?
         .ok_or_else(|| io::Error::other("configured alias publication is missing"))?
@@ -13082,7 +13110,7 @@ fn configured_module_aliases_resolve_across_adapters_and_refresh_atomically()
         &detailed_relation_payload(
             &repo,
             &db,
-            "js/src/js-controller.js",
+            "src/js-controller.js",
             Some("useJsController"),
             "inbound",
         )?,

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -12844,6 +12844,323 @@ fn normal_reads_do_not_serve_offline_stale_index_state() -> Result<(), Box<dyn E
 }
 
 #[test]
+fn configured_module_aliases_resolve_across_adapters_and_refresh_atomically()
+-> Result<(), Box<dyn Error>> {
+    const ALTERNATE_DIR_NAME: &str = "alternate";
+    const CONTROLLER_TS_FILE: &str = "controller.ts";
+    const JS_DIR_NAME: &str = "js";
+    const TS_CONFIG: &str = r#"{
+  // JSONC is the native compiler configuration format.
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"],
+    },
+  },
+}
+"#;
+    const JS_CONFIG: &str = r#"{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}
+"#;
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("configured-module-aliases");
+    let source = repo.join(SRC_DIR_NAME);
+    let js_source = repo.join(JS_DIR_NAME).join(SRC_DIR_NAME);
+    fs::create_dir_all(&source)?;
+    fs::create_dir_all(&js_source)?;
+    let db = temp.path().join("configured-module-aliases.db");
+    let ts_config = repo.join("tsconfig.json");
+    let js_config = repo.join(JS_DIR_NAME).join("jsconfig.json");
+    fs::write(&ts_config, TS_CONFIG)?;
+    fs::write(&js_config, JS_CONFIG)?;
+    fs::write(
+        source.join(CONTROLLER_TS_FILE),
+        "export function useController(): string { return \"ok\"; }\n",
+    )?;
+    fs::write(
+        source.join("Page.vue"),
+        "<script setup lang=\"ts\">\nimport { useController } from \"@/controller\";\nconst value = useController();\n</script>\n<template><div>{{ value }}</div></template>\n",
+    )?;
+    fs::write(
+        js_source.join("js-controller.js"),
+        "export function useJsController() { return \"ok\"; }\n",
+    )?;
+    fs::write(
+        js_source.join("js-page.js"),
+        "import { useJsController } from \"@/js-controller\";\nexport const value = useJsController();\n",
+    )?;
+    run_scan(&repo, &db)?;
+
+    let ts_file = detailed_relation_payload(&repo, &db, "src/controller.ts", None, "inbound")?;
+    assert_detailed_resolution(&ts_file, 1, "resolved")?;
+    let ts_symbol = detailed_relation_payload(
+        &repo,
+        &db,
+        "src/controller.ts",
+        Some("useController"),
+        "inbound",
+    )?;
+    assert_detailed_resolution(&ts_symbol, 1, "resolved")?;
+    let js_file =
+        detailed_relation_payload(&repo, &db, "js/src/js-controller.js", None, "inbound")?;
+    assert_detailed_resolution(&js_file, 1, "resolved")?;
+    let js_symbol = detailed_relation_payload(
+        &repo,
+        &db,
+        "js/src/js-controller.js",
+        Some("useJsController"),
+        "inbound",
+    )?;
+    assert_detailed_resolution(&js_symbol, 1, "resolved")?;
+
+    let impact = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .env("PROJECTATLAS_NO_TELEMETRY", "1")
+        .arg("--db")
+        .arg(&db)
+        .args([
+            "--format",
+            "json",
+            "symbols",
+            "relations",
+            "--view",
+            "analysis",
+            "--analysis-mode",
+            "impact",
+            "--vcs",
+            "working-tree",
+            "--include-dead-code",
+            "--file",
+            "src/controller.ts",
+            "--symbol",
+            "useController",
+            "--direction",
+            "inbound",
+            "--depth",
+            "2",
+            "--limit",
+            "50",
+        ])
+        .output()?;
+    if !impact.status.success() {
+        return Err(io::Error::other(format!(
+            "configured alias impact analysis failed: {}",
+            String::from_utf8_lossy(&impact.stderr)
+        ))
+        .into());
+    }
+    let impact: Value = serde_json::from_slice(&impact.stdout)?;
+    let dead_code_nodes = impact
+        .pointer("/symbol_relations/findings")
+        .and_then(Value::as_array)
+        .and_then(|findings| {
+            findings
+                .iter()
+                .find(|finding| finding.get("kind").and_then(Value::as_str) == Some("dead_code"))
+        })
+        .and_then(|finding| finding.get("nodes"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| io::Error::other("impact analysis omitted typed dead-code findings"))?;
+    if dead_code_nodes.iter().any(|node| {
+        node.pointer("/node/entity/selector/symbol/name")
+            .and_then(Value::as_str)
+            == Some("useController")
+    }) {
+        return Err(io::Error::other(
+            "configured alias target was presented as a dead-code candidate",
+        )
+        .into());
+    }
+
+    let messages = vec![
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"configured-module-e2e","version":"0.1.0"}}}"#.to_string(),
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#.to_string(),
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "atlas_symbol_relations",
+                "arguments": {
+                    "view": "detailed",
+                    "file": "src/controller.ts",
+                    "direction": "inbound",
+                    "limit": 10
+                }
+            }
+        })
+        .to_string(),
+    ];
+    let executable = assert_cmd::cargo::cargo_bin("projectatlas");
+    let stdout = run_mcp_stdio_with_env(
+        &executable,
+        &repo,
+        &[
+            "--db".to_string(),
+            db.display().to_string(),
+            "mcp".to_string(),
+        ],
+        &messages,
+        &[("PROJECTATLAS_NO_TELEMETRY", Some("1"))],
+    )?;
+    let mcp = mcp_tool_text(&stdout, 2)?;
+    for expected in ["status: resolved", "value: 1", "src/controller.ts"] {
+        if !mcp.contains(expected) {
+            return Err(io::Error::other(format!(
+                "configured alias MCP result omitted {expected:?}: {mcp}"
+            ))
+            .into());
+        }
+    }
+
+    fs::create_dir_all(source.join(ALTERNATE_DIR_NAME))?;
+    fs::write(
+        source.join(ALTERNATE_DIR_NAME).join(CONTROLLER_TS_FILE),
+        "export function useController(): string { return \"alternate\"; }\n",
+    )?;
+    fs::write(
+        &ts_config,
+        r#"{"compilerOptions":{"baseUrl":"src","paths":{"@/*":["alternate/*"]}}}"#,
+    )?;
+    run_watch_once(&repo, &db)?;
+    assert_detailed_resolution(
+        &detailed_relation_payload(&repo, &db, "src/controller.ts", None, "inbound")?,
+        0,
+        "resolved",
+    )?;
+    assert_detailed_resolution(
+        &detailed_relation_payload(&repo, &db, "src/alternate/controller.ts", None, "inbound")?,
+        1,
+        "resolved",
+    )?;
+
+    fs::remove_file(&ts_config)?;
+    run_watch_once(&repo, &db)?;
+    assert_detailed_resolution(
+        &detailed_relation_payload(&repo, &db, "src/alternate/controller.ts", None, "inbound")?,
+        0,
+        "resolved",
+    )?;
+    let unresolved = detailed_relation_payload(&repo, &db, "src/Page.vue", None, "outbound")?;
+    assert_detailed_resolution(&unresolved, 2, "unresolved")?;
+
+    let generation_before_failure = AtlasStore::open(&db)?
+        .index_publication()?
+        .ok_or_else(|| io::Error::other("configured alias publication is missing"))?
+        .generation;
+    fs::write(
+        &js_config,
+        r#"{"compilerOptions":{"baseUrl":"src","paths":["invalid"]}}"#,
+    )?;
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .env("PROJECTATLAS_NO_TELEMETRY", "1")
+        .arg("--db")
+        .arg(&db)
+        .args(["watch", ".", "--once"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("field 'paths' must be an object"));
+    fs::write(&js_config, JS_CONFIG)?;
+    let generation_after_failure = AtlasStore::open(&db)?
+        .index_publication()?
+        .ok_or_else(|| io::Error::other("configured alias publication disappeared"))?
+        .generation;
+    if generation_after_failure != generation_before_failure {
+        return Err(io::Error::other(
+            "malformed compiler configuration advanced the published generation",
+        )
+        .into());
+    }
+    assert_detailed_resolution(
+        &detailed_relation_payload(
+            &repo,
+            &db,
+            "js/src/js-controller.js",
+            Some("useJsController"),
+            "inbound",
+        )?,
+        1,
+        "resolved",
+    )?;
+    Ok(())
+}
+
+fn detailed_relation_payload(
+    repo: &Path,
+    db: &Path,
+    file: &str,
+    symbol: Option<&str>,
+    direction: &str,
+) -> Result<Value, Box<dyn Error>> {
+    let mut command = Command::cargo_bin("projectatlas")?;
+    command
+        .current_dir(repo)
+        .env("PROJECTATLAS_NO_TELEMETRY", "1")
+        .arg("--db")
+        .arg(db)
+        .args([
+            "--format",
+            "json",
+            "symbols",
+            "relations",
+            "--view",
+            "detailed",
+            "--file",
+            file,
+            "--direction",
+            direction,
+            "--limit",
+            "50",
+        ]);
+    if let Some(symbol) = symbol {
+        command.args(["--symbol", symbol]);
+    }
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "configured alias relation query failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ))
+        .into());
+    }
+    Ok(serde_json::from_slice(&output.stdout)?)
+}
+
+fn assert_detailed_resolution(
+    payload: &Value,
+    expected_total: usize,
+    expected_resolution: &str,
+) -> Result<(), Box<dyn Error>> {
+    require_json_usize(
+        payload,
+        &["symbol_relations", "total", "value"],
+        expected_total,
+    )?;
+    let rows = payload
+        .pointer("/symbol_relations/rows")
+        .and_then(Value::as_array)
+        .ok_or_else(|| io::Error::other("detailed relation rows are missing"))?;
+    if rows.iter().any(|row| {
+        row.pointer("/relation/resolution/status")
+            .and_then(Value::as_str)
+            != Some(expected_resolution)
+    }) {
+        return Err(io::Error::other(format!(
+            "relation rows did not all retain {expected_resolution:?}: {rows:?}"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+#[test]
 fn dependency_aware_refresh_re_resolves_unchanged_inbound_callers() -> Result<(), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let repo = temp.path().join(TEST_REPO_DIR);

--- a/crates/projectatlas-symbols/src/configured_modules.rs
+++ b/crates/projectatlas-symbols/src/configured_modules.rs
@@ -1,0 +1,493 @@
+//! Validated repository-configured ECMAScript module scopes.
+
+use crate::resolution_keys::strip_known_source_extension;
+use std::error::Error;
+use std::fmt;
+
+/// Maximum compiler configuration files admitted to one resolution snapshot.
+pub const MAX_CONFIGURED_MODULE_CONFIGS: usize = 1_024;
+/// Maximum path mappings admitted across one resolution snapshot.
+pub const MAX_CONFIGURED_MODULE_MAPPINGS: usize = 4_096;
+/// Maximum target substitutions admitted for one path mapping.
+pub const MAX_CONFIGURED_MODULE_TARGETS: usize = 64;
+/// Maximum bytes admitted for one normalized pattern or repository path.
+pub const MAX_CONFIGURED_MODULE_IDENTITY_BYTES: usize = 1_024;
+
+/// ECMAScript compiler configuration family.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum EcmaScriptConfigKind {
+    /// `tsconfig.json`.
+    TypeScript,
+    /// `jsconfig.json`.
+    JavaScript,
+}
+
+/// One validated compiler `paths` pattern and its repository-normalized targets.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct EcmaScriptPathMapping {
+    /// Module specifier pattern from the compiler configuration.
+    pattern: String,
+    /// Repository-normalized target substitutions.
+    targets: Vec<String>,
+}
+
+impl EcmaScriptPathMapping {
+    /// Construct one bounded mapping.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the pattern or normalized targets are unsafe or
+    /// exceed the per-mapping target bound.
+    pub fn new(
+        pattern: impl Into<String>,
+        targets: Vec<String>,
+    ) -> Result<Self, ConfiguredModuleError> {
+        let pattern = pattern.into();
+        validate_pattern("module pattern", &pattern)?;
+        if targets.is_empty() || targets.len() > MAX_CONFIGURED_MODULE_TARGETS {
+            return Err(ConfiguredModuleError::TargetCount {
+                requested: targets.len(),
+            });
+        }
+        let mut targets = targets;
+        for target in &targets {
+            validate_repository_pattern("module target", target)?;
+        }
+        targets.sort();
+        targets.dedup();
+        Ok(Self { pattern, targets })
+    }
+}
+
+/// One repository-contained `tsconfig.json` or `jsconfig.json` scope.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct EcmaScriptModuleConfig {
+    /// Repository-relative compiler configuration path.
+    config_path: String,
+    /// Repository-relative directory that owns the configuration scope.
+    directory: String,
+    /// Compiler configuration family used for same-scope precedence.
+    kind: EcmaScriptConfigKind,
+    /// Repository-normalized `baseUrl`, when configured.
+    base_url: Option<String>,
+    /// Validated and deterministically ordered path mappings.
+    mappings: Vec<EcmaScriptPathMapping>,
+}
+
+impl EcmaScriptModuleConfig {
+    /// Construct one validated direct compiler configuration.
+    ///
+    /// `base_url` and every mapping target must already be normalized relative
+    /// to the repository root by the filesystem-owning caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any path is absolute, traversing, malformed, or
+    /// exceeds the configured identity bounds.
+    pub fn new(
+        config_path: impl Into<String>,
+        kind: EcmaScriptConfigKind,
+        base_url: Option<String>,
+        mut mappings: Vec<EcmaScriptPathMapping>,
+    ) -> Result<Self, ConfiguredModuleError> {
+        let config_path = config_path.into();
+        validate_repository_path("configuration path", &config_path)?;
+        let expected_name = match kind {
+            EcmaScriptConfigKind::TypeScript => "tsconfig.json",
+            EcmaScriptConfigKind::JavaScript => "jsconfig.json",
+        };
+        if config_path.rsplit('/').next() != Some(expected_name) {
+            return Err(ConfiguredModuleError::InvalidIdentity {
+                field: "configuration path",
+                value: config_path,
+            });
+        }
+        if let Some(base_url) = base_url.as_deref() {
+            validate_repository_path_allow_root("baseUrl", base_url)?;
+        }
+        mappings.sort();
+        mappings.dedup();
+        let directory = config_path
+            .rsplit_once('/')
+            .map_or_else(String::new, |(directory, _)| directory.to_string());
+        Ok(Self {
+            config_path,
+            directory,
+            kind,
+            base_url,
+            mappings,
+        })
+    }
+}
+
+/// Deterministic compiler configuration snapshot shared by graph projections.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ConfiguredModuleResolution {
+    /// Validated configurations ordered for deterministic selection.
+    configs: Vec<EcmaScriptModuleConfig>,
+}
+
+impl ConfiguredModuleResolution {
+    /// Construct one sorted, bounded configuration snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when configuration or aggregate mapping counts exceed
+    /// their owning bounds.
+    pub fn new(mut configs: Vec<EcmaScriptModuleConfig>) -> Result<Self, ConfiguredModuleError> {
+        if configs.len() > MAX_CONFIGURED_MODULE_CONFIGS {
+            return Err(ConfiguredModuleError::ConfigCount {
+                requested: configs.len(),
+            });
+        }
+        let mapping_count = configs
+            .iter()
+            .map(|config| config.mappings.len())
+            .try_fold(0_usize, usize::checked_add)
+            .unwrap_or(usize::MAX);
+        if mapping_count > MAX_CONFIGURED_MODULE_MAPPINGS {
+            return Err(ConfiguredModuleError::MappingCount {
+                requested: mapping_count,
+            });
+        }
+        configs.sort();
+        configs.dedup();
+        Ok(Self { configs })
+    }
+
+    /// Resolve configured candidate scopes for one non-relative import.
+    pub(crate) fn scopes_for_import(&self, caller_path: &str, module_spec: &str) -> Vec<String> {
+        if module_spec.starts_with("./") || module_spec.starts_with("../") || module_spec.is_empty()
+        {
+            return Vec::new();
+        }
+        let Some(config) = self.applicable_config(caller_path) else {
+            return Vec::new();
+        };
+        let mut matched = config
+            .mappings
+            .iter()
+            .filter_map(|mapping| {
+                match_module_pattern(&mapping.pattern, module_spec)
+                    .map(|capture| (mapping, capture))
+            })
+            .collect::<Vec<_>>();
+        if !matched.is_empty() {
+            let best_specificity = matched
+                .iter()
+                .map(|(mapping, _)| pattern_specificity(&mapping.pattern))
+                .max()
+                .unwrap_or_default();
+            matched
+                .retain(|(mapping, _)| pattern_specificity(&mapping.pattern) == best_specificity);
+            let mut scopes = matched
+                .into_iter()
+                .flat_map(|(mapping, capture)| {
+                    mapping.targets.iter().map(move |target| match capture {
+                        ModulePatternMatch::Exact => target.clone(),
+                        ModulePatternMatch::Wildcard(capture) => target.replacen('*', capture, 1),
+                    })
+                })
+                .map(|scope| strip_known_source_extension(&scope))
+                .collect::<Vec<_>>();
+            scopes.sort();
+            scopes.dedup();
+            return scopes;
+        }
+        let Some(base_url) = config.base_url.as_deref() else {
+            return Vec::new();
+        };
+        let scope = if base_url.is_empty() {
+            module_spec.to_string()
+        } else {
+            format!("{base_url}/{module_spec}")
+        };
+        vec![strip_known_source_extension(&scope)]
+    }
+
+    /// Select the nearest containing config, preferring the source-family kind
+    /// only when both kinds exist at that same scope.
+    fn applicable_config(&self, caller_path: &str) -> Option<&EcmaScriptModuleConfig> {
+        let preferred = preferred_config_kind(caller_path);
+        self.configs
+            .iter()
+            .filter(|config| directory_contains(&config.directory, caller_path))
+            .max_by(|left, right| {
+                directory_depth(&left.directory)
+                    .cmp(&directory_depth(&right.directory))
+                    .then_with(|| {
+                        (left.kind == preferred)
+                            .cmp(&(right.kind == preferred))
+                            .then_with(|| right.config_path.cmp(&left.config_path))
+                    })
+            })
+    }
+}
+
+/// Typed validation failure for configured module resolution.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ConfiguredModuleError {
+    /// One identity was not a bounded normalized repository value.
+    InvalidIdentity {
+        /// Owning configuration field.
+        field: &'static str,
+        /// Rejected value.
+        value: String,
+    },
+    /// Too many configuration files were supplied.
+    ConfigCount {
+        /// Requested count.
+        requested: usize,
+    },
+    /// Too many aggregate path mappings were supplied.
+    MappingCount {
+        /// Requested count.
+        requested: usize,
+    },
+    /// One mapping supplied too many or no targets.
+    TargetCount {
+        /// Requested count.
+        requested: usize,
+    },
+}
+
+impl fmt::Display for ConfiguredModuleError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidIdentity { field, value } => {
+                write!(formatter, "invalid configured module {field}: {value:?}")
+            }
+            Self::ConfigCount { requested } => write!(
+                formatter,
+                "configured module snapshot contains {requested} configs; maximum is {MAX_CONFIGURED_MODULE_CONFIGS}"
+            ),
+            Self::MappingCount { requested } => write!(
+                formatter,
+                "configured module snapshot contains {requested} mappings; maximum is {MAX_CONFIGURED_MODULE_MAPPINGS}"
+            ),
+            Self::TargetCount { requested } => write!(
+                formatter,
+                "configured module mapping contains {requested} targets; admitted range is 1..={MAX_CONFIGURED_MODULE_TARGETS}"
+            ),
+        }
+    }
+}
+
+impl Error for ConfiguredModuleError {}
+
+/// Match result that preserves whether wildcard substitution is required.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ModulePatternMatch<'a> {
+    /// The complete module specifier matched a non-wildcard pattern.
+    Exact,
+    /// A wildcard matched this bounded portion of the module specifier.
+    Wildcard(
+        /// Source text captured by the pattern wildcard.
+        &'a str,
+    ),
+}
+
+/// Choose the compiler configuration family preferred by the caller extension.
+fn preferred_config_kind(path: &str) -> EcmaScriptConfigKind {
+    if matches!(path.rsplit('.').next(), Some("js" | "jsx" | "mjs" | "cjs")) {
+        EcmaScriptConfigKind::JavaScript
+    } else {
+        EcmaScriptConfigKind::TypeScript
+    }
+}
+
+/// Return whether a configuration directory contains the caller path.
+fn directory_contains(directory: &str, path: &str) -> bool {
+    directory.is_empty()
+        || path
+            .strip_prefix(directory)
+            .is_some_and(|rest| rest.starts_with('/'))
+}
+
+/// Count normalized path components for nearest-config selection.
+fn directory_depth(directory: &str) -> usize {
+    directory
+        .split('/')
+        .filter(|component| !component.is_empty())
+        .count()
+}
+
+/// Rank a path pattern by the literal prefix before its optional wildcard.
+fn pattern_specificity(pattern: &str) -> usize {
+    pattern.find('*').unwrap_or(pattern.len())
+}
+
+/// Match one compiler path pattern against an imported module specifier.
+fn match_module_pattern<'a>(pattern: &str, module_spec: &'a str) -> Option<ModulePatternMatch<'a>> {
+    let Some((prefix, suffix)) = pattern.split_once('*') else {
+        return (pattern == module_spec).then_some(ModulePatternMatch::Exact);
+    };
+    module_spec
+        .strip_prefix(prefix)?
+        .strip_suffix(suffix)
+        .map(ModulePatternMatch::Wildcard)
+}
+
+/// Validate one bounded compiler pattern with at most one wildcard.
+fn validate_pattern(field: &'static str, value: &str) -> Result<(), ConfiguredModuleError> {
+    validate_compact(field, value)?;
+    if value.matches('*').count() > 1 {
+        return Err(ConfiguredModuleError::InvalidIdentity {
+            field,
+            value: value.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Validate one compiler pattern that must stay within repository scope.
+fn validate_repository_pattern(
+    field: &'static str,
+    value: &str,
+) -> Result<(), ConfiguredModuleError> {
+    validate_pattern(field, value)?;
+    validate_repository_components(field, value)
+}
+
+/// Validate one non-root repository-relative path.
+fn validate_repository_path(field: &'static str, value: &str) -> Result<(), ConfiguredModuleError> {
+    validate_compact(field, value)?;
+    if value.contains('*') {
+        return Err(ConfiguredModuleError::InvalidIdentity {
+            field,
+            value: value.to_string(),
+        });
+    }
+    validate_repository_components(field, value)
+}
+
+/// Validate one repository-relative path while admitting the root identity.
+fn validate_repository_path_allow_root(
+    field: &'static str,
+    value: &str,
+) -> Result<(), ConfiguredModuleError> {
+    if value.is_empty() {
+        return Ok(());
+    }
+    validate_repository_path(field, value)
+}
+
+/// Validate common size, separator, and control-character constraints.
+fn validate_compact(field: &'static str, value: &str) -> Result<(), ConfiguredModuleError> {
+    if value.is_empty()
+        || value.len() > MAX_CONFIGURED_MODULE_IDENTITY_BYTES
+        || value.contains('\\')
+        || value.chars().any(char::is_control)
+    {
+        return Err(ConfiguredModuleError::InvalidIdentity {
+            field,
+            value: value.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Reject absolute, drive-qualified, empty, current, and parent components.
+fn validate_repository_components(
+    field: &'static str,
+    value: &str,
+) -> Result<(), ConfiguredModuleError> {
+    if value.starts_with('/')
+        || value.contains(':')
+        || value
+            .split('/')
+            .any(|component| component.is_empty() || component == "." || component == "..")
+    {
+        return Err(ConfiguredModuleError::InvalidIdentity {
+            field,
+            value: value.to_string(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ConfiguredModuleResolution, EcmaScriptConfigKind, EcmaScriptModuleConfig,
+        EcmaScriptPathMapping,
+    };
+    use std::error::Error;
+
+    #[test]
+    fn nearest_config_and_most_specific_pattern_win() -> Result<(), Box<dyn Error>> {
+        let root = EcmaScriptModuleConfig::new(
+            "tsconfig.json",
+            EcmaScriptConfigKind::TypeScript,
+            Some("src".to_string()),
+            vec![EcmaScriptPathMapping::new(
+                "@/*",
+                vec!["src/*".to_string()],
+            )?],
+        )?;
+        let nested = EcmaScriptModuleConfig::new(
+            "packages/app/tsconfig.json",
+            EcmaScriptConfigKind::TypeScript,
+            Some("packages/app/src".to_string()),
+            vec![
+                EcmaScriptPathMapping::new("@/*", vec!["packages/app/src/*".to_string()])?,
+                EcmaScriptPathMapping::new(
+                    "@/models/*",
+                    vec!["packages/shared/models/*".to_string()],
+                )?,
+            ],
+        )?;
+        let configured = ConfiguredModuleResolution::new(vec![root, nested])?;
+        if configured.scopes_for_import("packages/app/src/page.ts", "@/models/user")
+            != vec!["packages/shared/models/user"]
+        {
+            return Err(std::io::Error::other("nearest config or specific pattern lost").into());
+        }
+        if configured.scopes_for_import("src/page.ts", "@/controller") != vec!["src/controller"] {
+            return Err(std::io::Error::other("root alias did not resolve").into());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn source_family_preference_and_index_targets_are_deterministic() -> Result<(), Box<dyn Error>>
+    {
+        let ts = EcmaScriptModuleConfig::new(
+            "tsconfig.json",
+            EcmaScriptConfigKind::TypeScript,
+            None,
+            vec![EcmaScriptPathMapping::new(
+                "@/*",
+                vec!["src/typed/*/index.ts".to_string()],
+            )?],
+        )?;
+        let js = EcmaScriptModuleConfig::new(
+            "jsconfig.json",
+            EcmaScriptConfigKind::JavaScript,
+            None,
+            vec![EcmaScriptPathMapping::new(
+                "@/*",
+                vec!["src/script/*/index.js".to_string()],
+            )?],
+        )?;
+        let configured = ConfiguredModuleResolution::new(vec![ts, js])?;
+        if configured.scopes_for_import("src/page.tsx", "@/tools") != vec!["src/typed/tools/index"]
+        {
+            return Err(std::io::Error::other("TypeScript config preference lost").into());
+        }
+        if configured.scopes_for_import("src/page.jsx", "@/tools") != vec!["src/script/tools/index"]
+        {
+            return Err(std::io::Error::other("JavaScript config preference lost").into());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn unsafe_or_excessive_targets_are_rejected() {
+        assert!(EcmaScriptPathMapping::new("@/*", vec!["../outside/*".to_string()]).is_err());
+        assert!(
+            EcmaScriptPathMapping::new("@/*", (0..65).map(|i| format!("src/{i}/*")).collect())
+                .is_err()
+        );
+    }
+}

--- a/crates/projectatlas-symbols/src/configured_modules.rs
+++ b/crates/projectatlas-symbols/src/configured_modules.rs
@@ -127,6 +127,13 @@ pub struct ConfiguredModuleResolution {
     configs: Vec<EcmaScriptModuleConfig>,
 }
 
+/// One configuration selected once for a source graph.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ConfiguredModuleSource<'a> {
+    /// Nearest applicable compiler configuration, when one exists.
+    config: Option<&'a EcmaScriptModuleConfig>,
+}
+
 impl ConfiguredModuleResolution {
     /// Construct one sorted, bounded configuration snapshot.
     ///
@@ -155,13 +162,40 @@ impl ConfiguredModuleResolution {
         Ok(Self { configs })
     }
 
+    /// Select the applicable compiler configuration once for a source graph.
+    pub(crate) fn for_source(&self, caller_path: &str) -> ConfiguredModuleSource<'_> {
+        ConfiguredModuleSource {
+            config: self.applicable_config(caller_path),
+        }
+    }
+
+    /// Select the nearest containing config, preferring the source-family kind
+    /// only when both kinds exist at that same scope.
+    fn applicable_config(&self, caller_path: &str) -> Option<&EcmaScriptModuleConfig> {
+        let preferred = preferred_config_kind(caller_path);
+        self.configs
+            .iter()
+            .filter(|config| directory_contains(&config.directory, caller_path))
+            .max_by(|left, right| {
+                directory_depth(&left.directory)
+                    .cmp(&directory_depth(&right.directory))
+                    .then_with(|| {
+                        (left.kind == preferred)
+                            .cmp(&(right.kind == preferred))
+                            .then_with(|| right.config_path.cmp(&left.config_path))
+                    })
+            })
+    }
+}
+
+impl ConfiguredModuleSource<'_> {
     /// Resolve configured candidate scopes for one non-relative import.
-    pub(crate) fn scopes_for_import(&self, caller_path: &str, module_spec: &str) -> Vec<String> {
+    pub(crate) fn scopes_for_import(self, module_spec: &str) -> Vec<String> {
         if module_spec.starts_with("./") || module_spec.starts_with("../") || module_spec.is_empty()
         {
             return Vec::new();
         }
-        let Some(config) = self.applicable_config(caller_path) else {
+        let Some(config) = self.config else {
             return Vec::new();
         };
         let mut matched = config
@@ -203,24 +237,6 @@ impl ConfiguredModuleResolution {
             format!("{base_url}/{module_spec}")
         };
         vec![strip_known_source_extension(&scope)]
-    }
-
-    /// Select the nearest containing config, preferring the source-family kind
-    /// only when both kinds exist at that same scope.
-    fn applicable_config(&self, caller_path: &str) -> Option<&EcmaScriptModuleConfig> {
-        let preferred = preferred_config_kind(caller_path);
-        self.configs
-            .iter()
-            .filter(|config| directory_contains(&config.directory, caller_path))
-            .max_by(|left, right| {
-                directory_depth(&left.directory)
-                    .cmp(&directory_depth(&right.directory))
-                    .then_with(|| {
-                        (left.kind == preferred)
-                            .cmp(&(right.kind == preferred))
-                            .then_with(|| right.config_path.cmp(&left.config_path))
-                    })
-            })
     }
 }
 
@@ -438,12 +454,18 @@ mod tests {
             ],
         )?;
         let configured = ConfiguredModuleResolution::new(vec![root, nested])?;
-        if configured.scopes_for_import("packages/app/src/page.ts", "@/models/user")
+        if configured
+            .for_source("packages/app/src/page.ts")
+            .scopes_for_import("@/models/user")
             != vec!["packages/shared/models/user"]
         {
             return Err(std::io::Error::other("nearest config or specific pattern lost").into());
         }
-        if configured.scopes_for_import("src/page.ts", "@/controller") != vec!["src/controller"] {
+        if configured
+            .for_source("src/page.ts")
+            .scopes_for_import("@/controller")
+            != vec!["src/controller"]
+        {
             return Err(std::io::Error::other("root alias did not resolve").into());
         }
         Ok(())
@@ -471,11 +493,17 @@ mod tests {
             )?],
         )?;
         let configured = ConfiguredModuleResolution::new(vec![ts, js])?;
-        if configured.scopes_for_import("src/page.tsx", "@/tools") != vec!["src/typed/tools/index"]
+        if configured
+            .for_source("src/page.tsx")
+            .scopes_for_import("@/tools")
+            != vec!["src/typed/tools/index"]
         {
             return Err(std::io::Error::other("TypeScript config preference lost").into());
         }
-        if configured.scopes_for_import("src/page.jsx", "@/tools") != vec!["src/script/tools/index"]
+        if configured
+            .for_source("src/page.jsx")
+            .scopes_for_import("@/tools")
+            != vec!["src/script/tools/index"]
         {
             return Err(std::io::Error::other("JavaScript config preference lost").into());
         }

--- a/crates/projectatlas-symbols/src/lib.rs
+++ b/crates/projectatlas-symbols/src/lib.rs
@@ -1,13 +1,21 @@
 //! Purpose: Extract tree-sitter-backed `ProjectAtlas` symbol graphs.
 
+mod configured_modules;
 mod languages;
 mod resolution_keys;
 mod semantic;
 
+pub use configured_modules::{
+    ConfiguredModuleError, ConfiguredModuleResolution, EcmaScriptConfigKind,
+    EcmaScriptModuleConfig, EcmaScriptPathMapping, MAX_CONFIGURED_MODULE_CONFIGS,
+    MAX_CONFIGURED_MODULE_IDENTITY_BYTES, MAX_CONFIGURED_MODULE_MAPPINGS,
+    MAX_CONFIGURED_MODULE_TARGETS,
+};
 pub use resolution_keys::{
     ImportReference, ImportSyntax, MAX_RESOLUTION_KEYS_PER_FACT, RelationResolutionKeys,
-    ResolutionKeyProjection, ResolutionProjectionError, SEMANTIC_RESOLUTION_CONTRACT_VERSION,
-    SymbolResolutionKeys, derive_resolution_keys, module_aliases_for_path, parse_import_references,
+    ResolutionKeyProjection, ResolutionProjectionContext, ResolutionProjectionError,
+    SEMANTIC_RESOLUTION_CONTRACT_VERSION, SymbolResolutionKeys, derive_resolution_keys,
+    derive_resolution_keys_with_context, module_aliases_for_path, parse_import_references,
     resolve_relative_import_path, semantic_resolution_contract_digest, source_stems_for_path,
 };
 

--- a/crates/projectatlas-symbols/src/resolution_keys.rs
+++ b/crates/projectatlas-symbols/src/resolution_keys.rs
@@ -1,5 +1,6 @@
 //! Canonical import facts and resolution-key projection for extracted symbol graphs.
 
+use crate::ConfiguredModuleResolution;
 use crate::semantic;
 use blake3::Hasher;
 use projectatlas_core::graph::{
@@ -15,7 +16,7 @@ use std::fmt;
 /// Maximum canonical keys emitted for one source, symbol, or relation fact.
 pub const MAX_RESOLUTION_KEYS_PER_FACT: usize = 64;
 /// Version of the currently implemented semantic relation-resolution contract.
-pub const SEMANTIC_RESOLUTION_CONTRACT_VERSION: u32 = 2;
+pub const SEMANTIC_RESOLUTION_CONTRACT_VERSION: u32 = 3;
 
 /// Return a deterministic digest of the live semantic resolution-key contract.
 ///
@@ -135,6 +136,25 @@ pub struct ResolutionKeyProjection {
     symbols: Vec<SymbolResolutionKeys>,
     /// Canonical dependencies associated with relation facts.
     relations: Vec<RelationResolutionKeys>,
+}
+
+/// Repository configuration supplied to provider-owned semantic projection.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ResolutionProjectionContext<'a> {
+    /// Validated configured-module snapshot, when the runtime supplied one.
+    configured_modules: Option<&'a ConfiguredModuleResolution>,
+}
+
+impl<'a> ResolutionProjectionContext<'a> {
+    /// Construct a projection context with one validated configured-module snapshot.
+    #[must_use]
+    pub const fn with_configured_modules(
+        configured_modules: &'a ConfiguredModuleResolution,
+    ) -> Self {
+        Self {
+            configured_modules: Some(configured_modules),
+        }
+    }
 }
 
 impl ResolutionKeyProjection {
@@ -356,6 +376,26 @@ pub fn derive_resolution_keys(
     package: Option<&str>,
     graph: &SymbolGraph,
 ) -> Result<ResolutionKeyProjection, ResolutionProjectionError> {
+    derive_resolution_keys_with_context(
+        project,
+        package,
+        graph,
+        ResolutionProjectionContext::default(),
+    )
+}
+
+/// Derive bounded canonical keys with explicit repository module configuration.
+///
+/// # Errors
+///
+/// Returns an error when a graph identity is invalid or one parser fact exceeds
+/// the bounded canonical-key fan-out.
+pub fn derive_resolution_keys_with_context(
+    project: ProjectInstanceId,
+    package: Option<&str>,
+    graph: &SymbolGraph,
+    context: ResolutionProjectionContext<'_>,
+) -> Result<ResolutionKeyProjection, ResolutionProjectionError> {
     let Some(provider_owner) = semantic::provider_for_graph(graph) else {
         return Ok(ResolutionKeyProjection {
             source: Vec::new(),
@@ -484,6 +524,7 @@ pub fn derive_resolution_keys(
                     package.as_ref(),
                     &relation.path,
                     &parsed_imports[relation_index],
+                    context,
                 )?
             }
             RelationKind::Calls if semantic::supports_source_dependencies(provider_owner) => {
@@ -496,6 +537,7 @@ pub fn derive_resolution_keys(
                     &relation.path,
                     &relation.target_name,
                     &aliases,
+                    context,
                 )?
             }
             RelationKind::DependsOn if semantic::supports_package_dependencies(provider_owner) => {
@@ -536,10 +578,16 @@ fn import_dependency_keys(
     package: Option<&GraphIdentityText>,
     caller_path: &str,
     references: &[ImportReference],
+    context: ResolutionProjectionContext<'_>,
 ) -> Result<Vec<CanonicalResolutionKey>, ResolutionProjectionError> {
     let mut keys = Vec::new();
     for reference in references {
-        let scopes = semantic::import_scopes(provider_owner, caller_path, reference);
+        let scopes = semantic::import_scopes(
+            provider_owner,
+            caller_path,
+            reference,
+            context.configured_modules,
+        );
         for scope in &scopes {
             keys.push(canonical_key(
                 project,
@@ -566,6 +614,7 @@ fn call_dependency_keys(
     caller_path: &str,
     target: &str,
     aliases: &BTreeMap<&str, Vec<&ImportReference>>,
+    context: ResolutionProjectionContext<'_>,
 ) -> Result<Vec<CanonicalResolutionKey>, ResolutionProjectionError> {
     let (prefix, remainder) = split_qualified_target(target);
     let alias = prefix.unwrap_or(target).trim();
@@ -576,7 +625,12 @@ fn call_dependency_keys(
             let Some(identity) = identity else {
                 continue;
             };
-            let mut scopes = semantic::import_scopes(provider_owner, caller_path, reference);
+            let mut scopes = semantic::import_scopes(
+                provider_owner,
+                caller_path,
+                reference,
+                context.configured_modules,
+            );
             if remainder.is_some()
                 && let Some(imported_parent) = reference.imported()
             {
@@ -747,11 +801,15 @@ pub(super) fn strip_known_source_extension(path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        ImportReference, ImportSyntax, RelationKind, ResolutionProjectionError,
-        SEMANTIC_RESOLUTION_CONTRACT_VERSION, derive_resolution_keys, parse_import_references,
-        resolve_relative_import_path, semantic_resolution_contract_digest,
+        ImportReference, ImportSyntax, RelationKind, ResolutionProjectionContext,
+        ResolutionProjectionError, SEMANTIC_RESOLUTION_CONTRACT_VERSION, derive_resolution_keys,
+        derive_resolution_keys_with_context, parse_import_references, resolve_relative_import_path,
+        semantic_resolution_contract_digest,
     };
-    use crate::extract_symbol_graph;
+    use crate::{
+        ConfiguredModuleResolution, EcmaScriptConfigKind, EcmaScriptModuleConfig,
+        EcmaScriptPathMapping, extract_symbol_graph,
+    };
     use projectatlas_core::graph::{CanonicalResolutionKey, ProjectInstanceId};
     use projectatlas_core::symbols::SymbolGraph;
     use std::error::Error;
@@ -776,7 +834,7 @@ mod tests {
         const PRE_MODULE_CALLBACK_DIGEST: &str =
             "487625adf2f9ec76f98034d4ef5667e707960b6b8afd280b213021cb64a0f10f";
         let first = semantic_resolution_contract_digest();
-        assert_eq!(SEMANTIC_RESOLUTION_CONTRACT_VERSION, 2);
+        assert_eq!(SEMANTIC_RESOLUTION_CONTRACT_VERSION, 3);
         assert_eq!(first.len(), 64);
         assert!(first.bytes().all(|byte| byte.is_ascii_hexdigit()));
         assert_eq!(first, semantic_resolution_contract_digest());
@@ -996,6 +1054,155 @@ mod tests {
             "read",
             &python_caller,
             &["reader.read"],
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn configured_aliases_share_file_and_declaration_keys_across_ecmascript_hosts()
+    -> Result<(), Box<dyn Error>> {
+        let project = project_id(21)?;
+        let configured = ConfiguredModuleResolution::new(vec![
+            EcmaScriptModuleConfig::new(
+                "tsconfig.json",
+                EcmaScriptConfigKind::TypeScript,
+                Some("src".to_string()),
+                vec![
+                    EcmaScriptPathMapping::new("@/*", vec!["src/*".to_string()])?,
+                    EcmaScriptPathMapping::new("@index/*", vec!["src/*/index.ts".to_string()])?,
+                ],
+            )?,
+            EcmaScriptModuleConfig::new(
+                "jsconfig.json",
+                EcmaScriptConfigKind::JavaScript,
+                Some("src".to_string()),
+                vec![EcmaScriptPathMapping::new(
+                    "@/*",
+                    vec!["src/*".to_string()],
+                )?],
+            )?,
+        ])?;
+        let context = ResolutionProjectionContext::with_configured_modules(&configured);
+
+        for (target_path, language, target_source, caller_path, caller_source) in [
+            (
+                "src/controller.ts",
+                "typescript",
+                "export function useController(): string { return 'ok'; }\n",
+                "src/page.ts",
+                "import { useController } from '@/controller';\nexport const value = useController();\n",
+            ),
+            (
+                "src/controller.ts",
+                "typescript",
+                "export function useController(): string { return 'ok'; }\n",
+                "src/page.tsx",
+                "import { useController } from '@/controller';\nexport function Page() { useController(); return <div />; }\n",
+            ),
+            (
+                "src/controller.js",
+                "javascript",
+                "export function useController() { return 'ok'; }\n",
+                "src/page.jsx",
+                "import { useController } from '@/controller';\nexport function Page() { useController(); return <div />; }\n",
+            ),
+            (
+                "src/controller.ts",
+                "typescript",
+                "export function useController(): string { return 'ok'; }\n",
+                "src/Page.vue",
+                "<script setup lang=\"ts\">\nimport { useController } from '@/controller';\nconst value = useController();\n</script>\n<template><div>{{ value }}</div></template>\n",
+            ),
+        ] {
+            let target = extract_symbol_graph(target_path, Some(language), target_source);
+            let caller_extension = std::path::Path::new(caller_path)
+                .extension()
+                .and_then(std::ffi::OsStr::to_str);
+            let caller_language = match caller_extension {
+                Some(extension) if extension.eq_ignore_ascii_case("vue") => "vue",
+                Some(extension)
+                    if extension.eq_ignore_ascii_case("js")
+                        || extension.eq_ignore_ascii_case("jsx") =>
+                {
+                    "javascript"
+                }
+                Some(extension) if extension.eq_ignore_ascii_case("tsx") => "tsx",
+                _ => "typescript",
+            };
+            let caller = extract_symbol_graph(caller_path, Some(caller_language), caller_source);
+            let target_projection = derive_resolution_keys(project, Some("app"), &target)?;
+            let caller_projection =
+                derive_resolution_keys_with_context(project, Some("app"), &caller, context)?;
+            let imports = relation_keys_of_kind(&caller, &caller_projection, RelationKind::Imports);
+            require(
+                imports
+                    .iter()
+                    .any(|keys| keys_intersect(keys, target_projection.source_keys())),
+                "configured import did not share the target file key",
+            )?;
+            require(
+                keys_intersect(
+                    relation_keys(&caller, &caller_projection, "useController"),
+                    symbol_keys(&target, &target_projection, "useController"),
+                ),
+                "configured call did not share the target declaration key",
+            )?;
+        }
+
+        let index_target = extract_symbol_graph(
+            "src/tools/index.ts",
+            Some("typescript"),
+            "export function useTool() { return 'ok'; }\n",
+        );
+        let index_caller = extract_symbol_graph(
+            "src/index-page.ts",
+            Some("typescript"),
+            "import { useTool } from '@index/tools';\nexport const value = useTool();\n",
+        );
+        let index_target_projection = derive_resolution_keys(project, Some("app"), &index_target)?;
+        let index_caller_projection =
+            derive_resolution_keys_with_context(project, Some("app"), &index_caller, context)?;
+        require(
+            relation_keys_of_kind(
+                &index_caller,
+                &index_caller_projection,
+                RelationKind::Imports,
+            )
+            .iter()
+            .any(|keys| keys_intersect(keys, index_target_projection.source_keys())),
+            "configured index target did not reuse package-entry source keys",
+        )?;
+        require(
+            keys_intersect(
+                relation_keys(&index_caller, &index_caller_projection, "useTool"),
+                symbol_keys(&index_target, &index_target_projection, "useTool"),
+            ),
+            "configured index target did not reuse declaration keys",
+        )?;
+
+        let extension_caller = extract_symbol_graph(
+            "src/extension-page.ts",
+            Some("typescript"),
+            "import { useController } from '@/controller.ts';\nexport const value = useController();\n",
+        );
+        let extension_target = extract_symbol_graph(
+            "src/controller.ts",
+            Some("typescript"),
+            "export function useController(): string { return 'ok'; }\n",
+        );
+        let extension_caller_projection =
+            derive_resolution_keys_with_context(project, Some("app"), &extension_caller, context)?;
+        let extension_target_projection =
+            derive_resolution_keys(project, Some("app"), &extension_target)?;
+        require(
+            relation_keys_of_kind(
+                &extension_caller,
+                &extension_caller_projection,
+                RelationKind::Imports,
+            )
+            .iter()
+            .any(|keys| keys_intersect(keys, extension_target_projection.source_keys())),
+            "configured extension target did not reuse extensionless source keys",
         )?;
         Ok(())
     }

--- a/crates/projectatlas-symbols/src/resolution_keys.rs
+++ b/crates/projectatlas-symbols/src/resolution_keys.rs
@@ -434,6 +434,18 @@ pub fn derive_resolution_keys_with_context(
                 RelationKind::Imports,
                 scope,
             )?);
+            if provider_owner == SemanticProviderOwner::EcmaScript && package.is_some() {
+                source_keys.push(canonical_key(
+                    project,
+                    ResolutionKeyDomain::Module,
+                    &provider,
+                    &language,
+                    None,
+                    None,
+                    RelationKind::Imports,
+                    scope,
+                )?);
+            }
         }
     }
     let source_keys = bounded_keys(source_keys, "source", 0)?;
@@ -485,6 +497,21 @@ pub fn derive_resolution_keys_with_context(
                         Some(GraphRelationKind::from_legacy(RelationKind::Calls)),
                         &identity,
                     ));
+                    if provider_owner == SemanticProviderOwner::EcmaScript
+                        && package.is_some()
+                        && scope.is_some()
+                    {
+                        keys.push(CanonicalResolutionKey::new(
+                            project,
+                            ResolutionKeyDomain::Declaration,
+                            &provider,
+                            &language,
+                            None,
+                            scope.as_ref(),
+                            Some(GraphRelationKind::from_legacy(RelationKind::Calls)),
+                            &identity,
+                        ));
+                    }
                 }
             }
             _ => {}
@@ -531,6 +558,7 @@ pub fn derive_resolution_keys_with_context(
             RelationKind::Imports if semantic::supports_source_dependencies(provider_owner) => {
                 import_dependency_keys(
                     project,
+                    provider_owner,
                     &provider,
                     &language,
                     package.as_ref(),
@@ -542,6 +570,7 @@ pub fn derive_resolution_keys_with_context(
             RelationKind::Calls if semantic::supports_source_dependencies(provider_owner) => {
                 call_dependency_keys(
                     project,
+                    provider_owner,
                     &provider,
                     &language,
                     package.as_ref(),
@@ -622,6 +651,7 @@ fn cached_import_scopes<'a>(
 /// Derive canonical module-target keys for import references.
 fn import_dependency_keys(
     project: ProjectInstanceId,
+    provider_owner: SemanticProviderOwner,
     provider: &GraphIdentityText,
     language: &GraphIdentityText,
     package: Option<&GraphIdentityText>,
@@ -632,6 +662,7 @@ fn import_dependency_keys(
     let mut keys = Vec::new();
     for reference in references {
         let scopes = cached_import_scopes(import_scopes, caller_path, reference);
+        let package = dependency_package(provider_owner, reference, package);
         for scope in scopes {
             keys.push(canonical_key(
                 project,
@@ -651,6 +682,7 @@ fn import_dependency_keys(
 /// Derive canonical declaration keys for one call, including local aliases.
 fn call_dependency_keys(
     project: ProjectInstanceId,
+    provider_owner: SemanticProviderOwner,
     provider: &GraphIdentityText,
     language: &GraphIdentityText,
     package: Option<&GraphIdentityText>,
@@ -669,6 +701,7 @@ fn call_dependency_keys(
                 continue;
             };
             let scopes = cached_import_scopes(import_scopes, caller_path, reference);
+            let package = dependency_package(provider_owner, reference, package);
             for scope in scopes {
                 let scoped_parent;
                 let scope = if remainder.is_some()
@@ -712,6 +745,22 @@ fn call_dependency_keys(
         RelationKind::Calls,
         identity,
     )?])
+}
+
+/// Configured ECMAScript targets are repository paths, so caller Cargo
+/// ownership must not prevent them from matching a sibling package export.
+fn dependency_package<'a>(
+    provider_owner: SemanticProviderOwner,
+    reference: &ImportReference,
+    package: Option<&'a GraphIdentityText>,
+) -> Option<&'a GraphIdentityText> {
+    if provider_owner == SemanticProviderOwner::EcmaScript
+        && !(reference.module().starts_with("./") || reference.module().starts_with("../"))
+    {
+        None
+    } else {
+        package
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1170,7 +1219,7 @@ mod tests {
                 _ => "typescript",
             };
             let caller = extract_symbol_graph(caller_path, Some(caller_language), caller_source);
-            let target_projection = derive_resolution_keys(project, Some("app"), &target)?;
+            let target_projection = derive_resolution_keys(project, Some("shared"), &target)?;
             let caller_projection =
                 derive_resolution_keys_with_context(project, Some("app"), &caller, context)?;
             let imports = relation_keys_of_kind(&caller, &caller_projection, RelationKind::Imports);

--- a/crates/projectatlas-symbols/src/resolution_keys.rs
+++ b/crates/projectatlas-symbols/src/resolution_keys.rs
@@ -1,6 +1,7 @@
 //! Canonical import facts and resolution-key projection for extracted symbol graphs.
 
 use crate::ConfiguredModuleResolution;
+use crate::configured_modules::ConfiguredModuleSource;
 use crate::semantic;
 use blake3::Hasher;
 use projectatlas_core::graph::{
@@ -144,6 +145,9 @@ pub struct ResolutionProjectionContext<'a> {
     /// Validated configured-module snapshot, when the runtime supplied one.
     configured_modules: Option<&'a ConfiguredModuleResolution>,
 }
+
+/// Provider scopes expanded once per unique import in one source graph.
+type ImportScopeCache = BTreeMap<String, BTreeMap<String, Vec<String>>>;
 
 impl<'a> ResolutionProjectionContext<'a> {
     /// Construct a projection context with one validated configured-module snapshot.
@@ -511,6 +515,15 @@ pub fn derive_resolution_keys_with_context(
                 .push(reference);
         }
     }
+    let configured_source = context
+        .configured_modules
+        .map(|configured| configured.for_source(&graph.path));
+    let import_scopes = build_import_scope_cache(
+        provider_owner,
+        graph,
+        &parsed_imports,
+        configured_source.as_ref(),
+    );
 
     let mut relation_keys = Vec::new();
     for (relation_index, relation) in graph.relations.iter().enumerate() {
@@ -518,26 +531,24 @@ pub fn derive_resolution_keys_with_context(
             RelationKind::Imports if semantic::supports_source_dependencies(provider_owner) => {
                 import_dependency_keys(
                     project,
-                    provider_owner,
                     &provider,
                     &language,
                     package.as_ref(),
                     &relation.path,
                     &parsed_imports[relation_index],
-                    context,
+                    &import_scopes,
                 )?
             }
             RelationKind::Calls if semantic::supports_source_dependencies(provider_owner) => {
                 call_dependency_keys(
                     project,
-                    provider_owner,
                     &provider,
                     &language,
                     package.as_ref(),
                     &relation.path,
                     &relation.target_name,
                     &aliases,
-                    context,
+                    &import_scopes,
                 )?
             }
             RelationKind::DependsOn if semantic::supports_package_dependencies(provider_owner) => {
@@ -569,26 +580,59 @@ pub fn derive_resolution_keys_with_context(
     })
 }
 
+/// Expand each unique import scope once for the complete source graph.
+fn build_import_scope_cache(
+    provider_owner: SemanticProviderOwner,
+    graph: &SymbolGraph,
+    parsed_imports: &[Vec<ImportReference>],
+    configured_source: Option<&ConfiguredModuleSource<'_>>,
+) -> ImportScopeCache {
+    let mut cache = ImportScopeCache::new();
+    for (relation, references) in graph.relations.iter().zip(parsed_imports) {
+        let caller_path = &relation.path;
+        let modules = cache.entry(caller_path.clone()).or_default();
+        for reference in references {
+            modules
+                .entry(reference.module().to_string())
+                .or_insert_with(|| {
+                    semantic::import_scopes(
+                        provider_owner,
+                        caller_path,
+                        reference,
+                        configured_source,
+                    )
+                });
+        }
+    }
+    cache
+}
+
+/// Borrow one pre-expanded import scope list without allocating lookup keys.
+fn cached_import_scopes<'a>(
+    cache: &'a ImportScopeCache,
+    caller_path: &str,
+    reference: &ImportReference,
+) -> &'a [String] {
+    cache
+        .get(caller_path)
+        .and_then(|modules| modules.get(reference.module()))
+        .map_or(&[], Vec::as_slice)
+}
+
 /// Derive canonical module-target keys for import references.
 fn import_dependency_keys(
     project: ProjectInstanceId,
-    provider_owner: SemanticProviderOwner,
     provider: &GraphIdentityText,
     language: &GraphIdentityText,
     package: Option<&GraphIdentityText>,
     caller_path: &str,
     references: &[ImportReference],
-    context: ResolutionProjectionContext<'_>,
+    import_scopes: &ImportScopeCache,
 ) -> Result<Vec<CanonicalResolutionKey>, ResolutionProjectionError> {
     let mut keys = Vec::new();
     for reference in references {
-        let scopes = semantic::import_scopes(
-            provider_owner,
-            caller_path,
-            reference,
-            context.configured_modules,
-        );
-        for scope in &scopes {
+        let scopes = cached_import_scopes(import_scopes, caller_path, reference);
+        for scope in scopes {
             keys.push(canonical_key(
                 project,
                 ResolutionKeyDomain::Module,
@@ -607,14 +651,13 @@ fn import_dependency_keys(
 /// Derive canonical declaration keys for one call, including local aliases.
 fn call_dependency_keys(
     project: ProjectInstanceId,
-    provider_owner: SemanticProviderOwner,
     provider: &GraphIdentityText,
     language: &GraphIdentityText,
     package: Option<&GraphIdentityText>,
     caller_path: &str,
     target: &str,
     aliases: &BTreeMap<&str, Vec<&ImportReference>>,
-    context: ResolutionProjectionContext<'_>,
+    import_scopes: &ImportScopeCache,
 ) -> Result<Vec<CanonicalResolutionKey>, ResolutionProjectionError> {
     let (prefix, remainder) = split_qualified_target(target);
     let alias = prefix.unwrap_or(target).trim();
@@ -625,28 +668,24 @@ fn call_dependency_keys(
             let Some(identity) = identity else {
                 continue;
             };
-            let mut scopes = semantic::import_scopes(
-                provider_owner,
-                caller_path,
-                reference,
-                context.configured_modules,
-            );
-            if remainder.is_some()
-                && let Some(imported_parent) = reference.imported()
-            {
-                scopes = scopes
-                    .into_iter()
-                    .map(|scope| format!("{scope}/{imported_parent}"))
-                    .collect();
-            }
+            let scopes = cached_import_scopes(import_scopes, caller_path, reference);
             for scope in scopes {
+                let scoped_parent;
+                let scope = if remainder.is_some()
+                    && let Some(imported_parent) = reference.imported()
+                {
+                    scoped_parent = format!("{scope}/{imported_parent}");
+                    scoped_parent.as_str()
+                } else {
+                    scope.as_str()
+                };
                 keys.push(canonical_key(
                     project,
                     ResolutionKeyDomain::Declaration,
                     provider,
                     language,
                     package,
-                    Some(&scope),
+                    Some(scope),
                     RelationKind::Calls,
                     identity,
                 )?);
@@ -802,15 +841,16 @@ pub(super) fn strip_known_source_extension(path: &str) -> String {
 mod tests {
     use super::{
         ImportReference, ImportSyntax, RelationKind, ResolutionProjectionContext,
-        ResolutionProjectionError, SEMANTIC_RESOLUTION_CONTRACT_VERSION, derive_resolution_keys,
-        derive_resolution_keys_with_context, parse_import_references, resolve_relative_import_path,
-        semantic_resolution_contract_digest,
+        ResolutionProjectionError, SEMANTIC_RESOLUTION_CONTRACT_VERSION, build_import_scope_cache,
+        derive_resolution_keys, derive_resolution_keys_with_context, parse_import_references,
+        resolve_relative_import_path, semantic_resolution_contract_digest,
     };
     use crate::{
         ConfiguredModuleResolution, EcmaScriptConfigKind, EcmaScriptModuleConfig,
         EcmaScriptPathMapping, extract_symbol_graph,
     };
     use projectatlas_core::graph::{CanonicalResolutionKey, ProjectInstanceId};
+    use projectatlas_core::language::SemanticProviderOwner;
     use projectatlas_core::symbols::SymbolGraph;
     use std::error::Error;
     use std::io;
@@ -1204,6 +1244,58 @@ mod tests {
             .any(|keys| keys_intersect(keys, extension_target_projection.source_keys())),
             "configured extension target did not reuse extensionless source keys",
         )?;
+        Ok(())
+    }
+
+    #[test]
+    fn configured_import_scopes_are_expanded_once_per_source_graph() -> Result<(), Box<dyn Error>> {
+        let configured = ConfiguredModuleResolution::new(vec![EcmaScriptModuleConfig::new(
+            "tsconfig.json",
+            EcmaScriptConfigKind::TypeScript,
+            Some("src".to_string()),
+            vec![EcmaScriptPathMapping::new(
+                "@/*",
+                vec!["src/*".to_string()],
+            )?],
+        )?])?;
+        let graph = extract_symbol_graph(
+            "src/page.ts",
+            Some("typescript"),
+            "import { useController } from '@/controller';\n\
+             export const first = useController();\n\
+             export const second = useController();\n",
+        );
+        let parsed_imports = graph
+            .relations
+            .iter()
+            .map(|relation| {
+                if relation.kind == RelationKind::Imports {
+                    crate::semantic::parse_imports(
+                        SemanticProviderOwner::EcmaScript,
+                        &relation.target_name,
+                    )
+                } else {
+                    Vec::new()
+                }
+            })
+            .collect::<Vec<_>>();
+        let configured_source = configured.for_source(&graph.path);
+        let cache = build_import_scope_cache(
+            SemanticProviderOwner::EcmaScript,
+            &graph,
+            &parsed_imports,
+            Some(&configured_source),
+        );
+        let modules = cache
+            .get("src/page.ts")
+            .ok_or_else(|| io::Error::other("source graph omitted its import-scope cache"))?;
+        if modules.len() != 1 || modules.get("@/controller") != Some(&vec!["src/controller".into()])
+        {
+            return Err(io::Error::other(
+                "repeated imported calls did not reuse one configured scope expansion",
+            )
+            .into());
+        }
         Ok(())
     }
 

--- a/crates/projectatlas-symbols/src/semantic/ecmascript.rs
+++ b/crates/projectatlas-symbols/src/semantic/ecmascript.rs
@@ -3,6 +3,7 @@
 use super::{
     ImportReference, ImportSyntax, is_compact_name, module_reference, named_reference, quoted_text,
 };
+use crate::configured_modules::ConfiguredModuleResolution;
 use projectatlas_core::symbols::SymbolGraph;
 
 /// Parse accepted named and namespace ECMAScript import forms.
@@ -56,10 +57,17 @@ pub(super) fn is_export_candidate(graph: &SymbolGraph, symbol_index: usize) -> b
 }
 
 /// Resolve and normalize scopes referenced by one ECMAScript import.
-pub(super) fn import_scopes(caller_path: &str, reference: &ImportReference) -> Vec<String> {
-    resolve_relative_import_path(caller_path, reference.module())
-        .map(|scope| vec![scope])
-        .unwrap_or_default()
+pub(super) fn import_scopes(
+    caller_path: &str,
+    reference: &ImportReference,
+    configured_modules: Option<&ConfiguredModuleResolution>,
+) -> Vec<String> {
+    if let Some(scope) = resolve_relative_import_path(caller_path, reference.module()) {
+        return vec![scope];
+    }
+    configured_modules.map_or_else(Vec::new, |configured| {
+        configured.scopes_for_import(caller_path, reference.module())
+    })
 }
 
 /// Resolve one repository-relative ECMAScript module specifier.

--- a/crates/projectatlas-symbols/src/semantic/ecmascript.rs
+++ b/crates/projectatlas-symbols/src/semantic/ecmascript.rs
@@ -3,7 +3,7 @@
 use super::{
     ImportReference, ImportSyntax, is_compact_name, module_reference, named_reference, quoted_text,
 };
-use crate::configured_modules::ConfiguredModuleResolution;
+use crate::configured_modules::ConfiguredModuleSource;
 use projectatlas_core::symbols::SymbolGraph;
 
 /// Parse accepted named and namespace ECMAScript import forms.
@@ -60,13 +60,13 @@ pub(super) fn is_export_candidate(graph: &SymbolGraph, symbol_index: usize) -> b
 pub(super) fn import_scopes(
     caller_path: &str,
     reference: &ImportReference,
-    configured_modules: Option<&ConfiguredModuleResolution>,
+    configured_source: Option<&ConfiguredModuleSource<'_>>,
 ) -> Vec<String> {
     if let Some(scope) = resolve_relative_import_path(caller_path, reference.module()) {
         return vec![scope];
     }
-    configured_modules.map_or_else(Vec::new, |configured| {
-        configured.scopes_for_import(caller_path, reference.module())
+    configured_source.map_or_else(Vec::new, |configured| {
+        configured.scopes_for_import(reference.module())
     })
 }
 

--- a/crates/projectatlas-symbols/src/semantic/mod.rs
+++ b/crates/projectatlas-symbols/src/semantic/mod.rs
@@ -6,6 +6,7 @@ pub(super) mod embedded_source;
 mod python;
 mod rust;
 
+use crate::configured_modules::ConfiguredModuleResolution;
 use crate::resolution_keys::{ImportReference, ImportSyntax};
 use projectatlas_core::language::{EmbeddedHostKind, SemanticProviderOwner, language_capability};
 use projectatlas_core::symbols::{ParserKind, SymbolGraph};
@@ -74,10 +75,13 @@ pub(super) fn import_scopes(
     provider: SemanticProviderOwner,
     caller_path: &str,
     reference: &ImportReference,
+    configured_modules: Option<&ConfiguredModuleResolution>,
 ) -> Vec<String> {
     match provider {
         SemanticProviderOwner::Rust => rust::import_scopes(caller_path, reference),
-        SemanticProviderOwner::EcmaScript => ecmascript::import_scopes(caller_path, reference),
+        SemanticProviderOwner::EcmaScript => {
+            ecmascript::import_scopes(caller_path, reference, configured_modules)
+        }
         SemanticProviderOwner::Python => python::import_scopes(caller_path, reference),
         SemanticProviderOwner::Cargo | SemanticProviderOwner::Unavailable => Vec::new(),
     }

--- a/crates/projectatlas-symbols/src/semantic/mod.rs
+++ b/crates/projectatlas-symbols/src/semantic/mod.rs
@@ -6,7 +6,7 @@ pub(super) mod embedded_source;
 mod python;
 mod rust;
 
-use crate::configured_modules::ConfiguredModuleResolution;
+use crate::configured_modules::ConfiguredModuleSource;
 use crate::resolution_keys::{ImportReference, ImportSyntax};
 use projectatlas_core::language::{EmbeddedHostKind, SemanticProviderOwner, language_capability};
 use projectatlas_core::symbols::{ParserKind, SymbolGraph};
@@ -75,12 +75,12 @@ pub(super) fn import_scopes(
     provider: SemanticProviderOwner,
     caller_path: &str,
     reference: &ImportReference,
-    configured_modules: Option<&ConfiguredModuleResolution>,
+    configured_source: Option<&ConfiguredModuleSource<'_>>,
 ) -> Vec<String> {
     match provider {
         SemanticProviderOwner::Rust => rust::import_scopes(caller_path, reference),
         SemanticProviderOwner::EcmaScript => {
-            ecmascript::import_scopes(caller_path, reference, configured_modules)
+            ecmascript::import_scopes(caller_path, reference, configured_source)
         }
         SemanticProviderOwner::Python => python::import_scopes(caller_path, reference),
         SemanticProviderOwner::Cargo | SemanticProviderOwner::Unavailable => Vec::new(),

--- a/openspec/changes/resolve-configured-module-aliases/.openspec.yaml
+++ b/openspec/changes/resolve-configured-module-aliases/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/resolve-configured-module-aliases/design.md
+++ b/openspec/changes/resolve-configured-module-aliases/design.md
@@ -1,0 +1,85 @@
+## Context
+
+The v0.4.0 parsers already retain ECMAScript import statements and calls. `projectatlas-symbols` derives canonical module and declaration keys from those parser facts, and `projectatlas-cli` binds the keys to file and symbol entities before atomically publishing one SQLite graph generation. The ECMAScript provider currently derives scopes only for `./` and `../`, so configured aliases emit no dependency keys even though equivalent relative imports resolve.
+
+The fix crosses semantic key derivation, bounded repository configuration reads, and watcher invalidation, but it does not change graph identity, storage, query, transaction, WAL, or adapter ownership.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give the shared semantic projection an explicit typed configured-module context.
+- Resolve direct `compilerOptions.baseUrl` and `compilerOptions.paths` mappings from applicable `tsconfig.json` and `jsconfig.json` files for JavaScript, JSX, TypeScript, TSX, and embedded Vue source.
+- Preserve existing relative imports, extension inference, package-entry (`index`) inference, typed unresolved/ambiguous outcomes, and file/exact-symbol agreement.
+- Make configuration creation, edits, and removal invalidate all configuration-derived graph edges.
+- Bound configuration count, bytes, mappings, target fan-out, CPU work, and retained memory under the existing cancellation/deadline and atomic publication boundary.
+
+**Non-Goals:**
+
+- Arbitrary bundler or runtime alias configuration, plugin execution, or JavaScript evaluation.
+- A parser-local TypeScript or Vue path.
+- A new crate, dependency, schema, migration, graph query, CLI/MCP command, or provider claim.
+- Applying ECMAScript alias rules to Python, Rust, or Cargo identities.
+
+## Decisions
+
+### 1. Semantic resolution owns alias matching; the CLI runtime owns filesystem configuration
+
+`projectatlas-symbols` will own validated typed ECMAScript configuration scopes and deterministic module-specifier matching. Its projection context will be supplied to both import and alias-derived call key generation. `projectatlas-cli` will own bounded JSONC reads, direct compiler-option decoding, repository-path normalization, nearest-config selection inputs, and translation of malformed or over-limit configuration into typed scan failure.
+
+This keeps language semantics out of the parser and filesystem authority out of the semantic crate.
+
+**Alternative considered:** resolve aliases directly in Vue/TypeScript extraction. JavaScript would remain broken and exact call keys could drift from import keys.
+
+### 2. Applicable configuration is selected by repository containment and source family
+
+Configuration files are ordered by their containing repository directory. The nearest containing configuration wins. TypeScript, TSX, and Vue prefer `tsconfig.json`; JavaScript and JSX prefer `jsconfig.json`, with the other kind used only when no preferred configuration exists at the same nearest scope. Direct `baseUrl` and `paths` values are resolved relative to the configuration directory and normalized to repository paths.
+
+For a matched `paths` pattern, only the most-specific pattern is expanded. Its bounded target list becomes canonical candidate scopes. If no pattern matches, a configured `baseUrl` supplies the local candidate. Existing relative resolution remains authoritative for `./` and `../`.
+
+**Alternative considered:** combine all parent configurations or every matching pattern. That would invent candidates, turn resolvable imports ambiguous, and diverge from compiler path precedence.
+
+### 3. Existing graph candidate binding owns resolved, ambiguous, and unresolved outcomes
+
+Alias expansion emits the same canonical module and declaration dependency keys used by relative imports. Existing source export aliases already cover extensionless and `index` entry forms. One matching entity remains resolved, several distinct matching entities remain ambiguous, and no matching entity remains unresolved. No resolver-specific status or persistence rows are added.
+
+**Alternative considered:** inspect target files in the semantic crate and emit a pre-resolved entity. That would duplicate repository candidate authority and bypass generation-bound ambiguity handling.
+
+### 4. Compiler-configuration changes force a complete derived refresh
+
+`tsconfig.json` and `jsconfig.json` are indexed source inputs. Watcher classification will treat creation, edits, renames, and removal of either basename at any repository depth as full-refresh events. Full and incremental graph staging load the current bounded configuration snapshot from the expected node set, and existing final source revalidation prevents a changed configuration from being published against stale bytes.
+
+Full refresh is intentionally used because one root configuration can affect every ECMAScript source file; attempting a guessed local closure could retain stale inbound or dead-code results.
+
+**Alternative considered:** invalidate only the configuration directory. `baseUrl`, broad wildcard mappings, and parent configurations can affect callers outside a cheaply inferred subtree.
+
+### 5. Provider audit does not broaden semantics
+
+Python already owns absolute and dot-relative module scopes without a ProjectAtlas repository setting for source roots. Rust owns lexical `crate`, `self`, and `super` scopes. Cargo package identities and dependency renames come from parsed manifests and their existing package resolver. The change will retain focused compatibility coverage for those providers and record the ECMAScript configuration as not applicable to them.
+
+### 6. Storage and performance contracts stay intact
+
+The loader uses the existing JSONC dependency and controlled source reader. It enforces per-file and aggregate byte ceilings, configuration/mapping/target count ceilings, normalized repository containment, periodic cancellation checks, and the existing per-fact key fan-out. Configuration is read once per graph stage, sorted deterministically, and shared by all graph projections. SQLite schema, indexes, prepared statements, transactions, savepoints, WAL, recovery, persistent bytes, and write amplification remain unchanged; publication still replaces one complete generation atomically.
+
+## Risks / Trade-offs
+
+- **Common JSONC syntax is rejected** → parse with the already shipped JSONC parser rather than strict JSON.
+- **A mapping escapes the repository or expands excessively** → normalize lexically, reject root escape/absolute targets, and enforce file, mapping, target, byte, and key-fan-out limits.
+- **Configuration precedence creates false ambiguity** → select the nearest applicable config and only its most-specific matching path pattern.
+- **A configuration changes during projection** → compare controlled-read bytes to the scanned node hash and retain final publication input revalidation.
+- **A configuration edit leaves old callers reachable** → classify every `tsconfig.json`/`jsconfig.json` event as a full refresh.
+- **The compatibility helper without configuration drifts** → retain the existing context-free API as a no-config wrapper and test that relative/provider behavior is unchanged.
+
+## Migration Plan
+
+1. Add typed configured-module matching and unit coverage in `projectatlas-symbols`.
+2. Add the bounded runtime loader and wire one shared snapshot through full and incremental graph projection.
+3. Add config-path full-refresh classification and incremental edit/removal coverage.
+4. Add real CLI/MCP graph fixtures for JavaScript, TypeScript, TSX, and Vue plus provider compatibility controls.
+5. Run focused crate, integration, E2E, strict OpenSpec, issue-checklist, formatting, check, and clippy gates without benchmarks.
+
+Rollback is an ordinary source revert before v0.4.1. There is no database or authored-state migration to undo; the next scan rebuilds derived rows under the prior semantic contract.
+
+## Open Questions
+
+None.

--- a/openspec/changes/resolve-configured-module-aliases/proposal.md
+++ b/openspec/changes/resolve-configured-module-aliases/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+ProjectAtlas v0.4.0 parses configured ECMAScript imports but cannot resolve `tsconfig.json` or `jsconfig.json` path aliases, so real callers can disappear from inbound, impact, and dead-code analysis. The equivalent relative imports already resolve, which isolates the bug to the shared semantic-resolution contract rather than language parsing.
+
+## What Changes
+
+- Load bounded, validated `baseUrl` and `paths` mappings from the applicable `tsconfig.json` or `jsconfig.json`.
+- Supply repository module configuration to the shared ECMAScript semantic resolver used by JavaScript, JSX, TypeScript, TSX, and embedded Vue source.
+- Resolve configured aliases with existing extension and package-entry inference while preserving typed unresolved and ambiguous outcomes.
+- Treat compiler-configuration edits and removal as graph-invalidating inputs so incremental refresh cannot retain stale alias edges.
+- Audit the Python, Rust, and Cargo provider contracts for equivalent configuration-owned roots or renames and record behavior as covered or not applicable without applying ECMAScript rules across providers.
+- Preserve CLI/MCP parity, bounded work, cancellation, atomic publication, and the last complete SQLite generation.
+
+## Capabilities
+
+### New Capabilities
+
+- `configured-module-resolution`: Resolve repository-configured ECMAScript aliases into the same file and exact-symbol graph edges as equivalent relative imports, including incremental configuration freshness.
+
+### Modified Capabilities
+
+None.
+
+## Non-Goals
+
+- No runtime-only aliases absent from repository configuration.
+- No execution of bundler plugins or arbitrary JavaScript configuration.
+- No parser-local TypeScript or Vue special case.
+- No new crate, dependency, database schema, migration, graph storage model, CLI command, or MCP tool.
+- No semantic-support claim for detection-only or fallback-only languages.
+
+## Impact
+
+- Shared semantic-resolution keys in `projectatlas-symbols`.
+- Repository configuration discovery and graph derivation/invalidation in the existing CLI runtime.
+- Focused unit and real CLI/MCP graph coverage for alias resolution and configuration freshness.
+- Existing SQLite publication and WAL ownership remain unchanged; only the derived resolution inputs and affected-source selection change.
+
+This v0.4.1 bug fix is ready for implementation.

--- a/openspec/changes/resolve-configured-module-aliases/specs/configured-module-resolution/spec.md
+++ b/openspec/changes/resolve-configured-module-aliases/specs/configured-module-resolution/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Applicable ECMAScript configuration resolves repository modules
+ProjectAtlas SHALL load bounded, validated direct `compilerOptions.baseUrl` and `compilerOptions.paths` values from the nearest applicable `tsconfig.json` or `jsconfig.json`. JavaScript, JSX, TypeScript, TSX, and embedded Vue imports SHALL use the shared ECMAScript semantic resolver rather than parser-local alias handling.
+
+#### Scenario: TypeScript and Vue use tsconfig aliases
+- **WHEN** a containing `tsconfig.json` maps an alias to an indexed TypeScript module and TypeScript, TSX, or Vue source imports and calls an exported declaration through that alias
+- **THEN** file-level import and exact-symbol call relations resolve to the same targets as the equivalent relative import
+
+#### Scenario: JavaScript uses jsconfig aliases
+- **WHEN** a containing `jsconfig.json` maps an alias to an indexed JavaScript or JSX module
+- **THEN** file-level and exact-symbol inbound and outbound traversal resolve the configured alias
+
+#### Scenario: Extension and package entry inference
+- **WHEN** a mapped target is referenced with or without its supported source extension or resolves to an `index` module
+- **THEN** existing source export aliases select the indexed file and declaration without inventing a second resolution model
+
+#### Scenario: No applicable configuration
+- **WHEN** a repository has no applicable compiler configuration
+- **THEN** relative ECMAScript imports and all Python, Rust, and Cargo provider behavior remain compatible and an unconfigured alias remains typed unresolved
+
+### Requirement: Configuration precedence and outcomes remain deterministic
+ProjectAtlas SHALL choose the nearest containing configuration and the most-specific matching `paths` pattern, normalize targets within the repository, sort and deduplicate emitted candidate scopes, and preserve existing typed resolution outcomes.
+
+#### Scenario: Nested configuration overrides a parent
+- **WHEN** parent and nested configuration files could map the same module specifier for a nested caller
+- **THEN** only the nearest applicable configuration supplies candidates
+
+#### Scenario: Multiple configured targets exist
+- **WHEN** the selected mapping expands to more than one distinct indexed target
+- **THEN** the relation is typed ambiguous and no arbitrary first target is reported as resolved
+
+#### Scenario: Configured target is absent
+- **WHEN** the selected mapping produces no indexed target
+- **THEN** the relation is typed unresolved and impact or dead-code analysis does not claim a resolved caller
+
+#### Scenario: Configuration is malformed or escapes the repository
+- **WHEN** an applicable configuration cannot be parsed, exceeds a bound, or contains an absolute or repository-escaping target
+- **THEN** derivation fails before publication and the last complete graph generation remains readable
+
+### Requirement: Configuration freshness invalidates derived graph state
+ProjectAtlas SHALL treat creation, edits, renames, and removal of `tsconfig.json` and `jsconfig.json` at any repository depth as route-affecting graph inputs requiring a complete derived refresh.
+
+#### Scenario: Alias mapping changes
+- **WHEN** a mapping changes from one indexed target to another
+- **THEN** the next refresh removes the old file and symbol edges and publishes only the new resolved targets in one generation
+
+#### Scenario: Alias configuration is removed
+- **WHEN** the applicable configuration is deleted
+- **THEN** the next refresh removes configuration-derived edges and retains the same imports as typed unresolved unless another applicable configuration resolves them
+
+#### Scenario: Configuration changes during publication
+- **WHEN** configuration bytes differ from the scanned node or change before final source revalidation
+- **THEN** publication fails without partial rows or generation advancement
+
+### Requirement: Alias resolution preserves bounded adapter-equivalent analysis
+Configured resolution SHALL preserve row, input-byte, retained-memory, deadline, cancellation, and output limits. CLI and MCP graph traversal SHALL read the same generation-bound graph and return equivalent resolved, ambiguous, or unresolved states for the same project and selector.
+
+#### Scenario: File and symbol views agree
+- **WHEN** a configured import calls one exported declaration
+- **THEN** file inbound, exact-symbol inbound, outbound, impact, and conservative dead-code views use the same resolved edge
+
+#### Scenario: CLI and MCP query the same alias edge
+- **WHEN** CLI and MCP relation calls address the same project database and exact selector
+- **THEN** both adapters return the same target identity, resolution state, generation, and exact total
+
+#### Scenario: Configuration fan-out exceeds a bound
+- **WHEN** admitted configuration count, bytes, mappings, targets, or per-fact canonical keys exceed the owning limit
+- **THEN** the operation returns a typed resource failure, observes cancellation and deadline checks, and does not publish partial graph state

--- a/openspec/changes/resolve-configured-module-aliases/tasks.md
+++ b/openspec/changes/resolve-configured-module-aliases/tasks.md
@@ -1,0 +1,8 @@
+## 1. OpenSpec Task Checklist
+
+- [x] 1.1 Add a typed, bounded configured-module projection context in `projectatlas-symbols`; resolve nearest applicable ECMAScript `baseUrl` and most-specific `paths` candidates through shared import and call keys while preserving relative, extension, `index`, unresolved, and ambiguous behavior.
+- [x] 1.2 Add bounded JSONC `tsconfig.json` / `jsconfig.json` discovery and repository-contained normalization in the CLI runtime; share one deterministic snapshot across full and incremental graph projection without adding a crate, dependency, schema, or transaction owner.
+- [x] 1.3 Treat compiler-configuration creation, edits, renames, and removal as complete-refresh inputs; reject malformed, escaping, over-limit, or concurrently changed configuration before atomic publication.
+- [x] 1.4 Audit Python, Rust, and Cargo semantic providers, retain applicable compatibility coverage, and record ECMAScript compiler aliases as not applicable without broadening provider claims.
+- [x] 1.5 Add coherent unit, integration, and real CLI/MCP fixtures covering JavaScript, JSX, TypeScript, TSX, Vue, file and exact-symbol traversal, outbound resolution, impact/dead-code safety, extension and `index` inference, nearest precedence, missing/no-config controls, ambiguity, malformed input, configuration edit/removal, bounds, cancellation, atomicity, and adapter equivalence.
+- [ ] 1.6 Pass focused crate and E2E tests, formatting, workspace check/clippy, strict OpenSpec validation, issue-checklist validation, and live GitHub review-feedback audit without running benchmarks; leave task completion and remote issue state for exact-head parent review.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -31,6 +31,7 @@
       ]
     },
     "publish-rustdoc-readme-links": 300,
+    "resolve-configured-module-aliases": 385,
     "reuse-release-proof-by-inputs": 366,
     "reuse-unchanged-ci-build-layers": 341,
     "show-agent-efficiency-dashboard": 340,


### PR DESCRIPTION
## Summary

- resolve direct `tsconfig.json` and `jsconfig.json` `baseUrl`/`paths` aliases through the existing typed ECMAScript graph projection
- load one bounded repository-contained JSONC configuration snapshot and retain atomic graph publication on malformed or changed configuration
- cover JavaScript, JSX, TypeScript, TSX, Vue, file/symbol relations, impact/dead-code, MCP, edits, removal, ambiguity, cancellation, and rollback

## Verification

- configured-alias unit and real CLI/MCP E2E suites
- workspace check/clippy/tests/docs from the implementation pass
- strict string-contract lint
- strict OpenSpec and issue-checklist validation
- formatting and diff integrity

Benchmarks were not run; the manual-only historical benchmark is not required for this correctness fix.

Fixes #385
