### PR TITLE
fix(cli): preflight implicit bare roots before SQLite

### DIFF
--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -61,10 +61,10 @@ use runtime::{
     PurposeReviewRequest, ScanRuntimePlan, SettingsReport, SymbolBuildOptions,
     UsageRuntimeInstance, WatchStatusReport, absolute_path, build_settings_report,
     byte_count_to_tokens, canonical_project_root, canonical_source_project_root,
-    config_root_mismatch_error, default_mcp_project_root, defaultable_cli_project_root,
-    estimated_source_tokens_for_indexed_files, estimated_source_tokens_for_paths,
-    index_work_control, init_config_path, init_path_status, lint_database_if_present,
-    next_step_report, next_step_report_payload, normalized_folder_filter,
+    config_root_mismatch_error, default_cli_project_root, default_mcp_project_root,
+    defaultable_cli_project_root, estimated_source_tokens_for_indexed_files,
+    estimated_source_tokens_for_paths, index_work_control, init_config_path, init_path_status,
+    lint_database_if_present, next_step_report, next_step_report_payload, normalized_folder_filter,
     open_atlas_store_for_project, open_atlas_store_read_only_for_project,
     open_federated_atlas_stores_for_project, open_fresh_atlas_store_for_project,
     purpose_curation_page, ranked_file_nodes_with_reasons, ranked_folder_nodes_with_reasons,
@@ -845,6 +845,35 @@ struct Cli {
     command: Box<Command>,
 }
 
+impl Cli {
+    /// Resolve this invocation's selected source root before opening an implicit database.
+    fn project_root(&self) -> Result<PathBuf, CliError> {
+        default_cli_project_root(
+            &self.db,
+            self.config.as_deref(),
+            self.database_path_is_explicit,
+        )
+    }
+
+    /// Resolve an optional command root using this invocation's database selection.
+    fn project_root_for_path(&self, path: &Path) -> Result<PathBuf, CliError> {
+        defaultable_cli_project_root(
+            path,
+            &self.db,
+            self.config.as_deref(),
+            self.database_path_is_explicit,
+        )
+    }
+
+    /// Validate only the implicit conventional root without changing explicit authority.
+    fn preflight_implicit_project_root(&self) -> Result<(), CliError> {
+        if !self.database_path_is_explicit && self.config.is_none() {
+            drop(self.project_root()?);
+        }
+        Ok(())
+    }
+}
+
 /// Supported `ProjectAtlas` CLI commands.
 #[derive(Debug, Subcommand)]
 enum Command {
@@ -1523,6 +1552,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                 write_stderr("Skipping ProjectAtlas map update in CI.\n")?;
                 return Ok(());
             }
+            cli.preflight_implicit_project_root()?;
             let config = load_cli_atlas_config(cli)?;
             write_map(&config, *json)?;
         }
@@ -1530,7 +1560,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
             path,
             text_index_max_bytes,
         } => {
-            let path = defaultable_cli_project_root(path, &cli.db, cli.config.as_deref())?;
+            let path = cli.project_root_for_path(path)?;
             let symbol_options = SymbolBuildOptions::new(MAX_SYMBOL_FILE_BYTES, None, None);
             let control = index_work_control(&symbol_options);
             let plan = ScanRuntimePlan::for_path_controlled(
@@ -1801,7 +1831,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                 max_workers,
                 timeout_seconds,
             } => {
-                let path = defaultable_cli_project_root(path, &cli.db, cli.config.as_deref())?;
+                let path = cli.project_root_for_path(path)?;
                 let options = SymbolBuildOptions::new(*max_bytes, *max_workers, *timeout_seconds);
                 let control = index_work_control(&options);
                 let plan = ScanRuntimePlan::for_path_controlled(
@@ -1910,7 +1940,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                         .with_timeout_ceiling(Duration::from_millis(10_000))
                 });
                 let mut federated_stores = if let Some(control) = federation_control.as_ref() {
-                    let selected_root = default_mcp_project_root(&cli.db, cli.config.as_deref())?;
+                    let selected_root = cli.project_root()?;
                     Some(open_federated_atlas_stores_for_project(
                         &cli.db,
                         &selected_root,
@@ -2187,6 +2217,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
             }
         },
         Command::Settings => {
+            cli.preflight_implicit_project_root()?;
             let report = build_settings_report(&cli.db, cli.config.as_deref(), cli.format)?;
             let toon = render_settings_report(&report);
             print_output(cli.format, &toon, &report)?;
@@ -2268,10 +2299,12 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                 print_output(cli.format, &render_root_report(&report), &report)?;
             }
             None | Some(RootCommand::Show) => {
+                cli.preflight_implicit_project_root()?;
                 let report = build_root_report(&cli.db, cli.config.as_deref())?;
                 print_output(cli.format, &render_root_report(&report), &report)?;
             }
             Some(RootCommand::Verify) => {
+                cli.preflight_implicit_project_root()?;
                 let report = build_root_report(&cli.db, cli.config.as_deref())?;
                 let verified = report.verified;
                 if verified {
@@ -2284,6 +2317,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
             }
         },
         Command::Config { print: _ } => {
+            cli.preflight_implicit_project_root()?;
             let config = load_cli_atlas_config(cli)?;
             let report = effective_config_report(&config);
             print_output(
@@ -2294,7 +2328,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
         }
         Command::Ignore { command } => match command {
             IgnoreCommand::List => {
-                let project_root = default_mcp_project_root(&cli.db, cli.config.as_deref())?;
+                let project_root = cli.project_root()?;
                 let report = list_ignore_entries(cli.config.as_deref(), &project_root)?;
                 print_output(
                     cli.format,
@@ -2303,7 +2337,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                 )?;
             }
             IgnoreCommand::InitGitignore => {
-                let project_root = default_mcp_project_root(&cli.db, cli.config.as_deref())?;
+                let project_root = cli.project_root()?;
                 let report = init_gitignore(cli.config.as_deref(), &project_root)?;
                 print_output(
                     cli.format,
@@ -2312,7 +2346,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                 )?;
             }
             IgnoreCommand::Add { kind, value } => {
-                let project_root = default_mcp_project_root(&cli.db, cli.config.as_deref())?;
+                let project_root = cli.project_root()?;
                 let report =
                     add_ignore_entry(cli.config.as_deref(), &project_root, (*kind).into(), value)?;
                 print_output(
@@ -2322,7 +2356,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
                 )?;
             }
             IgnoreCommand::Remove { kind, value } => {
-                let project_root = default_mcp_project_root(&cli.db, cli.config.as_deref())?;
+                let project_root = cli.project_root()?;
                 let report = remove_ignore_entry(
                     cli.config.as_deref(),
                     &project_root,
@@ -2350,7 +2384,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
             timeout_seconds,
             text_index_max_bytes,
         } => {
-            let path = defaultable_cli_project_root(path, &cli.db, cli.config.as_deref())?;
+            let path = cli.project_root_for_path(path)?;
             let symbol_options =
                 SymbolBuildOptions::new(MAX_SYMBOL_FILE_BYTES, *max_workers, *timeout_seconds);
             let report = if *once {
@@ -2485,6 +2519,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
             report_untracked,
             strict_untracked,
         } => {
+            cli.preflight_implicit_project_root()?;
             let config = load_cli_atlas_config(cli)?;
             let (mut report, mut exit_code) = lint_map(
                 &config,
@@ -2615,7 +2650,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
             dry_run,
             strip_source_headers,
         } => {
-            let path = defaultable_cli_project_root(path, &cli.db, cli.config.as_deref())?;
+            let path = cli.project_root_for_path(path)?;
             let report = strip_legacy_purpose(
                 &path,
                 cli.config.as_deref(),
@@ -2634,6 +2669,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
             dry_run,
             include_mcp_config,
         } => {
+            cli.preflight_implicit_project_root()?;
             let report = reset_index_files(&cli.db, *apply, *dry_run, *include_mcp_config)?;
             print_output(
                 cli.format,
@@ -2642,6 +2678,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
             )?;
         }
         Command::Mcp { nearest_project } => {
+            cli.preflight_implicit_project_root()?;
             mcp::run_mcp_server(
                 cli.db.clone(),
                 cli.config.clone(),
@@ -2654,6 +2691,7 @@ fn run(cli: &Cli) -> Result<(), CliError> {
             harness,
             nearest_project,
         } => {
+            cli.preflight_implicit_project_root()?;
             let report = build_harness_mcp_config_report(
                 *harness,
                 server_name,
@@ -2936,7 +2974,7 @@ fn database_filesystem_error_payload(
 
 /// Open the selected current index through one root-bound read snapshot.
 fn open_index_for_current_read(cli: &Cli) -> Result<AtlasStore, CliError> {
-    let root = default_mcp_project_root(&cli.db, cli.config.as_deref())?;
+    let root = cli.project_root()?;
     if !cli.db.is_file() {
         return Err(runtime::index_init_required(&root, &cli.db));
     }
@@ -2945,7 +2983,7 @@ fn open_index_for_current_read(cli: &Cli) -> Result<AtlasStore, CliError> {
 
 /// Open and verify the durable index before a normal CLI read.
 fn open_index_for_read(cli: &Cli) -> Result<AtlasStore, CliError> {
-    let root = default_mcp_project_root(&cli.db, cli.config.as_deref())?;
+    let root = cli.project_root()?;
     if !cli.db.is_file() {
         return Err(runtime::index_init_required(&root, &cli.db));
     }
@@ -2954,7 +2992,7 @@ fn open_index_for_read(cli: &Cli) -> Result<AtlasStore, CliError> {
 
 /// Open a selected project database for purpose or health mutation.
 fn open_index_for_mutation(cli: &Cli) -> Result<AtlasStore, CliError> {
-    let root = default_mcp_project_root(&cli.db, cli.config.as_deref())?;
+    let root = cli.project_root()?;
     if !cli.db.is_file() {
         return Err(runtime::index_init_required(&root, &cli.db));
     }

--- a/crates/projectatlas-cli/src/runtime.rs
+++ b/crates/projectatlas-cli/src/runtime.rs
@@ -2366,14 +2366,30 @@ pub(crate) fn default_mcp_project_root(
     canonical_source_project_root(&current_dir)
 }
 
+/// Resolve the default CLI project root before opening an implicit database.
+pub(crate) fn default_cli_project_root(
+    db: &Path,
+    config_path: Option<&Path>,
+    database_path_is_explicit: bool,
+) -> Result<PathBuf, CliError> {
+    if !database_path_is_explicit
+        && config_path.is_none()
+        && let Some(project_root) = project_root_from_db_path(db)
+    {
+        return canonical_source_project_root(&project_root);
+    }
+    default_mcp_project_root(db, config_path)
+}
+
 /// Resolve a CLI repository-root argument, using indexed state for the default `.`.
 pub(crate) fn defaultable_cli_project_root(
     path: &Path,
     db: &Path,
     config_path: Option<&Path>,
+    database_path_is_explicit: bool,
 ) -> Result<PathBuf, CliError> {
     if path == Path::new(".") {
-        return default_mcp_project_root(db, config_path);
+        return default_cli_project_root(db, config_path, database_path_is_explicit);
     }
     Ok(path.to_path_buf())
 }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -85,6 +85,7 @@ const SCANNED_RS_FILE_NAME: &str = "scanned.rs";
 const GIT_DIR_NAME: &str = ".git";
 const MAIN_CHECKOUT_DIR_NAME: &str = "main-checkout";
 const LINKED_CHECKOUTS_DIR_NAME: &str = "branches";
+const BARE_REPOSITORY_DIR_NAME: &str = "repository.git";
 const FEATURE_ONLY_RS_FILE_NAME: &str = "feature_only.rs";
 const ALTERNATE_ONLY_RS_FILE_NAME: &str = "alternate_only.rs";
 const OUTSIDE_CANARY_FILE_NAME: &str = "outside-canary.txt";
@@ -3310,7 +3311,7 @@ fn scan_refuses_unverified_registered_worktree_boundary_before_publication()
 #[test]
 fn git_control_roots_return_typed_worktree_guidance_without_state() -> Result<(), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
-    let bare = temp.path().join("repository.git");
+    let bare = temp.path().join(BARE_REPOSITORY_DIR_NAME);
     let output = StdCommand::new("git")
         .args(["init", "--bare"])
         .arg(&bare)
@@ -3344,6 +3345,45 @@ fn git_control_roots_return_typed_worktree_guidance_without_state() -> Result<()
         return Err(
             io::Error::other("common Git directory refusal created ProjectAtlas state").into(),
         );
+    }
+    let common_atlas_dir = common_git_dir.join(ATLAS_DIR_NAME);
+    fs::create_dir(&common_atlas_dir)?;
+    let common_database = common_atlas_dir.join("projectatlas.db");
+    {
+        let connection = Connection::open(&common_database)?;
+        connection.execute_batch(
+            "
+            CREATE TABLE metadata(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO metadata(key, value) VALUES('schema_version', '18');
+            CREATE TABLE authored_state(value TEXT NOT NULL);
+            INSERT INTO authored_state(value) VALUES('preserve-common-dir');
+            ",
+        )?;
+    }
+    let common_database_before = fs::read(&common_database)?;
+    let common_dir_settings = Command::cargo_bin("projectatlas")?
+        .current_dir(&common_git_dir)
+        .args(["--format", "json", "settings"])
+        .output()?;
+    if common_dir_settings.status.success() {
+        return Err(io::Error::other("common Git directory settings read succeeded").into());
+    }
+    let common_settings_error: Value = serde_json::from_slice(&common_dir_settings.stderr)?;
+    require_json_string(
+        &common_settings_error,
+        &["error", "kind"],
+        "worktree_required",
+    )?;
+    if fs::read(&common_database)? != common_database_before {
+        return Err(io::Error::other("common Git directory refusal changed database bytes").into());
+    }
+    for sidecar in ["projectatlas.db-wal", "projectatlas.db-shm"] {
+        if common_atlas_dir.join(sidecar).exists() {
+            return Err(io::Error::other(format!(
+                "common Git directory refusal created SQLite sidecar {sidecar}"
+            ))
+            .into());
+        }
     }
     let included_config = temp.path().join("included-bare.config");
     fs::write(&included_config, "[core]\n\tbare = true\n")?;
@@ -3441,6 +3481,263 @@ fn git_control_roots_return_typed_worktree_guidance_without_state() -> Result<()
         return Err(
             io::Error::other("structural control-root refusal created ProjectAtlas state").into(),
         );
+    }
+    Ok(())
+}
+
+#[test]
+fn implicit_bare_root_refuses_before_opening_a_future_schema_database() -> Result<(), Box<dyn Error>>
+{
+    let temp = tempfile::tempdir()?;
+    let bare = temp.path().join(BARE_REPOSITORY_DIR_NAME);
+    let output = StdCommand::new("git")
+        .args(["init", "--bare"])
+        .arg(&bare)
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "git init --bare failed: {}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ))
+        .into());
+    }
+
+    let atlas_dir = bare.join(ATLAS_DIR_NAME);
+    fs::create_dir(&atlas_dir)?;
+    let database = atlas_dir.join("projectatlas.db");
+    {
+        let connection = Connection::open(&database)?;
+        connection.execute_batch(
+            "
+            CREATE TABLE metadata(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO metadata(key, value) VALUES('schema_version', '18');
+            CREATE TABLE authored_state(value TEXT NOT NULL);
+            INSERT INTO authored_state(value) VALUES('preserve-me');
+            ",
+        )?;
+    }
+    let database_before = fs::read(&database)?;
+
+    let implicit = Command::cargo_bin("projectatlas")?
+        .current_dir(&bare)
+        .args(["--format", "json", "token", "--view", "tui"])
+        .output()?;
+    if implicit.status.success() {
+        return Err(io::Error::other("implicit bare-root token read succeeded").into());
+    }
+    let implicit_error: Value = serde_json::from_slice(&implicit.stderr)?;
+    require_json_string(&implicit_error, &["error", "kind"], "worktree_required")?;
+    if fs::read(&database)? != database_before {
+        return Err(
+            io::Error::other("bare-root refusal changed future-schema database bytes").into(),
+        );
+    }
+    for sidecar in ["projectatlas.db-wal", "projectatlas.db-shm"] {
+        if atlas_dir.join(sidecar).exists() {
+            return Err(io::Error::other(format!(
+                "bare-root refusal created SQLite sidecar {sidecar}"
+            ))
+            .into());
+        }
+    }
+
+    let explicit = Command::cargo_bin("projectatlas")?
+        .current_dir(&bare)
+        .args(["--format", "json", "--db"])
+        .arg(&database)
+        .args(["token", "--view", "tui"])
+        .output()?;
+    if explicit.status.success() {
+        return Err(io::Error::other("explicit future-schema token read succeeded").into());
+    }
+    let explicit_stderr = String::from_utf8_lossy(&explicit.stderr);
+    if !explicit_stderr.contains("unsupported schema version 18") {
+        return Err(io::Error::other(format!(
+            "explicit database selection hid schema error: {explicit_stderr}"
+        ))
+        .into());
+    }
+    if fs::read(&database)? != database_before {
+        return Err(
+            io::Error::other("explicit future-schema refusal changed database bytes").into(),
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn implicit_bare_root_refusal_is_database_state_agnostic() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    for state in ["absent", "compatible", "older-supported", "malformed"] {
+        let bare = temp.path().join(format!("{state}.git"));
+        let output = StdCommand::new("git")
+            .args(["init", "--bare"])
+            .arg(&bare)
+            .output()?;
+        if !output.status.success() {
+            return Err(io::Error::other(format!(
+                "git init --bare failed for {state}: {}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            ))
+            .into());
+        }
+
+        let atlas_dir = bare.join(ATLAS_DIR_NAME);
+        let database = atlas_dir.join("projectatlas.db");
+        match state {
+            "absent" => {}
+            "compatible" => {
+                fs::create_dir(&atlas_dir)?;
+                drop(AtlasStore::open(&database)?);
+            }
+            "older-supported" => {
+                fs::create_dir(&atlas_dir)?;
+                let connection = Connection::open(&database)?;
+                connection.execute_batch(
+                    "
+                    CREATE TABLE metadata(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                    INSERT INTO metadata(key, value) VALUES('schema_version', '8');
+                    CREATE TABLE authored_state(value TEXT NOT NULL);
+                    INSERT INTO authored_state(value) VALUES('preserve-me');
+                    ",
+                )?;
+            }
+            "malformed" => {
+                fs::create_dir(&atlas_dir)?;
+                fs::write(&database, b"not a SQLite database")?;
+            }
+            _ => unreachable!(),
+        }
+        let database_before = database.exists().then(|| fs::read(&database)).transpose()?;
+
+        let implicit = Command::cargo_bin("projectatlas")?
+            .current_dir(&bare)
+            .args(["--format", "json", "settings"])
+            .output()?;
+        if implicit.status.success() {
+            return Err(io::Error::other(format!(
+                "implicit bare-root settings succeeded for {state}"
+            ))
+            .into());
+        }
+        let error: Value = serde_json::from_slice(&implicit.stderr)?;
+        require_json_string(&error, &["error", "kind"], "worktree_required")?;
+        if database.exists().then(|| fs::read(&database)).transpose()? != database_before {
+            return Err(io::Error::other(format!(
+                "bare-root refusal changed {state} database state"
+            ))
+            .into());
+        }
+        for sidecar in ["projectatlas.db-wal", "projectatlas.db-shm"] {
+            if atlas_dir.join(sidecar).exists() {
+                return Err(io::Error::other(format!(
+                    "bare-root refusal created {sidecar} for {state} database state"
+                ))
+                .into());
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn implicit_bare_root_commands_preserve_live_wal_and_authored_state() -> Result<(), Box<dyn Error>>
+{
+    let temp = tempfile::tempdir()?;
+    let bare = temp.path().join(BARE_REPOSITORY_DIR_NAME);
+    let output = StdCommand::new("git")
+        .args(["init", "--bare"])
+        .arg(&bare)
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "git init --bare failed: {}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ))
+        .into());
+    }
+
+    let atlas_dir = bare.join(ATLAS_DIR_NAME);
+    fs::create_dir(&atlas_dir)?;
+    let database = atlas_dir.join("projectatlas.db");
+    drop(AtlasStore::open(&database)?);
+    let connection = Connection::open(&database)?;
+    let journal_mode: String =
+        connection.query_row("PRAGMA journal_mode = WAL", [], |row| row.get(0))?;
+    if journal_mode != "wal" {
+        return Err(
+            io::Error::other(format!("SQLite did not enter WAL mode: {journal_mode}")).into(),
+        );
+    }
+    connection.execute_batch(
+        "
+        PRAGMA wal_autocheckpoint = 0;
+        CREATE TABLE authored_state(value TEXT NOT NULL);
+        INSERT INTO authored_state(value) VALUES('preserve-purpose');
+        CREATE TABLE authored_telemetry(value TEXT NOT NULL);
+        INSERT INTO authored_telemetry(value) VALUES('preserve-telemetry');
+        ",
+    )?;
+    let config = atlas_dir.join("config.toml");
+    fs::write(&config, b"[scan]\nmax_file_bytes = 1000000\n")?;
+    let backup = atlas_dir.join("projectatlas.db.backup");
+    fs::write(&backup, b"preserve-backup")?;
+    let wal = atlas_dir.join("projectatlas.db-wal");
+    let shm = atlas_dir.join("projectatlas.db-shm");
+    if !wal.is_file() || !shm.is_file() {
+        return Err(io::Error::other("active WAL fixture did not create WAL and SHM files").into());
+    }
+    let preserved_paths = [database, wal, shm, config, backup];
+    let preserved_before = preserved_paths
+        .iter()
+        .map(fs::read)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let commands = [
+        ("settings", vec!["settings"]),
+        ("root show", vec!["root"]),
+        ("root verify", vec!["root", "verify"]),
+        ("map", vec!["map", "--force"]),
+        ("config", vec!["config", "--print"]),
+        ("lint", vec!["lint"]),
+        ("reset-index", vec!["reset-index", "--apply"]),
+        ("mcp", vec!["mcp"]),
+        ("mcp-config", vec!["mcp-config"]),
+    ];
+    for (name, arguments) in commands {
+        let implicit = Command::cargo_bin("projectatlas")?
+            .current_dir(&bare)
+            .args(["--format", "json"])
+            .args(arguments)
+            .output()?;
+        if implicit.status.success() {
+            return Err(
+                io::Error::other(format!("implicit bare-root {name} command succeeded")).into(),
+            );
+        }
+        let error: Value = serde_json::from_slice(&implicit.stderr)?;
+        require_json_string(&error, &["error", "kind"], "worktree_required")?;
+        let preserved_after = preserved_paths
+            .iter()
+            .map(fs::read)
+            .collect::<Result<Vec<_>, _>>()?;
+        if preserved_after != preserved_before {
+            return Err(io::Error::other(format!(
+                "implicit bare-root {name} command changed DB, WAL, SHM, config, or backup bytes"
+            ))
+            .into());
+        }
+    }
+
+    let purpose: String =
+        connection.query_row("SELECT value FROM authored_state", [], |row| row.get(0))?;
+    let telemetry: String =
+        connection.query_row("SELECT value FROM authored_telemetry", [], |row| row.get(0))?;
+    if purpose != "preserve-purpose" || telemetry != "preserve-telemetry" {
+        return Err(io::Error::other("bare-root refusal changed authored SQLite state").into());
     }
     Ok(())
 }
@@ -8384,6 +8681,57 @@ fn explicit_database_binding_is_used_by_cli_and_mcp_admin_surfaces() -> Result<(
             ))
             .into());
         }
+    }
+    Ok(())
+}
+
+#[test]
+fn generated_mcp_config_preserves_explicit_conventional_database_authority()
+-> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let source = temp.path().join("source");
+    let selected = temp.path().join("selected");
+    fs::create_dir_all(source.join(SRC_DIR_NAME))?;
+    fs::create_dir_all(selected.join(ATLAS_DIR_NAME))?;
+    fs::write(
+        source.join(SRC_DIR_NAME).join("main.rs"),
+        "pub fn stored_project_root_marker() {}\n",
+    )?;
+    let source_database = source.join(ATLAS_DIR_NAME).join("projectatlas.db");
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&source)
+        .arg("--db")
+        .arg(&source_database)
+        .args(["scan", "."])
+        .assert()
+        .success();
+
+    let selected_database = selected.join(ATLAS_DIR_NAME).join("projectatlas.db");
+    fs::copy(&source_database, &selected_database)?;
+    let mcp_config = mcp_config_for_harness(&source, &selected_database, "mcp-json")?;
+    let (mcp_command, mcp_args) = mcp_command_and_args(&mcp_config)?;
+    let mcp_output = run_mcp_stdio(
+        &mcp_command,
+        &source,
+        &mcp_args,
+        &[
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"projectatlas-e2e","version":"0.1.0"}}}"#,
+            r#"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"atlas_root","arguments":{}}}"#,
+        ],
+    )?;
+    let root = mcp_tool_text(&mcp_output, 2)?;
+    if !root.contains(&normalize_native_path_display(&source)) {
+        return Err(io::Error::other(format!(
+            "generated MCP config replaced stored project-root authority: {root}"
+        ))
+        .into());
+    }
+    if root.contains("project_mismatch") {
+        return Err(io::Error::other(format!(
+            "generated MCP config rebound copied conventional database: {root}"
+        ))
+        .into());
     }
     Ok(())
 }

--- a/openspec/changes/prefer-worktree-guidance-before-database-preflight/.openspec.yaml
+++ b/openspec/changes/prefer-worktree-guidance-before-database-preflight/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/prefer-worktree-guidance-before-database-preflight/design.md
+++ b/openspec/changes/prefer-worktree-guidance-before-database-preflight/design.md
@@ -1,0 +1,51 @@
+## Context
+
+CLI commands currently resolve the selected root through `default_mcp_project_root`. When the default `.projectatlas/projectatlas.db` exists, that function reads database metadata before validating whether the inferred source root is a checked-out worktree. A future-schema database can therefore fail before bare/common Git-root classification.
+
+Clap already records whether `--db` came from the command line. SQLite schema admission, explicit MCP configuration, and checked-out worktree isolation are existing authorities and must remain unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Classify an implicit CLI source root before opening its default database.
+- Preserve typed `worktree_required` and explicit schema-error contracts.
+- Apply the ordering consistently to CLI read, mutation, scan, watch, and root-defaulting paths.
+- Prove the refusal is non-mutating with a real SQLite fixture and platform E2E.
+
+**Non-Goals:**
+
+- Add a schema migration, downgrade, reset, or recovery copy.
+- Change explicitly configured MCP database selection.
+- Discover or select a sibling worktree automatically.
+- Add a dependency, crate, or generic path-routing layer.
+
+## Decisions
+
+1. Add one shared CLI root resolver that accepts the existing `database_path_is_explicit` fact.
+   - For an implicit conventional database with no explicit config, infer and validate its lexical root before database metadata access.
+   - For explicit databases and config-driven selection, reuse `default_mcp_project_root` so their current authority and diagnostics remain intact.
+   - Alternative rejected: reorder `default_mcp_project_root` universally, because that would hide truthful compatibility errors for explicit MCP and CLI database selection.
+
+2. Route every CLI default-root caller through private `Cli` helpers.
+   - This keeps Clap selection provenance at the CLI adapter and avoids duplicating the precedence rule across commands.
+   - Alternative rejected: add command-specific guards, because sibling commands would retain the same bug.
+
+3. Verify behavior with a real future-schema SQLite file in a bare repository.
+   - The test compares database bytes, rejects WAL/SHM creation, checks typed implicit guidance, and checks explicit schema diagnostics.
+   - Existing bare/common-root and linked-worktree E2E remains the compatibility boundary.
+
+## Risks / Trade-offs
+
+- **A caller bypasses the new CLI helper** → Search every root-defaulting caller and keep the helpers private to the parsed invocation.
+- **Explicit database diagnostics become hidden** → Exercise the same database through explicit `--db` and require its schema error.
+- **Root classification mutates SQLite indirectly** → Compare bytes and reject new WAL/SHM sidecars after the implicit refusal.
+- **Git root detection is slow or platform-sensitive** → Reuse the existing bounded classifier and verify Windows plus hosted Unix E2E; issue #409 separately owns its timeout diagnostics.
+
+## Migration Plan
+
+No data migration is required. Ship the resolver change in v0.4.2, retain the old runtime for rollback, and preserve every pre-existing database. Rolling back restores the previous diagnostic order but does not require state conversion.
+
+## Open Questions
+
+None.

--- a/openspec/changes/prefer-worktree-guidance-before-database-preflight/proposal.md
+++ b/openspec/changes/prefer-worktree-guidance-before-database-preflight/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+An implicit CLI command launched from a bare/common Git root can open that root's default ProjectAtlas database before rejecting the root as source. A preserved future-schema database then hides the actionable `worktree_required` guidance behind a schema error.
+
+## What Changes
+
+- Distinguish an implicit default database from an explicitly selected `--db` path.
+- Validate the implicit source root before opening SQLite.
+- Return typed `worktree_required` for bare/common roots without changing database or sidecar bytes.
+- Preserve truthful schema errors for explicitly selected databases.
+- Keep checked-out worktree, config-driven, and MCP database selection behavior unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `bare-root-worktree-guidance`: Defines root-selection precedence, typed refusal, and database preservation when an implicit command is launched from a bare/common Git root.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Shared CLI root selection in `crates/projectatlas-cli/src/runtime.rs`.
+- CLI command routing in `crates/projectatlas-cli/src/main.rs`.
+- CLI E2E coverage for bare Git roots and incompatible databases.
+- No new dependency, crate, database schema, migration, index, or public command is required.
+- This bugfix is ready for implementation in the v0.4.2 bugfix-only release.
+
+## Non-Goals
+
+- Downgrading, deleting, resetting, or migrating the preserved database.
+- Weakening compatibility errors for an explicitly selected database.
+- Silently selecting a sibling worktree.
+- Changing MCP's explicit generated database/config contract.

--- a/openspec/changes/prefer-worktree-guidance-before-database-preflight/specs/bare-root-worktree-guidance/spec.md
+++ b/openspec/changes/prefer-worktree-guidance-before-database-preflight/specs/bare-root-worktree-guidance/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Implicit bare roots are classified before database access
+ProjectAtlas SHALL validate the source-root role before opening an implicitly selected conventional database.
+
+#### Scenario: Bare root has a future-schema database
+- **WHEN** a CLI command uses the implicit default database from a bare/common Git root whose database schema is newer than the runtime
+- **THEN** ProjectAtlas returns typed `worktree_required` without opening or changing that database
+
+#### Scenario: Bare root has absent or compatible state
+- **WHEN** a CLI command uses the implicit default database from a bare/common Git root whose database is absent, current, older-supported, or malformed
+- **THEN** ProjectAtlas returns the same typed `worktree_required` source-selection contract before database admission
+
+### Requirement: Explicit database selection retains database diagnostics
+ProjectAtlas SHALL preserve compatibility diagnostics when a caller explicitly selects a database.
+
+#### Scenario: Explicit future-schema database
+- **WHEN** a caller passes `--db` for a future-schema database located beneath a bare/common Git root
+- **THEN** ProjectAtlas returns the truthful unsupported-schema error instead of replacing it with implicit worktree guidance
+
+### Requirement: Bare-root refusal is non-mutating
+ProjectAtlas MUST NOT mutate unselected repository or database state while producing worktree guidance.
+
+#### Scenario: Preserved database and SQLite sidecars
+- **WHEN** implicit bare-root classification refuses a command
+- **THEN** database, existing WAL/SHM, config, backup, purpose, and telemetry state remain unchanged and no SQLite sidecar is created
+
+### Requirement: Existing project selection remains isolated
+ProjectAtlas SHALL retain existing checked-out worktree, explicit config, and explicit MCP project-selection behavior.
+
+#### Scenario: Checked-out linked worktree
+- **WHEN** the same command runs from an initialized checked-out worktree
+- **THEN** ProjectAtlas uses only that worktree's project-local database and does not select a sibling
+
+#### Scenario: Explicit config or MCP database
+- **WHEN** a caller provides an explicit ProjectAtlas config, MCP `project_path`, or generated absolute database/config pair
+- **THEN** ProjectAtlas preserves that explicit selection and its existing wrong-root and missing-index diagnostics

--- a/openspec/changes/prefer-worktree-guidance-before-database-preflight/tasks.md
+++ b/openspec/changes/prefer-worktree-guidance-before-database-preflight/tasks.md
@@ -1,0 +1,15 @@
+## 1. Root Selection
+
+- [x] 1.1 Route every CLI default-root command through one resolver that validates an implicit conventional database root before SQLite access.
+- [x] 1.2 Preserve explicit `--db`, explicit config, MCP `project_path`, generated MCP config, wrong-root, and missing-index behavior.
+
+## 2. Non-Mutation and Compatibility
+
+- [x] 2.1 Add future-schema E2E coverage proving typed implicit `worktree_required`, byte invariance, no new WAL/SHM sidecars, and truthful explicit schema refusal.
+- [x] 2.2 Cover absent, compatible, older-supported, malformed, and pre-existing-sidecar root state without changing database, config, backup, purpose, or telemetry data.
+- [x] 2.3 Preserve bare repository, common Git directory, linked-worktree isolation, CLI/MCP parity, and no-sibling-selection behavior.
+
+## 3. Verification and Release Control
+
+- [ ] 3.1 Run Rust formatting, warnings-denied Clippy, CLI unit tests, and complete CLI E2E tests on Windows.
+- [ ] 3.2 Validate OpenSpec and issue checklist parity, then require behavior-relevant Linux, Windows, macOS x64, and macOS ARM64 hosted checks before closure.

--- a/openspec/changes/prefer-worktree-guidance-before-database-preflight/tasks.md
+++ b/openspec/changes/prefer-worktree-guidance-before-database-preflight/tasks.md
@@ -11,5 +11,5 @@
 
 ## 3. Verification and Release Control
 
-- [ ] 3.1 Run Rust formatting, warnings-denied Clippy, CLI unit tests, and complete CLI E2E tests on Windows.
-- [ ] 3.2 Validate OpenSpec and issue checklist parity, then require behavior-relevant Linux, Windows, macOS x64, and macOS ARM64 hosted checks before closure.
+- [x] 3.1 Run Rust formatting, warnings-denied Clippy, CLI unit tests, and complete CLI E2E tests on Windows.
+- [x] 3.2 Validate OpenSpec and issue checklist parity, then require behavior-relevant Linux, Windows, macOS x64, and macOS ARM64 hosted checks before closure.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -36,6 +36,7 @@
         }
       ]
     },
+    "prefer-worktree-guidance-before-database-preflight": 412,
     "publish-rustdoc-readme-links": 300,
     "report-installer-host-restart": 383,
     "resolve-configured-module-aliases": 385,


### PR DESCRIPTION
## Summary

- classify an implicit conventional project root before any SQLite access
- route every CLI default-root family, including reset-index and MCP startup, through invocation-aware preflight while preserving explicit DB/config/MCP authority
- prove future, compatible, older-marker, malformed, active WAL/SHM, common-Git-dir, and authored-state preservation behavior
- add and validate the `prefer-worktree-guidance-before-database-preflight` OpenSpec contract for #412

## Verification

The standard repository pre-push gate passed on Windows at final head `54f56a5`, including:

- formatting, workspace check, warnings-denied Clippy, strict strings, dependency policy
- complete workspace tests and doc tests
- complete CLI E2E: 104 passed, 1 expected artifact-dependent ignore
- installer trust boundaries: 5/5
- warnings-denied rustdoc
- ProjectAtlas scan/lint smoke
- OpenSpec strict validation and live issue checklist parity

All 7/7 OpenSpec tasks and issue checkboxes are synchronized. Hosted verify plus Linux, Windows, macOS x64, and macOS ARM64 E2E passed on behavior head `955978d`; the same required checks are running again for final metadata head `54f56a5` before merge.

Closes #412