### PR TITLE
fix(scan): accept UTF-8 BOM in compiler configs

### DIFF
--- a/crates/projectatlas-cli/src/runtime/module_resolution.rs
+++ b/crates/projectatlas-cli/src/runtime/module_resolution.rs
@@ -386,20 +386,27 @@ mod tests {
         let control = IndexWorkControl::new(IndexCancellation::new(), None);
 
         for config_path in ["tsconfig.json", "jsconfig.json"] {
-            let malformed = [UTF8_BOM, b"{"].concat();
-            fs::write(temp.path().join(config_path), &malformed)?;
-            match load_configured_module_resolution(
-                temp.path(),
-                &[config_node(config_path, &malformed)],
-                &control,
-            ) {
-                Err(CliError::InvalidInput(message))
-                    if message.contains("failed to parse compiler configuration") => {}
-                result => {
-                    return Err(std::io::Error::other(format!(
-                        "{config_path} malformed BOM input returned {result:?}"
-                    ))
-                    .into());
+            for (case, malformed) in [
+                ("after a leading BOM", [UTF8_BOM, b"{"].concat()),
+                (
+                    "with a complete BOM after byte zero",
+                    [b"{".as_slice(), UTF8_BOM, b"}".as_slice()].concat(),
+                ),
+            ] {
+                fs::write(temp.path().join(config_path), &malformed)?;
+                match load_configured_module_resolution(
+                    temp.path(),
+                    &[config_node(config_path, &malformed)],
+                    &control,
+                ) {
+                    Err(CliError::InvalidInput(message))
+                        if message.contains("failed to parse compiler configuration") => {}
+                    result => {
+                        return Err(std::io::Error::other(format!(
+                            "{config_path} malformed input {case} returned {result:?}"
+                        ))
+                        .into());
+                    }
                 }
             }
 

--- a/crates/projectatlas-cli/src/runtime/module_resolution.rs
+++ b/crates/projectatlas-cli/src/runtime/module_resolution.rs
@@ -18,6 +18,8 @@ use std::path::Path;
 const MAX_MODULE_CONFIG_FILE_BYTES: u64 = 1024 * 1024;
 /// Maximum aggregate compiler-configuration bytes retained by one graph stage.
 const MAX_MODULE_CONFIG_TOTAL_BYTES: u64 = 16 * 1024 * 1024;
+/// Optional byte-order mark accepted at the start of UTF-8 compiler configuration.
+const UTF8_BOM: &[u8] = b"\xEF\xBB\xBF";
 /// Work interval between cancellation/deadline checks while decoding mappings.
 const MODULE_CONFIG_CONTROL_INTERVAL: usize = 64;
 
@@ -87,14 +89,16 @@ pub(super) fn load_configured_module_resolution(
         if node.content_hash.as_deref() != Some(current_hash.as_str()) {
             return Err(source_changed_during_derivation(root, &node.path));
         }
-        let content = String::from_utf8(bytes).map_err(|_utf8_error| {
-            CliError::InvalidInput(format!(
-                "compiler configuration '{}' is not valid UTF-8",
-                node.path
-            ))
-        })?;
+        let content = std::str::from_utf8(bytes.strip_prefix(UTF8_BOM).unwrap_or(&bytes)).map_err(
+            |_utf8_error| {
+                CliError::InvalidInput(format!(
+                    "compiler configuration '{}' is not valid UTF-8",
+                    node.path
+                ))
+            },
+        )?;
         let value: Value =
-            parse_to_serde_value(&content, &JsoncParseOptions::default()).map_err(|error| {
+            parse_to_serde_value(content, &JsoncParseOptions::default()).map_err(|error| {
                 CliError::InvalidInput(format!(
                     "failed to parse compiler configuration '{}': {error}",
                     node.path
@@ -283,7 +287,7 @@ fn module_config_resource_limit(
 #[cfg(test)]
 mod tests {
     use super::{
-        CliError, MAX_MODULE_CONFIG_FILE_BYTES, MAX_MODULE_CONFIG_TOTAL_BYTES,
+        CliError, MAX_MODULE_CONFIG_FILE_BYTES, MAX_MODULE_CONFIG_TOTAL_BYTES, UTF8_BOM,
         claim_module_config_total, decode_config, load_configured_module_resolution,
         normalize_repository_target,
     };
@@ -340,6 +344,86 @@ mod tests {
             return Err(std::io::Error::other("expected both configured path mappings").into());
         }
         let _configured = projectatlas_symbols::ConfiguredModuleResolution::new(vec![config])?;
+        Ok(())
+    }
+
+    #[test]
+    fn compiler_config_loader_accepts_utf8_bom_for_both_config_kinds() -> Result<(), Box<dyn Error>>
+    {
+        let temp = tempfile::tempdir()?;
+        let content = br#"{"compilerOptions":{"baseUrl":"src"}}"#;
+        let control = IndexWorkControl::new(IndexCancellation::new(), None);
+
+        for config_path in ["tsconfig.json", "jsconfig.json"] {
+            fs::write(temp.path().join(config_path), content)?;
+            let plain = load_configured_module_resolution(
+                temp.path(),
+                &[config_node(config_path, content)],
+                &control,
+            )?;
+
+            let bom_content = [UTF8_BOM, content].concat();
+            fs::write(temp.path().join(config_path), &bom_content)?;
+            let with_bom = load_configured_module_resolution(
+                temp.path(),
+                &[config_node(config_path, &bom_content)],
+                &control,
+            )?;
+            if with_bom != plain {
+                return Err(std::io::Error::other(format!(
+                    "{config_path} decoded differently with a UTF-8 BOM"
+                ))
+                .into());
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn compiler_config_loader_rejects_malformed_and_non_utf8_after_bom()
+    -> Result<(), Box<dyn Error>> {
+        let temp = tempfile::tempdir()?;
+        let control = IndexWorkControl::new(IndexCancellation::new(), None);
+
+        for config_path in ["tsconfig.json", "jsconfig.json"] {
+            let malformed = [UTF8_BOM, b"{"].concat();
+            fs::write(temp.path().join(config_path), &malformed)?;
+            match load_configured_module_resolution(
+                temp.path(),
+                &[config_node(config_path, &malformed)],
+                &control,
+            ) {
+                Err(CliError::InvalidInput(message))
+                    if message.contains("failed to parse compiler configuration") => {}
+                result => {
+                    return Err(std::io::Error::other(format!(
+                        "{config_path} malformed BOM input returned {result:?}"
+                    ))
+                    .into());
+                }
+            }
+
+            for (case, non_utf8) in [
+                ("after a BOM", [UTF8_BOM, &[0xFF]].concat()),
+                ("with a partial BOM", b"\xEF\xBB{}".to_vec()),
+            ] {
+                fs::write(temp.path().join(config_path), &non_utf8)?;
+                match load_configured_module_resolution(
+                    temp.path(),
+                    &[config_node(config_path, &non_utf8)],
+                    &control,
+                ) {
+                    Err(CliError::InvalidInput(message))
+                        if message.contains("is not valid UTF-8") => {}
+                    result => {
+                        return Err(std::io::Error::other(format!(
+                            "{config_path} non-UTF-8 input {case} returned {result:?}"
+                        ))
+                        .into());
+                    }
+                }
+            }
+        }
         Ok(())
     }
 

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -15318,18 +15318,21 @@ fn normal_reads_do_not_serve_offline_stale_index_state() -> Result<(), Box<dyn E
 #[test]
 fn compiler_config_utf8_bom_refreshes_through_cli_and_mcp() -> Result<(), Box<dyn Error>> {
     const UTF8_BOM: &[u8] = b"\xEF\xBB\xBF";
+    const COMPILER_CONFIG: &[u8] =
+        br#"{"compilerOptions":{"baseUrl":"src","paths":{"@/*":["*"]}}}"#;
     let temp = tempfile::tempdir()?;
     let repo = temp.path().join("compiler-config-utf8-bom");
     fs::create_dir_all(repo.join(SRC_DIR_NAME))?;
     fs::write(
-        repo.join(SRC_DIR_NAME).join("index.ts"),
-        "export const value = 1;\n",
+        repo.join(SRC_DIR_NAME).join("controller.ts"),
+        "export function useController(): string { return \"ok\"; }\n",
+    )?;
+    fs::write(
+        repo.join(SRC_DIR_NAME).join("page.ts"),
+        "import { useController } from \"@/controller\";\nexport const value = useController();\n",
     )?;
     let config_path = repo.join("tsconfig.json");
-    fs::write(
-        &config_path,
-        [UTF8_BOM, br#"{"compilerOptions":{"baseUrl":"src"}}"#].concat(),
-    )?;
+    fs::write(&config_path, [UTF8_BOM, COMPILER_CONFIG].concat())?;
 
     let init = Command::cargo_bin("projectatlas")?
         .current_dir(&repo)
@@ -15345,37 +15348,75 @@ fn compiler_config_utf8_bom_refreshes_through_cli_and_mcp() -> Result<(), Box<dy
     }
     let db = repo.join(ATLAS_DIR_NAME).join("projectatlas.db");
     run_scan(&repo, &db)?;
-
-    fs::write(
-        &config_path,
-        [
-            UTF8_BOM,
-            br#"{"compilerOptions":{"baseUrl":"src","paths":{"@/*":["*"]}}}"#,
-        ]
-        .concat(),
+    let current_generation = || -> Result<usize, Box<dyn Error>> {
+        let generation = AtlasStore::open(&db)?
+            .index_publication()?
+            .ok_or_else(|| io::Error::other("compiler-config publication is missing"))?
+            .generation;
+        Ok(usize::try_from(generation.get())?)
+    };
+    let bom_relation = detailed_relation_payload(&repo, &db, "src/controller.ts", None, "inbound")?;
+    assert_detailed_resolution(&bom_relation, 1, "resolved")?;
+    require_json_usize(
+        &bom_relation,
+        &["symbol_relations", "generation"],
+        current_generation()?,
     )?;
+    let expected_alias_semantics = detailed_resolution_semantics(&bom_relation)
+        .ok_or_else(|| io::Error::other("initial alias relation omitted semantic fields"))?;
+
+    fs::write(&config_path, COMPILER_CONFIG)?;
     run_watch_once(&repo, &db)?;
-
-    fs::write(
-        &config_path,
-        [
-            UTF8_BOM,
-            br#"{// MCP refresh must use the same loader.
-"compilerOptions":{"baseUrl":"src"}}"#,
-        ]
-        .concat(),
+    let plain_relation =
+        detailed_relation_payload(&repo, &db, "src/controller.ts", None, "inbound")?;
+    assert_detailed_resolution(&plain_relation, 1, "resolved")?;
+    require_json_usize(
+        &plain_relation,
+        &["symbol_relations", "generation"],
+        current_generation()?,
     )?;
+    if detailed_resolution_semantics(&plain_relation) != Some(expected_alias_semantics) {
+        return Err(io::Error::other(
+            "CLI BOM-to-plain refresh changed configured alias semantics",
+        )
+        .into());
+    }
+
+    fs::write(&config_path, [UTF8_BOM, COMPILER_CONFIG].concat())?;
     let executable = assert_cmd::cargo::cargo_bin("projectatlas");
     let mut session = McpContractSession::spawn(&executable, &repo, &db)?;
     let report = session.call_tool(
         "atlas_watch_once",
-        &serde_json::json!({"project_path": repo, "path": repo}),
+        &serde_json::json!({"project_path": repo.as_path(), "path": repo.as_path()}),
     )?;
+    let mcp_relation: Value = toon_format::decode_default(&session.call_tool(
+        "atlas_symbol_relations",
+        &serde_json::json!({
+            "project_path": repo.as_path(),
+            "view": "detailed",
+            "compact": true,
+            "file": "src/controller.ts",
+            "direction": "inbound",
+            "limit": 10
+        }),
+    )?)?;
     session.shutdown()?;
     if !report.contains("watch:") || !report.contains("single-refresh") {
         return Err(io::Error::other(format!(
             "MCP watch did not report a successful BOM refresh: {report}"
         ))
+        .into());
+    }
+    assert_detailed_resolution(&mcp_relation, 1, "resolved")?;
+    require_json_usize(
+        &mcp_relation,
+        &["symbol_relations", "generation"],
+        current_generation()?,
+    )?;
+    if detailed_resolution_semantics(&mcp_relation) != Some(expected_alias_semantics) {
+        return Err(io::Error::other(
+            "MCP plain-to-BOM refresh changed configured alias semantics",
+        )
         .into());
     }
     Ok(())
@@ -15724,6 +15765,13 @@ fn assert_detailed_resolution(
         .into());
     }
     Ok(())
+}
+
+fn detailed_resolution_semantics(payload: &Value) -> Option<(&Value, &Value)> {
+    Some((
+        payload.pointer("/symbol_relations/rows/0/relation/kind")?,
+        payload.pointer("/symbol_relations/rows/0/relation/resolution/selector")?,
+    ))
 }
 
 #[test]

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -95,6 +95,7 @@ const GITHOOKS_DIR_NAME: &str = ".githooks";
 const ISSUE_TEMPLATE_DIR_NAME: &str = "ISSUE_TEMPLATE";
 const VERSIONS_DIR_NAME: &str = "versions";
 const PRE_PUSH_HOOK_FILE_NAME: &str = "pre-push";
+const TS_CONFIG_FILE_NAME: &str = "tsconfig.json";
 const GIT_REPOSITORY_ENVIRONMENT_VARIABLES: &[&str] = &[
     "GIT_ALTERNATE_OBJECT_DIRECTORIES",
     "GIT_CONFIG",
@@ -15331,7 +15332,7 @@ fn compiler_config_utf8_bom_refreshes_through_cli_and_mcp() -> Result<(), Box<dy
         repo.join(SRC_DIR_NAME).join("page.ts"),
         "import { useController } from \"@/controller\";\nexport const value = useController();\n",
     )?;
-    let config_path = repo.join("tsconfig.json");
+    let config_path = repo.join(TS_CONFIG_FILE_NAME);
     fs::write(&config_path, [UTF8_BOM, COMPILER_CONFIG].concat())?;
 
     let init = Command::cargo_bin("projectatlas")?
@@ -15454,7 +15455,7 @@ fn configured_module_aliases_resolve_across_adapters_and_refresh_atomically()
     fs::create_dir_all(&source)?;
     fs::create_dir_all(&js_source)?;
     let db = temp.path().join("configured-module-aliases.db");
-    let ts_config = repo.join("tsconfig.json");
+    let ts_config = repo.join(TS_CONFIG_FILE_NAME);
     let js_config = repo.join(JS_DIR_NAME).join("jsconfig.json");
     fs::write(&ts_config, TS_CONFIG)?;
     fs::write(&js_config, JS_CONFIG)?;

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -15316,6 +15316,72 @@ fn normal_reads_do_not_serve_offline_stale_index_state() -> Result<(), Box<dyn E
 }
 
 #[test]
+fn compiler_config_utf8_bom_refreshes_through_cli_and_mcp() -> Result<(), Box<dyn Error>> {
+    const UTF8_BOM: &[u8] = b"\xEF\xBB\xBF";
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("compiler-config-utf8-bom");
+    fs::create_dir_all(repo.join(SRC_DIR_NAME))?;
+    fs::write(
+        repo.join(SRC_DIR_NAME).join("index.ts"),
+        "export const value = 1;\n",
+    )?;
+    let config_path = repo.join("tsconfig.json");
+    fs::write(
+        &config_path,
+        [UTF8_BOM, br#"{"compilerOptions":{"baseUrl":"src"}}"#].concat(),
+    )?;
+
+    let init = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .env("PROJECTATLAS_NO_TELEMETRY", "1")
+        .args(["--format", "json", "init"])
+        .output()?;
+    if !init.status.success() {
+        return Err(io::Error::other(format!(
+            "init rejected UTF-8 BOM compiler configuration: {}",
+            String::from_utf8_lossy(&init.stderr)
+        ))
+        .into());
+    }
+    let db = repo.join(ATLAS_DIR_NAME).join("projectatlas.db");
+    run_scan(&repo, &db)?;
+
+    fs::write(
+        &config_path,
+        [
+            UTF8_BOM,
+            br#"{"compilerOptions":{"baseUrl":"src","paths":{"@/*":["*"]}}}"#,
+        ]
+        .concat(),
+    )?;
+    run_watch_once(&repo, &db)?;
+
+    fs::write(
+        &config_path,
+        [
+            UTF8_BOM,
+            br#"{// MCP refresh must use the same loader.
+"compilerOptions":{"baseUrl":"src"}}"#,
+        ]
+        .concat(),
+    )?;
+    let executable = assert_cmd::cargo::cargo_bin("projectatlas");
+    let mut session = McpContractSession::spawn(&executable, &repo, &db)?;
+    let report = session.call_tool(
+        "atlas_watch_once",
+        &serde_json::json!({"project_path": repo, "path": repo}),
+    )?;
+    session.shutdown()?;
+    if !report.contains("watch:") || !report.contains("single-refresh") {
+        return Err(io::Error::other(format!(
+            "MCP watch did not report a successful BOM refresh: {report}"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+#[test]
 fn configured_module_aliases_resolve_across_adapters_and_refresh_atomically()
 -> Result<(), Box<dyn Error>> {
     const ALTERNATE_DIR_NAME: &str = "alternate";

--- a/openspec/changes/accept-compiler-config-utf8-bom/.openspec.yaml
+++ b/openspec/changes/accept-compiler-config-utf8-bom/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/accept-compiler-config-utf8-bom/design.md
+++ b/openspec/changes/accept-compiler-config-utf8-bom/design.md
@@ -1,0 +1,29 @@
+## Context
+
+`load_configured_module_resolution` is the single filesystem boundary used by full and incremental graph staging. It already applies per-file and aggregate byte bounds, controlled reads, source-hash currentness, strict UTF-8 decoding, JSONC parsing, deadline/cancellation checks, and typed failures before either CLI or MCP publication. Its UTF-8 decoder currently receives the leading BOM and the JSONC parser rejects that character.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Treat one exact leading UTF-8 BOM as an encoding marker for both supported compiler-configuration basenames.
+- Keep the original bytes authoritative for size and source-currentness checks.
+- Preserve strict parse and non-UTF-8 failures and adapter-equivalent publication.
+
+**Non-Goals:**
+
+- Add another decoder, parser, dependency, or configuration abstraction.
+- Remove any prefix other than exact `EF BB BF` at byte zero.
+- Change configuration semantics, refresh selection, persistence, or public adapters.
+
+## Decisions
+
+- After the controlled read and hash comparison, borrow either the bytes following exact `EF BB BF` or the complete byte slice and pass that slice to the standard UTF-8 decoder. This keeps size/hash authority on the complete file, avoids a copy, and changes only the parser input.
+- Keep the behavior in `load_configured_module_resolution`, where both `tsconfig.json` and `jsconfig.json` and both full/incremental staging already converge. A command-specific guard would leave sibling adapters inconsistent.
+- Verify BOM/non-BOM equivalence and malformed/non-UTF-8 rejection directly at the loader, then use one focused real adapter test for CLI init/scan/watch and MCP watch refresh. No new test framework or fixture layer is needed.
+
+## Risks / Trade-offs
+
+- [A partial or misplaced BOM is accidentally accepted] → Match only the complete three-byte prefix at offset zero and retain strict UTF-8/JSONC errors otherwise.
+- [Size or currentness behavior drifts] → Perform stripping only after the existing complete-byte bounds and hash comparison.
+- [One refresh adapter remains broken] → Keep the production change in the shared loader and exercise the existing real CLI/MCP refresh entry points.

--- a/openspec/changes/accept-compiler-config-utf8-bom/proposal.md
+++ b/openspec/changes/accept-compiler-config-utf8-bom/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+ProjectAtlas rejects otherwise valid `tsconfig.json` and `jsconfig.json` files when their UTF-8 text begins with the optional `EF BB BF` byte-order mark. Because the shared compiler-configuration loader runs during full and incremental graph publication, the decode failure blocks `init`, `scan`, `watch --once`, and MCP refresh.
+
+## What Changes
+
+- Accept one exact UTF-8 BOM prefix before compiler-configuration UTF-8 decoding and JSONC parsing.
+- Preserve byte limits, source hashing/currentness, deadline and cancellation checks, and strict malformed or non-UTF-8 failures.
+- Cover both compiler-configuration filenames through the shared loader and the narrow real CLI/MCP refresh boundary.
+
+## Capabilities
+
+### New Capabilities
+
+- `compiler-config-utf8-decoding`: Defines equivalent compiler-configuration loading with or without an exact leading UTF-8 BOM.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The change affects only the existing compiler-configuration byte loader in `projectatlas-cli` and focused unit/E2E coverage. It adds no dependency, crate, schema, migration, public API, command, MCP tool, or persistence behavior.
+
+## Non-Goals
+
+- Accepting arbitrary leading bytes, malformed JSONC, or non-UTF-8 input.
+- Rewriting user configuration files or changing alias-resolution semantics.
+- Changing file-size accounting, source-currentness checks, refresh routing, or database publication.
+
+This v0.4.2 bug fix is ready for implementation.

--- a/openspec/changes/accept-compiler-config-utf8-bom/proposal.md
+++ b/openspec/changes/accept-compiler-config-utf8-bom/proposal.md
@@ -28,4 +28,4 @@ The change affects only the existing compiler-configuration byte loader in `proj
 - Rewriting user configuration files or changing alias-resolution semantics.
 - Changing file-size accounting, source-currentness checks, refresh routing, or database publication.
 
-This v0.4.2 bug fix is ready for implementation.
+This v0.4.3 bug fix is ready for implementation.

--- a/openspec/changes/accept-compiler-config-utf8-bom/specs/compiler-config-utf8-decoding/spec.md
+++ b/openspec/changes/accept-compiler-config-utf8-bom/specs/compiler-config-utf8-decoding/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Compiler configuration accepts an optional UTF-8 BOM
+
+ProjectAtlas SHALL decode `tsconfig.json` and `jsconfig.json` equivalently when valid UTF-8 JSONC begins either at byte zero or immediately after the exact `EF BB BF` prefix.
+
+#### Scenario: TypeScript configuration begins with a BOM
+
+- **WHEN** a valid `tsconfig.json` begins with exact UTF-8 BOM bytes
+- **THEN** `init`, `scan`, `watch --once`, and MCP refresh load the same compiler configuration as the equivalent non-BOM file
+
+#### Scenario: JavaScript configuration begins with a BOM
+
+- **WHEN** a valid `jsconfig.json` begins with exact UTF-8 BOM bytes
+- **THEN** the shared loader produces the same configured module resolution as the equivalent non-BOM file
+
+### Requirement: BOM handling preserves strict failure and work controls
+
+ProjectAtlas MUST strip only one exact leading UTF-8 BOM before decoding and parsing while retaining complete-file byte accounting, source-currentness checks, deadline/cancellation behavior, and typed malformed or non-UTF-8 failures.
+
+#### Scenario: JSONC is malformed after a BOM
+
+- **WHEN** an applicable compiler configuration has an exact leading UTF-8 BOM followed by malformed JSONC
+- **THEN** refresh returns the existing typed compiler-configuration parse failure without publishing a partial generation
+
+#### Scenario: Input is not valid UTF-8
+
+- **WHEN** a compiler configuration contains non-UTF-8 bytes with or without a leading UTF-8 BOM
+- **THEN** refresh returns the existing typed non-UTF-8 failure
+
+#### Scenario: Prefix is partial or misplaced
+
+- **WHEN** BOM-like bytes are incomplete or do not begin at byte zero
+- **THEN** they are not stripped and the existing strict decoder or parser behavior is preserved
+
+### Requirement: Refresh adapters share BOM behavior
+
+CLI and MCP refresh MUST use the same compiler-configuration loader and preserve equivalent generation-bound graph publication for BOM and non-BOM input.
+
+#### Scenario: Configuration changes between encoding forms
+
+- **WHEN** a CLI or MCP refresh observes an otherwise equivalent compiler configuration changed between BOM and non-BOM UTF-8
+- **THEN** refresh completes through the existing full or incremental publication path without changing alias-resolution semantics

--- a/openspec/changes/accept-compiler-config-utf8-bom/tasks.md
+++ b/openspec/changes/accept-compiler-config-utf8-bom/tasks.md
@@ -1,0 +1,6 @@
+## 1. Compiler Configuration UTF-8 BOM Support
+
+- [x] 1.1 Map `accept-compiler-config-utf8-bom` to GitHub issue #408 and keep the local OpenSpec artifacts internally consistent without mutating the remote issue.
+- [x] 1.2 Strip only one exact leading UTF-8 BOM at the shared compiler-configuration decode boundary while preserving complete-byte bounds/hash authority, deadline/cancellation behavior, parse failures, and non-UTF-8 rejection.
+- [x] 1.3 Add focused loader coverage for equivalent BOM/non-BOM `tsconfig.json` and `jsconfig.json`, malformed and non-UTF-8 input, plus one narrow real CLI/MCP refresh regression.
+- [x] 1.4 Run strict OpenSpec validation, the issue-checklist diagnostic, formatting, focused tests, and warnings-denied workspace Clippy with hard timeouts.

--- a/openspec/changes/accept-compiler-config-utf8-bom/tasks.md
+++ b/openspec/changes/accept-compiler-config-utf8-bom/tasks.md
@@ -3,4 +3,4 @@
 - [x] 1.1 Map `accept-compiler-config-utf8-bom` to GitHub issue #408 and keep the local OpenSpec artifacts internally consistent without mutating the remote issue.
 - [x] 1.2 Strip only one exact leading UTF-8 BOM at the shared compiler-configuration decode boundary while preserving complete-byte bounds/hash authority, deadline/cancellation behavior, parse failures, and non-UTF-8 rejection.
 - [x] 1.3 Add focused loader coverage for equivalent BOM/non-BOM `tsconfig.json` and `jsconfig.json`, malformed and non-UTF-8 input, plus one narrow real CLI/MCP refresh regression.
-- [x] 1.4 Run strict OpenSpec validation, the issue-checklist diagnostic, formatting, focused tests, and warnings-denied workspace Clippy with hard timeouts.
+- [ ] 1.4 Run strict OpenSpec validation, the issue-checklist diagnostic, formatting, focused tests, and warnings-denied workspace Clippy with hard timeouts.

--- a/openspec/changes/accept-compiler-config-utf8-bom/tasks.md
+++ b/openspec/changes/accept-compiler-config-utf8-bom/tasks.md
@@ -3,4 +3,4 @@
 - [x] 1.1 Map `accept-compiler-config-utf8-bom` to GitHub issue #408 and keep the local OpenSpec artifacts internally consistent without mutating the remote issue.
 - [x] 1.2 Strip only one exact leading UTF-8 BOM at the shared compiler-configuration decode boundary while preserving complete-byte bounds/hash authority, deadline/cancellation behavior, parse failures, and non-UTF-8 rejection.
 - [x] 1.3 Add focused loader coverage for equivalent BOM/non-BOM `tsconfig.json` and `jsconfig.json`, malformed and non-UTF-8 input, plus one narrow real CLI/MCP refresh regression.
-- [ ] 1.4 Run strict OpenSpec validation, the issue-checklist diagnostic, formatting, focused tests, and warnings-denied workspace Clippy with hard timeouts.
+- [x] 1.4 Run strict OpenSpec validation, the issue-checklist diagnostic, formatting, focused tests, and warnings-denied workspace Clippy with hard timeouts.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -1,6 +1,7 @@
 {
   "schema_version": 2,
   "changes": {
+    "accept-compiler-config-utf8-bom": 408,
     "add-agent-session-brief": 292,
     "add-mcp-task-progress-model": 295,
     "add-nearest-project-routing": 276,


### PR DESCRIPTION
## Summary

- accept one exact leading UTF-8 BOM in the shared `tsconfig.json` / `jsconfig.json` loader
- preserve complete-byte size, hash/currentness, cancellation, and strict malformed/non-UTF-8 behavior
- prove BOM-to-plain and plain-to-BOM CLI/MCP refreshes preserve generation-bound alias graph semantics
- add strict misplaced/partial BOM regression coverage and synchronize the `accept-compiler-config-utf8-bom` OpenSpec contract for v0.4.3

## Verification

The standard Windows pre-push gate passed at exact head `52804345a8c112b2fe1e2a3caf75ef6c295bba17`, including:

- formatting, all-target/all-feature workspace check, warnings-denied Clippy, strict string contracts, and dependency policy
- complete workspace tests and doc tests
- complete CLI E2E: 107 passed, 1 expected artifact-dependent ignore
- installer trust boundaries: 5/5
- warnings-denied rustdoc
- OpenSpec strict validation and live issue checklist parity at 4/4
- isolated ProjectAtlas scan/lint smoke
- accumulated #409 SwipingGale-shaped persistent MCP startup regression
- all 40 advertised MCP tools against their real SQLite effects
- BOM refresh and atomic-publication compatibility through real CLI and MCP paths

Independent review found no material code, architecture, correctness, security, performance, or coverage issue in the behavior change. Exact-head hosted Linux, Windows, macOS x64, and macOS arm64 checks plus Codex/review-thread disposition remain required before merge.

Closes #408