### PR TITLE
Update README with installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ ProjectAtlas is a native Rust CLI and MCP server that keeps a project-local map 
 
 The map is deliberately agent-first: purposes identify the responsible area, graph relationships reveal connected code, compact summaries and outlines explain the selected files, and exact source slices provide the final evidence. Agents narrow before they read broadly.
 
+No required `.purpose` files. No source-header tax. No hosted index or credentials. Project state lives beside the repository in `.projectatlas/`.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ ProjectAtlas is a native Rust CLI and MCP server that keeps a project-local map 
 
 The map is deliberately agent-first: purposes identify the responsible area, graph relationships reveal connected code, compact summaries and outlines explain the selected files, and exact source slices provide the final evidence. Agents narrow before they read broadly.
 
-No required `.purpose` files. No source-header tax. No hosted index or credentials. Project state lives beside the repository in `.projectatlas/`.
 
 ## Install
+
+Point your agent to the ProjectAtlas GitHub repository and ask it to install the latest version of ProjectAtlas.
 
 The Codex plugin is the recommended path:
 


### PR DESCRIPTION
Added installation instructions for ProjectAtlas.

## Summary

Describe what this change does and why.

## Issue

Refs #381

Use `Closes #NNN` only when this pull request completes the issue.

## Checklist

- [ ] `projectatlas scan` run when indexed context changed.
- [ ] `projectatlas lint --report-untracked --purpose-level low` passes, and `projectatlas purpose queue` has been reviewed for touched high-value paths.
- [ ] `cargo fmt --all --check` clean.
- [ ] `cargo check --workspace --all-targets --all-features --locked` clean.
- [ ] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean.
- [ ] `cargo test --workspace --all-features --locked` and stable workspace doctests clean.
- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked` clean.
- [ ] Tests updated or added where behavior changed.
- [ ] All active OpenSpec changes are mapped in `openspec/issue-map.json`, linked issue task sections exactly mirror local task text and state, and `.github/scripts/issue-checklists.py` passes. Full issue and milestone completion is required only when closing or releasing, not for every incremental `dev` slice.
- [ ] README, Markdown docs, and GitHub Pages/rustdoc-facing content are updated or confirmed current for this change.
- [ ] PR text contains no private or internal-only details (release notes are generated from PR text).

