### PR TITLE
fix(analysis): bound impact analysis deadlines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ tiktoken = "3.5.1"
 tokio = { version = "1.48", features = ["io-std", "macros", "rt-multi-thread", "time"] }
 toml = "0.8"
 toml_edit = "0.22"
-toon-format = { version = "0.5.0", default-features = false }
+toon-format = { version = "0.5.0", default-features = false, features = ["json_stream"] }
 tree-sitter = "=0.26.9"
 tree-sitter-c = "=0.24.2"
 tree-sitter-c-sharp = "=0.23.5"

--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -29,12 +29,13 @@ use projectatlas_core::telemetry::{
     TokenCalibrationOverview, TokenTrendWindow as CoreTokenTrendWindow, UsageInstanceOwner,
 };
 use projectatlas_core::toon::{
-    encode_agent_payload, render_outline, render_overview, render_ranked_node_rows,
-    render_ranked_nodes, render_symbol_relations, render_symbols, render_token_overview,
-    render_token_trends,
+    encode_agent_payload, encode_error_text, render_outline, render_overview,
+    render_ranked_node_rows, render_ranked_nodes, render_symbol_relations, render_symbols,
+    render_token_overview, render_token_trends,
 };
 use projectatlas_core::{
-    PurposeSource, PurposeStatus, normalize_native_path_display, normalize_repo_path_prefix,
+    IndexWorkControl, IndexWorkStage, PurposeSource, PurposeStatus, normalize_native_path_display,
+    normalize_repo_path_prefix,
 };
 use projectatlas_db::{
     AtlasStore, DbError, HealthQuery, HealthResolution, HealthScope, ProjectRootTransition,
@@ -99,6 +100,8 @@ const PROJECTATLAS_MAJOR_VERSION: u8 = 3;
 const DEFAULT_CALLER_LABEL: &str = "default";
 /// Default maximum rows returned per structured file-summary section.
 const DEFAULT_FILE_SUMMARY_LIMIT: usize = 25;
+/// CLI top-level field for detailed and analysis relation responses.
+const CLI_PAYLOAD_SYMBOL_RELATIONS: &str = "symbol_relations";
 /// One-shot watcher refresh mode.
 const WATCH_MODE_ONCE: &str = "single-refresh";
 /// Event-backed watcher mode.
@@ -527,6 +530,24 @@ struct DetailedRelationLimitArgs {
     /// Maximum exact occurrences retained per detailed relation.
     #[arg(long, default_value_t = 25)]
     occurrence_limit: u32,
+    /// Maximum adjacency rows inspected across the complete request.
+    #[arg(long)]
+    edge_limit: Option<u32>,
+    /// Maximum unique traversal nodes retained across the complete request.
+    #[arg(long)]
+    node_limit: Option<u32>,
+    /// Maximum unique visited identities retained across continuation pages.
+    #[arg(long)]
+    visited_limit: Option<u32>,
+    /// Maximum exact occurrences retained across the complete request.
+    #[arg(long)]
+    occurrence_total_limit: Option<u32>,
+    /// Maximum decoded, cursor, and service-composition intermediate bytes.
+    #[arg(long)]
+    intermediate_bytes: Option<u64>,
+    /// Maximum service-owned elapsed milliseconds.
+    #[arg(long)]
+    deadline_ms: Option<u64>,
     /// Maximum encoded bytes admitted to the detailed response.
     #[arg(long, default_value_t = 256 * 1024)]
     output_bytes: u32,
@@ -1829,6 +1850,12 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                             depth,
                             include_occurrences,
                             occurrence_limit,
+                            edge_limit,
+                            node_limit,
+                            visited_limit,
+                            occurrence_total_limit,
+                            intermediate_bytes,
+                            deadline_ms,
                             output_bytes,
                         },
                     analysis,
@@ -1970,7 +1997,15 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                         minimum_confidence: (*minimum_confidence).into(),
                         resolution: (*resolution).into(),
                         include_occurrences: *include_occurrences,
-                        budget: DetailedRelationBudget::from_graph_limits(limits),
+                        budget: DetailedRelationBudget::from_graph_limits(limits)
+                            .with_aggregate_limits(
+                                *edge_limit,
+                                *node_limit,
+                                *visited_limit,
+                                *occurrence_total_limit,
+                                *intermediate_bytes,
+                                *deadline_ms,
+                            )?,
                         cursor: cursor.clone(),
                     };
                     let output = if *view == RelationViewArg::Detailed {
@@ -2056,10 +2091,13 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                             })?;
                             let draft =
                                 load_federated_relation_analysis(stores, &query, Some(control))?;
-                            let (_report, output) = draft.fit_output(|report| {
-                                let payload = json!({ "symbol_relations": report });
-                                let toon = encode_agent_payload(&payload);
-                                serialized_output(cli.format, &toon, &payload)
+                            let (_report, output) = draft.fit_output(|report, control| {
+                                controlled_named_output(
+                                    cli.format,
+                                    CLI_PAYLOAD_SYMBOL_RELATIONS,
+                                    report,
+                                    control,
+                                )
                             })?;
                             output
                         } else {
@@ -2072,10 +2110,13 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                                 &query,
                                 None,
                             )?;
-                            let (_report, output) = draft.fit_output(|report| {
-                                let payload = json!({ "symbol_relations": report });
-                                let toon = encode_agent_payload(&payload);
-                                serialized_output(cli.format, &toon, &payload)
+                            let (_report, output) = draft.fit_output(|report, control| {
+                                controlled_named_output(
+                                    cli.format,
+                                    CLI_PAYLOAD_SYMBOL_RELATIONS,
+                                    report,
+                                    control,
+                                )
                             })?;
                             output
                         }
@@ -3297,6 +3338,178 @@ fn serialized_output<T: serde::Serialize>(
     }
 }
 
+/// Maximum bytes copied between cooperative output-control checks.
+const CONTROLLED_ENCODING_CHUNK_BYTES: usize = 8 * 1024;
+
+/// One dynamic top-level payload field without an intermediate JSON value.
+struct NamedPayload<'a, T: ?Sized> {
+    /// Stable adapter-owned field name.
+    key: &'a str,
+    /// Borrowed service report.
+    payload: &'a T,
+}
+
+impl<T> Serialize for NamedPayload<'_, T>
+where
+    T: Serialize + ?Sized,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap as _;
+
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry(self.key, self.payload)?;
+        map.end()
+    }
+}
+
+/// Bounded output buffer that observes the request control between chunks.
+struct ControlledOutput<'a> {
+    /// Serialized bytes retained for the adapter result.
+    bytes: Vec<u8>,
+    /// Exact request control shared with service analysis.
+    control: &'a IndexWorkControl,
+    /// Whether a write stopped because the request became terminal.
+    interrupted: bool,
+}
+
+impl<'a> ControlledOutput<'a> {
+    /// Create an empty controlled output buffer.
+    const fn new(control: &'a IndexWorkControl) -> Self {
+        Self {
+            bytes: Vec::new(),
+            control,
+            interrupted: false,
+        }
+    }
+
+    /// Translate a terminal writer error back to the typed request failure.
+    fn check_terminal(&self) -> Result<(), CliError> {
+        self.control.check(IndexWorkStage::RepositoryTraversal)?;
+        Ok(())
+    }
+
+    /// Convert verified encoder output into UTF-8 text.
+    fn into_string(self) -> Result<String, CliError> {
+        String::from_utf8(self.bytes).map_err(|source| {
+            CliError::Output(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("encoded output was not UTF-8: {source}"),
+            ))
+        })
+    }
+}
+
+impl Write for ControlledOutput<'_> {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if self
+            .control
+            .check(IndexWorkStage::RepositoryTraversal)
+            .is_err()
+        {
+            self.interrupted = true;
+            return Err(io::Error::other("analysis output encoding interrupted"));
+        }
+        let retained = buffer.len().min(CONTROLLED_ENCODING_CHUNK_BYTES);
+        self.bytes.extend_from_slice(&buffer[..retained]);
+        Ok(retained)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Controlled reader used by the installed TOON streaming encoder.
+struct ControlledInput<'a> {
+    /// Compact JSON bytes consumed by the TOON encoder.
+    bytes: &'a [u8],
+    /// Current input offset.
+    offset: usize,
+    /// Exact request control shared with service analysis.
+    control: &'a IndexWorkControl,
+    /// Whether a read stopped because the request became terminal.
+    interrupted: bool,
+}
+
+impl<'a> ControlledInput<'a> {
+    /// Borrow one serialized payload as a cooperatively bounded input stream.
+    const fn new(bytes: &'a [u8], control: &'a IndexWorkControl) -> Self {
+        Self {
+            bytes,
+            offset: 0,
+            control,
+            interrupted: false,
+        }
+    }
+}
+
+impl Read for ControlledInput<'_> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if self
+            .control
+            .check(IndexWorkStage::RepositoryTraversal)
+            .is_err()
+        {
+            self.interrupted = true;
+            return Err(io::Error::other("analysis output encoding interrupted"));
+        }
+        let remaining = &self.bytes[self.offset..];
+        let read = remaining
+            .len()
+            .min(buffer.len())
+            .min(CONTROLLED_ENCODING_CHUNK_BYTES);
+        buffer[..read].copy_from_slice(&remaining[..read]);
+        self.offset = self.offset.saturating_add(read);
+        Ok(read)
+    }
+}
+
+/// Serialize one named analysis envelope while retaining deadline and cancellation.
+fn controlled_named_output<T>(
+    format: OutputFormat,
+    key: &str,
+    payload: &T,
+    control: &IndexWorkControl,
+) -> Result<String, CliError>
+where
+    T: Serialize + ?Sized,
+{
+    let payload = NamedPayload { key, payload };
+    let mut json = ControlledOutput::new(control);
+    let json_result = match format {
+        OutputFormat::Toon => serde_json::to_writer(&mut json, &payload),
+        OutputFormat::Json => serde_json::to_writer_pretty(&mut json, &payload),
+    };
+    if json.interrupted {
+        json.check_terminal()?;
+    }
+    json_result?;
+    json.check_terminal()?;
+    if format == OutputFormat::Json {
+        json.bytes.push(b'\n');
+        return json.into_string();
+    }
+
+    let mut input = ControlledInput::new(&json.bytes, control);
+    let mut output = ControlledOutput::new(control);
+    let toon_result = toon_format::encode_json_stream_default(&mut input, &mut output);
+    if input.interrupted || output.interrupted {
+        control.check(IndexWorkStage::RepositoryTraversal)?;
+    }
+    control.check(IndexWorkStage::RepositoryTraversal)?;
+    if let Err(error) = toon_result {
+        return Ok(format!(
+            "toon_error: {}\n",
+            encode_error_text(&error.to_string())
+        ));
+    }
+    output.bytes.push(b'\n');
+    output.into_string()
+}
+
 /// Build a bounded DB health query from CLI filter arguments.
 fn health_query_from_cli(
     start_index: usize,
@@ -4442,9 +4655,9 @@ mod tests {
     };
     use super::{
         Cli, CliError, Command, GraphRelationKind, OutputFormat, SearchRetrievalMode,
-        SearchRetrievalModeArg, ServiceError, build_runtime_info, load_token_atlas_relations,
-        render_cli_error, render_token_dashboard, serialized_output, token_atlas_network_relation,
-        truthy_env,
+        SearchRetrievalModeArg, ServiceError, build_runtime_info, controlled_named_output,
+        load_token_atlas_relations, render_cli_error, render_token_dashboard, serialized_output,
+        token_atlas_network_relation, truthy_env,
     };
     #[cfg(feature = "optional-parser-supervisor")]
     use super::{OptionalParserPackLifecycleError, ParserPackCommand};
@@ -4458,7 +4671,10 @@ mod tests {
         CodeSymbol, ParserKind, RelationKind, SymbolGraph, SymbolKind, SymbolRelation,
     };
     use projectatlas_core::telemetry::TokenOverview;
-    use projectatlas_core::{IndexGeneration, Node, NodeKind, normalize_native_path_display};
+    use projectatlas_core::{
+        IndexCancellation, IndexGeneration, IndexWorkControl, IndexWorkFailure, IndexWorkStage,
+        Node, NodeKind, normalize_native_path_display,
+    };
     use projectatlas_db::{AtlasStore, DbError, RepositoryGraphDirection};
     use projectatlas_fs::ScanOptions;
     use rmcp::model::{CallToolRequestParams, ClientInfo};
@@ -5413,6 +5629,56 @@ mod tests {
         }
         if json.len() <= toon.len() {
             return Err(io::Error::other("json output was not larger than toon fixture").into());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn analysis_output_encoding_is_equivalent_and_cancellable() -> Result<(), Box<dyn Error>> {
+        struct CancelDuringSerialize(IndexCancellation);
+
+        impl serde::Serialize for CancelDuringSerialize {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                use serde::ser::SerializeSeq as _;
+
+                let mut sequence = serializer.serialize_seq(Some(2))?;
+                sequence.serialize_element(&1_u8)?;
+                self.0.cancel();
+                sequence.serialize_element(&2_u8)?;
+                sequence.end()
+            }
+        }
+
+        let payload = json!({ "mode": "impact", "findings": [1, 2, 3] });
+        let control = IndexWorkControl::new(IndexCancellation::new(), None);
+        let expected =
+            projectatlas_core::toon::encode_agent_payload(&json!({ "symbol_relations": payload }));
+        let encoded =
+            controlled_named_output(OutputFormat::Toon, "symbol_relations", &payload, &control)?;
+        if encoded != expected {
+            return Err(io::Error::other("controlled TOON output changed its wire format").into());
+        }
+
+        let cancellation = IndexCancellation::new();
+        let control = IndexWorkControl::new(cancellation.clone(), None);
+        let result = controlled_named_output(
+            OutputFormat::Json,
+            "symbol_relations",
+            &CancelDuringSerialize(cancellation),
+            &control,
+        );
+        if !matches!(
+            result,
+            Err(CliError::IndexWork(IndexWorkFailure::Cancelled {
+                stage: IndexWorkStage::RepositoryTraversal
+            }))
+        ) {
+            return Err(
+                io::Error::other("analysis adapter continued encoding after cancellation").into(),
+            );
         }
         Ok(())
     }

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -36,9 +36,9 @@ use crate::{
     AgentErrorKind, CliError, DEFAULT_FILE_SUMMARY_LIMIT, DatabaseFilesystemErrorPayload,
     HarnessConfig, OutputFormat, RootTransition, RuntimeInfoReport, SearchRetrievalModeArg,
     build_harness_mcp_config_report, build_parity_report, build_root_report, build_runtime_info,
-    database_filesystem_error_payload, finalize_coverage_output, render_code_slice,
-    render_file_summary, render_parity_report, render_root_report, render_runtime_info,
-    render_search_report, render_watch_status,
+    controlled_named_output, database_filesystem_error_payload, finalize_coverage_output,
+    render_code_slice, render_file_summary, render_parity_report, render_root_report,
+    render_runtime_info, render_search_report, render_watch_status,
 };
 use projectatlas_core::graph::{
     Completeness, ConfidenceClass, CoverageRecord, EntitySelector, ExternalSelector,
@@ -5218,6 +5218,31 @@ impl ProjectAtlasMcpServer {
         Ok(audited)
     }
 
+    /// Prefix one controlled analysis payload with selected root/DB metadata.
+    fn with_selected_project_audit_controlled(
+        state: &McpProjectState,
+        routed_project: bool,
+        toon: String,
+        control: &IndexWorkControl,
+    ) -> Result<String, CliError> {
+        control.check(projectatlas_core::IndexWorkStage::RepositoryTraversal)?;
+        if !routed_project {
+            return Ok(toon);
+        }
+        let prefix = controlled_named_output(
+            OutputFormat::Toon,
+            MCP_PAYLOAD_SELECTED_PROJECT,
+            &Self::project_state_payload(state),
+            control,
+        )?;
+        let mut audited = String::with_capacity(prefix.len() + 1 + toon.len());
+        audited.push_str(&prefix);
+        audited.push('\n');
+        audited.push_str(&toon);
+        control.check(projectatlas_core::IndexWorkStage::RepositoryTraversal)?;
+        Ok(audited)
+    }
+
     /// Return a path parameter or the selected project root.
     fn path_or_project_root(
         state: &McpProjectState,
@@ -6482,11 +6507,17 @@ impl ProjectAtlasMcpServer {
                 SymbolRelationStores::Single(store) => {
                     let draft = load_relation_analysis(store, &query, Some(control))?;
                     draft
-                        .fit_output(|report| {
-                            Self::with_selected_project_audit(
+                        .fit_output(|report, control| {
+                            Self::with_selected_project_audit_controlled(
                                 state,
                                 routed_project,
-                                Self::encode_named_payload(MCP_PAYLOAD_SYMBOL_RELATIONS, report)?,
+                                controlled_named_output(
+                                    OutputFormat::Toon,
+                                    MCP_PAYLOAD_SYMBOL_RELATIONS,
+                                    report,
+                                    control,
+                                )?,
+                                control,
                             )
                         })?
                         .1
@@ -6494,11 +6525,17 @@ impl ProjectAtlasMcpServer {
                 SymbolRelationStores::Federated(stores) => {
                     let draft = load_federated_relation_analysis(stores, &query, Some(control))?;
                     draft
-                        .fit_output(|report| {
-                            Self::with_selected_project_audit(
+                        .fit_output(|report, control| {
+                            Self::with_selected_project_audit_controlled(
                                 state,
                                 routed_project,
-                                Self::encode_named_payload(MCP_PAYLOAD_SYMBOL_RELATIONS, report)?,
+                                controlled_named_output(
+                                    OutputFormat::Toon,
+                                    MCP_PAYLOAD_SYMBOL_RELATIONS,
+                                    report,
+                                    control,
+                                )?,
+                                control,
                             )
                         })?
                         .1
@@ -7278,7 +7315,7 @@ mod tests {
     use std::collections::BTreeSet;
     use std::fs;
     use std::io;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     fn require(condition: bool, message: &str) -> Result<(), Box<dyn std::error::Error>> {
         if condition {
@@ -8300,6 +8337,17 @@ mod tests {
             "MCP relation analysis omitted its closed mode, findings, work, or reusable next call",
         )?;
 
+        let state = ProjectAtlasMcpServer::project_state_from_root(Path::new(project_path))?;
+        let publication_before = ProjectAtlasMcpServer::open_read_store(&state)?
+            .index_publication()?
+            .ok_or_else(|| io::Error::other("MCP impact fixture publication missing"))?;
+        let task_records_before = server
+            .task_registry
+            .read()
+            .map_err(|_poisoned| io::Error::other("task registry lock poisoned"))?
+            .records
+            .len();
+        let impact_started = Instant::now();
         let impact = server.atlas_symbol_relations_response(
             &AtlasSymbolRelationsParams {
                 project_path: Some(project_path.to_string()),
@@ -8309,17 +8357,77 @@ mod tests {
                 symbol: Some("first".to_string()),
                 direction: Some("outbound".to_string()),
                 depth: Some(2),
-                limit: Some(50),
+                limit: Some(8),
+                edge_limit: Some(8),
+                node_limit: Some(16),
+                visited_limit: Some(16),
+                occurrence_total_limit: Some(16),
+                intermediate_bytes: Some(128 * 1_024),
+                deadline_ms: Some(1_000),
+                output_bytes: Some(64 * 1_024),
                 analysis_mode: Some("impact".to_string()),
                 vcs: Some("working_tree".to_string()),
+                include_dead_code: Some(true),
                 ..AtlasSymbolRelationsParams::default()
             },
             None,
         );
+        let impact_elapsed = impact_started.elapsed();
         require(
-            impact.contains("mode: impact")
+            impact_elapsed <= Duration::from_secs(5)
+                && impact.contains("mode: impact")
                 && (impact.contains("state: available") || impact.contains("state: unavailable")),
-            "MCP impact analysis omitted its closed mode or typed VCS state",
+            "MCP impact analysis exceeded its elapsed tolerance or omitted typed mode/VCS state",
+        )?;
+        let impact_value: serde_json::Value = toon_format::decode_default(&impact)?;
+        let impact_report = impact_value
+            .get(MCP_PAYLOAD_SYMBOL_RELATIONS)
+            .ok_or_else(|| io::Error::other("MCP impact response omitted its envelope"))?;
+        let bounded_work = [
+            ("/returned", 8_u64),
+            ("/work/relations/inspected_edges", 8),
+            ("/work/relations/active_nodes", 16),
+            ("/work/relations/visited_nodes", 16),
+            ("/work/analyzed_nodes", 16),
+            ("/work/analyzed_edges", 8),
+            ("/work/peak_intermediate_bytes", 128 * 1_024),
+            ("/work/rendered_output_bytes", 64 * 1_024),
+        ];
+        require(
+            impact.len() <= 64 * 1_024
+                && bounded_work.iter().all(|(path, limit)| {
+                    impact_report
+                        .pointer(path)
+                        .and_then(serde_json::Value::as_u64)
+                        .is_some_and(|observed| observed <= *limit)
+                }),
+            "MCP impact analysis crossed or omitted a declared row/node/edge/visited/intermediate/output budget",
+        )?;
+        require(
+            ProjectAtlasMcpServer::open_read_store(&state)?
+                .index_publication()?
+                .as_ref()
+                == Some(&publication_before)
+                && server
+                    .task_registry
+                    .read()
+                    .map_err(|_poisoned| io::Error::other("task registry lock poisoned"))?
+                    .records
+                    .len()
+                    == task_records_before,
+            "read-only MCP impact analysis changed publication or retained a task record",
+        )?;
+        let follow_up_started = Instant::now();
+        let follow_up = server.atlas_overview_response(
+            AtlasProjectParams {
+                project_path: Some(project_path.to_string()),
+            },
+            None,
+        );
+        require(
+            follow_up_started.elapsed() <= Duration::from_secs(2)
+                && follow_up.contains("overview:"),
+            "immediate MCP follow-up read was not responsive after bounded impact analysis",
         )?;
 
         let trace = server.atlas_symbol_relations_response(

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -47,7 +47,7 @@ use projectatlas_db::{
 };
 use rusqlite::types::ValueRef;
 use rusqlite::{Connection, OpenFlags, OptionalExtension};
-use serde_json::Value;
+use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
@@ -633,6 +633,7 @@ fn detailed_relation_cli_bounds_the_exact_json_envelope() -> Result<(), Box<dyn 
         .into());
     }
 
+    let impact_started = Instant::now();
     let impact = Command::cargo_bin("projectatlas")?
         .current_dir(&repo)
         .env("PROJECTATLAS_NO_TELEMETRY", "1")
@@ -652,13 +653,29 @@ fn detailed_relation_cli_bounds_the_exact_json_envelope() -> Result<(), Box<dyn 
             "--depth",
             "2",
             "--limit",
-            "50",
+            "8",
+            "--edge-limit",
+            "8",
+            "--node-limit",
+            "16",
+            "--visited-limit",
+            "16",
+            "--occurrence-total-limit",
+            "16",
+            "--intermediate-bytes",
+            "131072",
+            "--deadline-ms",
+            "1000",
+            "--output-bytes",
+            "65536",
             "--analysis-mode",
             "impact",
             "--vcs",
             "working-tree",
+            "--include-dead-code",
         ])
         .output()?;
+    let impact_elapsed = impact_started.elapsed();
     if !impact.status.success() {
         return Err(io::Error::other(format!(
             "public impact analysis CLI failed: {}",
@@ -666,8 +683,41 @@ fn detailed_relation_cli_bounds_the_exact_json_envelope() -> Result<(), Box<dyn 
         ))
         .into());
     }
+    if impact_elapsed > Duration::from_secs(5) {
+        return Err(io::Error::other(format!(
+            "bounded impact CLI exceeded its elapsed tolerance: {impact_elapsed:?}"
+        ))
+        .into());
+    }
     let impact_payload: Value = serde_json::from_slice(&impact.stdout)?;
     require_json_string(&impact_payload, &["symbol_relations", "mode"], "impact")?;
+    require_json_usize(
+        &impact_payload,
+        &["symbol_relations", "work", "rendered_output_bytes"],
+        impact.stdout.len(),
+    )?;
+    let bounded_work = [
+        ("/symbol_relations/returned", 8_u64),
+        ("/symbol_relations/work/relations/inspected_edges", 8),
+        ("/symbol_relations/work/relations/active_nodes", 16),
+        ("/symbol_relations/work/relations/visited_nodes", 16),
+        ("/symbol_relations/work/analyzed_nodes", 16),
+        ("/symbol_relations/work/analyzed_edges", 8),
+        ("/symbol_relations/work/peak_intermediate_bytes", 131_072),
+    ];
+    if impact.stdout.len() > 65_536
+        || bounded_work.iter().any(|(path, limit)| {
+            impact_payload
+                .pointer(path)
+                .and_then(Value::as_u64)
+                .is_none_or(|observed| observed > *limit)
+        })
+    {
+        return Err(io::Error::other(
+            "bounded impact CLI crossed a declared row/node/edge/visited/intermediate/output budget",
+        )
+        .into());
+    }
     if !matches!(
         impact_payload.pointer("/symbol_relations/vcs/state"),
         Some(Value::String(state)) if state == "available" || state == "unavailable"
@@ -784,6 +834,179 @@ fn detailed_relation_cli_bounds_the_exact_json_envelope() -> Result<(), Box<dyn 
             "analysis trace requires an exact file or symbol target",
         ));
     Ok(())
+}
+
+#[test]
+fn impact_analysis_deadline_and_mcp_cancellation_release_resources() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("bounded-impact-adapters");
+    let source_dir = repo.join(SRC_DIR_NAME);
+    fs::create_dir_all(&source_dir)?;
+    let mut source = String::from("pub fn entry() { leaf(); }\nfn leaf() {}\n");
+    for index in 0..12_000 {
+        writeln!(source, "fn unused_{index}() {{}}")?;
+    }
+    fs::write(source_dir.join("lib.rs"), source)?;
+
+    let executable = assert_cmd::cargo::cargo_bin("projectatlas");
+    let scan = StdCommand::new(&executable)
+        .current_dir(&repo)
+        .env("PROJECTATLAS_NO_TELEMETRY", "1")
+        .args(["--format", "json", "scan"])
+        .output()?;
+    if !scan.status.success() {
+        return Err(io::Error::other(format!(
+            "bounded impact fixture scan failed: {}",
+            String::from_utf8_lossy(&scan.stderr)
+        ))
+        .into());
+    }
+    let database = repo.join(ATLAS_DIR_NAME).join("projectatlas.db");
+    let before = mcp_database_snapshot(&database)?;
+    let common_cli_args = [
+        "--format",
+        "json",
+        "symbols",
+        "relations",
+        "--view",
+        "analysis",
+        "--file",
+        "src/lib.rs",
+        "--symbol",
+        "entry",
+        "--direction",
+        "outbound",
+        "--depth",
+        "2",
+        "--limit",
+        "1000",
+        "--edge-limit",
+        "10000",
+        "--node-limit",
+        "10000",
+        "--visited-limit",
+        "10000",
+        "--occurrence-total-limit",
+        "20000",
+        "--intermediate-bytes",
+        "33554432",
+        "--deadline-ms",
+        "1",
+        "--output-bytes",
+        "1048576",
+        "--analysis-mode",
+        "impact",
+        "--vcs",
+        "working-tree",
+        "--include-dead-code",
+    ];
+    let cli_started = Instant::now();
+    let expired = StdCommand::new(&executable)
+        .current_dir(&repo)
+        .env("PROJECTATLAS_NO_TELEMETRY", "1")
+        .args(common_cli_args)
+        .output()?;
+    if expired.status.success()
+        || cli_started.elapsed() > Duration::from_secs(5)
+        || !String::from_utf8_lossy(&expired.stderr)
+            .to_ascii_lowercase()
+            .contains("deadline")
+        || mcp_database_snapshot(&database)? != before
+    {
+        return Err(io::Error::other(format!(
+            "CLI deadline was not typed, prompt, and read-only: status={:?} elapsed={:?} stderr={}",
+            expired.status.code(),
+            cli_started.elapsed(),
+            String::from_utf8_lossy(&expired.stderr)
+        ))
+        .into());
+    }
+    let follow_up = StdCommand::new(&executable)
+        .current_dir(&repo)
+        .env("PROJECTATLAS_NO_TELEMETRY", "1")
+        .args(["--format", "json", "overview"])
+        .output()?;
+    if !follow_up.status.success() {
+        return Err(io::Error::other("CLI deadline blocked the immediate overview").into());
+    }
+    Connection::open(&database)?.execute_batch("BEGIN IMMEDIATE; ROLLBACK;")?;
+
+    let impact_arguments = |deadline_ms| {
+        json!({
+            "view": "analysis",
+            "analysis_mode": "impact",
+            "vcs": "working_tree",
+            "file": "src/lib.rs",
+            "symbol": "entry",
+            "direction": "outbound",
+            "depth": 2,
+            "limit": 1000,
+            "edge_limit": 20000,
+            "node_limit": 10000,
+            "visited_limit": 10000,
+            "occurrence_total_limit": 20000,
+            "intermediate_bytes": 33_554_432,
+            "deadline_ms": deadline_ms,
+            "output_bytes": 1_048_576,
+            "include_dead_code": true
+        })
+    };
+    let mut session = McpContractSession::spawn(&executable, &repo, &database)?;
+    let mcp_started = Instant::now();
+    let deadline_text = session.call_tool("atlas_symbol_relations", &impact_arguments(1_u64))?;
+    let deadline_payload: Value = toon_format::decode_default(&deadline_text)?;
+    if mcp_started.elapsed() > Duration::from_secs(5)
+        || deadline_payload
+            .pointer("/error/kind")
+            .and_then(Value::as_str)
+            != Some("error")
+        || !deadline_payload
+            .pointer("/error/message")
+            .and_then(Value::as_str)
+            .is_some_and(|message| message.to_ascii_lowercase().contains("deadline"))
+        || mcp_database_snapshot(&database)? != before
+    {
+        return Err(io::Error::other(format!(
+            "MCP deadline was not typed, prompt, and read-only: elapsed={:?} payload={deadline_payload}",
+            mcp_started.elapsed()
+        ))
+        .into());
+    }
+    session.call_tool("atlas_overview", &json!({}))?;
+    Connection::open(&database)?.execute_batch("BEGIN IMMEDIATE; ROLLBACK;")?;
+
+    let request_id = session.start_request(
+        "tools/call",
+        &json!({
+            "name": "atlas_symbol_relations",
+            "arguments": impact_arguments(5_000_u64)
+        }),
+    )?;
+    thread::sleep(Duration::from_millis(1));
+    session.notify(
+        "notifications/cancelled",
+        &json!({"requestId": request_id, "reason": "bounded impact contract"}),
+    )?;
+    let canceled = session.wait_for_response(request_id, "tools/call")?;
+    let canceled_text = canceled
+        .pointer("/result/content/0/text")
+        .and_then(Value::as_str)
+        .ok_or_else(|| io::Error::other("canceled MCP analysis returned no text"))?;
+    let canceled_payload: Value = toon_format::decode_default(canceled_text)?;
+    if !canceled_payload
+        .pointer("/error/message")
+        .and_then(Value::as_str)
+        .is_some_and(|message| message.to_ascii_lowercase().contains("cancel"))
+        || mcp_database_snapshot(&database)? != before
+    {
+        return Err(io::Error::other(format!(
+            "MCP cancellation was not typed and read-only: {canceled_payload}"
+        ))
+        .into());
+    }
+    session.call_tool("atlas_overview", &json!({}))?;
+    Connection::open(&database)?.execute_batch("BEGIN IMMEDIATE; ROLLBACK;")?;
+    session.shutdown()
 }
 
 #[cfg(feature = "optional-parser-supervisor")]
@@ -18686,6 +18909,12 @@ impl McpContractSession {
 
     /// Send one request and wait for its matching response under a fixed deadline.
     fn request(&mut self, method: &str, params: &Value) -> Result<Value, Box<dyn Error>> {
+        let request_id = self.start_request(method, params)?;
+        self.wait_for_response(request_id, method)
+    }
+
+    /// Send one request and return its id before waiting for the response.
+    fn start_request(&mut self, method: &str, params: &Value) -> Result<u64, Box<dyn Error>> {
         let request_id = self.next_request_id;
         self.next_request_id = self
             .next_request_id
@@ -18697,6 +18926,15 @@ impl McpContractSession {
             "method": method,
             "params": params
         }))?;
+        Ok(request_id)
+    }
+
+    /// Wait for one previously sent request under the contract deadline.
+    fn wait_for_response(
+        &mut self,
+        request_id: u64,
+        method: &str,
+    ) -> Result<Value, Box<dyn Error>> {
         let deadline = Instant::now()
             .checked_add(Duration::from_secs(10))
             .ok_or_else(|| io::Error::other("MCP contract response deadline overflowed"))?;

--- a/crates/projectatlas-db/src/lib.rs
+++ b/crates/projectatlas-db/src/lib.rs
@@ -11030,6 +11030,81 @@ mod tests {
             &1,
             "cleared repository traversal progress handler",
         )?;
+        store
+            .connection
+            .execute("CREATE TEMP TABLE follow_up(value INTEGER NOT NULL)", [])?;
+        store
+            .connection
+            .execute("INSERT INTO follow_up(value) VALUES(1)", [])?;
+        Ok(())
+    }
+
+    #[cfg(feature = "sqlite-progress-test-observer")]
+    #[test]
+    fn sqlite_read_progress_propagates_cancellation_during_an_active_batch()
+    -> Result<(), Box<dyn Error>> {
+        use crate::sqlite_progress_test_observer::{
+            SqliteReadProgressEvent, observe_sqlite_read_progress,
+        };
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let store = AtlasStore::in_memory()?;
+        let cancellation = projectatlas_core::IndexCancellation::new();
+        let control = IndexWorkControl::new(cancellation.clone(), None);
+        let callback_seen = Rc::new(Cell::new(false));
+        let cancelled = observe_sqlite_read_progress(
+            {
+                let callback_seen = Rc::clone(&callback_seen);
+                move |event| {
+                    if matches!(
+                        event,
+                        SqliteReadProgressEvent::CallbackEntered {
+                            stage: IndexWorkStage::RepositoryTraversal
+                        }
+                    ) {
+                        callback_seen.set(true);
+                        cancellation.cancel();
+                    }
+                }
+            },
+            || {
+                with_sqlite_read_progress(
+                    &store.connection,
+                    Some(&control),
+                    IndexWorkStage::RepositoryTraversal,
+                    || {
+                        store
+                            .connection
+                            .query_row(
+                                "WITH RECURSIVE numbers(value) AS (
+                                     VALUES(1)
+                                     UNION ALL
+                                     SELECT value + 1 FROM numbers WHERE value < 100000000
+                                 )
+                                 SELECT SUM(value) FROM numbers",
+                                [],
+                                |row| row.get::<_, i64>(0),
+                            )
+                            .map_err(DbError::from)
+                    },
+                )
+            },
+        );
+        require(
+            callback_seen.get()
+                && matches!(
+                    cancelled,
+                    Err(DbError::IndexWork(IndexWorkFailure::Cancelled {
+                        stage: IndexWorkStage::RepositoryTraversal
+                    }))
+                ),
+            "active SQLite batch did not propagate typed cancellation",
+        )?;
+        store.connection.execute(
+            "CREATE TEMP TABLE cancellation_follow_up(value INTEGER)",
+            [],
+        )?;
         Ok(())
     }
 

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -2,6 +2,67 @@
 
 mod impact;
 
+#[cfg(test)]
+mod analysis_test_observer {
+    use std::cell::RefCell;
+
+    /// Named production phase reached by one synchronous analysis request.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub(super) enum AnalysisPhaseEvent {
+        /// Induced relationship closure is about to traverse its first bounded frontier.
+        Traversal,
+        /// Admitted symbol hydration is about to enter bounded storage work.
+        SymbolHydration,
+        /// Topology and finding composition is about to retain aggregate output state.
+        Composition,
+        /// Optional dead-code candidate discovery has entered complete-scope work.
+        DeadCodeDiscovery,
+        /// Adapter-specific output fitting has begun under the retained request control.
+        OutputRendering,
+    }
+
+    /// Thread-local callback used only while one unit test owns observation.
+    type Observer = Box<dyn FnMut(AnalysisPhaseEvent)>;
+
+    thread_local! {
+        /// Observer scoped to the synchronous analysis test thread.
+        static OBSERVER: RefCell<Option<Observer>> = RefCell::new(None);
+    }
+
+    /// Restores a prior nested observer on every return or unwind path.
+    struct ObserverGuard {
+        /// Observer replaced for the current scope.
+        previous: Option<Observer>,
+    }
+
+    impl Drop for ObserverGuard {
+        fn drop(&mut self) {
+            OBSERVER.with(|slot| {
+                drop(slot.replace(self.previous.take()));
+            });
+        }
+    }
+
+    /// Run one operation while observing named production analysis phases.
+    pub(super) fn observe_analysis_phase<T>(
+        observer: impl FnMut(AnalysisPhaseEvent) + 'static,
+        operation: impl FnOnce() -> T,
+    ) -> T {
+        let previous = OBSERVER.with(|slot| slot.replace(Some(Box::new(observer))));
+        let _guard = ObserverGuard { previous };
+        operation()
+    }
+
+    /// Notify the current thread-local observer when one is installed.
+    pub(super) fn notify(event: AnalysisPhaseEvent) {
+        OBSERVER.with(|slot| {
+            if let Some(observer) = slot.borrow_mut().as_mut() {
+                observer(event);
+            }
+        });
+    }
+}
+
 use super::relations::{
     ExternalRelationIdentity, external_relation_identities, load_detailed_relations,
 };
@@ -293,6 +354,11 @@ impl RelationAnalysisDraft {
         &self.report
     }
 
+    /// Borrow the exact request control retained through output rendering.
+    pub(super) const fn control(&self) -> &IndexWorkControl {
+        &self.control
+    }
+
     /// Move the call-scoped rendezvous identities out before output fitting.
     pub(super) fn take_external_relation_identities(
         &mut self,
@@ -308,12 +374,15 @@ impl RelationAnalysisDraft {
     /// envelope exceeds the declared output or aggregate intermediate ceiling.
     pub fn fit_output<F, E, O>(self, mut encode: F) -> Result<(RelationAnalysisReport, O), E>
     where
-        F: FnMut(&RelationAnalysisReport) -> Result<O, E>,
+        F: FnMut(&RelationAnalysisReport, &IndexWorkControl) -> Result<O, E>,
         E: From<ServiceError>,
         O: AsRef<[u8]>,
     {
         check_control(Some(&self.control)).map_err(E::from)?;
-        let original_report_bytes = serialized_bytes(&self.report).map_err(E::from)?;
+        #[cfg(test)]
+        analysis_test_observer::notify(analysis_test_observer::AnalysisPhaseEvent::OutputRendering);
+        let original_report_bytes =
+            serialized_bytes_controlled(&self.report, Some(&self.control)).map_err(E::from)?;
         let construction_peak = self.report.work.peak_intermediate_bytes;
         let mut low = 0;
         let mut high = self.report.findings.len();
@@ -355,7 +424,7 @@ impl RelationAnalysisDraft {
                 );
             }
             check_control(Some(&self.control)).map_err(E::from)?;
-            let mut encoded = encode(&candidate)?;
+            let mut encoded = encode(&candidate, &self.control)?;
             check_control(Some(&self.control)).map_err(E::from)?;
             let mut stable = false;
             for _ in 0..8 {
@@ -365,7 +434,9 @@ impl RelationAnalysisDraft {
                         "analysis rendered byte count overflowed: {source}"
                     )))
                 })?;
-                let candidate_report_bytes = serialized_bytes(&candidate).map_err(E::from)?;
+                let candidate_report_bytes =
+                    serialized_bytes_controlled(&candidate, Some(&self.control))
+                        .map_err(E::from)?;
                 let fitting_peak = original_report_bytes
                     .checked_add(candidate_report_bytes)
                     .and_then(|bytes| bytes.checked_add(rendered))
@@ -384,7 +455,7 @@ impl RelationAnalysisDraft {
                 candidate.work.rendered_output_bytes = rendered;
                 candidate.work.peak_intermediate_bytes = peak;
                 drop(encoded);
-                encoded = encode(&candidate)?;
+                encoded = encode(&candidate, &self.control)?;
                 check_control(Some(&self.control)).map_err(E::from)?;
             }
             if !stable {
@@ -626,7 +697,8 @@ fn load_relation_analysis_with_closure_deadline(
     } else {
         BTreeSet::new()
     };
-    let external_relation_identity_bytes = serialized_bytes(&external_relation_identities)?;
+    let external_relation_identity_bytes =
+        serialized_bytes_controlled(&external_relation_identities, control)?;
     let cursor_snapshot = AnalysisCursorSnapshot {
         project: relations.anchor.entity.key().project(),
         generation: relations.generation,
@@ -641,8 +713,8 @@ fn load_relation_analysis_with_closure_deadline(
         });
     }
     check_control(control)?;
-    let mut nodes = collect_nodes(&relations);
-    let mut edges = collect_report_edges(&relations);
+    let mut nodes = collect_nodes(&relations, control)?;
+    let mut edges = collect_report_edges(&relations, control)?;
     let mut closure_query = query.clone();
     closure_query.relations = relation_query;
     let closure = close_induced_edges(
@@ -654,8 +726,10 @@ fn load_relation_analysis_with_closure_deadline(
         &mut edges,
         control,
     )?;
+    check_control(control)?;
     let evidence_complete = relation_evidence_complete(&relations, &nodes, &edges, query, &closure);
     let dead_code_scope_complete = dead_code_scope_complete(&relations, query);
+    check_control(control)?;
     let vcs_load = if query.mode == RelationAnalysisMode::Impact {
         let selection = query.vcs.clone().unwrap_or(GitImpactSelection::WorkingTree);
         load_vcs_paths(
@@ -680,7 +754,8 @@ fn load_relation_analysis_with_closure_deadline(
     };
     let vcs = vcs_load.report;
     let vcs_digest = (query.mode == RelationAnalysisMode::Impact)
-        .then(|| digest_vcs_paths(&vcs_load.changed_paths));
+        .then(|| digest_vcs_paths(&vcs_load.changed_paths, control))
+        .transpose()?;
     if decoded_cursor
         .as_ref()
         .is_some_and(|cursor| cursor.vcs_digest != vcs_digest)
@@ -698,13 +773,17 @@ fn load_relation_analysis_with_closure_deadline(
             .saturating_add(external_relation_identity_bytes),
     );
     let projection_allowance = analysis_allowance.saturating_sub(vcs_load.retained_bytes);
+    #[cfg(test)]
+    analysis_test_observer::notify(analysis_test_observer::AnalysisPhaseEvent::Composition);
     let mut topology_bytes =
-        serde_json::to_vec(&(nodes.values().collect::<Vec<_>>(), &edges))?.len() as u64;
-    let mut gaps = resolution_gap_findings(&relations);
+        serialized_bytes_controlled(&(nodes.values().collect::<Vec<_>>(), &edges), control)?;
+    let mut gaps = resolution_gap_findings(&relations, control)?;
     gaps.extend(closure.resolution_gaps.iter().cloned());
+    check_control(control)?;
     gaps.sort_by(|left, right| resolution_gap_identity(left).cmp(resolution_gap_identity(right)));
     gaps.dedup_by(|left, right| resolution_gap_identity(left) == resolution_gap_identity(right));
-    let gap_bytes = serde_json::to_vec(&gaps)?.len() as u64;
+    check_control(control)?;
+    let gap_bytes = serialized_bytes_controlled(&gaps, control)?;
     let projection_safe = topology_bytes.saturating_add(gap_bytes) <= projection_allowance;
     let mut findings = if projection_safe {
         gaps
@@ -717,7 +796,7 @@ fn load_relation_analysis_with_closure_deadline(
         edges.clear();
         nodes.retain(|_, node| node.entity.key() == relations.anchor.entity.key());
         topology_bytes =
-            serde_json::to_vec(&(nodes.values().collect::<Vec<_>>(), &edges))?.len() as u64;
+            serialized_bytes_controlled(&(nodes.values().collect::<Vec<_>>(), &edges), control)?;
         vec![AnalysisFinding {
             kind: AnalysisFindingKind::Component,
             status: AnalysisStatus::Inconclusive,
@@ -727,7 +806,7 @@ fn load_relation_analysis_with_closure_deadline(
             evidence: None,
         }]
     };
-    let initial_finding_bytes = serde_json::to_vec(&findings)?.len() as u64;
+    let initial_finding_bytes = serialized_bytes_controlled(&findings, control)?;
     let symbol_byte_budget = projection_allowance
         .saturating_sub(topology_bytes)
         .saturating_sub(initial_finding_bytes);
@@ -764,19 +843,20 @@ fn load_relation_analysis_with_closure_deadline(
     let generated_finding_count = u32::try_from(findings.len()).map_err(|_overflow| {
         ServiceError::InvalidInput("analysis finding count overflowed".to_string())
     })?;
-    let mut finding_bytes = serde_json::to_vec(&findings)?.len() as u64;
+    let mut finding_bytes = serialized_bytes_controlled(&findings, control)?;
     supplemental_work.retained_composition_bytes = vcs_load
         .retained_bytes
         .saturating_add(topology_bytes)
         .saturating_add(finding_bytes);
     while supplemental_work.retained_composition_bytes > analysis_allowance && findings.len() > 1 {
+        check_control(control)?;
         findings.pop();
         supplemental_work.composition_truncated = true;
         push_limit(
             &mut supplemental_work.reached_limits,
             GraphLimitKind::IntermediateBytes,
         );
-        finding_bytes = serde_json::to_vec(&findings)?.len() as u64;
+        finding_bytes = serialized_bytes_controlled(&findings, control)?;
         supplemental_work.retained_composition_bytes = vcs_load
             .retained_bytes
             .saturating_add(topology_bytes)
@@ -789,7 +869,7 @@ fn load_relation_analysis_with_closure_deadline(
             &mut supplemental_work.reached_limits,
             GraphLimitKind::IntermediateBytes,
         );
-        finding_bytes = serde_json::to_vec(&findings)?.len() as u64;
+        finding_bytes = serialized_bytes_controlled(&findings, control)?;
         supplemental_work.retained_composition_bytes = vcs_load
             .retained_bytes
             .saturating_add(topology_bytes)
@@ -892,6 +972,7 @@ fn load_relation_analysis_with_closure_deadline(
         findings,
     };
     nodes.clear();
+    check_control(control)?;
     Ok(RelationAnalysisDraft {
         report,
         output_bytes: query.relations.budget.output_bytes(),
@@ -1064,10 +1145,14 @@ fn encode_analysis_cursor(
 }
 
 /// Collect unique non-external nodes from a detailed relation page.
-fn collect_nodes(report: &DetailedRelationReport) -> BTreeMap<String, DetailedRelationNode> {
+fn collect_nodes(
+    report: &DetailedRelationReport,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<BTreeMap<String, DetailedRelationNode>> {
     let mut nodes = BTreeMap::new();
     insert_node(&mut nodes, &report.anchor);
     for row in &report.rows {
+        check_control(control)?;
         insert_node(&mut nodes, &row.source);
         if let Some(target) = &row.target {
             insert_node(&mut nodes, target);
@@ -1076,22 +1161,25 @@ fn collect_nodes(report: &DetailedRelationReport) -> BTreeMap<String, DetailedRe
             insert_node(&mut nodes, node);
         }
     }
-    nodes
+    Ok(nodes)
 }
 
 /// Project unresolved and ambiguous relation rows into typed findings.
-fn resolution_gap_findings(report: &DetailedRelationReport) -> Vec<AnalysisFinding> {
-    report
-        .rows
-        .iter()
-        .filter(|row| {
-            matches!(
-                row.relation.resolution(),
-                RelationResolution::Ambiguous { .. } | RelationResolution::Unresolved { .. }
-            )
-        })
-        .map(|row| resolution_gap_finding(&row.relation, &row.source))
-        .collect()
+fn resolution_gap_findings(
+    report: &DetailedRelationReport,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<Vec<AnalysisFinding>> {
+    let mut findings = Vec::new();
+    for row in &report.rows {
+        check_control(control)?;
+        if matches!(
+            row.relation.resolution(),
+            RelationResolution::Ambiguous { .. } | RelationResolution::Unresolved { .. }
+        ) {
+            findings.push(resolution_gap_finding(&row.relation, &row.source));
+        }
+    }
+    Ok(findings)
 }
 
 /// Build one exact resolution-gap finding from a detailed relation row.
@@ -1173,12 +1261,18 @@ fn insert_node(nodes: &mut BTreeMap<String, DetailedRelationNode>, node: &Detail
 }
 
 /// Collect local edges from one detailed relation page.
-fn collect_report_edges(report: &DetailedRelationReport) -> Vec<LocalEdge> {
-    report
-        .rows
-        .iter()
-        .filter_map(|row| local_edge(&row.relation, &row.source.entity, row.target.as_ref()))
-        .collect()
+fn collect_report_edges(
+    report: &DetailedRelationReport,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<Vec<LocalEdge>> {
+    let mut edges = Vec::new();
+    for row in &report.rows {
+        check_control(control)?;
+        if let Some(edge) = local_edge(&row.relation, &row.source.entity, row.target.as_ref()) {
+            edges.push(edge);
+        }
+    }
+    Ok(edges)
 }
 
 /// Convert a resolved local relation row into an algorithm edge.
@@ -1231,11 +1325,16 @@ fn close_induced_edges(
         induced_scope_closed: query.relations.direction == RelationDirection::Outbound,
         ..ClosureWork::default()
     };
-    let keys = nodes
-        .values()
-        .map(|node| node.entity.key().clone())
-        .collect::<Vec<_>>();
-    let known = nodes.keys().cloned().collect::<BTreeSet<_>>();
+    let mut keys = Vec::with_capacity(nodes.len());
+    let mut known = BTreeSet::new();
+    for (key, node) in nodes {
+        check_control(control)?;
+        keys.push(node.entity.key().clone());
+        known.insert(key.clone());
+    }
+    #[cfg(test)]
+    analysis_test_observer::notify(analysis_test_observer::AnalysisPhaseEvent::Traversal);
+    check_control(control)?;
     for chunk in keys.chunks(MAX_REPOSITORY_GRAPH_FRONTIER) {
         let mut continuation: Option<RepositoryGraphAdjacencyContinuation> = None;
         loop {
@@ -1299,6 +1398,7 @@ fn close_induced_edges(
                 })?;
             work.decoded_bytes = work.decoded_bytes.saturating_add(read.work.decoded_bytes);
             for row in read.page.rows {
+                check_control(control)?;
                 if !analysis_relation_matches(&row.detail.relation, &query.relations) {
                     continue;
                 }
@@ -1808,11 +1908,14 @@ fn load_admitted_symbols(
             complete: !path_truncated,
             rows_retained: 0,
             retained_bytes: 0,
-            peak_bytes: symbol_path_request_bytes(&paths)?,
+            peak_bytes: symbol_path_request_bytes(&paths, control)?,
             reached_limits,
         });
     }
-    let grouping_reserve = symbol_hydration_reserve_bytes(&paths)?;
+    #[cfg(test)]
+    analysis_test_observer::notify(analysis_test_observer::AnalysisPhaseEvent::SymbolHydration);
+    check_control(control)?;
+    let grouping_reserve = symbol_hydration_reserve_bytes(&paths, control)?;
     let decoded_byte_limit = byte_limit.saturating_sub(grouping_reserve);
     if decoded_byte_limit == 0 {
         push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
@@ -1822,7 +1925,7 @@ fn load_admitted_symbols(
             complete: false,
             rows_retained: 0,
             retained_bytes: 0,
-            peak_bytes: symbol_path_request_bytes(&paths)?,
+            peak_bytes: symbol_path_request_bytes(&paths, control)?,
             reached_limits,
         });
     }
@@ -1844,12 +1947,12 @@ fn load_admitted_symbols(
         }
         None => {}
     }
-    let ranges = symbol_path_ranges(&read.rows);
+    let ranges = symbol_path_ranges(&read.rows, control)?;
     let retained_bytes = read
         .work
         .decoded_bytes
-        .saturating_add(symbol_range_index_bytes(&ranges)?);
-    let peak_bytes = retained_bytes.saturating_add(symbol_path_request_bytes(&paths)?);
+        .saturating_add(symbol_range_index_bytes(&ranges, control)?);
+    let peak_bytes = retained_bytes.saturating_add(symbol_path_request_bytes(&paths, control)?);
     Ok(AdmittedSymbols {
         rows: read.rows,
         ranges,
@@ -1862,12 +1965,17 @@ fn load_admitted_symbols(
 }
 
 /// Build sorted non-overlapping exact-path ranges over sorted symbol rows.
-fn symbol_path_ranges(rows: &[CodeSymbol]) -> Vec<SymbolPathRange> {
+fn symbol_path_ranges(
+    rows: &[CodeSymbol],
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<Vec<SymbolPathRange>> {
     let mut ranges = Vec::new();
     let mut start = 0;
     while start < rows.len() {
+        check_control(control)?;
         let mut end = start.saturating_add(1);
         while end < rows.len() && rows[end].path == rows[start].path {
+            check_control(control)?;
             end = end.saturating_add(1);
         }
         ranges.push(SymbolPathRange {
@@ -1877,41 +1985,65 @@ fn symbol_path_ranges(rows: &[CodeSymbol]) -> Vec<SymbolPathRange> {
         });
         start = end;
     }
-    ranges.into_boxed_slice().into_vec()
+    Ok(ranges.into_boxed_slice().into_vec())
 }
 
 /// Count serialized request-path and worst-case path-range auxiliaries.
-fn symbol_hydration_reserve_bytes(paths: &[String]) -> ServiceResult<u64> {
-    let ranges = paths
-        .iter()
-        .map(|path| SymbolPathRange {
+fn symbol_hydration_reserve_bytes(
+    paths: &[String],
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<u64> {
+    let mut ranges = Vec::with_capacity(paths.len());
+    for path in paths {
+        check_control(control)?;
+        ranges.push(SymbolPathRange {
             path: path.clone(),
             start: 0,
             end: 0,
-        })
-        .collect::<Vec<_>>();
-    Ok(symbol_path_request_bytes(paths)?.saturating_add(serialized_bytes(&ranges)?))
+        });
+    }
+    Ok(symbol_path_request_bytes(paths, control)?
+        .saturating_add(serialized_bytes_controlled(&ranges, control)?))
 }
 
 /// Count serialized-equivalent request-path bytes.
-fn symbol_path_request_bytes(paths: &[String]) -> ServiceResult<u64> {
-    serialized_bytes(paths)
+fn symbol_path_request_bytes(
+    paths: &[String],
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<u64> {
+    serialized_bytes_controlled(paths, control)
 }
 
 /// Count serialized-equivalent retained path-range bytes.
-fn symbol_range_index_bytes(ranges: &[SymbolPathRange]) -> ServiceResult<u64> {
-    serialized_bytes(ranges)
+fn symbol_range_index_bytes(
+    ranges: &[SymbolPathRange],
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<u64> {
+    serialized_bytes_controlled(ranges, control)
 }
 
-#[derive(Default)]
 /// Allocation-free serialized-equivalent byte counter.
-struct SerializedByteCounter {
+struct SerializedByteCounter<'a> {
     /// Bytes that the serializer would write.
     bytes: u64,
+    /// Shared request control checked between serializer writes.
+    control: Option<&'a IndexWorkControl>,
+    /// Whether serialization stopped on cancellation or deadline.
+    interrupted: bool,
 }
 
-impl Write for SerializedByteCounter {
+impl Write for SerializedByteCounter<'_> {
     fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if self
+            .control
+            .is_some_and(|control| control.check(IndexWorkStage::RepositoryTraversal).is_err())
+        {
+            self.interrupted = true;
+            // `Write::write_all` retries `Interrupted` indefinitely. Use a
+            // non-retriable transport error and translate it back to the
+            // control's typed terminal failure after serialization returns.
+            return Err(io::Error::other("analysis serialization interrupted"));
+        }
         self.bytes = self
             .bytes
             .checked_add(u64::try_from(buffer.len()).unwrap_or(u64::MAX))
@@ -1924,10 +2056,22 @@ impl Write for SerializedByteCounter {
     }
 }
 
-/// Measure one bounded auxiliary value without retaining an encoding.
-fn serialized_bytes<T: Serialize + ?Sized>(value: &T) -> ServiceResult<u64> {
-    let mut counter = SerializedByteCounter::default();
-    serde_json::to_writer(&mut counter, value)?;
+/// Measure one bounded value while retaining the request deadline and cancellation.
+fn serialized_bytes_controlled<T: Serialize + ?Sized>(
+    value: &T,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<u64> {
+    let mut counter = SerializedByteCounter {
+        bytes: 0,
+        control,
+        interrupted: false,
+    };
+    let result = serde_json::to_writer(&mut counter, value);
+    if counter.interrupted {
+        check_control(control)?;
+    }
+    result?;
+    check_control(control)?;
     Ok(counter.bytes)
 }
 
@@ -2141,18 +2285,21 @@ fn degrees(
 fn usage_indegrees(
     nodes: &BTreeMap<String, DetailedRelationNode>,
     edges: &[LocalEdge],
-) -> BTreeMap<String, usize> {
-    let mut values = nodes
-        .keys()
-        .map(|key| (key.clone(), 0))
-        .collect::<BTreeMap<_, _>>();
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<BTreeMap<String, usize>> {
+    let mut values = BTreeMap::new();
+    for key in nodes.keys() {
+        check_control(control)?;
+        values.insert(key.clone(), 0);
+    }
     for edge in edges
         .iter()
         .filter(|edge| edge.kind != GraphRelationKind::Legacy(RelationKind::Contains))
     {
+        check_control(control)?;
         *values.entry(edge.target.clone()).or_default() += 1;
     }
-    values
+    Ok(values)
 }
 
 /// Project selected canonical identities into reusable analysis nodes.

--- a/crates/projectatlas-service/src/analysis/impact.rs
+++ b/crates/projectatlas-service/src/analysis/impact.rs
@@ -57,6 +57,7 @@ pub(super) fn impact_findings(
     supplemental_work: &mut SupplementalWork,
     control: Option<&IndexWorkControl>,
 ) -> ServiceResult<Vec<AnalysisFinding>> {
+    check_control(control)?;
     let mut findings = if query.include_dead_code {
         dead_code_findings(
             store,
@@ -72,17 +73,21 @@ pub(super) fn impact_findings(
         Vec::new()
     };
     if let VcsImpact::Available { .. } = vcs {
-        let changed = changed_paths.iter().cloned().collect::<BTreeSet<_>>();
-        let seeds = nodes
-            .iter()
-            .filter_map(|(key, node)| {
-                entity_path(&node.entity)
-                    .is_some_and(|path| changed.contains(path))
-                    .then_some(key.clone())
-            })
-            .collect::<Vec<_>>();
+        let mut changed = BTreeSet::new();
+        for path in changed_paths {
+            check_control(control)?;
+            changed.insert(path.clone());
+        }
+        let mut seeds = Vec::new();
+        for (key, node) in nodes {
+            check_control(control)?;
+            if entity_path(&node.entity).is_some_and(|path| changed.contains(path)) {
+                seeds.push(key.clone());
+            }
+        }
         let mut reverse = BTreeMap::<String, Vec<String>>::new();
         for edge in edges.iter().filter(|edge| dependency_relation(edge.kind)) {
+            check_control(control)?;
             reverse
                 .entry(edge.target.clone())
                 .or_default()
@@ -91,16 +96,19 @@ pub(super) fn impact_findings(
         let mut distance = BTreeMap::<String, u32>::new();
         let mut queue = VecDeque::new();
         for seed in seeds {
+            check_control(control)?;
             distance.insert(seed.clone(), 0);
             queue.push_back(seed);
         }
         while let Some(target) = queue.pop_front() {
+            check_control(control)?;
             let next_distance = distance
                 .get(&target)
                 .copied()
                 .unwrap_or_default()
                 .saturating_add(1);
             for dependent in reverse.get(&target).into_iter().flatten() {
+                check_control(control)?;
                 if !distance.contains_key(dependent) {
                     distance.insert(dependent.clone(), next_distance);
                     queue.push_back(dependent.clone());
@@ -127,6 +135,7 @@ pub(super) fn impact_findings(
             });
         }
         for (key, hops) in distance {
+            check_control(control)?;
             findings.push(AnalysisFinding {
                 kind: AnalysisFindingKind::Impact,
                 status: AnalysisStatus::Candidate,
@@ -151,6 +160,7 @@ pub(super) fn impact_findings(
             evidence: None,
         });
     }
+    check_control(control)?;
     Ok(findings)
 }
 
@@ -165,6 +175,7 @@ fn dead_code_findings(
     supplemental_work: &mut SupplementalWork,
     control: Option<&IndexWorkControl>,
 ) -> ServiceResult<Vec<AnalysisFinding>> {
+    check_control(control)?;
     if !scope_complete {
         return Ok(vec![AnalysisFinding {
             kind: AnalysisFindingKind::DeadCode,
@@ -176,6 +187,11 @@ fn dead_code_findings(
             evidence: None,
         }]);
     }
+    #[cfg(test)]
+    super::analysis_test_observer::notify(
+        super::analysis_test_observer::AnalysisPhaseEvent::DeadCodeDiscovery,
+    );
+    check_control(control)?;
     let symbols = load_admitted_symbols(store, nodes, symbol_byte_budget, control)?;
     supplemental_work.hydrated_symbols = supplemental_work
         .hydrated_symbols
@@ -201,28 +217,34 @@ fn dead_code_findings(
             evidence: None,
         }]);
     }
-    let indegree = usage_indegrees(nodes, edges);
-    let candidate = nodes
-        .iter()
-        .find(|(_, node)| entity_matches_anchor(&node.entity, anchor))
-        .and_then(|(key, node)| {
-            (indegree.get(key).copied().unwrap_or_default() == 0).then_some((key, node))
-        })
-        .and_then(|(key, node)| {
-            let (path, name, kind, parent, signature) = symbol_identity(&node.entity)?;
-            symbols
-                .rows_for_path(path)
-                .is_some_and(|rows| {
-                    rows.iter().any(|symbol| {
-                        !symbol.exported
-                            && symbol.name == name
-                            && symbol.kind == kind
-                            && symbol.parent.as_deref() == parent
-                            && symbol.signature == signature
-                    })
-                })
-                .then_some(key.clone())
-        });
+    let indegree = usage_indegrees(nodes, edges, control)?;
+    let mut candidate = None;
+    for (key, node) in nodes {
+        check_control(control)?;
+        if !entity_matches_anchor(&node.entity, anchor)
+            || indegree.get(key).copied().unwrap_or_default() != 0
+        {
+            continue;
+        }
+        let Some((path, name, kind, parent, signature)) = symbol_identity(&node.entity) else {
+            continue;
+        };
+        if let Some(rows) = symbols.rows_for_path(path) {
+            for symbol in rows {
+                check_control(control)?;
+                if !symbol.exported
+                    && symbol.name == name
+                    && symbol.kind == kind
+                    && symbol.parent.as_deref() == parent
+                    && symbol.signature == signature
+                {
+                    candidate = Some(key.clone());
+                    break;
+                }
+            }
+        }
+        break;
+    }
     drop(symbols);
     check_control(control)?;
     Ok(candidate.map_or_else(Vec::new, |key| {
@@ -281,14 +303,20 @@ struct GitPathNormalizationError {
 }
 
 /// Digest the normalized changed-path set for cursor freshness.
-pub(super) fn digest_vcs_paths(paths: &[String]) -> [u8; 32] {
+pub(super) fn digest_vcs_paths(
+    paths: &[String],
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<[u8; 32]> {
+    check_control(control)?;
     let mut hasher = blake3::Hasher::new();
     hasher.update(b"projectatlas:analysis-vcs:v1\0");
     for path in paths {
+        check_control(control)?;
         hasher.update(path.as_bytes());
         hasher.update(&[0]);
     }
-    *hasher.finalize().as_bytes()
+    check_control(control)?;
+    Ok(*hasher.finalize().as_bytes())
 }
 
 /// Load one bounded normalized changed-path set from Git.
@@ -374,7 +402,7 @@ pub(super) fn load_vcs_paths(
     }
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
     match run_git(command, command_budget, deadline, control) {
-        Ok(output) => match parse_git_paths(&selection, &output, command_budget) {
+        Ok(output) => match parse_git_paths(&selection, &output, command_budget, control) {
             Ok(normalized) => LoadedVcs {
                 report: VcsImpact::Available {
                     selection,
@@ -609,14 +637,27 @@ fn parse_git_paths(
     selection: &GitImpactSelection,
     output: &GitCommandOutput,
     byte_limit: u64,
+    control: Option<&IndexWorkControl>,
 ) -> Result<NormalizedGitPaths, GitPathNormalizationError> {
     let mut paths = Vec::new();
     let mut peak_bytes = output.stream_peak_bytes;
+    if let Err(error) = check_control(control) {
+        return Err(GitPathNormalizationError {
+            reason: error.to_string(),
+            peak_bytes,
+        });
+    }
     for raw in output
         .stdout
         .split(|byte| *byte == 0)
         .filter(|row| !row.is_empty())
     {
+        if let Err(error) = check_control(control) {
+            return Err(GitPathNormalizationError {
+                reason: error.to_string(),
+                peak_bytes,
+            });
+        }
         let raw = if matches!(selection, GitImpactSelection::WorkingTree) {
             raw.get(3..).ok_or_else(|| GitPathNormalizationError {
                 reason: "git status row was malformed".to_string(),
@@ -656,8 +697,26 @@ fn parse_git_paths(
             });
         }
     }
+    if let Err(error) = check_control(control) {
+        return Err(GitPathNormalizationError {
+            reason: error.to_string(),
+            peak_bytes,
+        });
+    }
     paths.sort();
+    if let Err(error) = check_control(control) {
+        return Err(GitPathNormalizationError {
+            reason: error.to_string(),
+            peak_bytes,
+        });
+    }
     paths.dedup();
+    if let Err(error) = check_control(control) {
+        return Err(GitPathNormalizationError {
+            reason: error.to_string(),
+            peak_bytes,
+        });
+    }
     Ok(NormalizedGitPaths { paths, peak_bytes })
 }
 

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1,3 +1,4 @@
+use super::analysis_test_observer::{AnalysisPhaseEvent, observe_analysis_phase};
 use super::*;
 use projectatlas_core::graph::{
     CoverageRecord, CoverageScope, GraphIdentityText, LogicalRelation, RelationResolution,
@@ -5,10 +6,35 @@ use projectatlas_core::graph::{
 };
 use projectatlas_core::symbols::{ParserKind, SymbolGraph, SymbolKind};
 use projectatlas_core::{IndexGeneration, Node, NodeKind, PurposeSource};
+use std::cell::Cell;
 use std::error::Error;
 use std::fs;
 use std::io;
 use std::num::NonZeroU32;
+use std::rc::Rc;
+
+fn cancel_at_analysis_phase<T>(
+    phase: AnalysisPhaseEvent,
+    cancellation: IndexCancellation,
+    operation: impl FnOnce() -> T,
+) -> Result<T, Box<dyn Error>> {
+    let seen = Rc::new(Cell::new(false));
+    let observer_seen = Rc::clone(&seen);
+    let result = observe_analysis_phase(
+        move |event| {
+            if event == phase {
+                observer_seen.set(true);
+                cancellation.cancel();
+            }
+        },
+        operation,
+    );
+    require(
+        seen.get(),
+        "the deterministic analysis phase hook was not reached",
+    )?;
+    Ok(result)
+}
 
 #[test]
 fn analysis_uses_real_graph_rows_dependency_sccs_and_resumable_output() -> Result<(), Box<dyn Error>>
@@ -16,11 +42,11 @@ fn analysis_uses_real_graph_rows_dependency_sccs_and_resumable_output() -> Resul
     let (_temp, store) = analysis_store()?;
     let query = analysis_query(RelationAnalysisMode::Architecture)?;
     let draft = load_relation_analysis(&store, &query, None)?;
-    let original_report_bytes = serialized_bytes(&draft.report)?;
-    let (report, encoded) = draft.fit_output::<_, ServiceError, _>(|report| {
+    let original_report_bytes = serialized_bytes_controlled(&draft.report, None)?;
+    let (report, encoded) = draft.fit_output::<_, ServiceError, _>(|report, _control| {
         serde_json::to_vec(report).map_err(ServiceError::from)
     })?;
-    let fitted_report_bytes = serialized_bytes(&report)?;
+    let fitted_report_bytes = serialized_bytes_controlled(&report, None)?;
     require(
         report.work.rendered_output_bytes == encoded.len() as u64,
         "analysis did not account exact rendered adapter bytes",
@@ -74,7 +100,7 @@ fn analysis_uses_real_graph_rows_dependency_sccs_and_resumable_output() -> Resul
     let mut fitted_prefix = None;
     for padding_per_finding in (512..=16 * 1024).step_by(512) {
         let draft = load_relation_analysis(&store, &query, None)?;
-        let result = draft.fit_output::<_, ServiceError, _>(|report| {
+        let result = draft.fit_output::<_, ServiceError, _>(|report, _control| {
             let mut bytes = serde_json::to_vec(report).map_err(ServiceError::from)?;
             bytes.resize(
                 bytes
@@ -111,7 +137,7 @@ fn analysis_uses_real_graph_rows_dependency_sccs_and_resumable_output() -> Resul
     resumed.relations.cursor = Some(cursor.clone());
     let resumed = load_relation_analysis(&store, &resumed, None)?;
     let (resumed, _) = resumed
-        .fit_output::<_, ServiceError, _>(|report| {
+        .fit_output::<_, ServiceError, _>(|report, _control| {
             serde_json::to_vec(report).map_err(ServiceError::from)
         })
         .map_err(|error| io::Error::other(format!("resumed fit failed: {error}")))?;
@@ -134,7 +160,7 @@ fn analysis_uses_real_graph_rows_dependency_sccs_and_resumable_output() -> Resul
     )?;
 
     let zero_prefix = load_relation_analysis(&store, &query, None)?
-        .fit_output::<_, ServiceError, _>(|report| {
+        .fit_output::<_, ServiceError, _>(|report, _control| {
             if report.findings.is_empty() {
                 serde_json::to_vec(report).map_err(ServiceError::from)
             } else {
@@ -160,7 +186,7 @@ fn analysis_uses_real_graph_rows_dependency_sccs_and_resumable_output() -> Resul
     let draft = load_relation_analysis(&store, &query, None)?;
     require(
         draft
-            .fit_output::<_, ServiceError, Vec<u8>>(|_report| Ok(vec![b'x'; 70 * 1024]))
+            .fit_output::<_, ServiceError, Vec<u8>>(|_report, _control| Ok(vec![b'x'; 70 * 1024]))
             .is_err(),
         "analysis accepted an oversized empty adapter envelope",
     )?;
@@ -177,7 +203,7 @@ fn analysis_uses_real_graph_rows_dependency_sccs_and_resumable_output() -> Resul
     let mut memory_prefix = None;
     for padding_per_finding in (256..=8 * 1024).step_by(256) {
         let draft = load_relation_analysis(&store, &memory_bounded, None)?;
-        let result = draft.fit_output::<_, ServiceError, _>(|report| {
+        let result = draft.fit_output::<_, ServiceError, _>(|report, _control| {
             let mut bytes = serde_json::to_vec(report).map_err(ServiceError::from)?;
             bytes.resize(
                 bytes
@@ -225,7 +251,7 @@ fn analysis_uses_real_graph_rows_dependency_sccs_and_resumable_output() -> Resul
         IndexWorkControl::with_deadline(IndexCancellation::new(), Instant::now());
     require(
         expired_render
-            .fit_output::<_, ServiceError, _>(|report| {
+            .fit_output::<_, ServiceError, _>(|report, _control| {
                 serde_json::to_vec(report).map_err(ServiceError::from)
             })
             .err()
@@ -237,7 +263,7 @@ fn analysis_uses_real_graph_rows_dependency_sccs_and_resumable_output() -> Resul
     cancelled_render.control.cancel();
     require(
         cancelled_render
-            .fit_output::<_, ServiceError, _>(|report| {
+            .fit_output::<_, ServiceError, _>(|report, _control| {
                 serde_json::to_vec(report).map_err(ServiceError::from)
             })
             .err()
@@ -253,8 +279,8 @@ fn impact_walks_dependency_dependents_but_not_contains_or_references() -> Result
     let (_temp, store) = analysis_store()?;
     let query = analysis_query(RelationAnalysisMode::Architecture)?;
     let relations = load_detailed_relations(&store, &query.relations, None)?;
-    let nodes = collect_nodes(&relations);
-    let mut edges = collect_report_edges(&relations);
+    let nodes = collect_nodes(&relations, None)?;
+    let mut edges = collect_report_edges(&relations, None)?;
     let closure = close_induced_edges(
         &store,
         &query,
@@ -298,6 +324,266 @@ fn impact_walks_dependency_dependents_but_not_contains_or_references() -> Result
         !impacted.contains("tools/c.rs"),
         "containment/reference relation was treated as dependency impact",
     )?;
+    Ok(())
+}
+
+#[test]
+fn impact_dead_code_control_releases_each_bounded_phase() -> Result<(), Box<dyn Error>> {
+    let (temp, read_store) = analysis_store()?;
+    drop(read_store);
+    let root = temp.path().join("analysis-service");
+    let database = root.join("projectatlas.db");
+    let store = AtlasStore::open_for_project(&database, &root)?;
+    let query = exact_symbol_impact_query("src/a.rs", "d_unused", "fn d_unused()")?;
+    let setup_control =
+        IndexWorkControl::new(IndexCancellation::new(), Some(Duration::from_secs(5)));
+    let relations = load_detailed_relations(&store, &query.relations, Some(&setup_control))?;
+    let nodes = collect_nodes(&relations, Some(&setup_control))?;
+    let mut edges = collect_report_edges(&relations, Some(&setup_control))?;
+    let closure = close_induced_edges(
+        &store,
+        &query,
+        &relations.work,
+        Instant::now() + Duration::from_secs(5),
+        &nodes,
+        &mut edges,
+        Some(&setup_control),
+    )?;
+    require(closure.complete, "dead-code fixture closure was incomplete")?;
+
+    let discovery_cancellation = IndexCancellation::new();
+    let discovery_control =
+        IndexWorkControl::new(discovery_cancellation.clone(), Some(Duration::from_secs(5)));
+    let mut discovery_work = SupplementalWork::default();
+    let discovery = cancel_at_analysis_phase(
+        AnalysisPhaseEvent::DeadCodeDiscovery,
+        discovery_cancellation,
+        || {
+            impact_findings(
+                &store,
+                &nodes,
+                &edges,
+                true,
+                true,
+                &VcsImpact::NotRequested,
+                &[],
+                &query,
+                64 * 1024,
+                &mut discovery_work,
+                Some(&discovery_control),
+            )
+        },
+    )?;
+    require(
+        matches!(
+            discovery,
+            Err(ServiceError::Db(DbError::IndexWork(
+                projectatlas_core::IndexWorkFailure::Cancelled {
+                    stage: IndexWorkStage::RepositoryTraversal
+                }
+            )))
+        ),
+        "dead-code discovery continued after deterministic in-phase cancellation",
+    )?;
+
+    let traversal_cancellation = IndexCancellation::new();
+    let traversal_control =
+        IndexWorkControl::new(traversal_cancellation.clone(), Some(Duration::from_secs(5)));
+    let mut traversal_edges = collect_report_edges(&relations, None)?;
+    let traversal = cancel_at_analysis_phase(
+        AnalysisPhaseEvent::Traversal,
+        traversal_cancellation,
+        || {
+            close_induced_edges(
+                &store,
+                &query,
+                &relations.work,
+                Instant::now() + Duration::from_secs(5),
+                &nodes,
+                &mut traversal_edges,
+                Some(&traversal_control),
+            )
+        },
+    )?;
+    require(
+        matches!(
+            traversal,
+            Err(ServiceError::Db(DbError::IndexWork(
+                projectatlas_core::IndexWorkFailure::Cancelled {
+                    stage: IndexWorkStage::RepositoryTraversal
+                }
+            )))
+        ),
+        "impact traversal continued after deterministic in-phase cancellation",
+    )?;
+
+    let hydration_cancellation = IndexCancellation::new();
+    let hydration_control =
+        IndexWorkControl::new(hydration_cancellation.clone(), Some(Duration::from_secs(5)));
+    let hydration = cancel_at_analysis_phase(
+        AnalysisPhaseEvent::SymbolHydration,
+        hydration_cancellation,
+        || load_admitted_symbols(&store, &nodes, 64 * 1024, Some(&hydration_control)),
+    )?;
+    require(
+        matches!(
+            hydration,
+            Err(ServiceError::Db(DbError::IndexWork(
+                projectatlas_core::IndexWorkFailure::Cancelled {
+                    stage: IndexWorkStage::RepositoryTraversal
+                }
+            )))
+        ),
+        "symbol hydration continued after deterministic in-phase cancellation",
+    )?;
+
+    let composition_cancellation = IndexCancellation::new();
+    let composition_control = IndexWorkControl::new(
+        composition_cancellation.clone(),
+        Some(Duration::from_secs(5)),
+    );
+    let composition = cancel_at_analysis_phase(
+        AnalysisPhaseEvent::Composition,
+        composition_cancellation,
+        || load_relation_analysis(&store, &query, Some(&composition_control)),
+    )?;
+    require(
+        matches!(
+            composition,
+            Err(ServiceError::Db(DbError::IndexWork(
+                projectatlas_core::IndexWorkFailure::Cancelled {
+                    stage: IndexWorkStage::RepositoryTraversal
+                }
+            )))
+        ),
+        "analysis composition continued after deterministic in-phase cancellation",
+    )?;
+
+    let output_cancellation = IndexCancellation::new();
+    let output_control =
+        IndexWorkControl::new(output_cancellation.clone(), Some(Duration::from_secs(5)));
+    let output_draft = load_relation_analysis(&store, &query, Some(&output_control))?;
+    let output = cancel_at_analysis_phase(
+        AnalysisPhaseEvent::OutputRendering,
+        output_cancellation,
+        || {
+            output_draft.fit_output::<_, ServiceError, _>(|report, _control| {
+                serde_json::to_vec(report).map_err(ServiceError::from)
+            })
+        },
+    )?;
+    require(
+        matches!(
+            output,
+            Err(ServiceError::Db(DbError::IndexWork(
+                projectatlas_core::IndexWorkFailure::Cancelled {
+                    stage: IndexWorkStage::RepositoryTraversal
+                }
+            )))
+        ),
+        "output rendering continued after deterministic in-phase cancellation",
+    )?;
+
+    let publication_before = store
+        .index_publication()?
+        .ok_or("analysis publication missing")?;
+    let successful = IndexWorkControl::new(IndexCancellation::new(), Some(Duration::from_secs(5)));
+    let (report, _encoded) = load_relation_analysis(&store, &query, Some(&successful))?
+        .fit_output::<_, ServiceError, _>(|report, _control| {
+        serde_json::to_vec(report).map_err(ServiceError::from)
+    })?;
+    require(
+        report.findings.iter().any(|finding| {
+            finding.kind == AnalysisFindingKind::DeadCode
+                && finding.status == AnalysisStatus::Candidate
+        }) && report.work.analyzed_nodes <= query.relations.budget.nodes()
+            && report.work.analyzed_edges <= query.relations.budget.edges()
+            && report.work.peak_intermediate_bytes <= query.relations.budget.intermediate_bytes()
+            && report.work.rendered_output_bytes
+                <= u64::from(query.relations.budget.output_bytes()),
+        "successful dead-code control changed findings or crossed aggregate limits",
+    )?;
+    require(
+        store.index_publication()?.as_ref() == Some(&publication_before),
+        "read-only impact analysis changed the authoritative publication",
+    )?;
+
+    require(
+        store.project_instance_id()?.is_some(),
+        "immediate follow-up read failed after terminal control",
+    )
+}
+
+#[test]
+fn leaf_and_larger_impact_entrypoints_share_every_terminal_phase() -> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store()?;
+    let queries = [
+        exact_symbol_impact_query("src/a.rs", "d_unused", "fn d_unused()")?,
+        exact_symbol_impact_query("src/a.rs", "a_long", "fn a_long()")?,
+    ];
+    for query in queries {
+        for phase in [
+            AnalysisPhaseEvent::DeadCodeDiscovery,
+            AnalysisPhaseEvent::Traversal,
+            AnalysisPhaseEvent::SymbolHydration,
+            AnalysisPhaseEvent::Composition,
+        ] {
+            let cancellation = IndexCancellation::new();
+            let control = IndexWorkControl::new(cancellation.clone(), Some(Duration::from_secs(5)));
+            let result = cancel_at_analysis_phase(phase, cancellation, || {
+                load_relation_analysis(&store, &query, Some(&control))
+            })?;
+            require(
+                matches!(
+                    result,
+                    Err(ServiceError::Db(DbError::IndexWork(
+                        projectatlas_core::IndexWorkFailure::Cancelled {
+                            stage: IndexWorkStage::RepositoryTraversal
+                        }
+                    )))
+                ),
+                "impact entrypoint continued after deterministic phase cancellation",
+            )?;
+        }
+
+        let cancellation = IndexCancellation::new();
+        let control = IndexWorkControl::new(cancellation.clone(), Some(Duration::from_secs(5)));
+        let draft = load_relation_analysis(&store, &query, Some(&control))?;
+        let output =
+            cancel_at_analysis_phase(AnalysisPhaseEvent::OutputRendering, cancellation, || {
+                draft.fit_output::<_, ServiceError, _>(|report, control| {
+                    serialized_bytes_controlled(report, Some(control))
+                        .map(|bytes| bytes.to_le_bytes().to_vec())
+                })
+            })?;
+        require(
+            matches!(
+                output,
+                Err(ServiceError::Db(DbError::IndexWork(
+                    projectatlas_core::IndexWorkFailure::Cancelled {
+                        stage: IndexWorkStage::RepositoryTraversal
+                    }
+                )))
+            ),
+            "impact entrypoint continued after output cancellation",
+        )?;
+
+        let successful =
+            IndexWorkControl::new(IndexCancellation::new(), Some(Duration::from_secs(5)));
+        let (report, _) = load_relation_analysis(&store, &query, Some(&successful))?
+            .fit_output::<_, ServiceError, _>(|report, control| {
+                serialized_bytes_controlled(report, Some(control))
+                    .map(|bytes| bytes.to_le_bytes().to_vec())
+            })?;
+        require(
+            report.mode == RelationAnalysisMode::Impact
+                && report.work.analyzed_nodes <= query.relations.budget.nodes()
+                && report.work.analyzed_edges <= query.relations.budget.edges()
+                && report.work.peak_intermediate_bytes
+                    <= query.relations.budget.intermediate_bytes(),
+            "non-expired impact entrypoint crossed its aggregate control",
+        )?;
+    }
     Ok(())
 }
 
@@ -416,9 +702,10 @@ fn analysis_modes_are_closed_and_partial_evidence_stays_inconclusive() -> Result
         Some(Instant::now()),
         false,
     )?;
-    let (deadline_limited, _) = deadline_limited.fit_output::<_, ServiceError, _>(|report| {
-        serde_json::to_vec(report).map_err(ServiceError::from)
-    })?;
+    let (deadline_limited, _) =
+        deadline_limited.fit_output::<_, ServiceError, _>(|report, _control| {
+            serde_json::to_vec(report).map_err(ServiceError::from)
+        })?;
     require(
         deadline_limited.truncated
             && deadline_limited
@@ -487,7 +774,7 @@ fn closure_preserves_late_resolution_gaps_and_symbol_findings() -> Result<(), Bo
     late_gap.include_cycles = false;
     let first_page = load_detailed_relations(&store, &late_gap.relations, None)?;
     require(
-        first_page.continuation.is_some() && resolution_gap_findings(&first_page).is_empty(),
+        first_page.continuation.is_some() && resolution_gap_findings(&first_page, None)?.is_empty(),
         "fixture did not place the ambiguous relation after the first detailed page",
     )?;
     let report = fitted_report(&store, &late_gap)?;
@@ -521,10 +808,10 @@ fn closure_preserves_late_resolution_gaps_and_symbol_findings() -> Result<(), Bo
             file: RepositoryFilePath::new(Path::new(anchor))?,
         };
         let relations = load_detailed_relations(&store, &query.relations, None)?;
-        for (key, node) in collect_nodes(&relations) {
+        for (key, node) in collect_nodes(&relations, None)? {
             nodes.entry(key).or_insert(node);
         }
-        edges.extend(collect_report_edges(&relations));
+        edges.extend(collect_report_edges(&relations, None)?);
     }
     for (path, name, signature) in [
         ("src/a.rs", "a_long", "fn a_long()"),
@@ -539,10 +826,10 @@ fn closure_preserves_late_resolution_gaps_and_symbol_findings() -> Result<(), Bo
             signature: Some(signature.to_string()),
         };
         let relations = load_detailed_relations(&store, &query.relations, None)?;
-        for (key, node) in collect_nodes(&relations) {
+        for (key, node) in collect_nodes(&relations, None)? {
             nodes.entry(key).or_insert(node);
         }
-        edges.extend(collect_report_edges(&relations));
+        edges.extend(collect_report_edges(&relations, None)?);
     }
     let mut work = SupplementalWork::default();
     let structural = structural_findings(&store, &nodes, &edges, true, 64 * 1024, &mut work, None)?;
@@ -824,7 +1111,7 @@ fn vcs_zero_intersection_cursor_freshness_and_shared_budget_are_explicit()
 
     let draft = load_relation_analysis(&store, &impact, None)?;
     let prefix = draft
-        .fit_output::<_, ServiceError, _>(|report| {
+        .fit_output::<_, ServiceError, _>(|report, _control| {
             if report.findings.is_empty() {
                 serde_json::to_vec(report).map_err(ServiceError::from)
             } else {
@@ -850,8 +1137,8 @@ fn vcs_zero_intersection_cursor_freshness_and_shared_budget_are_explicit()
 
     let exact = exact_symbol_impact_query("src/a.rs", "d_unused", "fn d_unused()")?;
     let relations = load_detailed_relations(&store, &exact.relations, None)?;
-    let nodes = collect_nodes(&relations);
-    let mut edges = collect_report_edges(&relations);
+    let nodes = collect_nodes(&relations, None)?;
+    let mut edges = collect_report_edges(&relations, None)?;
     let closure = close_induced_edges(
         &store,
         &exact,
@@ -956,7 +1243,7 @@ fn fitted_report(
     query: &RelationAnalysisQuery,
 ) -> Result<RelationAnalysisReport, Box<dyn Error>> {
     let draft = load_relation_analysis(store, query, None)?;
-    let (report, _encoded) = draft.fit_output::<_, ServiceError, _>(|report| {
+    let (report, _encoded) = draft.fit_output::<_, ServiceError, _>(|report, _control| {
         serde_json::to_vec(report).map_err(ServiceError::from)
     })?;
     Ok(report)

--- a/crates/projectatlas-service/src/federation.rs
+++ b/crates/projectatlas-service/src/federation.rs
@@ -332,16 +332,22 @@ impl FederatedAnalysisDraft {
     /// cursor cannot be wrapped, or the empty federated envelope is oversized.
     pub fn fit_output<F, E, O>(self, mut encode: F) -> Result<(FederatedAnalysisReport, O), E>
     where
-        F: FnMut(&FederatedAnalysisReport) -> Result<O, E>,
+        F: FnMut(&FederatedAnalysisReport, &IndexWorkControl) -> Result<O, E>,
         E: From<ServiceError>,
         O: AsRef<[u8]>,
     {
         let context = self.context;
-        let (primary, encoded) = self.primary.fit_output(|primary| {
-            let report = context.analysis_report(primary.clone()).map_err(E::from)?;
-            encode(&report)
+        let control = self.primary.control().clone();
+        let (primary, encoded) = self.primary.fit_output(|primary, control| {
+            let report = context
+                .analysis_report(primary.clone(), Some(control))
+                .map_err(E::from)?;
+            encode(&report, control)
         })?;
-        let report = context.analysis_report(primary).map_err(E::from)?;
+        check_control(Some(&control)).map_err(E::from)?;
+        let report = context
+            .analysis_report(primary, Some(&control))
+            .map_err(E::from)?;
         Ok((report, encoded))
     }
 }
@@ -406,7 +412,9 @@ impl FederatedContext {
     fn analysis_report(
         &self,
         mut primary: RelationAnalysisReport,
+        control: Option<&IndexWorkControl>,
     ) -> ServiceResult<FederatedAnalysisReport> {
+        check_control(control)?;
         primary.continuation = wrap_continuation(
             primary.continuation.as_deref(),
             &self.cursor_participants,
@@ -414,6 +422,7 @@ impl FederatedContext {
         )?;
         let mut reached_limits = primary.reached_limits.clone();
         for limit in &self.rendezvous_limits {
+            check_control(control)?;
             push_limit(&mut reached_limits, *limit);
         }
         let mut work = self.base_work.clone();
@@ -428,6 +437,7 @@ impl FederatedContext {
             primary.continuation.as_deref(),
             self.budget,
         )?;
+        check_control(control)?;
         Ok(FederatedAnalysisReport {
             participants: self.participants.clone(),
             truncated: primary.truncated || !self.rendezvous_limits.is_empty(),
@@ -1257,8 +1267,9 @@ mod tests {
                 .is_empty(),
             "federated analysis retained temporary rendezvous identities through output fitting",
         )?;
-        let (analysis, _) =
-            analysis.fit_output(|report| serde_json::to_vec(report).map_err(ServiceError::from))?;
+        let (analysis, _) = analysis.fit_output(|report, _control| {
+            serde_json::to_vec(report).map_err(ServiceError::from)
+        })?;
         require(
             analysis.rendezvous.len() == 2
                 && analysis
@@ -1304,8 +1315,9 @@ mod tests {
             },
             None,
         )?;
-        let (inbound_analysis, _) = inbound_analysis
-            .fit_output(|report| serde_json::to_vec(report).map_err(ServiceError::from))?;
+        let (inbound_analysis, _) = inbound_analysis.fit_output(|report, _control| {
+            serde_json::to_vec(report).map_err(ServiceError::from)
+        })?;
         require(
             inbound_analysis.rendezvous.is_empty()
                 && inbound_analysis.work.rendezvous_database_rows == 0,

--- a/openspec/changes/bound-impact-analysis-deadlines/.openspec.yaml
+++ b/openspec/changes/bound-impact-analysis-deadlines/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/bound-impact-analysis-deadlines/design.md
+++ b/openspec/changes/bound-impact-analysis-deadlines/design.md
@@ -1,0 +1,57 @@
+## Context
+
+Impact analysis already receives an aggregate request control with deadline, cancellation, row, node, edge, visited-state, intermediate-byte, and output-byte limits. The control is captured at the service boundary, but the optional dead-code path performs candidate discovery and hydration through helpers that do not consistently check or forward it. A small request can therefore retain a SQLite read snapshot and CPU work until the MCP host's unrelated timeout.
+
+The graph is rebuildable SQLite state. Analysis is read-only and candidate-labeled; it must never publish partial authoritative data. CLI and MCP compose the same service result.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Use one captured deadline and cancellation source across every impact/dead-code phase.
+- Check control before and during bounded database reads, traversal, hydration, composition, and rendering.
+- Return the existing typed deadline, cancellation, or truncation result within a bounded tolerance.
+- Drop statements, snapshots, task records, and intermediate collections before return.
+- Preserve successful analysis behavior and deterministic bounded output.
+
+**Non-Goals:**
+
+- Creating a background analysis executor or another task registry.
+- Returning unbounded partial candidates after expiry.
+- Changing graph schema, indexes, publication, or MCP request fields; the CLI only exposes aggregate limits the service and MCP route already accept.
+- Converting synchronous SQLite reads to async work.
+
+## Decisions
+
+### Thread the existing concrete request control
+
+Pass the existing analysis/request control by shared reference into dead-code candidate discovery, usage indegree reads, admitted-symbol hydration, node composition, and final accounting. Each loop and each database batch checks the same absolute deadline and cancellation state.
+
+A new trait, token type, or nested timeout was rejected because the existing control already owns all required limits and typed errors. Relative per-phase timers were rejected because they could extend the caller's total deadline.
+
+### Bound database work at the storage boundary
+
+Reuse controlled, prepared, paged database queries where available. If a current helper materializes a complete symbol or usage set, add the smallest controlled page/batch boundary and check between batches. The service owns orchestration; SQL and statement lifetime remain in `projectatlas-db`.
+
+### Fail through existing typed result composition
+
+Deadline and cancellation propagate through the normal analysis result mapping. Safe completed rows may be retained only when the existing result contract marks coverage and total state accurately; no failure becomes an exact or authoritative answer. RAII drops the snapshot and statements before adapter serialization.
+
+### Test elapsed behavior without millisecond brittleness
+
+Deterministic test hooks expire control at named analysis stages. Wall-clock integration tests use a generous upper tolerance relative to the requested deadline and require an immediate harmless follow-up call. Both CLI and MCP tests exercise the real adapter route.
+
+## Risks / Trade-offs
+
+- **A helper remains unbounded between checks** → Cover expiry during candidate discovery, SQLite iteration, traversal, hydration, and rendering with stage-specific tests.
+- **Cancellation returns but retains a read snapshot or task record** → Reopen/write after expiry and require immediate status/read responsiveness.
+- **Tiny deadline tests are flaky on loaded CI** → Use deterministic stage hooks for phase coverage and tolerant elapsed assertions only at adapter boundaries.
+- **Checks add hot-loop overhead** → Reuse the existing cheap control check at batch/loop boundaries; work remains bounded by requested nodes, edges, rows, bytes, and deadline.
+
+## Migration Plan
+
+No durable migration is required. Ship the service and storage-boundary fix in v0.4.1 with CLI/MCP compatibility tests.
+
+## Open Questions
+
+None.

--- a/openspec/changes/bound-impact-analysis-deadlines/proposal.md
+++ b/openspec/changes/bound-impact-analysis-deadlines/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Impact analysis with dead-code candidates can ignore a one-second request deadline until the MCP host reaches its five-minute timeout. ProjectAtlas must own the complete bounded operation and return typed deadline or cancellation state promptly instead of relying on the host to abort it.
+
+## What Changes
+
+- Capture one request control and apply it across candidate discovery, SQLite reads, traversal, hydration, composition, and rendering.
+- Stop at deadline or cancellation with the existing typed bounded-result contract and no authoritative mutation.
+- Release statements, read snapshots, task records, and intermediate allocations before returning.
+- Cover leaf, larger-entrypoint, SQLite-expiry, cancellation, successful control, CLI, MCP, and immediate follow-up responsiveness.
+
+## Capabilities
+
+### New Capabilities
+
+- `bounded-impact-analysis`: Defines deadline, cancellation, resource, typed-result, and compatibility behavior for impact and dead-code analysis.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `projectatlas-service` analysis orchestration and impact/dead-code phases.
+- Existing bounded `projectatlas-db` read APIs where a phase currently omits request control.
+- CLI and MCP integration coverage; no new MCP tool or request field, with additive CLI flags exposing the existing aggregate service budgets.
+
+## Non-Goals
+
+- Removing dead-code or impact analysis.
+- Raising host timeouts or substituting unbounded background work.
+- Weakening freshness, snapshot consistency, confidence, or truncation semantics.
+- Adding an executor, task registry, or database schema change.
+
+## Status
+
+Ready for implementation in the v0.4.1 bugfix-only stabilization release.

--- a/openspec/changes/bound-impact-analysis-deadlines/specs/bounded-impact-analysis/spec.md
+++ b/openspec/changes/bound-impact-analysis-deadlines/specs/bounded-impact-analysis/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: One aggregate control bounds complete impact analysis
+ProjectAtlas SHALL apply one captured absolute deadline, cancellation source, and aggregate resource budget across impact and optional dead-code candidate discovery, SQLite reads, graph traversal, hydration, composition, and output encoding.
+
+#### Scenario: Deadline expires during dead-code discovery
+- **WHEN** `include_dead_code` is true and the absolute deadline expires while discovering or reading candidate usage
+- **THEN** ProjectAtlas stops the phase and returns typed deadline or bounded-partial state without waiting for the host timeout
+
+#### Scenario: Deadline expires during traversal or hydration
+- **WHEN** the absolute deadline expires after discovery while traversing relationships or hydrating symbols, files, purposes, or selectors
+- **THEN** ProjectAtlas stops using the same deadline and does not start another unbounded phase
+
+#### Scenario: Cancellation races a database batch
+- **WHEN** cancellation becomes terminal before or during a bounded SQLite batch
+- **THEN** ProjectAtlas returns typed cancellation state and does not continue iteration, traversal, or rendering
+
+#### Scenario: Successful control
+- **WHEN** impact and dead-code analysis completes inside every declared budget
+- **THEN** ProjectAtlas returns the same deterministic candidates, selectors, confidence, coverage, and total-state contract as a successful compatible request
+
+### Requirement: Expiry releases read and task resources
+ProjectAtlas SHALL release SQLite statements and snapshots, service task records, and intermediate collections before returning deadline, cancellation, truncation, or failure.
+
+#### Scenario: Immediate follow-up after expiry
+- **WHEN** a bounded impact request expires
+- **THEN** an immediate harmless MCP status/read call completes promptly and a subsequent database write is not blocked by the expired request
+
+#### Scenario: No authoritative partial publication
+- **WHEN** impact analysis expires after producing intermediate candidates
+- **THEN** ProjectAtlas publishes no source, graph, purpose, or analysis state and labels any permitted returned candidates with non-exact coverage and total state
+
+### Requirement: CLI and MCP expose equivalent bounded behavior
+ProjectAtlas SHALL enforce the same service deadline and cancellation behavior through the CLI and `atlas_symbol_relations` MCP analysis route.
+
+#### Scenario: One-second MCP request
+- **WHEN** an MCP impact request with `include_dead_code: true` declares a one-second deadline and small traversal budgets
+- **THEN** it returns a typed ProjectAtlas result within a bounded tolerance rather than reaching the host's 300-second timeout
+
+#### Scenario: Equivalent CLI request
+- **WHEN** the equivalent CLI analysis declares the same deadline and budgets
+- **THEN** it terminates through the same bounded service result and does not perform additional unbounded work
+
+#### Scenario: Larger entrypoint remains bounded
+- **WHEN** a larger entrypoint produces more impact and dead-code candidates than a leaf file
+- **THEN** declared node, edge, visited-state, intermediate-byte, output-byte, deadline, and cancellation limits remain authoritative

--- a/openspec/changes/bound-impact-analysis-deadlines/tasks.md
+++ b/openspec/changes/bound-impact-analysis-deadlines/tasks.md
@@ -1,0 +1,15 @@
+## 1. Reproduction and Ownership
+
+- [x] 1.1 Map `bound-impact-analysis-deadlines` to GitHub issue #380 in `openspec/issue-map.json` and keep the issue checklist synchronized with this file.
+- [x] 1.2 Add deterministic leaf and larger-entrypoint regressions that expire during dead-code discovery, SQLite work, traversal, hydration, and output, plus a successful non-expired control.
+
+## 2. Complete Aggregate Control
+
+- [x] 2.1 Thread the existing captured request control through every impact/dead-code candidate, traversal, hydration, composition, and rendering phase using one absolute deadline and cancellation source.
+- [x] 2.2 Make every owning SQLite read bounded and interruptible at its batch/iteration boundary, and prove statements, snapshots, task records, and intermediate collections are released on terminal control.
+- [x] 2.3 Preserve typed deadline, cancellation, truncation, coverage, confidence, total-state, and safe-partial semantics through the shared service result and equivalent CLI/MCP adapters.
+
+## 3. Adapter and Release Verification
+
+- [x] 3.1 Add real MCP and CLI elapsed-tolerance tests, immediate follow-up responsiveness, no partial authoritative mutation, and declared row/node/edge/visited/intermediate/output budget coverage.
+- [ ] 3.2 Run focused service/database/CLI/MCP tests, `cargo fmt --check`, workspace check/clippy/test/doc gates, OpenSpec validation, IssueOps, and live review-feedback reconciliation.

--- a/openspec/changes/bound-impact-analysis-deadlines/tasks.md
+++ b/openspec/changes/bound-impact-analysis-deadlines/tasks.md
@@ -12,4 +12,4 @@
 ## 3. Adapter and Release Verification
 
 - [x] 3.1 Add real MCP and CLI elapsed-tolerance tests, immediate follow-up responsiveness, no partial authoritative mutation, and declared row/node/edge/visited/intermediate/output budget coverage.
-- [ ] 3.2 Run focused service/database/CLI/MCP tests, `cargo fmt --check`, workspace check/clippy/test/doc gates, OpenSpec validation, IssueOps, and live review-feedback reconciliation.
+- [x] 3.2 Run focused service/database/CLI/MCP tests, `cargo fmt --check`, workspace check/clippy/test/doc gates, OpenSpec validation, IssueOps, and live review-feedback reconciliation.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -5,6 +5,7 @@
     "add-mcp-task-progress-model": 295,
     "add-nearest-project-routing": 276,
     "advance-rust-repository-intelligence": 308,
+    "bound-impact-analysis-deadlines": 380,
     "centralize-cargo-dependency-management": 316,
     "close-mcp-cli-parity": 281,
     "complete-v040-release-readiness": 311,


### PR DESCRIPTION
## Summary

- carry one existing request control through SQLite reads, impact/dead-code traversal, hydration, composition, and adapter encoding
- interrupt active SQLite work and release statements/snapshots/resources on deadline or cancellation
- preserve typed bounds and equivalent buffered CLI/MCP responses without partial mutation or output

## Verification

- exact SQLite deadline and active-batch cancellation tests
- deterministic service phase tests for leaf and larger entrypoints
- real 12k-symbol CLI/MCP cancellation and resource-release E2E
- all-feature focused Clippy, strict strings, formatting, OpenSpec, IssueOps, and full ordinary pre-push gates

Benchmarks were not run; the manual-only historical benchmark is not required for this correctness fix.

Fixes #380
