### PR TITLE
fix(parser): stabilize hostile fixture admission

### DIFF
--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -75,10 +75,34 @@ const ARTIFACT_ADMISSION_TIMEOUT: Duration = Duration::from_secs(15);
 const ARTIFACT_ADMISSION_AGGREGATE_TIMEOUT: Duration = Duration::from_secs(20 * 60);
 /// Maximum interval without meaningful worker progress during artifact admission.
 const ARTIFACT_ADMISSION_NO_PROGRESS_TIMEOUT: Duration = Duration::from_secs(5);
+/// Test-only launch allowance for hostile fixtures that do not stall admission.
+#[cfg(test)]
+const ADVERSARIAL_NON_STALL_LAUNCH_NO_PROGRESS: Duration = Duration::from_secs(2);
 /// Source bytes that force post-admission parser allocation through the Windows job limit.
 const WINDOWS_MEMORY_PROBE_SOURCE_BYTES: usize = 1024 * 1024;
 /// Declared maximum interval between sampled Linux resident-memory observations.
 pub const PARSER_LINUX_RSS_OBSERVATION_INTERVAL: Duration = Duration::from_millis(20);
+
+/// Select the launch/admission allowance without changing the operation allowance.
+#[cfg(test)]
+fn adversarial_launch_no_progress(scenario: &str, operation_no_progress: Duration) -> Duration {
+    match scenario {
+        "pre-ready-stall" | "admission-stall" => operation_no_progress,
+        _ => ADVERSARIAL_NON_STALL_LAUNCH_NO_PROGRESS,
+    }
+}
+
+/// Require an adversarial absolute-deadline failure from the intended protocol phase.
+#[cfg(test)]
+fn adversarial_deadline_matches(
+    error: &ParserSupervisorError,
+    expected_phase: &'static str,
+) -> bool {
+    matches!(
+        error,
+        ParserSupervisorError::DeadlineExceeded { phase } if *phase == expected_phase
+    )
+}
 
 /// Closed memory ceilings owned by one supervisor instance.
 #[derive(Clone, Copy)]
@@ -5161,7 +5185,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     #[derive(Clone, Copy)]
     enum ExpectedFailure {
         Cancelled,
-        Deadline,
+        Deadline(&'static str),
         InvalidAdmission,
         Io,
         NoProgress,
@@ -5209,10 +5233,13 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     fn error_matches(error: &ParserSupervisorError, expected: ExpectedFailure) -> bool {
         match (error, expected) {
             (ParserSupervisorError::Cancelled { .. }, ExpectedFailure::Cancelled)
-            | (ParserSupervisorError::DeadlineExceeded { .. }, ExpectedFailure::Deadline)
             | (ParserSupervisorError::InvalidAdmission, ExpectedFailure::InvalidAdmission)
             | (ParserSupervisorError::IoThread { .. }, ExpectedFailure::Io)
             | (ParserSupervisorError::NoProgress { .. }, ExpectedFailure::NoProgress) => true,
+            (
+                ParserSupervisorError::DeadlineExceeded { .. },
+                ExpectedFailure::Deadline(expected_phase),
+            ) => adversarial_deadline_matches(error, expected_phase),
             (
                 ParserSupervisorError::Protocol {
                     source: ParserProtocolError::ProgressRegression { field },
@@ -5349,7 +5376,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
             ParserMemoryLimits::PRODUCTION,
             Instant::now(),
             deadline,
-            Duration::from_secs(1),
+            ADVERSARIAL_NON_STALL_LAUNCH_NO_PROGRESS,
             &cancellation,
             command_for(peer, "idle-close")?,
         )
@@ -5447,7 +5474,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
                 ParserMemoryLimits::PRODUCTION,
                 Instant::now(),
                 deadline,
-                Duration::from_secs(1),
+                ADVERSARIAL_NON_STALL_LAUNCH_NO_PROGRESS,
                 &cancellation,
                 command_for(peer, "idle-close")?,
             )
@@ -5532,7 +5559,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
             ParserMemoryLimits::PRODUCTION,
             now,
             deadline,
-            case.no_progress,
+            adversarial_launch_no_progress(case.scenario, case.no_progress),
             &cancellation,
             command_for(peer, case.scenario).map_err(|source| ParserSupervisorError::IoThread {
                 phase: "adversarial test command",
@@ -5671,7 +5698,10 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
             "progress-regression",
             ExpectedFailure::Progress("completed_work"),
         )?,
-        case("progress-endless", ExpectedFailure::Deadline)?,
+        case(
+            "progress-endless",
+            ExpectedFailure::Deadline("request response"),
+        )?,
         case("progress-no-work", ExpectedFailure::NoProgress)?,
         case(
             "completion-malformed",
@@ -5707,7 +5737,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
     blocked_cancel.cancellation_after_launch = Some(Duration::from_millis(75));
     blocked_cancel.no_progress = Duration::from_secs(1);
     cases.push(blocked_cancel);
-    let mut blocked_deadline = case("blocked-write", ExpectedFailure::Deadline)?;
+    let mut blocked_deadline = case("blocked-write", ExpectedFailure::Deadline("request write"))?;
     blocked_deadline.source_bytes = 4 * 1024 * 1024;
     blocked_deadline.deadline_after_launch = Some(Duration::from_millis(125));
     blocked_deadline.no_progress = Duration::from_secs(1);
@@ -5716,7 +5746,7 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         .iter_mut()
         .find(|candidate| candidate.scenario == "progress-endless")
     {
-        progress_endless.deadline = Duration::from_millis(250);
+        progress_endless.deadline_after_launch = Some(Duration::from_millis(250));
         progress_endless.no_progress = Duration::from_secs(1);
     }
     if let Some(output_limit) = cases
@@ -5790,6 +5820,57 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn adversarial_launch_allowance_is_phase_specific_and_production_independent() {
+        let operation_no_progress = Duration::from_millis(500);
+        assert_eq!(
+            adversarial_launch_no_progress("pre-ready-stall", operation_no_progress),
+            operation_no_progress
+        );
+        assert_eq!(
+            adversarial_launch_no_progress("admission-stall", operation_no_progress),
+            operation_no_progress
+        );
+        for scenario in [
+            "progress-no-work",
+            "admission-forged",
+            "completion-malformed",
+        ] {
+            assert_eq!(
+                adversarial_launch_no_progress(scenario, operation_no_progress),
+                ADVERSARIAL_NON_STALL_LAUNCH_NO_PROGRESS
+            );
+        }
+        assert_eq!(ARTIFACT_ADMISSION_TIMEOUT, Duration::from_secs(15));
+        assert_eq!(
+            ARTIFACT_ADMISSION_AGGREGATE_TIMEOUT,
+            Duration::from_secs(20 * 60)
+        );
+        assert_eq!(
+            ARTIFACT_ADMISSION_NO_PROGRESS_TIMEOUT,
+            Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn adversarial_deadline_expectation_requires_the_exact_operation_phase() {
+        let delayed_admission = ParserSupervisorError::DeadlineExceeded {
+            phase: "containment admission",
+        };
+        assert!(!adversarial_deadline_matches(
+            &delayed_admission,
+            "request response"
+        ));
+
+        let response_deadline = ParserSupervisorError::DeadlineExceeded {
+            phase: "request response",
+        };
+        assert!(adversarial_deadline_matches(
+            &response_deadline,
+            "request response"
+        ));
     }
 
     #[test]

--- a/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
+++ b/crates/projectatlas-cli/tests/parser_supervisor_adversarial.rs
@@ -30,6 +30,8 @@ mod parser_supervisor;
 const TEST_ARTIFACT_BYTES: &[u8] = b"parser-supervisor-hostile-peer";
 /// Cargo-visible target name used for libtest-compatible substring filtering.
 const HARNESS_NAME: &str = "parser_supervisor_adversarial";
+/// Launch/admission delay that deliberately exceeds the progress-endless operation deadline.
+const PROGRESS_ENDLESS_LAUNCH_DELAY: Duration = Duration::from_millis(300);
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut arguments = env::args();
@@ -85,6 +87,10 @@ fn hostile_peer(scenario: &str) -> Result<(), Box<dyn std::error::Error>> {
     let mut input = io::stdin().lock();
     let mut output = io::stdout().lock();
     let mut diagnostic = io::stderr().lock();
+
+    if scenario == "progress-endless" {
+        thread::sleep(PROGRESS_ENDLESS_LAUNCH_DELAY);
+    }
 
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
     match scenario {

--- a/openspec/changes/stabilize-hostile-parser-fixture-admission/.openspec.yaml
+++ b/openspec/changes/stabilize-hostile-parser-fixture-admission/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/stabilize-hostile-parser-fixture-admission/design.md
+++ b/openspec/changes/stabilize-hostile-parser-fixture-admission/design.md
@@ -1,0 +1,30 @@
+## Context
+
+`run_adversarial_process_suite` owns test-only hostile peer policy. Its `Case::no_progress` value currently flows into both `ResidentParserSession::launch_command` and `ResidentParserSession::parse`, so the 500 ms operation-stall budget also limits ordinary Windows process creation and containment admission. The `progress-endless` fixture also replaces the shared case deadline before launch, allowing a launch or admission `DeadlineExceeded` to satisfy a broad deadline expectation without reaching the response phase. The same suite's resident-reuse preflight separately hardcodes a one-second launch/admission allowance.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the 500 ms bound at the phase intentionally stalled by pre-ready, admission, and progress-stall fixtures.
+- Let every other hostile fixture perform one bounded launch/admission attempt before its existing exact typed assertion.
+- Retain mandatory child/thread cleanup and keep all production parser constants unchanged.
+
+**Non-Goals:**
+
+- Retrying cases, weakening expected errors, changing production timing, or changing the #391 healthy-recovery policy.
+- Introducing a reusable policy framework for one test harness.
+
+## Decisions
+
+1. Add one test-only bounded non-stall launch/admission allowance at the existing harness owner. The closed pre-ready and admission stall scenarios retain the case's short no-progress value; all other cases and both resident-reuse launches use the non-stall allowance. This adds no production API or abstraction. A separate case type was rejected because the scenario set is closed inside one function.
+2. Continue passing `Case::no_progress` unchanged to `ResidentParserSession::parse`. Start any fixture-specific operation deadline only after successful launch/admission, leaving the ordinary bounded launch deadline intact. This preserves the progress-stall contract while preventing launch scheduling from consuming the response-phase deadline.
+3. Keep one `operate` call per hostile case and preserve `error_matches`, cleanup-failure rejection, process-spawn lease checks, and the healthy restart. Require deadline expectations to name their exact phase (`request response` for endless progress and `request write` for the blocked writer); an earlier launch/admission deadline is a mismatch. Retries were rejected because they could mask leaked ownership or a first-attempt cleanup failure.
+4. Protect the selector and exact deadline classification with focused deterministic checks and the complete process-owning adversarial suite. The progress-endless peer deliberately delays launch/admission longer than its later operation deadline, proving the two bounds are independent. The selector and comparison are constant-time and allocation-free; the fixture adds one bounded test-only sleep but no extra child processes, threads, filesystem I/O, persistent bytes, or storage work.
+
+## Risks / Trade-offs
+
+- [A newly added launch-stall scenario is not classified as short] -> Keep the closed selector and its focused positive/negative classification coverage beside the harness.
+- [A longer launch allowance hides a leaked child] -> Preserve one attempt plus the existing mandatory cleanup, process-spawn lease, and healthy-restart checks after every case.
+- [An operation deadline is accidentally reused for launch or a broad match accepts the wrong phase] -> Delay the deadline-owned peer before admission, derive its deadline after launch, and match the exact operation phase.
+- [Test policy drifts into production] -> Keep all new names and logic under `cfg(test)` and assert the relevant production admission constants remain unchanged.

--- a/openspec/changes/stabilize-hostile-parser-fixture-admission/proposal.md
+++ b/openspec/changes/stabilize-hostile-parser-fixture-admission/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The Windows adversarial parser harness applies its 500 ms deliberate-stall allowance to process launch and containment admission for every hostile fixture. On loaded hosts, non-stall fixtures can therefore fail with an unrelated admission `NoProgress` result before reaching the exact protocol, I/O, limit, cancellation, or deadline behavior they own.
+
+## What Changes
+
+- Classify hostile fixtures by whether their expected behavior intentionally depends on a short launch/admission no-progress bound.
+- Give non-stall fixtures one separate bounded launch/admission allowance while preserving their existing operation bounds, single attempt, exact typed assertions, and mandatory cleanup.
+- Add deterministic harness-policy coverage and repeatedly run the complete Windows adversarial suite without changing production parser budgets.
+
+## Capabilities
+
+### New Capabilities
+
+- `hostile-parser-fixture-admission`: Defines phase-specific adversarial-harness allowances, exact failure expectations, and cleanup proof for hostile parser fixtures.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The change is ready for implementation and is limited to the test-only adversarial policy in `crates/projectatlas-cli/src/parser_supervisor.rs`, its focused coverage, and OpenSpec routing. Production parser deadlines, no-progress limits, containment, protocol validation, resource limits, cancellation, and public APIs remain unchanged; no dependency or storage change is required.
+
+## Non-Goals
+
+- Retrying a hostile fixture after launch or admission failure.
+- Accepting an unrelated admission timeout in place of a fixture's exact typed result.
+- Changing the healthy-only recovery allowance from #391 or any production supervisor constant.

--- a/openspec/changes/stabilize-hostile-parser-fixture-admission/specs/hostile-parser-fixture-admission/spec.md
+++ b/openspec/changes/stabilize-hostile-parser-fixture-admission/specs/hostile-parser-fixture-admission/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Hostile fixture allowances are phase-specific
+The adversarial parser harness MUST retain the short no-progress allowance for the phase intentionally stalled by pre-ready, containment-admission, and progress-stall fixtures. A hostile fixture that does not intentionally stall launch or admission SHALL receive one separate bounded launch/admission no-progress allowance before its operation uses the fixture's existing no-progress and deadline policy. A fixture-specific operation deadline MUST begin only after launch/admission succeeds.
+
+#### Scenario: Launch or admission stall remains short
+- **WHEN** a pre-ready or containment-admission fixture intentionally makes no launch progress
+- **THEN** the harness returns the exact typed no-progress failure within the short hostile allowance
+
+#### Scenario: Progress stall remains short after admission
+- **WHEN** a progress-stall fixture launches and admits successfully but then makes no meaningful parse progress
+- **THEN** the harness applies the short operation allowance and returns the exact typed no-progress failure
+
+#### Scenario: Non-stall hostile fixture reaches its behavior
+- **WHEN** a non-stall hostile fixture runs on a loaded supported host
+- **THEN** one bounded launch/admission attempt reaches and proves the fixture's exact protocol, I/O, limit, cancellation, or deadline result without accepting an unrelated admission timeout
+
+#### Scenario: Response deadline is independent from delayed launch
+- **WHEN** the endless-progress fixture spends longer than its operation deadline in launch/admission before successfully reaching request processing
+- **THEN** its post-launch operation expires with `DeadlineExceeded` during `request response`, and a launch/admission deadline does not satisfy that expectation
+
+### Requirement: Fixture isolation remains strict
+The adversarial parser harness MUST NOT retry hostile cases, MUST reject weakened or mismatched typed results, and MUST complete mandatory process, pipe, reap, and thread cleanup before continuing. Test-only allowances MUST NOT change production parser deadlines, no-progress limits, containment, cancellation, resource limits, or protocol validation.
+
+#### Scenario: Hostile case fails and cleans up
+- **WHEN** a hostile fixture returns its expected failure
+- **THEN** the harness verifies no mandatory cleanup failure or active process-spawn ownership remains before one healthy restart succeeds
+
+#### Scenario: Production budgets remain independent
+- **WHEN** the test-only launch/admission policy is compiled or executed
+- **THEN** the production artifact-admission timeout, aggregate timeout, and no-progress timeout retain their existing values
+
+### Requirement: Windows scheduling tolerance is verified
+The complete process-owning adversarial harness SHALL pass repeatedly on Windows, and focused ordinary cross-platform Rust gates SHALL pass without production behavior changes.
+
+#### Scenario: Repeated supported-host execution
+- **WHEN** the complete adversarial test is run repeatedly with hard command timeouts on Windows
+- **THEN** every run reaches each exact hostile result and completes without leaked child ownership

--- a/openspec/changes/stabilize-hostile-parser-fixture-admission/tasks.md
+++ b/openspec/changes/stabilize-hostile-parser-fixture-admission/tasks.md
@@ -1,0 +1,9 @@
+## 1. Harness Policy
+
+- [x] 1.1 Split the test-only launch/admission no-progress allowance from the existing hostile operation allowance, retaining the short bound for deliberate pre-ready, admission, and progress stalls without retries or production changes.
+- [x] 1.2 Add deterministic positive and negative classification coverage while preserving exact typed failure assertions, mandatory cleanup checks, and production admission constants.
+
+## 2. Routing and Verification
+
+- [x] 2.1 Map issue #397 to this change, synchronize its live checklist, pass `openspec validate stabilize-hostile-parser-fixture-admission --strict`, and run `.github/scripts/issue-checklists.py`.
+- [x] 2.2 Pass `cargo fmt --check`, warnings-denied workspace Clippy, focused policy tests, and repeated complete Windows `parser_supervisor_adversarial` runs with explicit hard timeouts.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -43,6 +43,7 @@
     "reuse-unchanged-ci-build-layers": 341,
     "show-agent-efficiency-dashboard": 340,
     "simplify-token-tui-dashboard": 296,
+    "stabilize-hostile-parser-fixture-admission": 397,
     "stabilize-parser-recovery-harness": 391
   }
 }


### PR DESCRIPTION
## Summary

- separate deliberate hostile-stall bounds from ordinary launch and containment admission in the existing test-owned harness
- start fixture-specific operation deadlines only after successful launch and require exact deadline phases
- preserve one attempt, exact typed failures, mandatory cleanup, healthy restart proof, and all production parser limits
- synchronize the `stabilize-hostile-parser-fixture-admission` OpenSpec contract and live issue checklist at 4/4

## Verification

The standard Windows pre-push gate passed at exact head `a15f2f0`, including:

- formatting, workspace check, warnings-denied Clippy, strict string contracts, and dependency policy
- complete workspace tests and doc tests
- complete CLI E2E and installer trust-boundary suites
- the complete process-owning `parser_supervisor_adversarial` suite that failed without this fix
- warnings-denied rustdoc
- OpenSpec strict validation and live issue checklist parity at 4/4
- isolated ProjectAtlas scan/lint smoke

Focused exact-head checks also passed for phase classification and the complete adversarial process harness. Independent review found no material code, architecture, correctness, security, cleanup, compatibility, performance, or coverage issue. Hosted exact-head checks and fresh review feedback remain required before merge.

Closes #397
