### PR TITLE
chore(release): repair v0.4.1 metadata gate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 *.md text eol=lf
 *.rs text eol=lf
 *.sh text eol=lf
+*.sql text eol=lf
 *.toml text eol=lf
 *.toon text eol=lf
 *.ts text eol=lf

--- a/openspec/changes/consolidate-projectatlas-landing-page/.openspec.yaml
+++ b/openspec/changes/consolidate-projectatlas-landing-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/consolidate-projectatlas-landing-page/design.md
+++ b/openspec/changes/consolidate-projectatlas-landing-page/design.md
@@ -1,0 +1,30 @@
+## Context
+
+The README is the GitHub landing page and must explain ProjectAtlas before routing readers to detailed documentation. The v0.4.1 revision already consolidated repeated prose, removed stale comparison material, and added the approved TUI screenshot.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep one concise Rust-native, local, large-codebase product statement.
+- Show the agent-first navigation flow and TUI without duplicating reference documentation.
+- Keep every performance statement scoped to its published workload.
+- Verify the real GitHub rendering at desktop and narrow widths in light and dark appearances.
+
+**Non-Goals:**
+
+- Redesign the TUI or rerun benchmarks.
+- Change runtime, installer, CLI, MCP, or database behavior.
+
+## Decisions
+
+- The README owns product positioning and discovery; detailed procedures remain in their existing documentation owners.
+- The repository-owned TUI screenshot is the primary product example and is paired with `projectatlas token --view tui`.
+- The large-application audit table stays adjacent to its chart so the workload qualifier is not separated from the result.
+- Visual acceptance is based on the rendered GitHub page, not Markdown source alone.
+
+## Risks / Trade-offs
+
+- [Linked documentation drifts] → Keep one owner per detailed topic and validate links.
+- [A screenshot becomes stale] → Track future TUI visual changes separately rather than expanding this release correction.
+- [Performance wording becomes universal] → Keep the workload qualifier adjacent to each result.

--- a/openspec/changes/consolidate-projectatlas-landing-page/proposal.md
+++ b/openspec/changes/consolidate-projectatlas-landing-page/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The ProjectAtlas landing page repeated product and operator material, obscured its Rust-native large-repository positioning, and retained an irrelevant historical comparison. The v0.4.1 documentation consolidation needs durable issue ownership so release checklist validation covers the work that already landed.
+
+## What Changes
+
+- Consolidate the opening, About explanation, installation choices, and documentation routing.
+- Present the token-impact TUI early with its exact terminal command.
+- Keep the representative large-application audit beside its chart and scope the claim to that workload.
+- Remove the historical v0.3.26 and plain-control comparison.
+- Align GitHub About metadata and verify the rendered landing page at desktop and narrow widths in light and dark appearances.
+
+## Capabilities
+
+### New Capabilities
+
+- `projectatlas-landing-page`: Defines the concise, agent-first ProjectAtlas landing-page content and visual-review contract.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The completed change affects `README.md`, its repository-owned visual assets, GitHub About metadata, and documentation links. It changes no runtime, CLI, MCP, database, package, or benchmark behavior.
+
+## Non-Goals
+
+- No TUI redesign.
+- No benchmark rerun or new performance claim.
+- No installer, CLI, MCP, database, or runtime behavior change.
+
+This release-scoped documentation change is implemented and ready for v0.4.1 verification.

--- a/openspec/changes/consolidate-projectatlas-landing-page/specs/projectatlas-landing-page/spec.md
+++ b/openspec/changes/consolidate-projectatlas-landing-page/specs/projectatlas-landing-page/spec.md
@@ -14,6 +14,20 @@ The landing page SHALL explain the purpose-to-graph-to-compact-evidence-to-exact
 - **WHEN** a reader follows a detailed ProjectAtlas topic from the landing page
 - **THEN** the reader reaches the owning document without a duplicated command inventory on the landing page
 
+### Requirement: Discoverable installation choices
+The landing page SHALL keep plugin, native release, and Cargo installation choices easy to find while routing full installation and repair procedures to their owning documentation.
+
+#### Scenario: Reader chooses an installation path
+- **WHEN** a reader looks for a supported way to install ProjectAtlas
+- **THEN** the landing page exposes the three installation choices without duplicating the complete installer procedure
+
+### Requirement: Synchronized repository metadata
+The GitHub About description and topics MUST remain aligned with the landing page's Rust-native, local, large-codebase, and coding-agent positioning.
+
+#### Scenario: Visitor discovers ProjectAtlas through GitHub metadata
+- **WHEN** GitHub displays the repository About metadata
+- **THEN** its description and topics reinforce the same concise positioning as the landing page
+
 ### Requirement: Visible TUI example and scoped evidence
 The landing page SHALL present the approved token-impact TUI with the exact `projectatlas token --view tui` command and SHALL keep the representative large-application audit result adjacent to its workload-specific qualifier.
 

--- a/openspec/changes/consolidate-projectatlas-landing-page/specs/projectatlas-landing-page/spec.md
+++ b/openspec/changes/consolidate-projectatlas-landing-page/specs/projectatlas-landing-page/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Concise product positioning
+The ProjectAtlas landing page SHALL identify ProjectAtlas as Rust-native, fast local repository intelligence for large codebases and SHALL explain its persistent coding-agent benefit without repeating the same product claim.
+
+#### Scenario: Visitor reads the first screen
+- **WHEN** a visitor opens the ProjectAtlas repository
+- **THEN** the first screen communicates the Rust-native local large-codebase purpose and agent benefit without historical comparison prose
+
+### Requirement: Agent-first workflow and documentation routing
+The landing page SHALL explain the purpose-to-graph-to-compact-evidence-to-exact-source workflow once and SHALL route detailed CLI, MCP, configuration, workflow, methodology, and architecture material to their owning documents.
+
+#### Scenario: Reader needs operational detail
+- **WHEN** a reader follows a detailed ProjectAtlas topic from the landing page
+- **THEN** the reader reaches the owning document without a duplicated command inventory on the landing page
+
+### Requirement: Visible TUI example and scoped evidence
+The landing page SHALL present the approved token-impact TUI with the exact `projectatlas token --view tui` command and SHALL keep the representative large-application audit result adjacent to its workload-specific qualifier.
+
+#### Scenario: Reader evaluates the product overview
+- **WHEN** a reader scans the landing page before the detailed evidence sections
+- **THEN** the TUI example is visible and the 99.8% result is explicitly limited to its one large-application audit
+
+### Requirement: Rendered landing-page review
+The landing page MUST remain readable on the actual GitHub rendering at desktop and narrow widths in light and dark appearances.
+
+#### Scenario: Visual review completes
+- **WHEN** the branch or pull-request README is inspected at the required widths and appearances
+- **THEN** text, screenshots, charts, wrapping, and links are readable without horizontal overflow

--- a/openspec/changes/consolidate-projectatlas-landing-page/tasks.md
+++ b/openspec/changes/consolidate-projectatlas-landing-page/tasks.md
@@ -1,0 +1,12 @@
+## 1. Landing Page Consolidation
+
+- [x] 1.1 Keep the first screen concise while combining Rust-native implementation, fast local operation, large-codebase intent, persistent repository intelligence, and the coding-agent benefit.
+- [x] 1.2 Keep one short About section for purposes -> graph relationships -> compact summaries/outlines -> exact source slices.
+- [x] 1.3 Add `Screenshot 2026-07-30 163043.png` as a repository-owned README asset with useful alt text and place it near the top beside the exact `projectatlas token --view tui` command.
+- [x] 1.4 Keep plugin, native release, and Cargo installation choices easy to find without duplicating the full installer procedure.
+- [x] 1.5 Replace detailed CLI/MCP call inventories and host-repair prose with concise summaries and links to the owning documentation.
+- [x] 1.6 Move the representative large-application audit table beside its chart lower on the page; keep 99.8% explicitly scoped to that one audit.
+- [x] 1.7 Remove the historical v0.3.26 comparison, the 3.9x medium-task result, and the plain-control comparison from the landing page.
+- [x] 1.8 Update GitHub About metadata to match the consolidated positioning.
+- [x] 1.9 Review the actual GitHub-rendered branch/PR page with Playwright at desktop and narrow widths in light and dark appearances; verify screenshot/chart legibility, wrapping, links, and horizontal overflow.
+- [x] 1.10 Run focused Markdown/link/issue checks without running the manual long navigation benchmark.

--- a/openspec/changes/pin-sql-fixture-line-endings/.openspec.yaml
+++ b/openspec/changes/pin-sql-fixture-line-endings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/pin-sql-fixture-line-endings/design.md
+++ b/openspec/changes/pin-sql-fixture-line-endings/design.md
@@ -1,0 +1,26 @@
+## Context
+
+`projectatlas-db` uses `include_str!` to embed captured schema-8 SQL fixtures. A focused drift test replaces exact LF-terminated DDL fragments. The repository already pins source and documentation formats in `.gitattributes`, but SQL was omitted and therefore inherited platform checkout conversion.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make embedded SQL fixture bytes deterministic on every supported checkout platform.
+- Preserve the strict semantic-drift test unchanged.
+- Verify the database suite on Windows.
+
+**Non-Goals:**
+
+- Change production migration code or accepted schema shapes.
+- Add runtime normalization or another fixture-loading layer.
+
+## Decisions
+
+- Add `*.sql text eol=lf` to the existing repository line-ending policy.
+- Retain the existing test mutations and fixtures so the regression remains observable if checkout normalization drifts again.
+
+## Risks / Trade-offs
+
+- Existing worktrees may retain CRLF files until refreshed; release verification uses a refreshed checkout and explicitly confirms LF checkout state.
+- Contributors editing SQL on Windows receive LF working-tree files, matching the embedded test contract and canonical Git blobs.

--- a/openspec/changes/pin-sql-fixture-line-endings/proposal.md
+++ b/openspec/changes/pin-sql-fixture-line-endings/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Released-schema tests embed captured SQL fixtures at compile time and mutate exact DDL fragments to prove incompatible drift is rejected. On Windows, Git checked those fixtures out with CRLF endings while the test mutations use LF, so the release gate failed before exercising schema validation.
+
+## What Changes
+
+- Pin repository SQL files to LF checkouts alongside the existing Rust, JSON, TOML, and documentation line-ending contracts.
+- Keep the released schema fixtures byte-stable across Windows, Linux, and macOS checkouts.
+- Verify the evolved released-schema drift test and the complete database test suite on Windows.
+
+## Capabilities
+
+### New Capabilities
+
+- `released-schema-fixture-portability`: Defines platform-independent checkout behavior for embedded released-schema fixtures.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The change affects only Git checkout normalization for `*.sql` files and release-gate verification. It does not change production schema DDL, migration logic, database contents, dependencies, or public interfaces.
+
+## Non-Goals
+
+- Changing schema admission or migration behavior.
+- Normalizing database contents at runtime.
+- Adding a custom line-ending parser or test abstraction.

--- a/openspec/changes/pin-sql-fixture-line-endings/specs/released-schema-fixture-portability/spec.md
+++ b/openspec/changes/pin-sql-fixture-line-endings/specs/released-schema-fixture-portability/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Embedded released-schema fixtures are platform independent
+
+The repository MUST check out SQL fixtures with LF line endings on every supported platform so compile-time embedded DDL has deterministic bytes.
+
+#### Scenario: Windows checkout embeds a released schema fixture
+
+- **WHEN** a released-schema SQL fixture is checked out and embedded during a Windows build
+- **THEN** its line endings match the canonical LF bytes used by the schema-drift tests
+
+### Requirement: Portability does not weaken schema validation
+
+The fixture portability correction MUST preserve production schema DDL, migration behavior, and strict rejection of incompatible released-schema drift.
+
+#### Scenario: A captured predecessor schema is changed semantically
+
+- **WHEN** the drift test removes, renames, adds, or changes a captured schema object
+- **THEN** preflight rejects the lookalike without mutating the database
+
+### Requirement: Database release gate covers the checkout contract
+
+Release verification MUST confirm SQL checkout normalization and run the owning drift test plus the complete database test suite on Windows.
+
+#### Scenario: The database release gate runs
+
+- **WHEN** the v0.4.1 database gate evaluates the portability correction
+- **THEN** LF checkout state, focused drift coverage, and all database tests pass

--- a/openspec/changes/pin-sql-fixture-line-endings/tasks.md
+++ b/openspec/changes/pin-sql-fixture-line-endings/tasks.md
@@ -1,0 +1,5 @@
+## 1. SQL Fixture Portability
+
+- [x] 1.1 Map `pin-sql-fixture-line-endings` to its GitHub issue and synchronize the issue checklist.
+- [x] 1.2 Pin repository SQL checkouts to LF without changing captured schema DDL or production migration behavior.
+- [x] 1.3 Verify LF checkout state, the evolved released-schema drift test, and the complete `projectatlas-db` test suite on Windows.

--- a/openspec/changes/stabilize-parser-recovery-harness/.openspec.yaml
+++ b/openspec/changes/stabilize-parser-recovery-harness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/stabilize-parser-recovery-harness/design.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/design.md
@@ -7,7 +7,7 @@ The adversarial parser-supervisor harness uses a short no-progress budget to kee
 **Goals:**
 
 - Separate the healthy recovery allowance from hostile-case stall budgets.
-- Preserve one healthy launch attempt and the existing absolute test deadline.
+- Preserve one healthy launch attempt and its existing two-second deadline.
 - Retain exact hostile failure classification, containment, and cleanup coverage.
 
 **Non-Goals:**
@@ -18,7 +18,7 @@ The adversarial parser-supervisor harness uses a short no-progress budget to kee
 ## Decisions
 
 - Override only the existing healthy recovery case's no-progress value.
-- Set the recovery allowance to the harness's existing absolute deadline, so the premature cutoff is removed without extending total test time.
+- Set the recovery allowance to the healthy attempt's existing deadline, so the premature cutoff is removed without lengthening that attempt.
 - Keep the existing adversarial suite as the owning verification surface.
 
 ## Risks / Trade-offs

--- a/openspec/changes/stabilize-parser-recovery-harness/design.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/design.md
@@ -1,0 +1,28 @@
+## Context
+
+The adversarial parser-supervisor harness uses a short no-progress budget to keep hostile stalls bounded. Reusing that same budget for the healthy post-failure recovery probe made the Windows release gate sensitive to ordinary launch scheduling.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Separate the healthy recovery allowance from hostile-case stall budgets.
+- Preserve one healthy launch attempt and the existing absolute test deadline.
+- Retain exact hostile failure classification, containment, and cleanup coverage.
+
+**Non-Goals:**
+
+- Change production parser deadlines, protocol, cancellation, containment, or cleanup.
+- Add retries or widen hostile-case bounds.
+
+## Decisions
+
+- Override only the existing healthy recovery case's no-progress value.
+- Set the recovery allowance to the harness's existing absolute deadline, so the premature cutoff is removed without extending total test time.
+- Keep the existing adversarial suite as the owning verification surface.
+
+## Risks / Trade-offs
+
+- [A broad timeout change weakens hostile assertions] → Leave the shared hostile default unchanged.
+- [A retry masks leaked state] → Keep exactly one healthy recovery attempt.
+- [Loaded Windows hosts remain variable] → Verify repeatedly on Windows and retain ordinary cross-platform CI.

--- a/openspec/changes/stabilize-parser-recovery-harness/proposal.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The Windows adversarial parser gate applied its 500 ms hostile-stall allowance to the healthy recovery probe, so normal launch scheduling could fail after correct hostile cleanup. The v0.4.1 test-harness correction needs durable issue ownership so release checklist validation covers the completed fix.
+
+## What Changes
+
+- Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance.
+- Preserve the short hostile-case budgets, exact typed failures, single launch attempt, and existing absolute test deadline.
+- Keep all production parser deadlines, protocol, containment, cancellation, and cleanup behavior unchanged.
+- Require repeated Windows adversarial success plus ordinary cross-platform CI.
+
+## Capabilities
+
+### New Capabilities
+
+- `parser-recovery-harness`: Defines the bounded distinction between hostile parser scenarios and the healthy recovery probe used by release tests.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The completed change affects only the adversarial parser-supervisor harness in `crates/projectatlas-cli/src/parser_supervisor.rs` and its release verification. Production runtime behavior, storage, dependencies, and public interfaces are unchanged.
+
+## Non-Goals
+
+- No production timeout or protocol change.
+- No relaxation of hostile-stall assertions.
+- No retry that could mask leaked process state.
+
+This release-scoped test-harness correction is implemented and ready for v0.4.1 verification.

--- a/openspec/changes/stabilize-parser-recovery-harness/proposal.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/proposal.md
@@ -5,7 +5,7 @@ The Windows adversarial parser gate applied its 500 ms hostile-stall allowance t
 ## What Changes
 
 - Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance.
-- Preserve the short hostile-case budgets, exact typed failures, single launch attempt, and existing absolute test deadline.
+- Preserve the short hostile-case budgets, exact typed failures, single launch attempt, and existing deadline for each attempt.
 - Keep all production parser deadlines, protocol, containment, cancellation, and cleanup behavior unchanged.
 - Require repeated Windows adversarial success plus ordinary cross-platform CI.
 

--- a/openspec/changes/stabilize-parser-recovery-harness/specs/parser-recovery-harness/spec.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/specs/parser-recovery-harness/spec.md
@@ -1,11 +1,11 @@
 ## ADDED Requirements
 
 ### Requirement: Separate healthy recovery tolerance
-The adversarial parser harness SHALL give the healthy probe after hostile cleanup a no-progress allowance distinct from the hostile-case allowance and MUST keep the existing absolute harness deadline.
+The adversarial parser harness SHALL give the healthy probe after hostile cleanup a no-progress allowance distinct from the hostile-case allowance and MUST keep one launch attempt with its existing attempt deadline.
 
 #### Scenario: Healthy recovery follows hostile cleanup
 - **WHEN** a hostile parser peer produces its expected typed failure and cleanup completes
-- **THEN** the single healthy recovery probe can use the platform-tolerant allowance without extending the absolute test deadline
+- **THEN** the single healthy recovery probe can use the platform-tolerant allowance without lengthening that attempt
 
 ### Requirement: Hostile cases retain strict bounds
 The adversarial parser harness MUST retain the short hostile no-progress bounds, exact typed failure expectations, containment checks, and cleanup requirements.

--- a/openspec/changes/stabilize-parser-recovery-harness/specs/parser-recovery-harness/spec.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/specs/parser-recovery-harness/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Separate healthy recovery tolerance
+The adversarial parser harness SHALL give the healthy probe after hostile cleanup a no-progress allowance distinct from the hostile-case allowance and MUST keep the existing absolute harness deadline.
+
+#### Scenario: Healthy recovery follows hostile cleanup
+- **WHEN** a hostile parser peer produces its expected typed failure and cleanup completes
+- **THEN** the single healthy recovery probe can use the platform-tolerant allowance without extending the absolute test deadline
+
+### Requirement: Hostile cases retain strict bounds
+The adversarial parser harness MUST retain the short hostile no-progress bounds, exact typed failure expectations, containment checks, and cleanup requirements.
+
+#### Scenario: Hostile peer stalls
+- **WHEN** a hostile parser fixture makes no progress
+- **THEN** the harness rejects it within the existing hostile bound and reports the expected typed failure
+
+### Requirement: Recovery verification remains release-grade
+The correction MUST be verified by repeated Windows adversarial runs and ordinary cross-platform workspace gates without changing production parser behavior.
+
+#### Scenario: Release verification runs
+- **WHEN** the parser recovery correction is evaluated for release
+- **THEN** repeated Windows adversarial coverage and ordinary cross-platform CI pass with production behavior unchanged

--- a/openspec/changes/stabilize-parser-recovery-harness/tasks.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Recovery Harness Correction
 
-- [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and the existing absolute deadline.
+- [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and its existing attempt deadline.
 - [x] 1.2 Preserve hostile-case no-progress bounds, exact typed failures, containment checks, and cleanup requirements.
 - [x] 1.3 Verify repeated adversarial-suite success on Windows.
 - [x] 1.4 Run the owning parser-supervisor tests and ordinary hosted cross-platform gates without changing production behavior.

--- a/openspec/changes/stabilize-parser-recovery-harness/tasks.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/tasks.md
@@ -1,0 +1,6 @@
+## 1. Recovery Harness Correction
+
+- [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and the existing absolute deadline.
+- [x] 1.2 Preserve hostile-case no-progress bounds, exact typed failures, containment checks, and cleanup requirements.
+- [x] 1.3 Verify repeated adversarial-suite success on Windows.
+- [x] 1.4 Run the owning parser-supervisor tests and ordinary hosted cross-platform gates without changing production behavior.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -24,6 +24,7 @@
     "isolate-linked-worktree-atlases": 382,
     "match-token-impact-reference-tui": 302,
     "migrate-released-database-layouts": 379,
+    "pin-sql-fixture-line-endings": 401,
     "persist-agent-project-context": {
       "contract": "checklist-v1",
       "primary_issue": 314,

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -9,6 +9,7 @@
     "centralize-cargo-dependency-management": 316,
     "close-mcp-cli-parity": 281,
     "complete-v040-release-readiness": 311,
+    "consolidate-projectatlas-landing-page": 381,
     "converge-claude-code-installer": 278,
     "converge-opencode-installer": 279,
     "delegate-bulk-purpose-curation": 301,
@@ -40,6 +41,7 @@
     "reuse-release-proof-by-inputs": 366,
     "reuse-unchanged-ci-build-layers": 341,
     "show-agent-efficiency-dashboard": 340,
-    "simplify-token-tui-dashboard": 296
+    "simplify-token-tui-dashboard": 296,
+    "stabilize-parser-recovery-harness": 391
   }
 }


### PR DESCRIPTION
## Summary

- map the completed v0.4.1 landing-page and parser-harness issues into OpenSpec so release milestone verification owns them
- pin SQL fixture checkouts to LF so embedded released-schema drift tests are deterministic on Windows and other platforms
- add the synchronized OpenSpec contract for #401 without changing production schema or migration behavior

## Verification

- `cargo test -p projectatlas-db` (152 passed)
- full pre-push ordinary gate, including workspace check/clippy/test/doc, 182 CLI/TUI tests, 100 E2E tests, 153 database tests in the workspace profile, installer boundaries, OpenSpec, and IssueOps
- system-scale and agent-navigation benchmarks remained historical and were not executed

Closes #401
