### PR TITLE
test(parser): make worker crash proof race-free (#308)

### DIFF
--- a/crates/projectatlas-cli/tests/optional_parser_worker_failure.rs
+++ b/crates/projectatlas-cli/tests/optional_parser_worker_failure.rs
@@ -791,9 +791,11 @@ fn contained_worker_crash_preserves_active_generation() -> Result<(), Box<dyn Er
     let mut scan = ScanProcess::spawn(&repo, &host)?;
     let runtime = wait_for_runtime_processes(&mut scan, PROCESS_DISCOVERY_TIMEOUT)?;
     let tracked = runtime.tracked();
+    let mut suspended = SuspendedProcess::suspend(runtime.worker.clone())?;
     terminate_process(&runtime.worker)?;
     let output = scan.finish(PROCESS_EXIT_TIMEOUT)?;
     wait_for_process_cleanup(&tracked, PROCESS_CLEANUP_TIMEOUT)?;
+    suspended.disarm_after_exit();
     require_optional_worker_failure(&output)?;
     let retained_store = AtlasStore::open_read_only(&database)?;
     let retained_publication = retained_store


### PR DESCRIPTION
## Outcome

Makes the existing packaged optional-parser worker-crash proof deterministic on Windows by suspending the exact observed worker before terminating it, then disarming the existing RAII resume guard only after exact subtree cleanup.

The previous exact candidate proof run 30642696011 exposed the race: Windows process discovery and termination use separate bounded PowerShell/CIM operations, so the worker could finish between them and the scan could legitimately exit successfully. This is test-only; v0.4.2 product/runtime behavior is unchanged.

## Verification

- complete Git Bash pre-push gate passed at exact head d3b6389
- 105 E2E passed, including persistent #409 MCP startup and all-40 real MCP/SQLite contract; 1 packaged proof test remained intentionally ignored outside the workflow
- targeted optional-parser fault test compiled and targeted Clippy passed
- independent exact-diff Rust/release review: GO
- fresh exact-head Linux/Windows packaged parser proof is required before promotion

The local Codex-hosted Windows session could not admit the downloaded parser archive (`optional parser made no progress during containment admission`); the workflow-built archive passed hosted construction and verification on both platforms. Hosted exact-head proof therefore remains the authority for the changed real-process boundary.