### PR TITLE
fix(parser): separate healthy recovery tolerance

### DIFF
--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -5608,7 +5608,8 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
             )));
         }
 
-        let healthy = case("healthy", ExpectedFailure::Io)?;
+        let mut healthy = case("healthy", ExpectedFailure::Io)?;
+        healthy.no_progress = healthy.deadline;
         let evidence = operate(peer, &healthy).map_err(|error| {
             io::Error::other(format!(
                 "healthy restart after {} failed: {error:?}",


### PR DESCRIPTION
## Summary

- give only the post-hostile healthy parser probe the existing two-second absolute no-progress allowance
- retain the 500 ms hostile no-progress budget, one launch attempt, and all production supervisor behavior

## Validation

- seven consecutive warm Windows adversarial-suite passes plus one final standalone pass
- 31 owning parser-supervisor unit tests
- affected check, strict Clippy, formatting, and strict-string gates
- no benchmark

A later run while other workspace builds were active reached the separate existing 500 ms hostile containment-admission bound before its intended hostile scenario. It did not involve the healthy recovery and this PR deliberately does not lengthen hostile budgets or add retries.

Fixes #391