### PR TITLE
test(parser): prove recovery tolerance boundary

### DIFF
--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -5173,9 +5173,10 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         Worker(ParserFailureCode),
     }
 
+    const CONTROLLED_RECOVERY_PROGRESS_AGE: Duration = Duration::from_millis(550);
+
     struct Case {
         scenario: &'static str,
-        recovery_scenario: &'static str,
         expected: ExpectedFailure,
         source_bytes: usize,
         cancel_before_launch: bool,
@@ -5194,7 +5195,6 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     fn case(scenario: &'static str, expected: ExpectedFailure) -> io::Result<Case> {
         Ok(Case {
             scenario,
-            recovery_scenario: "healthy",
             expected,
             source_bytes: 32,
             cancel_before_launch: false,
@@ -5514,6 +5514,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     fn operate(
         peer: &Path,
         case: &Case,
+        initial_progress_age: Duration,
     ) -> Result<ParserCompletionEvidence, ParserSupervisorError> {
         let launch = test_launch(peer).map_err(|source| ParserSupervisorError::IoThread {
             phase: "adversarial test launch",
@@ -5524,13 +5525,14 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         if case.cancel_before_launch {
             cancellation.cancel();
         }
-        let now = Instant::now();
-        let deadline = now.checked_add(case.deadline).unwrap_or(now);
+        let started = Instant::now();
+        let last_progress = started.checked_sub(initial_progress_age).unwrap_or(started);
+        let deadline = started.checked_add(case.deadline).unwrap_or(started);
         let resident = ResidentParserSession::launch_command(
             &launch,
             grammar,
             ParserMemoryLimits::PRODUCTION,
-            now,
+            last_progress,
             deadline,
             case.no_progress,
             &cancellation,
@@ -5591,7 +5593,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     }
 
     fn require_failure(peer: &Path, hostile: &Case) -> io::Result<()> {
-        let Err(error) = operate(peer, hostile) else {
+        let Err(error) = operate(peer, hostile, Duration::ZERO) else {
             return Err(io::Error::other(format!(
                 "hostile scenario {} unexpectedly succeeded",
                 hostile.scenario
@@ -5610,8 +5612,13 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
             )));
         }
 
-        let mut healthy = case(hostile.recovery_scenario, ExpectedFailure::Io)?;
+        let mut healthy = case("healthy", ExpectedFailure::Io)?;
         healthy.no_progress = healthy.deadline;
+        let recovery_progress_age = if hostile.scenario == "pre-ready-stall" {
+            CONTROLLED_RECOVERY_PROGRESS_AGE
+        } else {
+            Duration::ZERO
+        };
         let cleanup_deadline = Instant::now() + healthy.deadline;
         while PROCESS_SPAWN_ACTIVE.load(Ordering::Acquire) && Instant::now() < cleanup_deadline {
             thread::yield_now();
@@ -5624,7 +5631,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         }
         require_process_spawn_cleanup_health()
             .map_err(|error| io::Error::other(error.to_string()))?;
-        let evidence = operate(peer, &healthy).map_err(|error| {
+        let evidence = operate(peer, &healthy, recovery_progress_age).map_err(|error| {
             io::Error::other(format!(
                 "healthy restart after {} failed: {error:?}",
                 hostile.scenario
@@ -5644,11 +5651,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
             opening_cancel.cancel_before_launch = true;
             opening_cancel
         },
-        {
-            let mut pre_ready_stall = case("pre-ready-stall", ExpectedFailure::NoProgress)?;
-            pre_ready_stall.recovery_scenario = "healthy-delayed";
-            pre_ready_stall
-        },
+        case("pre-ready-stall", ExpectedFailure::NoProgress)?,
         case("ready-session", ExpectedFailure::Ready("session"))?,
         case("ready-artifact", ExpectedFailure::Ready("artifact"))?,
         case("ready-containment", ExpectedFailure::Ready("containment"))?,

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -5175,6 +5175,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
 
     struct Case {
         scenario: &'static str,
+        recovery_scenario: &'static str,
         expected: ExpectedFailure,
         source_bytes: usize,
         cancel_before_launch: bool,
@@ -5193,6 +5194,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     fn case(scenario: &'static str, expected: ExpectedFailure) -> io::Result<Case> {
         Ok(Case {
             scenario,
+            recovery_scenario: "healthy",
             expected,
             source_bytes: 32,
             cancel_before_launch: false,
@@ -5608,7 +5610,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
             )));
         }
 
-        let mut healthy = case("healthy", ExpectedFailure::Io)?;
+        let mut healthy = case(hostile.recovery_scenario, ExpectedFailure::Io)?;
         healthy.no_progress = healthy.deadline;
         let cleanup_deadline = Instant::now() + healthy.deadline;
         while PROCESS_SPAWN_ACTIVE.load(Ordering::Acquire) && Instant::now() < cleanup_deadline {
@@ -5642,7 +5644,11 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
             opening_cancel.cancel_before_launch = true;
             opening_cancel
         },
-        case("pre-ready-stall", ExpectedFailure::NoProgress)?,
+        {
+            let mut pre_ready_stall = case("pre-ready-stall", ExpectedFailure::NoProgress)?;
+            pre_ready_stall.recovery_scenario = "healthy-delayed";
+            pre_ready_stall
+        },
         case("ready-session", ExpectedFailure::Ready("session"))?,
         case("ready-artifact", ExpectedFailure::Ready("artifact"))?,
         case("ready-containment", ExpectedFailure::Ready("containment"))?,

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -5173,7 +5173,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         Worker(ParserFailureCode),
     }
 
-    const CONTROLLED_RECOVERY_PROGRESS_AGE: Duration = Duration::from_millis(550);
+    const RECOVERY_ALLOWANCE_PROBE_AGE: Duration = Duration::from_millis(550);
 
     struct Case {
         scenario: &'static str,
@@ -5514,7 +5514,6 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     fn operate(
         peer: &Path,
         case: &Case,
-        initial_progress_age: Duration,
     ) -> Result<ParserCompletionEvidence, ParserSupervisorError> {
         let launch = test_launch(peer).map_err(|source| ParserSupervisorError::IoThread {
             phase: "adversarial test launch",
@@ -5525,14 +5524,13 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         if case.cancel_before_launch {
             cancellation.cancel();
         }
-        let started = Instant::now();
-        let last_progress = started.checked_sub(initial_progress_age).unwrap_or(started);
-        let deadline = started.checked_add(case.deadline).unwrap_or(started);
+        let now = Instant::now();
+        let deadline = now.checked_add(case.deadline).unwrap_or(now);
         let resident = ResidentParserSession::launch_command(
             &launch,
             grammar,
             ParserMemoryLimits::PRODUCTION,
-            last_progress,
+            now,
             deadline,
             case.no_progress,
             &cancellation,
@@ -5593,7 +5591,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     }
 
     fn require_failure(peer: &Path, hostile: &Case) -> io::Result<()> {
-        let Err(error) = operate(peer, hostile, Duration::ZERO) else {
+        let Err(error) = operate(peer, hostile) else {
             return Err(io::Error::other(format!(
                 "hostile scenario {} unexpectedly succeeded",
                 hostile.scenario
@@ -5614,11 +5612,15 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
 
         let mut healthy = case("healthy", ExpectedFailure::Io)?;
         healthy.no_progress = healthy.deadline;
-        let recovery_progress_age = if hostile.scenario == "pre-ready-stall" {
-            CONTROLLED_RECOVERY_PROGRESS_AGE
-        } else {
-            Duration::ZERO
-        };
+        if hostile.scenario == "pre-ready-stall"
+            && !(hostile.no_progress < RECOVERY_ALLOWANCE_PROBE_AGE
+                && RECOVERY_ALLOWANCE_PROBE_AGE < healthy.no_progress)
+        {
+            return Err(io::Error::other(format!(
+                "controlled recovery age {:?} must exceed hostile allowance {:?} and remain below healthy allowance {:?}",
+                RECOVERY_ALLOWANCE_PROBE_AGE, hostile.no_progress, healthy.no_progress
+            )));
+        }
         let cleanup_deadline = Instant::now() + healthy.deadline;
         while PROCESS_SPAWN_ACTIVE.load(Ordering::Acquire) && Instant::now() < cleanup_deadline {
             thread::yield_now();
@@ -5631,7 +5633,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         }
         require_process_spawn_cleanup_health()
             .map_err(|error| io::Error::other(error.to_string()))?;
-        let evidence = operate(peer, &healthy, recovery_progress_age).map_err(|error| {
+        let evidence = operate(peer, &healthy).map_err(|error| {
             io::Error::other(format!(
                 "healthy restart after {} failed: {error:?}",
                 hostile.scenario

--- a/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
+++ b/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
@@ -30,6 +30,8 @@ mod parser_supervisor;
 const TEST_ARTIFACT_BYTES: &[u8] = b"parser-supervisor-hostile-peer";
 /// Cargo-visible target name used for libtest-compatible substring filtering.
 const HARNESS_NAME: &str = "parser_supervisor_adversarial";
+/// Healthy completion delay beyond the hostile 500 ms no-progress budget.
+const DELAYED_HEALTHY_COMPLETION: Duration = Duration::from_millis(550);
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut arguments = env::args();
@@ -284,17 +286,22 @@ fn hostile_peer(scenario: &str) -> Result<(), Box<dyn std::error::Error>> {
             1,
             "source_file_with_a_deliberately_long_but_valid_name",
         )?,
-        "healthy" | "idle-close" => write_completion(
-            &mut output,
-            &request,
-            request.source().byte_len(),
-            1,
-            1,
-            "source_file",
-        )?,
+        "healthy" | "healthy-delayed" | "idle-close" => {
+            if scenario == "healthy-delayed" {
+                thread::sleep(DELAYED_HEALTHY_COMPLETION);
+            }
+            write_completion(
+                &mut output,
+                &request,
+                request.source().byte_len(),
+                1,
+                1,
+                "source_file",
+            )?;
+        }
         _ => {}
     }
-    if matches!(scenario, "healthy" | "idle-close") {
+    if matches!(scenario, "healthy" | "healthy-delayed" | "idle-close") {
         io::copy(&mut input, &mut io::sink())?;
     }
     Ok(())

--- a/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
+++ b/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
@@ -30,8 +30,6 @@ mod parser_supervisor;
 const TEST_ARTIFACT_BYTES: &[u8] = b"parser-supervisor-hostile-peer";
 /// Cargo-visible target name used for libtest-compatible substring filtering.
 const HARNESS_NAME: &str = "parser_supervisor_adversarial";
-/// Healthy completion delay beyond the hostile 500 ms no-progress budget.
-const DELAYED_HEALTHY_COMPLETION: Duration = Duration::from_millis(550);
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut arguments = env::args();
@@ -286,22 +284,17 @@ fn hostile_peer(scenario: &str) -> Result<(), Box<dyn std::error::Error>> {
             1,
             "source_file_with_a_deliberately_long_but_valid_name",
         )?,
-        "healthy" | "healthy-delayed" | "idle-close" => {
-            if scenario == "healthy-delayed" {
-                thread::sleep(DELAYED_HEALTHY_COMPLETION);
-            }
-            write_completion(
-                &mut output,
-                &request,
-                request.source().byte_len(),
-                1,
-                1,
-                "source_file",
-            )?;
-        }
+        "healthy" | "idle-close" => write_completion(
+            &mut output,
+            &request,
+            request.source().byte_len(),
+            1,
+            1,
+            "source_file",
+        )?,
         _ => {}
     }
-    if matches!(scenario, "healthy" | "healthy-delayed" | "idle-close") {
+    if matches!(scenario, "healthy" | "idle-close") {
         io::copy(&mut input, &mut io::sink())?;
     }
     Ok(())

--- a/openspec/changes/pin-sql-fixture-line-endings/tasks.md
+++ b/openspec/changes/pin-sql-fixture-line-endings/tasks.md
@@ -2,4 +2,4 @@
 
 - [x] 1.1 Map `pin-sql-fixture-line-endings` to its GitHub issue and synchronize the issue checklist.
 - [x] 1.2 Pin repository SQL checkouts to LF without changing captured schema DDL or production migration behavior.
-- [x] 1.3 Verify LF checkout state, the evolved released-schema drift test, and the complete `projectatlas-db` test suite on Windows.
+- [x] 1.3 On Windows, run `git ls-files --eol -- crates/projectatlas-db/tests/fixtures/*.sql`, `cargo test --locked -p projectatlas-db schema::tests::evolved_released_schema_drift_is_refused_without_mutation -- --exact`, and `cargo test --locked -p projectatlas-db --all-features`, each with a 20-minute process timeout, to verify LF checkout state, the evolved released-schema drift test, and the complete database suite.

--- a/openspec/changes/stabilize-parser-recovery-harness/tasks.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/tasks.md
@@ -2,5 +2,5 @@
 
 - [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and its existing attempt deadline.
 - [x] 1.2 Preserve hostile-case no-progress bounds, exact typed failures, containment checks, and cleanup requirements.
-- [x] 1.3 Verify repeated adversarial-suite success on Windows, including one healthy recovery whose launch progress epoch is already 550 ms old so the suite deterministically exercises the interval beyond the hostile 500 ms no-progress bound and below the unchanged two-second attempt deadline.
+- [x] 1.3 Verify repeated adversarial-suite success on Windows and, before the post-stall healthy launch, probe its configured no-progress allowance at a synthetic 550 ms progress age so the suite deterministically rejects the hostile 500 ms bound without consuming any of the real two-second recovery window.
 - [x] 1.4 Run `cargo test --locked -p projectatlas-cli --test parser_supervisor_adversarial --all-features`, `cargo test --workspace --all-targets --all-features --locked`, and `cargo test --workspace --doc --all-features --locked` with a 20-minute timeout per command, then run `gh pr checks --watch --fail-fast` with a 60-minute timeout against the ordinary `01-CI` Windows/Linux/macOS x64/macOS arm64 gates without changing production behavior.

--- a/openspec/changes/stabilize-parser-recovery-harness/tasks.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/tasks.md
@@ -2,5 +2,5 @@
 
 - [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and its existing attempt deadline.
 - [x] 1.2 Preserve hostile-case no-progress bounds, exact typed failures, containment checks, and cleanup requirements.
-- [x] 1.3 Verify repeated adversarial-suite success on Windows.
-- [x] 1.4 Run `cargo test --locked -p projectatlas-cli --test parser_supervisor_adversarial --all-features`, `cargo test --workspace --all-targets --all-features --locked`, `cargo test --workspace --doc --all-features --locked`, and `gh pr checks --watch --fail-fast` against the ordinary `01-CI` Windows/Linux/macOS x64/macOS arm64 gates without changing production behavior.
+- [x] 1.3 Verify repeated adversarial-suite success on Windows, including one controlled healthy recovery completion after 550 ms so the suite deterministically exercises the interval beyond the hostile 500 ms no-progress bound and below the unchanged two-second attempt deadline.
+- [x] 1.4 Run `cargo test --locked -p projectatlas-cli --test parser_supervisor_adversarial --all-features`, `cargo test --workspace --all-targets --all-features --locked`, and `cargo test --workspace --doc --all-features --locked` with a 20-minute timeout per command, then run `gh pr checks --watch --fail-fast` with a 60-minute timeout against the ordinary `01-CI` Windows/Linux/macOS x64/macOS arm64 gates without changing production behavior.

--- a/openspec/changes/stabilize-parser-recovery-harness/tasks.md
+++ b/openspec/changes/stabilize-parser-recovery-harness/tasks.md
@@ -2,5 +2,5 @@
 
 - [x] 1.1 Give only the post-failure healthy recovery probe a platform-tolerant no-progress allowance while retaining one launch attempt and its existing attempt deadline.
 - [x] 1.2 Preserve hostile-case no-progress bounds, exact typed failures, containment checks, and cleanup requirements.
-- [x] 1.3 Verify repeated adversarial-suite success on Windows, including one controlled healthy recovery completion after 550 ms so the suite deterministically exercises the interval beyond the hostile 500 ms no-progress bound and below the unchanged two-second attempt deadline.
+- [x] 1.3 Verify repeated adversarial-suite success on Windows, including one healthy recovery whose launch progress epoch is already 550 ms old so the suite deterministically exercises the interval beyond the hostile 500 ms no-progress bound and below the unchanged two-second attempt deadline.
 - [x] 1.4 Run `cargo test --locked -p projectatlas-cli --test parser_supervisor_adversarial --all-features`, `cargo test --workspace --all-targets --all-features --locked`, and `cargo test --workspace --doc --all-features --locked` with a 20-minute timeout per command, then run `gh pr checks --watch --fail-fast` with a 60-minute timeout against the ordinary `01-CI` Windows/Linux/macOS x64/macOS arm64 gates without changing production behavior.


### PR DESCRIPTION
## Summary

- exercise one post-hostile healthy recovery after 550 ms so the old 500 ms budget fails deterministically
- retain the existing two-second absolute deadline, hostile budgets, one launch attempt, and all production behavior
- record the exact parser and database verification commands plus process timeouts in the mirrored OpenSpec checklists

## Verification

- focused adversarial harness: pass with the recovery allowance; expected failure with the old 500 ms allowance; pass again after restoration
- focused parser Clippy and strict-string lint
- SQL fixtures report LF working-tree bytes
- focused evolved-schema drift test and all 153 projectatlas-db tests
- full ordinary local pre-push workspace, docs, installer, MCP/CLI, and issue-checklist gates

Refs #391 and #401.