### PR TITLE
release: promote v0.4.1 stabilization correction (#401)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 *.md text eol=lf
 *.rs text eol=lf
 *.sh text eol=lf
+*.sql text eol=lf
 *.toml text eol=lf
 *.toon text eol=lf
 *.ts text eol=lf

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -5173,9 +5173,10 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         Worker(ParserFailureCode),
     }
 
+    const CONTROLLED_RECOVERY_PROGRESS_AGE: Duration = Duration::from_millis(550);
+
     struct Case {
         scenario: &'static str,
-        recovery_scenario: &'static str,
         expected: ExpectedFailure,
         source_bytes: usize,
         cancel_before_launch: bool,
@@ -5194,7 +5195,6 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     fn case(scenario: &'static str, expected: ExpectedFailure) -> io::Result<Case> {
         Ok(Case {
             scenario,
-            recovery_scenario: "healthy",
             expected,
             source_bytes: 32,
             cancel_before_launch: false,
@@ -5514,6 +5514,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     fn operate(
         peer: &Path,
         case: &Case,
+        initial_progress_age: Duration,
     ) -> Result<ParserCompletionEvidence, ParserSupervisorError> {
         let launch = test_launch(peer).map_err(|source| ParserSupervisorError::IoThread {
             phase: "adversarial test launch",
@@ -5524,13 +5525,14 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         if case.cancel_before_launch {
             cancellation.cancel();
         }
-        let now = Instant::now();
-        let deadline = now.checked_add(case.deadline).unwrap_or(now);
+        let started = Instant::now();
+        let last_progress = started.checked_sub(initial_progress_age).unwrap_or(started);
+        let deadline = started.checked_add(case.deadline).unwrap_or(started);
         let resident = ResidentParserSession::launch_command(
             &launch,
             grammar,
             ParserMemoryLimits::PRODUCTION,
-            now,
+            last_progress,
             deadline,
             case.no_progress,
             &cancellation,
@@ -5591,7 +5593,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     }
 
     fn require_failure(peer: &Path, hostile: &Case) -> io::Result<()> {
-        let Err(error) = operate(peer, hostile) else {
+        let Err(error) = operate(peer, hostile, Duration::ZERO) else {
             return Err(io::Error::other(format!(
                 "hostile scenario {} unexpectedly succeeded",
                 hostile.scenario
@@ -5610,8 +5612,13 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
             )));
         }
 
-        let mut healthy = case(hostile.recovery_scenario, ExpectedFailure::Io)?;
+        let mut healthy = case("healthy", ExpectedFailure::Io)?;
         healthy.no_progress = healthy.deadline;
+        let recovery_progress_age = if hostile.scenario == "pre-ready-stall" {
+            CONTROLLED_RECOVERY_PROGRESS_AGE
+        } else {
+            Duration::ZERO
+        };
         let cleanup_deadline = Instant::now() + healthy.deadline;
         while PROCESS_SPAWN_ACTIVE.load(Ordering::Acquire) && Instant::now() < cleanup_deadline {
             thread::yield_now();
@@ -5624,7 +5631,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         }
         require_process_spawn_cleanup_health()
             .map_err(|error| io::Error::other(error.to_string()))?;
-        let evidence = operate(peer, &healthy).map_err(|error| {
+        let evidence = operate(peer, &healthy, recovery_progress_age).map_err(|error| {
             io::Error::other(format!(
                 "healthy restart after {} failed: {error:?}",
                 hostile.scenario
@@ -5644,11 +5651,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
             opening_cancel.cancel_before_launch = true;
             opening_cancel
         },
-        {
-            let mut pre_ready_stall = case("pre-ready-stall", ExpectedFailure::NoProgress)?;
-            pre_ready_stall.recovery_scenario = "healthy-delayed";
-            pre_ready_stall
-        },
+        case("pre-ready-stall", ExpectedFailure::NoProgress)?,
         case("ready-session", ExpectedFailure::Ready("session"))?,
         case("ready-artifact", ExpectedFailure::Ready("artifact"))?,
         case("ready-containment", ExpectedFailure::Ready("containment"))?,

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -5175,6 +5175,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
 
     struct Case {
         scenario: &'static str,
+        recovery_scenario: &'static str,
         expected: ExpectedFailure,
         source_bytes: usize,
         cancel_before_launch: bool,
@@ -5193,6 +5194,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     fn case(scenario: &'static str, expected: ExpectedFailure) -> io::Result<Case> {
         Ok(Case {
             scenario,
+            recovery_scenario: "healthy",
             expected,
             source_bytes: 32,
             cancel_before_launch: false,
@@ -5608,7 +5610,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
             )));
         }
 
-        let mut healthy = case("healthy", ExpectedFailure::Io)?;
+        let mut healthy = case(hostile.recovery_scenario, ExpectedFailure::Io)?;
         healthy.no_progress = healthy.deadline;
         let cleanup_deadline = Instant::now() + healthy.deadline;
         while PROCESS_SPAWN_ACTIVE.load(Ordering::Acquire) && Instant::now() < cleanup_deadline {
@@ -5642,7 +5644,11 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
             opening_cancel.cancel_before_launch = true;
             opening_cancel
         },
-        case("pre-ready-stall", ExpectedFailure::NoProgress)?,
+        {
+            let mut pre_ready_stall = case("pre-ready-stall", ExpectedFailure::NoProgress)?;
+            pre_ready_stall.recovery_scenario = "healthy-delayed";
+            pre_ready_stall
+        },
         case("ready-session", ExpectedFailure::Ready("session"))?,
         case("ready-artifact", ExpectedFailure::Ready("artifact"))?,
         case("ready-containment", ExpectedFailure::Ready("containment"))?,

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -5173,7 +5173,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         Worker(ParserFailureCode),
     }
 
-    const CONTROLLED_RECOVERY_PROGRESS_AGE: Duration = Duration::from_millis(550);
+    const RECOVERY_ALLOWANCE_PROBE_AGE: Duration = Duration::from_millis(550);
 
     struct Case {
         scenario: &'static str,
@@ -5514,7 +5514,6 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     fn operate(
         peer: &Path,
         case: &Case,
-        initial_progress_age: Duration,
     ) -> Result<ParserCompletionEvidence, ParserSupervisorError> {
         let launch = test_launch(peer).map_err(|source| ParserSupervisorError::IoThread {
             phase: "adversarial test launch",
@@ -5525,14 +5524,13 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         if case.cancel_before_launch {
             cancellation.cancel();
         }
-        let started = Instant::now();
-        let last_progress = started.checked_sub(initial_progress_age).unwrap_or(started);
-        let deadline = started.checked_add(case.deadline).unwrap_or(started);
+        let now = Instant::now();
+        let deadline = now.checked_add(case.deadline).unwrap_or(now);
         let resident = ResidentParserSession::launch_command(
             &launch,
             grammar,
             ParserMemoryLimits::PRODUCTION,
-            last_progress,
+            now,
             deadline,
             case.no_progress,
             &cancellation,
@@ -5593,7 +5591,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     }
 
     fn require_failure(peer: &Path, hostile: &Case) -> io::Result<()> {
-        let Err(error) = operate(peer, hostile, Duration::ZERO) else {
+        let Err(error) = operate(peer, hostile) else {
             return Err(io::Error::other(format!(
                 "hostile scenario {} unexpectedly succeeded",
                 hostile.scenario
@@ -5614,11 +5612,15 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
 
         let mut healthy = case("healthy", ExpectedFailure::Io)?;
         healthy.no_progress = healthy.deadline;
-        let recovery_progress_age = if hostile.scenario == "pre-ready-stall" {
-            CONTROLLED_RECOVERY_PROGRESS_AGE
-        } else {
-            Duration::ZERO
-        };
+        if hostile.scenario == "pre-ready-stall"
+            && !(hostile.no_progress < RECOVERY_ALLOWANCE_PROBE_AGE
+                && RECOVERY_ALLOWANCE_PROBE_AGE < healthy.no_progress)
+        {
+            return Err(io::Error::other(format!(
+                "controlled recovery age {:?} must exceed hostile allowance {:?} and remain below healthy allowance {:?}",
+                RECOVERY_ALLOWANCE_PROBE_AGE, hostile.no_progress, healthy.no_progress
+            )));
+        }
         let cleanup_deadline = Instant::now() + healthy.deadline;
         while PROCESS_SPAWN_ACTIVE.load(Ordering::Acquire) && Instant::now() < cleanup_deadline {
             thread::yield_now();
@@ -5631,7 +5633,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         }
         require_process_spawn_cleanup_health()
             .map_err(|error| io::Error::other(error.to_string()))?;
-        let evidence = operate(peer, &healthy, recovery_progress_age).map_err(|error| {
+        let evidence = operate(peer, &healthy).map_err(|error| {
             io::Error::other(format!(
                 "healthy restart after {} failed: {error:?}",
                 hostile.scenario

--- a/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
+++ b/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
@@ -30,6 +30,8 @@ mod parser_supervisor;
 const TEST_ARTIFACT_BYTES: &[u8] = b"parser-supervisor-hostile-peer";
 /// Cargo-visible target name used for libtest-compatible substring filtering.
 const HARNESS_NAME: &str = "parser_supervisor_adversarial";
+/// Healthy completion delay beyond the hostile 500 ms no-progress budget.
+const DELAYED_HEALTHY_COMPLETION: Duration = Duration::from_millis(550);
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut arguments = env::args();
@@ -284,17 +286,22 @@ fn hostile_peer(scenario: &str) -> Result<(), Box<dyn std::error::Error>> {
             1,
             "source_file_with_a_deliberately_long_but_valid_name",
         )?,
-        "healthy" | "idle-close" => write_completion(
-            &mut output,
-            &request,
-            request.source().byte_len(),
-            1,
-            1,
-            "source_file",
-        )?,
+        "healthy" | "healthy-delayed" | "idle-close" => {
+            if scenario == "healthy-delayed" {
+                thread::sleep(DELAYED_HEALTHY_COMPLETION);
+            }
+            write_completion(
+                &mut output,
+                &request,
+                request.source().byte_len(),
+                1,
+                1,
+                "source_file",
+            )?;
+        }
         _ => {}
     }
-    if matches!(scenario, "healthy" | "idle-close") {
+    if matches!(scenario, "healthy" | "healthy-delayed" | "idle-close") {
         io::copy(&mut input, &mut io::sink())?;
     }
     Ok(())

--- a/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
+++ b/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
@@ -30,8 +30,6 @@ mod parser_supervisor;
 const TEST_ARTIFACT_BYTES: &[u8] = b"parser-supervisor-hostile-peer";
 /// Cargo-visible target name used for libtest-compatible substring filtering.
 const HARNESS_NAME: &str = "parser_supervisor_adversarial";
-/// Healthy completion delay beyond the hostile 500 ms no-progress budget.
-const DELAYED_HEALTHY_COMPLETION: Duration = Duration::from_millis(550);
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut arguments = env::args();
@@ -286,22 +284,17 @@ fn hostile_peer(scenario: &str) -> Result<(), Box<dyn std::error::Error>> {
             1,
             "source_file_with_a_deliberately_long_but_valid_name",
         )?,
-        "healthy" | "healthy-delayed" | "idle-close" => {
-            if scenario == "healthy-delayed" {
-                thread::sleep(DELAYED_HEALTHY_COMPLETION);
-            }
-            write_completion(
-                &mut output,
-                &request,
-                request.source().byte_len(),
-                1,
-                1,
-                "source_file",
-            )?;
-        }
+        "healthy" | "idle-close" => write_completion(
+            &mut output,
+            &request,
+            request.source().byte_len(),
+            1,
+            1,
+            "source_file",
+        )?,
         _ => {}
     }
-    if matches!(scenario, "healthy" | "healthy-delayed" | "idle-close") {
+    if matches!(scenario, "healthy" | "idle-close") {
         io::copy(&mut input, &mut io::sink())?;
     }
     Ok(())

--- a/openspec/changes/consolidate-projectatlas-landing-page/.openspec.yaml
+++ b/openspec/changes/consolidate-projectatlas-landing-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/consolidate-projectatlas-landing-page/design.md
+++ b/openspec/changes/consolidate-projectatlas-landing-page/design.md
@@ -1,0 +1,30 @@
+## Context
+
+The README is the GitHub landing page and must explain ProjectAtlas before routing readers to detailed documentation. The v0.4.1 revision already consolidated repeated prose, removed stale comparison material, and added the approved TUI screenshot.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep one concise Rust-native, local, large-codebase product statement.
+- Show the agent-first navigation flow and TUI without duplicating reference documentation.
+- Keep every performance statement scoped to its published workload.
+- Verify the real GitHub rendering at desktop and narrow widths in light and dark appearances.
+
+**Non-Goals:**
+
+- Redesign the TUI or rerun benchmarks.
+- Change runtime, installer, CLI, MCP, or database behavior.
+
+## Decisions
+
+- The README owns product positioning and discovery; detailed procedures remain in their existing documentation owners.
+- The repository-owned TUI screenshot is the primary product example and is paired with `projectatlas token --view tui`.
+- The large-application audit table stays adjacent to its chart so the workload qualifier is not separated from the result.
+- Visual acceptance is based on the rendered GitHub page, not Markdown source alone.
+
+## Risks / Trade-offs
+
+- [Linked documentation drifts] → Keep one owner per detailed topic and validate links.
+- [A screenshot becomes stale] → Track future TUI visual changes separately rather than expanding this release correction.
+- [Performance wording becomes universal] → Keep the workload qualifier adjacent to each result.

--- a/openspec/changes/consolidate-projectatlas-landing-page/proposal.md
+++ b/openspec/changes/consolidate-projectatlas-landing-page/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The ProjectAtlas landing page repeated product and operator material, obscured its Rust-native large-repository positioning, and retained an irrelevant historical comparison. The v0.4.1 documentation consolidation needs durable issue ownership so release checklist validation covers the work that already landed.
+
+## What Changes
+
+- Consolidate the opening, About explanation, installation choices, and documentation routing.
+- Present the token-impact TUI early with its exact terminal command.
+- Keep the representative large-application audit beside its chart and scope the claim to that workload.
+- Remove the historical v0.3.26 and plain-control comparison.
+- Align GitHub About metadata and verify the rendered landing page at desktop and narrow widths in light and dark appearances.
+
+## Capabilities
+
+### New Capabilities
+
+- `projectatlas-landing-page`: Defines the concise, agent-first ProjectAtlas landing-page content and visual-review contract.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The completed change affects `README.md`, its repository-owned visual assets, GitHub About metadata, and documentation links. It changes no runtime, CLI, MCP, database, package, or benchmark behavior.
+
+## Non-Goals
+
+- No TUI redesign.
+- No benchmark rerun or new performance claim.
+- No installer, CLI, MCP, database, or runtime behavior change.
+
+This release-scoped documentation change is implemented and ready for v0.4.1 verification.

--- a/openspec/changes/consolidate-projectatlas-landing-page/specs/projectatlas-landing-page/spec.md
+++ b/openspec/changes/consolidate-projectatlas-landing-page/specs/projectatlas-landing-page/spec.md
@@ -14,6 +14,20 @@ The landing page SHALL explain the purpose-to-graph-to-compact-evidence-to-exact
 - **WHEN** a reader follows a detailed ProjectAtlas topic from the landing page
 - **THEN** the reader reaches the owning document without a duplicated command inventory on the landing page
 
+### Requirement: Discoverable installation choices
+The landing page SHALL keep plugin, native release, and Cargo installation choices easy to find while routing full installation and repair procedures to their owning documentation.
+
+#### Scenario: Reader chooses an installation path
+- **WHEN** a reader looks for a supported way to install ProjectAtlas
+- **THEN** the landing page exposes the three installation choices without duplicating the complete installer procedure
+
+### Requirement: Synchronized repository metadata
+The GitHub About description and topics MUST remain aligned with the landing page's Rust-native, local, large-codebase, and coding-agent positioning.
+
+#### Scenario: Visitor discovers ProjectAtlas through GitHub metadata
+- **WHEN** GitHub displays the repository About metadata
+- **THEN** its description and topics reinforce the same concise positioning as the landing page
+
 ### Requirement: Visible TUI example and scoped evidence
 The landing page SHALL present the approved token-impact TUI with the exact `projectatlas token --view tui` command and SHALL keep the representative large-application audit result adjacent to its workload-specific qualifier.
 

--- a/openspec/changes/consolidate-projectatlas-landing-page/specs/projectatlas-landing-page/spec.md
+++ b/openspec/changes/consolidate-projectatlas-landing-page/specs/projectatlas-landing-page/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Concise product positioning
+The ProjectAtlas landing page SHALL identify ProjectAtlas as Rust-native, fast local repository intelligence for large codebases and SHALL explain its persistent coding-agent benefit without repeating the same product claim.
+
+#### Scenario: Visitor reads the first screen
+- **WHEN** a visitor opens the ProjectAtlas repository
+- **THEN** the first screen communicates the Rust-native local large-codebase purpose and agent benefit without historical comparison prose
+
+### Requirement: Agent-first workflow and documentation routing
+The landing page SHALL explain the purpose-to-graph-to-compact-evidence-to-exact-source workflow once and SHALL route detailed CLI, MCP, configuration, workflow, methodology, and architecture material to their owning documents.
+
+#### Scenario: Reader needs operational detail
+- **WHEN** a reader follows a detailed ProjectAtlas topic from the landing page
+- **THEN** the reader reaches the owning document without a duplicated command inventory on the landing page
+
+### Requirement: Visible TUI example and scoped evidence
+The landing page SHALL present the approved token-impact TUI with the exact `projectatlas token --view tui` command and SHALL keep the representative large-application audit result adjacent to its workload-specific qualifier.
+
+#### Scenario: Reader evaluates the product overview
+- **WHEN** a reader scans the landing page before the detailed evidence sections
+- **THEN** the TUI example is visible and the 99.8% result is explicitly limited to its one large-application audit
+
+### Requirement: Rendered landing-page review
+The landing page MUST remain readable on the actual GitHub rendering at desktop and narrow widths in light and dark appearances.
+
+#### Scenario: Visual review completes
+- **WHEN** the branch or pull-request README is inspected at the required widths and appearances
+- **THEN** text, screenshots, charts, wrapping, and links are readable without horizontal overflow

--- a/openspec/changes/consolidate-projectatlas-landing-page/tasks.md
+++ b/openspec/changes/consolidate-projectatlas-landing-page/tasks.md
@@ -1,0 +1,12 @@
+## 1. Landing Page Consolidation
+
+- [x] 1.1 Keep the first screen concise while combining Rust-native implementation, fast local operation, large-codebase intent, persistent repository intelligence, and the coding-agent benefit.
+- [x] 1.2 Keep one short About section for purposes -> graph relationships -> compact summaries/outlines -> exact source slices.
+- [x] 1.3 Add `Screenshot 2026-07-30 163043.png` as a repository-owned README asset with useful alt text and place it near the top beside the exact `projectatlas token --view tui` command.
+- [x] 1.4 Keep plugin, native release, and Cargo installation choices easy to find without duplicating the full installer procedure.
+- [x] 1.5 Replace detailed CLI/MCP call inventories and host-repair prose with concise summaries and links to the owning documentation.
+- [x] 1.6 Move the representative large-application audit table beside its chart lower on the page; keep 99.8% explicitly scoped to that one audit.
+- [x] 1.7 Remove the historical v0.3.26 comparison, the 3.9x medium-task result, and the plain-control comparison from the landing page.
+- [x] 1.8 Update GitHub About metadata to match the consolidated positioning.
+- [x] 1.9 Review the actual GitHub-rendered branch/PR page with Playwright at desktop and narrow widths in light and dark appearances; verify screenshot/chart legibility, wrapping, links, and horizontal overflow.
+- [x] 1.10 Run focused Markdown/link/issue checks without running the manual long navigation benchmark.

--- a/openspec/changes/pin-sql-fixture-line-endings/.openspec.yaml
+++ b/openspec/changes/pin-sql-fixture-line-endings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/pin-sql-fixture-line-endings/design.md
+++ b/openspec/changes/pin-sql-fixture-line-endings/design.md
@@ -1,0 +1,26 @@
+## Context
+
+`projectatlas-db` uses `include_str!` to embed captured schema-8 SQL fixtures. A focused drift test replaces exact LF-terminated DDL fragments. The repository already pins source and documentation formats in `.gitattributes`, but SQL was omitted and therefore inherited platform checkout conversion.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make embedded SQL fixture bytes deterministic on every supported checkout platform.
+- Preserve the strict semantic-drift test unchanged.
+- Verify the database suite on Windows.
+
+**Non-Goals:**
+
+- Change production migration code or accepted schema shapes.
+- Add runtime normalization or another fixture-loading layer.
+
+## Decisions
+
+- Add `*.sql text eol=lf` to the existing repository line-ending policy.
+- Retain the existing test mutations and fixtures so the regression remains observable if checkout normalization drifts again.
+
+## Risks / Trade-offs
+
+- Existing worktrees may retain CRLF files until refreshed; release verification uses a refreshed checkout and explicitly confirms LF checkout state.
+- Contributors editing SQL on Windows receive LF working-tree files, matching the embedded test contract and canonical Git blobs.

--- a/openspec/changes/pin-sql-fixture-line-endings/proposal.md
+++ b/openspec/changes/pin-sql-fixture-line-endings/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Released-schema tests embed captured SQL fixtures at compile time and mutate exact DDL fragments to prove incompatible drift is rejected. On Windows, Git checked those fixtures out with CRLF endings while the test mutations use LF, so the release gate failed before exercising schema validation.
+
+## What Changes
+
+- Pin repository SQL files to LF checkouts alongside the existing Rust, JSON, TOML, and documentation line-ending contracts.
+- Keep the released schema fixtures byte-stable across Windows, Linux, and macOS checkouts.
+- Verify the evolved released-schema drift test and the complete database test suite on Windows.
+
+## Capabilities
+
+### New Capabilities
+
+- `released-schema-fixture-portability`: Defines platform-independent checkout behavior for embedded released-schema fixtures.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The change affects only Git checkout normalization for `*.sql` files and release-gate verification. It does not change production schema DDL, migration logic, database contents, dependencies, or public interfaces.
+
+## Non-Goals
+
+- Changing schema admission or migration behavior.
+- Normalizing database contents at runtime.
+- Adding a custom line-ending parser or test abstraction.

--- a/openspec/changes/pin-sql-fixture-line-endings/specs/released-schema-fixture-portability/spec.md
+++ b/openspec/changes/pin-sql-fixture-line-endings/specs/released-schema-fixture-portability/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Embedded released-schema fixtures are platform independent
+
+The repository MUST check out SQL fixtures with LF line endings on every supported platform so compile-time embedded DDL has deterministic bytes.
+
+#### Scenario: Windows checkout embeds a released schema fixture
+
+- **WHEN** a released-schema SQL fixture is checked out and embedded during a Windows build
+- **THEN** its line endings match the canonical LF bytes used by the schema-drift tests
+
+### Requirement: Portability does not weaken schema validation
+
+The fixture portability correction MUST preserve production schema DDL, migration behavior, and strict rejection of incompatible released-schema drift.
+
+#### Scenario: A captured predecessor schema is changed semantically
+
+- **WHEN** the drift test removes, renames, adds, or changes a captured schema object
+- **THEN** preflight rejects the lookalike without mutating the database
+
+### Requirement: Database release gate covers the checkout contract
+
+Release verification MUST confirm SQL checkout normalization and run the owning drift test plus the complete database test suite on Windows.
+
+#### Scenario: The database release gate runs
+
+- **WHEN** the v0.4.1 database gate evaluates the portability correction
+- **THEN** LF checkout state, focused drift coverage, and all database tests pass

--- a/openspec/changes/pin-sql-fixture-line-endings/tasks.md
+++ b/openspec/changes/pin-sql-fixture-line-endings/tasks.md
@@ -2,4 +2,4 @@
 
 - [x] 1.1 Map `pin-sql-fixture-line-endings` to its GitHub issue and synchronize the issue checklist.
 - [x] 1.2 Pin repository SQL checkouts to LF without changing captured schema DDL or production migration behavior.
-- [x] 1.3 Verify LF checkout state, the evolved released-schema drift test, and the complete `projectatlas-db` test suite on Windows.
+- [x] 1.3 On Windows, run `git ls-files --eol -- crates/projectatlas-db/tests/fixtures/*.sql`, `cargo test --locked -p projectatlas-db schema::tests::evolved_released_schema_drift_is_refused_without_mutation -- --exact`, and `cargo test --locked -p projectatlas-db --all-features`, each with a 20-minute process timeout, to verify LF checkout state, the evolved released-schema drift test, and the complete database suite.

--- a/openspec/changes/pin-sql-fixture-line-endings/tasks.md
+++ b/openspec/changes/pin-sql-fixture-line-endings/tasks.md
@@ -1,0 +1,5 @@
+## 1. SQL Fixture Portability
+
+- [x] 1.1 Map `pin-sql-fixture-line-endings` to its GitHub issue and synchronize the issue checklist.
+- [x] 1.2 Pin repository SQL checkouts to LF without changing captured schema DDL or production migration behavior.
+- [x] 1.3 Verify LF checkout state, the evolved released-schema drift test, and the complete `projectatlas-db` test suite on Windows.

--- a/openspec/changes/stabilize-parser-recovery-harness/.openspec.yaml
+++ b/openspec/changes/stabilize-parser-recovery-harness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/stabilize-parser-recovery-harness/design.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/design.md
@@ -7,7 +7,7 @@ The adversarial parser-supervisor harness uses a short no-progress budget to kee
 **Goals:**
 
 - Separate the healthy recovery allowance from hostile-case stall budgets.
-- Preserve one healthy launch attempt and the existing absolute test deadline.
+- Preserve one healthy launch attempt and its existing two-second deadline.
 - Retain exact hostile failure classification, containment, and cleanup coverage.
 
 **Non-Goals:**
@@ -18,7 +18,7 @@ The adversarial parser-supervisor harness uses a short no-progress budget to kee
 ## Decisions
 
 - Override only the existing healthy recovery case's no-progress value.
-- Set the recovery allowance to the harness's existing absolute deadline, so the premature cutoff is removed without extending total test time.
+- Set the recovery allowance to the healthy attempt's existing deadline, so the premature cutoff is removed without lengthening that attempt.
 - Keep the existing adversarial suite as the owning verification surface.
 
 ## Risks / Trade-offs

--- a/openspec/changes/stabilize-parser-recovery-harness/design.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/design.md
@@ -1,0 +1,28 @@
+## Context
+
+The adversarial parser-supervisor harness uses a short no-progress budget to keep hostile stalls bounded. Reusing that same budget for the healthy post-failure recovery probe made the Windows release gate sensitive to ordinary launch scheduling.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Separate the healthy recovery allowance from hostile-case stall budgets.
+- Preserve one healthy launch attempt and the existing absolute test deadline.
+- Retain exact hostile failure classification, containment, and cleanup coverage.
+
+**Non-Goals:**
+
+- Change production parser deadlines, protocol, cancellation, containment, or cleanup.
+- Add retries or widen hostile-case bounds.
+
+## Decisions
+
+- Override only the existing healthy recovery case's no-progress value.
+- Set the recovery allowance to the harness's existing absolute deadline, so the premature cutoff is removed without extending total test time.
+- Keep the existing adversarial suite as the owning verification surface.
+
+## Risks / Trade-offs
+
+- [A broad timeout change weakens hostile assertions] → Leave the shared hostile default unchanged.
+- [A retry masks leaked state] → Keep exactly one healthy recovery attempt.
+- [Loaded Windows hosts remain variable] → Verify repeatedly on Windows and retain ordinary cross-platform CI.

--- a/openspec/changes/stabilize-parser-recovery-harness/proposal.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The Windows adversarial parser gate applied its 500 ms hostile-stall allowance to the healthy recovery probe, so normal launch scheduling could fail after correct hostile cleanup. The v0.4.1 test-harness correction needs durable issue ownership so release checklist validation covers the completed fix.
+
+## What Changes
+
+- Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance.
+- Preserve the short hostile-case budgets, exact typed failures, single launch attempt, and existing absolute test deadline.
+- Keep all production parser deadlines, protocol, containment, cancellation, and cleanup behavior unchanged.
+- Require repeated Windows adversarial success plus ordinary cross-platform CI.
+
+## Capabilities
+
+### New Capabilities
+
+- `parser-recovery-harness`: Defines the bounded distinction between hostile parser scenarios and the healthy recovery probe used by release tests.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The completed change affects only the adversarial parser-supervisor harness in `crates/projectatlas-cli/src/parser_supervisor.rs` and its release verification. Production runtime behavior, storage, dependencies, and public interfaces are unchanged.
+
+## Non-Goals
+
+- No production timeout or protocol change.
+- No relaxation of hostile-stall assertions.
+- No retry that could mask leaked process state.
+
+This release-scoped test-harness correction is implemented and ready for v0.4.1 verification.

--- a/openspec/changes/stabilize-parser-recovery-harness/proposal.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/proposal.md
@@ -5,7 +5,7 @@ The Windows adversarial parser gate applied its 500 ms hostile-stall allowance t
 ## What Changes
 
 - Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance.
-- Preserve the short hostile-case budgets, exact typed failures, single launch attempt, and existing absolute test deadline.
+- Preserve the short hostile-case budgets, exact typed failures, single launch attempt, and existing deadline for each attempt.
 - Keep all production parser deadlines, protocol, containment, cancellation, and cleanup behavior unchanged.
 - Require repeated Windows adversarial success plus ordinary cross-platform CI.
 

--- a/openspec/changes/stabilize-parser-recovery-harness/specs/parser-recovery-harness/spec.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/specs/parser-recovery-harness/spec.md
@@ -1,11 +1,11 @@
 ## ADDED Requirements
 
 ### Requirement: Separate healthy recovery tolerance
-The adversarial parser harness SHALL give the healthy probe after hostile cleanup a no-progress allowance distinct from the hostile-case allowance and MUST keep the existing absolute harness deadline.
+The adversarial parser harness SHALL give the healthy probe after hostile cleanup a no-progress allowance distinct from the hostile-case allowance and MUST keep one launch attempt with its existing attempt deadline.
 
 #### Scenario: Healthy recovery follows hostile cleanup
 - **WHEN** a hostile parser peer produces its expected typed failure and cleanup completes
-- **THEN** the single healthy recovery probe can use the platform-tolerant allowance without extending the absolute test deadline
+- **THEN** the single healthy recovery probe can use the platform-tolerant allowance without lengthening that attempt
 
 ### Requirement: Hostile cases retain strict bounds
 The adversarial parser harness MUST retain the short hostile no-progress bounds, exact typed failure expectations, containment checks, and cleanup requirements.

--- a/openspec/changes/stabilize-parser-recovery-harness/specs/parser-recovery-harness/spec.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/specs/parser-recovery-harness/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Separate healthy recovery tolerance
+The adversarial parser harness SHALL give the healthy probe after hostile cleanup a no-progress allowance distinct from the hostile-case allowance and MUST keep the existing absolute harness deadline.
+
+#### Scenario: Healthy recovery follows hostile cleanup
+- **WHEN** a hostile parser peer produces its expected typed failure and cleanup completes
+- **THEN** the single healthy recovery probe can use the platform-tolerant allowance without extending the absolute test deadline
+
+### Requirement: Hostile cases retain strict bounds
+The adversarial parser harness MUST retain the short hostile no-progress bounds, exact typed failure expectations, containment checks, and cleanup requirements.
+
+#### Scenario: Hostile peer stalls
+- **WHEN** a hostile parser fixture makes no progress
+- **THEN** the harness rejects it within the existing hostile bound and reports the expected typed failure
+
+### Requirement: Recovery verification remains release-grade
+The correction MUST be verified by repeated Windows adversarial runs and ordinary cross-platform workspace gates without changing production parser behavior.
+
+#### Scenario: Release verification runs
+- **WHEN** the parser recovery correction is evaluated for release
+- **THEN** repeated Windows adversarial coverage and ordinary cross-platform CI pass with production behavior unchanged

--- a/openspec/changes/stabilize-parser-recovery-harness/tasks.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/tasks.md
@@ -2,5 +2,5 @@
 
 - [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and its existing attempt deadline.
 - [x] 1.2 Preserve hostile-case no-progress bounds, exact typed failures, containment checks, and cleanup requirements.
-- [x] 1.3 Verify repeated adversarial-suite success on Windows, including one healthy recovery whose launch progress epoch is already 550 ms old so the suite deterministically exercises the interval beyond the hostile 500 ms no-progress bound and below the unchanged two-second attempt deadline.
+- [x] 1.3 Verify repeated adversarial-suite success on Windows and, before the post-stall healthy launch, probe its configured no-progress allowance at a synthetic 550 ms progress age so the suite deterministically rejects the hostile 500 ms bound without consuming any of the real two-second recovery window.
 - [x] 1.4 Run `cargo test --locked -p projectatlas-cli --test parser_supervisor_adversarial --all-features`, `cargo test --workspace --all-targets --all-features --locked`, and `cargo test --workspace --doc --all-features --locked` with a 20-minute timeout per command, then run `gh pr checks --watch --fail-fast` with a 60-minute timeout against the ordinary `01-CI` Windows/Linux/macOS x64/macOS arm64 gates without changing production behavior.

--- a/openspec/changes/stabilize-parser-recovery-harness/tasks.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/tasks.md
@@ -2,5 +2,5 @@
 
 - [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and its existing attempt deadline.
 - [x] 1.2 Preserve hostile-case no-progress bounds, exact typed failures, containment checks, and cleanup requirements.
-- [x] 1.3 Verify repeated adversarial-suite success on Windows.
-- [x] 1.4 Run `cargo test --locked -p projectatlas-cli --test parser_supervisor_adversarial --all-features`, `cargo test --workspace --all-targets --all-features --locked`, `cargo test --workspace --doc --all-features --locked`, and `gh pr checks --watch --fail-fast` against the ordinary `01-CI` Windows/Linux/macOS x64/macOS arm64 gates without changing production behavior.
+- [x] 1.3 Verify repeated adversarial-suite success on Windows, including one controlled healthy recovery completion after 550 ms so the suite deterministically exercises the interval beyond the hostile 500 ms no-progress bound and below the unchanged two-second attempt deadline.
+- [x] 1.4 Run `cargo test --locked -p projectatlas-cli --test parser_supervisor_adversarial --all-features`, `cargo test --workspace --all-targets --all-features --locked`, and `cargo test --workspace --doc --all-features --locked` with a 20-minute timeout per command, then run `gh pr checks --watch --fail-fast` with a 60-minute timeout against the ordinary `01-CI` Windows/Linux/macOS x64/macOS arm64 gates without changing production behavior.

--- a/openspec/changes/stabilize-parser-recovery-harness/tasks.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Recovery Harness Correction
 
-- [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and the existing absolute deadline.
+- [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and its existing attempt deadline.
 - [x] 1.2 Preserve hostile-case no-progress bounds, exact typed failures, containment checks, and cleanup requirements.
 - [x] 1.3 Verify repeated adversarial-suite success on Windows.
 - [x] 1.4 Run the owning parser-supervisor tests and ordinary hosted cross-platform gates without changing production behavior.

--- a/openspec/changes/stabilize-parser-recovery-harness/tasks.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/tasks.md
@@ -1,0 +1,6 @@
+## 1. Recovery Harness Correction
+
+- [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and the existing absolute deadline.
+- [x] 1.2 Preserve hostile-case no-progress bounds, exact typed failures, containment checks, and cleanup requirements.
+- [x] 1.3 Verify repeated adversarial-suite success on Windows.
+- [x] 1.4 Run the owning parser-supervisor tests and ordinary hosted cross-platform gates without changing production behavior.

--- a/openspec/changes/stabilize-parser-recovery-harness/tasks.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/tasks.md
@@ -3,4 +3,4 @@
 - [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and its existing attempt deadline.
 - [x] 1.2 Preserve hostile-case no-progress bounds, exact typed failures, containment checks, and cleanup requirements.
 - [x] 1.3 Verify repeated adversarial-suite success on Windows.
-- [x] 1.4 Run the owning parser-supervisor tests and ordinary hosted cross-platform gates without changing production behavior.
+- [x] 1.4 Run `cargo test --locked -p projectatlas-cli --test parser_supervisor_adversarial --all-features`, `cargo test --workspace --all-targets --all-features --locked`, `cargo test --workspace --doc --all-features --locked`, and `gh pr checks --watch --fail-fast` against the ordinary `01-CI` Windows/Linux/macOS x64/macOS arm64 gates without changing production behavior.

--- a/openspec/changes/stabilize-parser-recovery-harness/tasks.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/tasks.md
@@ -2,5 +2,5 @@
 
 - [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and its existing attempt deadline.
 - [x] 1.2 Preserve hostile-case no-progress bounds, exact typed failures, containment checks, and cleanup requirements.
-- [x] 1.3 Verify repeated adversarial-suite success on Windows, including one controlled healthy recovery completion after 550 ms so the suite deterministically exercises the interval beyond the hostile 500 ms no-progress bound and below the unchanged two-second attempt deadline.
+- [x] 1.3 Verify repeated adversarial-suite success on Windows, including one healthy recovery whose launch progress epoch is already 550 ms old so the suite deterministically exercises the interval beyond the hostile 500 ms no-progress bound and below the unchanged two-second attempt deadline.
 - [x] 1.4 Run `cargo test --locked -p projectatlas-cli --test parser_supervisor_adversarial --all-features`, `cargo test --workspace --all-targets --all-features --locked`, and `cargo test --workspace --doc --all-features --locked` with a 20-minute timeout per command, then run `gh pr checks --watch --fail-fast` with a 60-minute timeout against the ordinary `01-CI` Windows/Linux/macOS x64/macOS arm64 gates without changing production behavior.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -24,6 +24,7 @@
     "isolate-linked-worktree-atlases": 382,
     "match-token-impact-reference-tui": 302,
     "migrate-released-database-layouts": 379,
+    "pin-sql-fixture-line-endings": 401,
     "persist-agent-project-context": {
       "contract": "checklist-v1",
       "primary_issue": 314,

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -9,6 +9,7 @@
     "centralize-cargo-dependency-management": 316,
     "close-mcp-cli-parity": 281,
     "complete-v040-release-readiness": 311,
+    "consolidate-projectatlas-landing-page": 381,
     "converge-claude-code-installer": 278,
     "converge-opencode-installer": 279,
     "delegate-bulk-purpose-curation": 301,
@@ -40,6 +41,7 @@
     "reuse-release-proof-by-inputs": 366,
     "reuse-unchanged-ci-build-layers": 341,
     "show-agent-efficiency-dashboard": 340,
-    "simplify-token-tui-dashboard": 296
+    "simplify-token-tui-dashboard": 296,
+    "stabilize-parser-recovery-harness": 391
   }
 }


### PR DESCRIPTION
## Summary

Promote the exact v0.4.1 stabilization head from `dev` to `main` after PR #402:

- complete release-milestone OpenSpec ownership for #381 and #391
- make embedded released-schema SQL fixtures deterministic across platforms
- include the exact-head Codex review corrections and synchronized issue contracts

## Verification

- exact `dev` candidate passed hosted verify plus Windows, Linux, macOS x64, and macOS arm64 installer/MCP smoke gates
- exact-head Codex review found no major issues and all review threads are resolved
- system-scale and agent-navigation benchmarks remained historical and were not executed

Closes #401
