### PR TITLE
fix(mcp): isolate Git config stdin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,3 +200,7 @@ jobs:
       - name: MCP project binding E2E
         timeout-minutes: 5
         run: cargo test --locked -p projectatlas-cli mcp_server_stays_bound_to_one_project_database --test e2e
+
+      - name: Persistent MCP Git config stdin E2E
+        timeout-minutes: 5
+        run: cargo test --locked -p projectatlas-cli persistent_mcp_stdin_does_not_block_repository_startup_probes --test e2e

--- a/crates/projectatlas-cli/src/runtime.rs
+++ b/crates/projectatlas-cli/src/runtime.rs
@@ -1995,6 +1995,7 @@ fn effective_git_config_bare_setting(
             "--bool",
             "core.bare",
         ])
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -1019,6 +1019,72 @@ fn impact_analysis_deadline_and_mcp_cancellation_release_resources() -> Result<(
     session.shutdown()
 }
 
+#[test]
+fn persistent_mcp_stdin_does_not_block_repository_startup_probes() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("persistent-git-probe");
+    fs::create_dir_all(repo.join(SRC_DIR_NAME))?;
+    fs::write(
+        repo.join(SRC_DIR_NAME).join("lib.rs"),
+        "pub fn ready() {}\n",
+    )?;
+    git_success(&repo, &["init", "--quiet"])?;
+    let database = repo.join(ATLAS_DIR_NAME).join("projectatlas.db");
+    let executable = assert_cmd::cargo::cargo_bin("projectatlas");
+    let init = StdCommand::new(&executable)
+        .current_dir(&repo)
+        .args(["--format", "json", "init"])
+        .output()?;
+    if !init.status.success() {
+        return Err(io::Error::other(format!(
+            "persistent-probe fixture init failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        ))
+        .into());
+    }
+
+    let project_path = repo.to_string_lossy().to_string();
+    let mut session = McpContractSession::spawn(&executable, &repo, &database)?;
+    for (tool, arguments, expected) in [
+        (
+            "atlas_session_brief",
+            json!({"project_path": project_path, "compact": true}),
+            "session_brief:",
+        ),
+        (
+            "atlas_root",
+            json!({"project_path": project_path, "verify": true}),
+            "root:",
+        ),
+        (
+            "atlas_init",
+            json!({"project_path": project_path, "no_scan": true}),
+            "init:",
+        ),
+    ] {
+        let started = Instant::now();
+        let text = session.call_tool(tool, &arguments)?;
+        if started.elapsed() > Duration::from_secs(5) || !text.contains(expected) {
+            return Err(io::Error::other(format!(
+                "{tool} did not complete over persistent stdin: elapsed={:?} text={text}",
+                started.elapsed()
+            ))
+            .into());
+        }
+    }
+    let followup = session.call_tool(
+        "atlas_root",
+        &json!({"project_path": project_path, "verify": true}),
+    )?;
+    if !followup.contains("verified: true") {
+        return Err(io::Error::other(format!(
+            "immediate root follow-up failed after persistent probes: {followup}"
+        ))
+        .into());
+    }
+    session.shutdown()
+}
+
 #[cfg(feature = "optional-parser-supervisor")]
 #[test]
 fn parser_pack_disable_does_not_require_default_user_storage() -> Result<(), Box<dyn Error>> {

--- a/openspec/changes/isolate-effective-git-config-stdin/.openspec.yaml
+++ b/openspec/changes/isolate-effective-git-config-stdin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/isolate-effective-git-config-stdin/design.md
+++ b/openspec/changes/isolate-effective-git-config-stdin/design.md
@@ -1,0 +1,27 @@
+## Context
+
+`effective_git_config_bare_setting` starts `git config` with piped output but no explicit stdin. Under a long-lived stdio MCP server, Windows passes the still-open transport handle to Git, so Git waits for input and root selection blocks until ProjectAtlas kills it at the existing deadline.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the shared effective Git-config probe independent of caller stdin.
+- Prove the real persistent MCP transport and immediate reuse of the same session.
+- Preserve current root classification, timeout, output, and error behavior.
+
+**Non-Goals:**
+
+- General subprocess supervision or new cancellation/containment guarantees.
+- New dependencies, public types, protocol fields, or database behavior.
+
+## Decisions
+
+- Set `stdin(Stdio::null())` on the existing `git config` command. This is the standard-library ownership boundary that fixes every caller without changing the established subprocess lifecycle.
+- Exercise the three affected MCP startup tools over one real stdio session whose stdin remains open. A direct unit test would not recreate the inherited transport handle that caused the bug.
+- Retain the existing implementation for deadlines, output collection, status parsing, and root semantics. A larger supervisor was considered and rejected for this patch because it would add unrelated process and platform contracts.
+
+## Risks / Trade-offs
+
+- A transport-only regression can be slower than a unit test. → Keep one focused E2E with a five-second per-call bound.
+- Other subprocess policy improvements remain outside this repair. → Track them separately only when a concrete failing contract requires them.

--- a/openspec/changes/isolate-effective-git-config-stdin/proposal.md
+++ b/openspec/changes/isolate-effective-git-config-stdin/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+ProjectAtlas can deadlock its effective local Git-config probe when an MCP server keeps its transport stdin open, because the spawned `git config` process inherits that same handle. Root discovery must complete independently of the lifetime of the caller's input stream before v0.4.2 ships.
+
+## What Changes
+
+- Give the effective `core.bare` Git subprocess a closed stdin instead of inheriting the CLI or MCP transport.
+- Add a real persistent-stdio MCP regression that exercises `atlas_session_brief`, `atlas_root`, and `atlas_init`, followed by an immediate root query in the same session.
+- Keep the existing timeout, bounded output, exit handling, and root-classification behavior unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `git-root-classification`: Require effective Git-config discovery to remain independent of caller stdin while preserving current repository-root semantics.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects the shared Git `core.bare` probe in `projectatlas-cli` and its CLI/MCP end-to-end tests.
+- Adds no dependency, public API, schema, migration, or protocol change.
+- Ready for implementation in the v0.4.2 bugfix release.
+
+## Non-Goals
+
+- Replacing the existing bounded Git subprocess loop with a general process supervisor.
+- Changing cancellation, output, timeout, privacy, database, or platform containment contracts.
+- Expanding v0.4.2 beyond bug fixes.

--- a/openspec/changes/isolate-effective-git-config-stdin/proposal.md
+++ b/openspec/changes/isolate-effective-git-config-stdin/proposal.md
@@ -5,7 +5,7 @@ ProjectAtlas can deadlock its effective local Git-config probe when an MCP serve
 ## What Changes
 
 - Give the effective `core.bare` Git subprocess a closed stdin instead of inheriting the CLI or MCP transport.
-- Add a real persistent-stdio MCP regression that exercises `atlas_session_brief`, `atlas_root`, and `atlas_init`, followed by an immediate root query in the same session.
+- Add a real persistent-stdio MCP regression that exercises `atlas_session_brief`, `atlas_root`, and `atlas_init`, followed by an immediate root query in the same session, and run it in the cross-platform E2E matrix.
 - Keep the existing timeout, bounded output, exit handling, and root-classification behavior unchanged.
 
 ## Capabilities
@@ -20,7 +20,7 @@ None.
 
 ## Impact
 
-- Affects the shared Git `core.bare` probe in `projectatlas-cli` and its CLI/MCP end-to-end tests.
+- Affects the shared Git `core.bare` probe in `projectatlas-cli`, its CLI/MCP end-to-end tests, and the existing cross-platform E2E CI matrix.
 - Adds no dependency, public API, schema, migration, or protocol change.
 - Ready for implementation in the v0.4.2 bugfix release.
 

--- a/openspec/changes/isolate-effective-git-config-stdin/specs/git-root-classification/spec.md
+++ b/openspec/changes/isolate-effective-git-config-stdin/specs/git-root-classification/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Effective Git configuration is independent of caller input
+ProjectAtlas SHALL run its effective local Git `core.bare` query with a closed child stdin so root classification never waits for CLI or MCP transport input.
+
+#### Scenario: Persistent MCP transport remains open
+- **WHEN** an MCP client keeps the server stdin open while calling `atlas_session_brief`, `atlas_root`, or `atlas_init`
+- **THEN** each tool completes its Git-root classification without waiting for transport shutdown
+
+#### Scenario: Session remains reusable
+- **WHEN** the client calls another root-sensitive tool immediately after the startup probes
+- **THEN** the same MCP session returns the correct root result without a stale or blocked Git child
+
+### Requirement: Existing Git-root outcomes remain compatible
+The stdin isolation MUST preserve existing effective-config inclusion, missing-key, linked-worktree, bare-root, wrong-root, missing-index, and no-implicit-mutation behavior.
+
+#### Scenario: Effective value comes from an included local config
+- **WHEN** local Git configuration includes a file that sets `core.bare`
+- **THEN** ProjectAtlas classifies the root from Git's effective included value
+
+#### Scenario: Local key is absent
+- **WHEN** `git config --get` returns its standard missing-key status
+- **THEN** ProjectAtlas treats `core.bare` as unset rather than as a probe failure
+
+#### Scenario: Selected root is not an initialized atlas
+- **WHEN** a read-only MCP tool addresses a wrong root or a root without a ProjectAtlas index
+- **THEN** ProjectAtlas returns the existing typed guidance and does not create project state implicitly
+
+#### Scenario: Linked and bare control roots retain their guidance
+- **WHEN** root selection encounters a linked worktree or a bare/common Git control root
+- **THEN** ProjectAtlas preserves the existing worktree-local routing or typed refusal before database access

--- a/openspec/changes/isolate-effective-git-config-stdin/tasks.md
+++ b/openspec/changes/isolate-effective-git-config-stdin/tasks.md
@@ -1,0 +1,11 @@
+## 1. Root-Cause Repair
+
+- [x] 1.1 Map issue #409 and align its live checklist with this narrow stdin-isolation contract.
+- [x] 1.2 Close stdin on the shared effective local Git-config subprocess without changing its existing lifecycle or result semantics.
+- [x] 1.3 Add a persistent-open stdio MCP regression covering `atlas_session_brief`, `atlas_root`, `atlas_init`, and immediate session reuse.
+
+## 2. Compatibility and Landing
+
+- [x] 2.1 Run the focused regression plus existing linked-worktree, bare-root, wrong-root, missing-index, included-config, and no-implicit-mutation coverage.
+- [x] 2.2 Pass `cargo fmt --all -- --check`, package Clippy with `-D warnings`, strict OpenSpec validation, and `.github/scripts/issue-checklists.py`.
+- [ ] 2.3 Review the exact current-main diff, inspect all hosted review feedback and checks, then land the verified head for v0.4.2.

--- a/openspec/changes/isolate-effective-git-config-stdin/tasks.md
+++ b/openspec/changes/isolate-effective-git-config-stdin/tasks.md
@@ -8,4 +8,4 @@
 
 - [x] 2.1 Run the focused regression plus existing linked-worktree, bare-root, wrong-root, missing-index, included-config, and no-implicit-mutation coverage.
 - [x] 2.2 Pass `cargo fmt --all -- --check`, package Clippy with `-D warnings`, strict OpenSpec validation, and `.github/scripts/issue-checklists.py`.
-- [ ] 2.3 Review the exact current-main diff, inspect all hosted review feedback and checks, then land the verified head for v0.4.2.
+- [x] 2.3 Review the exact current-main diff, inspect all hosted review feedback and checks, then land the verified head for v0.4.2.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -21,6 +21,7 @@
     "harden-project-path-types": 294,
     "enhance-projectatlas-init-first-run": 305,
     "fix-token-tui-reference-visual-regression": 304,
+    "isolate-effective-git-config-stdin": 409,
     "isolate-linked-worktree-atlases": 382,
     "match-token-impact-reference-tui": 302,
     "migrate-released-database-layouts": 379,


### PR DESCRIPTION
## Summary

- close stdin on the shared effective local Git `core.bare` probe so long-lived MCP transport input cannot block Git
- add a real persistent-stdio regression for `atlas_session_brief`, `atlas_root`, `atlas_init`, and immediate session reuse
- run that regression in the existing Linux, Windows, and macOS E2E matrix
- add and map the narrow `isolate-effective-git-config-stdin` OpenSpec change

## Verification

- `cargo test -p projectatlas-cli --all-features --test e2e persistent_mcp_stdin_does_not_block_repository_startup_probes -- --nocapture`
- `cargo test -p projectatlas-cli --all-features --test e2e git_control_roots_return_typed_worktree_guidance_without_state -- --nocapture`
- `cargo test -p projectatlas-cli --all-features --test e2e linked_worktrees_keep_local_atlases_across_scan_init_watch_and_mcp -- --nocapture`
- `cargo test -p projectatlas-cli --all-features --test e2e implicit_bare_root -- --nocapture`
- `cargo clippy -p projectatlas-cli --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `openspec validate isolate-effective-git-config-stdin --strict`
- `python .github/scripts/issue-checklists.py --repo styler-ai/ProjectAtlas`
- normal pre-push gate, including full workspace tests, Clippy, rustdoc, dependency policy, IssueOps, and packaged checks

## Risk

The production change is one standard-library process-builder setting at the shared owner. Existing deadline, output, exit, kill/reap, root-routing, database, protocol, and dependency behavior is unchanged. The cross-platform matrix test provides exact-head Windows proof for the originally observed transport boundary.

Closes #409
