### PR TITLE
fix(storage): refuse newer schemas before writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,10 +169,17 @@ jobs:
         timeout-minutes: 5
         run: cargo test --locked -p projectatlas-cli plugin_update_restores_current_ref_marketplace_when_plugin_reinstall_fails --test e2e
 
+      - name: Windows recovery config selection E2E
+        if: matrix.label == 'windows'
+        timeout-minutes: 5
+        run: cargo test --locked -p projectatlas-cli windows_installer_recovery_operation_preserves_config_selection --test e2e -- --exact
+
       - name: Windows locked runtime update E2E
         if: matrix.label == 'windows'
         timeout-minutes: 5
-        run: cargo test --locked -p projectatlas-cli windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is_locked --test e2e
+        env:
+          PROJECTATLAS_TEST_DISPOSABLE_RUNNER: ${{ runner.environment }}
+        run: cargo test --locked -p projectatlas-cli windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is_locked --test e2e -- --exact
 
       - name: Windows persisted User PATH E2E
         if: matrix.label == 'windows'

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 
 Every file not opened. Every folder not explored. ProjectAtlas guides coding agents with purpose metadata and an intelligent code graph, reducing token costs by over 90%.
 
+The "over 90%" figure is a workload-specific local estimate from the published audit, not a universal savings guarantee or provider-billing result; see [One Large-Application Audit](#one-large-application-audit).
+
 ProjectAtlas is a native Rust CLI and MCP server that keeps a project-local map of folders, files, reviewed purposes, deterministic summaries, symbols, graph relationships, searchable text, health findings, and token telemetry. `.gitignore`-aware scanning, BLAKE3 hashing, SQLite storage, filesystem watching, and compact TOON output keep repeated repository orientation local and fast.
 
 The map is deliberately agent-first: purposes identify the responsible area, graph relationships reveal connected code, compact summaries and outlines explain the selected files, and exact source slices provide the final evidence. Agents narrow before they read broadly.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 ## About
 
+Every file not opened. Every folder not explored. ProjectAtlas guides coding agents with purpose metadata and an intelligent code graph, reducing token costs by over 90%.
+
 ProjectAtlas is a native Rust CLI and MCP server that keeps a project-local map of folders, files, reviewed purposes, deterministic summaries, symbols, graph relationships, searchable text, health findings, and token telemetry. `.gitignore`-aware scanning, BLAKE3 hashing, SQLite storage, filesystem watching, and compact TOON output keep repeated repository orientation local and fast.
 
 The map is deliberately agent-first: purposes identify the responsible area, graph relationships reveal connected code, compact summaries and outlines explain the selected files, and exact source slices provide the final evidence. Agents narrow before they read broadly.

--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -110,6 +110,8 @@ const WATCH_MODE_NOTIFY: &str = "notify";
 const DATABASE_FILESYSTEM_RECOVERY: &str = "Place the selected local source tree and its .projectatlas database on a supported local filesystem, resolve any mount or permission uncertainty, and retry; ProjectAtlas will not weaken the WAL durability profile.";
 /// Recovery guidance for a database owned by another schema version.
 const SCHEMA_VERSION_MISMATCH_RECOVERY: &str = "Use a ProjectAtlas runtime that supports this database schema; do not reset, downgrade, or repair the database with this runtime.";
+/// Recovery guidance for an admitted predecessor database.
+const SCHEMA_MIGRATION_REQUIRED_RECOVERY: &str = "Apply the supported database-owned migration without changing the selected database: for CLI, use the `projectatlas init` action from the selected project root while preserving the same global `--db`/`--config` selection; for MCP, call `atlas_init` through the same MCP server/database binding. Do not reset or replace the database.";
 /// Existing CLI command that performs one bounded refresh pass.
 const CLI_REFRESH_COMMAND: &str = "watch";
 /// Existing CLI command that initializes one selected project root.
@@ -303,6 +305,8 @@ enum AgentErrorKind {
     DatabaseFilesystemUncertain,
     /// The selected database schema is unsupported by this runtime.
     SchemaVersionMismatch,
+    /// The selected database schema has a supported migration route.
+    SchemaMigrationRequired,
     /// The host has no accepted optional parser containment adapter.
     #[cfg(feature = "optional-parser-supervisor")]
     UnsupportedContainment,
@@ -357,6 +361,51 @@ struct SchemaVersionMismatchErrorPayload {
 struct SchemaVersionMismatchErrorResponse {
     /// Typed error details.
     error: SchemaVersionMismatchErrorPayload,
+}
+
+/// Typed supported-schema migration handoff shared by CLI and MCP adapters.
+#[derive(Clone, Debug, Serialize)]
+struct SchemaMigrationRequiredPayload {
+    /// Schema version stored by the database owner.
+    found_schema_version: i64,
+    /// Schema version supported by this runtime.
+    supported_schema_version: i64,
+    /// Remaining ordered database-owned migration steps.
+    migration_steps_remaining: u32,
+    /// Public `ProjectAtlas` package version executing the request.
+    runtime_version: &'static str,
+    /// Safe migration action.
+    recovery: &'static str,
+}
+
+impl SchemaMigrationRequiredPayload {
+    /// Render one content-free explanation for a command that requires the current schema.
+    fn message(&self) -> String {
+        format!(
+            "database schema version {} requires {} supported migration step(s) to version {} before this command can run",
+            self.found_schema_version,
+            self.migration_steps_remaining,
+            self.supported_schema_version
+        )
+    }
+}
+
+/// CLI error details for an admitted predecessor schema.
+#[derive(Serialize)]
+struct SchemaMigrationRequiredErrorPayload {
+    /// Machine-readable error kind.
+    kind: AgentErrorKind,
+    /// Human-readable migration handoff.
+    message: String,
+    /// Content-free supported migration details.
+    schema_migration_required: SchemaMigrationRequiredPayload,
+}
+
+/// Structured CLI response for an admitted predecessor schema.
+#[derive(Serialize)]
+struct SchemaMigrationRequiredErrorResponse {
+    /// Typed error details.
+    error: SchemaMigrationRequiredErrorPayload,
 }
 
 /// Typed optional search-capability failure shared by CLI and MCP adapters.
@@ -2847,6 +2896,24 @@ fn render_cli_error(format: OutputFormat, error: &CliError) -> Result<String, se
             }
         };
     }
+    if let Some(schema_migration_required) = schema_migration_required_payload(error) {
+        let message = schema_migration_required.message();
+        let response = SchemaMigrationRequiredErrorResponse {
+            error: SchemaMigrationRequiredErrorPayload {
+                kind: AgentErrorKind::SchemaMigrationRequired,
+                message,
+                schema_migration_required,
+            },
+        };
+        return match format {
+            OutputFormat::Toon => {
+                serde_json::to_value(response).map(|value| encode_agent_payload(&value))
+            }
+            OutputFormat::Json => {
+                serde_json::to_string_pretty(&response).map(|text| format!("{text}\n"))
+            }
+        };
+    }
     let details = match error {
         #[cfg(feature = "optional-parser-supervisor")]
         CliError::ParserPack(source) if source.is_unsupported_containment() => {
@@ -3026,18 +3093,36 @@ fn database_filesystem_error_payload(
 
 /// Extract one privacy-safe schema mismatch from the shared database error.
 fn schema_version_mismatch_payload(error: &CliError) -> Option<SchemaVersionMismatchPayload> {
-    let (found_schema_version, supported_schema_version) = match error {
-        CliError::Db(DbError::SchemaVersion { found, expected })
-        | CliError::Service(ServiceError::Db(DbError::SchemaVersion { found, expected })) => {
-            (*found, *expected)
-        }
-        _ => return None,
+    let (CliError::Db(database_error) | CliError::Service(ServiceError::Db(database_error))) =
+        error
+    else {
+        return None;
     };
+    let (found_schema_version, supported_schema_version) =
+        database_error.unsupported_schema_version()?;
     Some(SchemaVersionMismatchPayload {
         found_schema_version,
         supported_schema_version,
         runtime_version: env!("CARGO_PKG_VERSION"),
         recovery: SCHEMA_VERSION_MISMATCH_RECOVERY,
+    })
+}
+
+/// Extract one privacy-safe migration handoff from the shared database error.
+fn schema_migration_required_payload(error: &CliError) -> Option<SchemaMigrationRequiredPayload> {
+    let (CliError::Db(database_error) | CliError::Service(ServiceError::Db(database_error))) =
+        error
+    else {
+        return None;
+    };
+    let (found_schema_version, supported_schema_version, migration_steps_remaining) =
+        database_error.supported_schema_migration()?;
+    Some(SchemaMigrationRequiredPayload {
+        found_schema_version,
+        supported_schema_version,
+        migration_steps_remaining,
+        runtime_version: env!("CARGO_PKG_VERSION"),
+        recovery: SCHEMA_MIGRATION_REQUIRED_RECOVERY,
     })
 }
 
@@ -4818,9 +4903,11 @@ mod tests {
         watch_path_requires_full_scan, watcher_status_report,
     };
     use super::{
-        Cli, CliError, Command, GraphRelationKind, OutputFormat, SearchRetrievalMode,
+        Cli, CliError, Command, GraphRelationKind, OutputFormat,
+        SCHEMA_MIGRATION_REQUIRED_RECOVERY, SCHEMA_VERSION_MISMATCH_RECOVERY, SearchRetrievalMode,
         SearchRetrievalModeArg, ServiceError, build_runtime_info, controlled_named_output,
-        load_token_atlas_relations, render_cli_error, render_token_dashboard, serialized_output,
+        load_token_atlas_relations, render_cli_error, render_token_dashboard,
+        schema_migration_required_payload, schema_version_mismatch_payload, serialized_output,
         token_atlas_network_relation, truthy_env,
     };
     #[cfg(feature = "optional-parser-supervisor")]
@@ -5229,16 +5316,37 @@ mod tests {
 
     #[test]
     fn cli_schema_version_mismatches_are_typed_and_content_free() -> Result<(), Box<dyn Error>> {
-        for error in [
-            CliError::Db(DbError::SchemaVersion {
-                found: 17,
-                expected: 16,
-            }),
-            CliError::Service(ServiceError::Db(DbError::SchemaVersion {
-                found: 17,
-                expected: 16,
-            })),
+        for (error, found) in [
+            (
+                CliError::Db(DbError::SchemaVersion {
+                    found: 17,
+                    expected: 16,
+                }),
+                17,
+            ),
+            (
+                CliError::Service(ServiceError::Db(DbError::SchemaVersion {
+                    found: 17,
+                    expected: 16,
+                })),
+                17,
+            ),
+            (
+                CliError::Db(DbError::SchemaVersion {
+                    found: 7,
+                    expected: 16,
+                }),
+                7,
+            ),
+            (
+                CliError::Service(ServiceError::Db(DbError::SchemaVersion {
+                    found: 7,
+                    expected: 16,
+                })),
+                7,
+            ),
         ] {
+            let expected_message = format!("unsupported schema version {found}, expected 16");
             let json_text = render_cli_error(OutputFormat::Json, &error)?;
             let json: Value = serde_json::from_str(&json_text)?;
             require_condition(
@@ -5247,7 +5355,7 @@ mod tests {
                     && json
                         .pointer("/error/schema_version_mismatch/found_schema_version")
                         .and_then(Value::as_i64)
-                        == Some(17)
+                        == Some(found)
                     && json
                         .pointer("/error/schema_version_mismatch/supported_schema_version")
                         .and_then(Value::as_i64)
@@ -5261,7 +5369,7 @@ mod tests {
                         .and_then(Value::as_str)
                         .is_some_and(|value| value.contains("do not reset"))
                     && json.pointer("/error/message").and_then(Value::as_str)
-                        == Some("unsupported schema version 17, expected 16"),
+                        == Some(expected_message.as_str()),
                 "CLI JSON lost the typed schema-version mismatch contract",
             )?;
             require_condition(
@@ -5274,11 +5382,60 @@ mod tests {
             let toon = render_cli_error(OutputFormat::Toon, &error)?;
             require_condition(
                 toon.contains("kind: schema_version_mismatch")
-                    && toon.contains("found_schema_version: 17")
+                    && toon.contains(&format!("found_schema_version: {found}"))
                     && toon.contains("supported_schema_version: 16")
                     && toon.contains(env!("CARGO_PKG_VERSION"))
                     && toon.contains("do not reset"),
                 "CLI TOON lost typed schema-version details or recovery guidance",
+            )?;
+        }
+        for error in [
+            CliError::Db(DbError::SchemaVersion {
+                found: 8,
+                expected: 16,
+            }),
+            CliError::Service(ServiceError::Db(DbError::SchemaVersion {
+                found: 15,
+                expected: 16,
+            })),
+        ] {
+            require_condition(
+                schema_version_mismatch_payload(&error).is_none(),
+                "CLI treated an admitted predecessor as unsupported",
+            )?;
+            let migration = schema_migration_required_payload(&error).ok_or_else(|| {
+                std::io::Error::other("CLI omitted the admitted-predecessor migration handoff")
+            })?;
+            let expected_steps = u32::try_from(16 - migration.found_schema_version)?;
+            require_condition(
+                migration.supported_schema_version == 16
+                    && migration.migration_steps_remaining == expected_steps,
+                "CLI migration handoff drifted from the database migration inventory",
+            )?;
+            let rendered = render_cli_error(OutputFormat::Json, &error)?;
+            let json: Value = serde_json::from_str(&rendered)?;
+            require_condition(
+                json.pointer("/error/kind").and_then(Value::as_str)
+                    == Some("schema_migration_required")
+                    && json
+                        .pointer("/error/schema_migration_required/migration_steps_remaining")
+                        .and_then(Value::as_u64)
+                        == Some(u64::from(expected_steps))
+                    && json
+                        .pointer("/error/schema_migration_required/recovery")
+                        .and_then(Value::as_str)
+                        == Some(SCHEMA_MIGRATION_REQUIRED_RECOVERY)
+                    && rendered.contains("same global `--db`/`--config` selection")
+                    && rendered.contains("same MCP server/database binding")
+                    && json
+                        .pointer("/error/message")
+                        .and_then(Value::as_str)
+                        .is_some_and(|message| message.contains("supported migration step"))
+                    && !rendered.contains("schema_version_mismatch")
+                    && !rendered.contains(SCHEMA_VERSION_MISMATCH_RECOVERY)
+                    && !rendered.contains(".projectatlas")
+                    && !rendered.contains("project_root"),
+                "CLI did not return a private, actionable supported-migration handoff",
             )?;
         }
         Ok(())

--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -108,6 +108,8 @@ const WATCH_MODE_ONCE: &str = "single-refresh";
 const WATCH_MODE_NOTIFY: &str = "notify";
 /// Recovery guidance for a database whose local WAL-safe placement was rejected.
 const DATABASE_FILESYSTEM_RECOVERY: &str = "Place the selected local source tree and its .projectatlas database on a supported local filesystem, resolve any mount or permission uncertainty, and retry; ProjectAtlas will not weaken the WAL durability profile.";
+/// Recovery guidance for a database owned by another schema version.
+const SCHEMA_VERSION_MISMATCH_RECOVERY: &str = "Use a ProjectAtlas runtime that supports this database schema; do not reset, downgrade, or repair the database with this runtime.";
 /// Existing CLI command that performs one bounded refresh pass.
 const CLI_REFRESH_COMMAND: &str = "watch";
 /// Existing CLI command that initializes one selected project root.
@@ -299,6 +301,8 @@ enum AgentErrorKind {
     DatabaseFilesystemUnsupported,
     /// The database's required local filesystem guarantees could not be established.
     DatabaseFilesystemUncertain,
+    /// The selected database schema is unsupported by this runtime.
+    SchemaVersionMismatch,
     /// The host has no accepted optional parser containment adapter.
     #[cfg(feature = "optional-parser-supervisor")]
     UnsupportedContainment,
@@ -322,6 +326,37 @@ struct DatabaseFilesystemErrorPayload {
     reason: Option<String>,
     /// Safe recovery action.
     recovery: &'static str,
+}
+
+/// Typed schema-version mismatch shared by CLI and MCP adapters.
+#[derive(Clone, Debug, Serialize)]
+struct SchemaVersionMismatchPayload {
+    /// Schema version stored by the database owner.
+    found_schema_version: i64,
+    /// Schema version supported by this runtime.
+    supported_schema_version: i64,
+    /// Public `ProjectAtlas` package version executing the request.
+    runtime_version: &'static str,
+    /// Safe recovery action.
+    recovery: &'static str,
+}
+
+/// CLI error details for an incompatible database schema.
+#[derive(Serialize)]
+struct SchemaVersionMismatchErrorPayload {
+    /// Machine-readable error kind.
+    kind: AgentErrorKind,
+    /// Human-readable recovery guidance.
+    message: String,
+    /// Content-free incompatible schema details.
+    schema_version_mismatch: SchemaVersionMismatchPayload,
+}
+
+/// Structured CLI response for an incompatible database schema.
+#[derive(Serialize)]
+struct SchemaVersionMismatchErrorResponse {
+    /// Typed error details.
+    error: SchemaVersionMismatchErrorPayload,
 }
 
 /// Typed optional search-capability failure shared by CLI and MCP adapters.
@@ -2795,6 +2830,23 @@ fn run_parser_pack_command(
 
 /// Render typed source-state failures in the selected agent/script format.
 fn render_cli_error(format: OutputFormat, error: &CliError) -> Result<String, serde_json::Error> {
+    if let Some(schema_version_mismatch) = schema_version_mismatch_payload(error) {
+        let response = SchemaVersionMismatchErrorResponse {
+            error: SchemaVersionMismatchErrorPayload {
+                kind: AgentErrorKind::SchemaVersionMismatch,
+                message: error.to_string(),
+                schema_version_mismatch,
+            },
+        };
+        return match format {
+            OutputFormat::Toon => {
+                serde_json::to_value(response).map(|value| encode_agent_payload(&value))
+            }
+            OutputFormat::Json => {
+                serde_json::to_string_pretty(&response).map(|text| format!("{text}\n"))
+            }
+        };
+    }
     let details = match error {
         #[cfg(feature = "optional-parser-supervisor")]
         CliError::ParserPack(source) if source.is_unsupported_containment() => {
@@ -2970,6 +3022,23 @@ fn database_filesystem_error_payload(
             recovery: DATABASE_FILESYSTEM_RECOVERY,
         },
     ))
+}
+
+/// Extract one privacy-safe schema mismatch from the shared database error.
+fn schema_version_mismatch_payload(error: &CliError) -> Option<SchemaVersionMismatchPayload> {
+    let (found_schema_version, supported_schema_version) = match error {
+        CliError::Db(DbError::SchemaVersion { found, expected })
+        | CliError::Service(ServiceError::Db(DbError::SchemaVersion { found, expected })) => {
+            (*found, *expected)
+        }
+        _ => return None,
+    };
+    Some(SchemaVersionMismatchPayload {
+        found_schema_version,
+        supported_schema_version,
+        runtime_version: env!("CARGO_PKG_VERSION"),
+        recovery: SCHEMA_VERSION_MISMATCH_RECOVERY,
+    })
 }
 
 /// Open the selected current index through one root-bound read snapshot.
@@ -5155,6 +5224,63 @@ mod tests {
                 && toon.contains("supported local filesystem"),
             "CLI TOON lost typed filesystem details",
         )?;
+        Ok(())
+    }
+
+    #[test]
+    fn cli_schema_version_mismatches_are_typed_and_content_free() -> Result<(), Box<dyn Error>> {
+        for error in [
+            CliError::Db(DbError::SchemaVersion {
+                found: 17,
+                expected: 16,
+            }),
+            CliError::Service(ServiceError::Db(DbError::SchemaVersion {
+                found: 17,
+                expected: 16,
+            })),
+        ] {
+            let json_text = render_cli_error(OutputFormat::Json, &error)?;
+            let json: Value = serde_json::from_str(&json_text)?;
+            require_condition(
+                json.pointer("/error/kind").and_then(Value::as_str)
+                    == Some("schema_version_mismatch")
+                    && json
+                        .pointer("/error/schema_version_mismatch/found_schema_version")
+                        .and_then(Value::as_i64)
+                        == Some(17)
+                    && json
+                        .pointer("/error/schema_version_mismatch/supported_schema_version")
+                        .and_then(Value::as_i64)
+                        == Some(16)
+                    && json
+                        .pointer("/error/schema_version_mismatch/runtime_version")
+                        .and_then(Value::as_str)
+                        == Some(env!("CARGO_PKG_VERSION"))
+                    && json
+                        .pointer("/error/schema_version_mismatch/recovery")
+                        .and_then(Value::as_str)
+                        .is_some_and(|value| value.contains("do not reset"))
+                    && json.pointer("/error/message").and_then(Value::as_str)
+                        == Some("unsupported schema version 17, expected 16"),
+                "CLI JSON lost the typed schema-version mismatch contract",
+            )?;
+            require_condition(
+                !json_text.contains(".projectatlas")
+                    && !json_text.contains("session_id")
+                    && !json_text.contains("project_root"),
+                "CLI schema mismatch exposed private database context",
+            )?;
+
+            let toon = render_cli_error(OutputFormat::Toon, &error)?;
+            require_condition(
+                toon.contains("kind: schema_version_mismatch")
+                    && toon.contains("found_schema_version: 17")
+                    && toon.contains("supported_schema_version: 16")
+                    && toon.contains(env!("CARGO_PKG_VERSION"))
+                    && toon.contains("do not reset"),
+                "CLI TOON lost typed schema-version details or recovery guidance",
+            )?;
+        }
         Ok(())
     }
 

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -35,12 +35,13 @@ use crate::token_tui::{
 };
 use crate::{
     AgentErrorKind, CliError, DEFAULT_FILE_SUMMARY_LIMIT, DatabaseFilesystemErrorPayload,
-    HarnessConfig, OutputFormat, RootTransition, RuntimeInfoReport, SchemaVersionMismatchPayload,
-    SearchRetrievalModeArg, build_harness_mcp_config_report, build_parity_report,
-    build_root_report, build_runtime_info, controlled_named_output,
+    HarnessConfig, OutputFormat, RootTransition, RuntimeInfoReport, SchemaMigrationRequiredPayload,
+    SchemaVersionMismatchPayload, SearchRetrievalModeArg, build_harness_mcp_config_report,
+    build_parity_report, build_root_report, build_runtime_info, controlled_named_output,
     database_filesystem_error_payload, finalize_coverage_output, render_code_slice,
     render_file_summary, render_parity_report, render_root_report, render_runtime_info,
-    render_search_report, render_watch_status, schema_version_mismatch_payload,
+    render_search_report, render_watch_status, schema_migration_required_payload,
+    schema_version_mismatch_payload,
 };
 use projectatlas_core::graph::{
     Completeness, ConfidenceClass, CoverageRecord, EntitySelector, ExternalSelector,
@@ -1671,6 +1672,9 @@ struct McpErrorPayload {
     /// Content-free incompatible schema details.
     #[serde(skip_serializing_if = "Option::is_none")]
     schema_version_mismatch: Option<SchemaVersionMismatchPayload>,
+    /// Content-free supported migration handoff.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema_migration_required: Option<SchemaMigrationRequiredPayload>,
     /// Optional retrieval capability state and recovery guidance.
     #[serde(skip_serializing_if = "Option::is_none")]
     search_capability: Option<crate::SearchCapabilityErrorPayload>,
@@ -5371,6 +5375,11 @@ impl ProjectAtlasMcpServer {
     /// Encode an MCP error as a structured agent-readable payload.
     fn encode_error_payload(error: &CliError) -> String {
         let schema_version_mismatch = schema_version_mismatch_payload(error);
+        let schema_migration_required = schema_migration_required_payload(error);
+        let message = schema_migration_required.as_ref().map_or_else(
+            || error.to_string(),
+            SchemaMigrationRequiredPayload::message,
+        );
         let (
             kind,
             refresh_required,
@@ -5473,6 +5482,17 @@ impl ProjectAtlasMcpServer {
                 None,
                 None,
             ),
+            _ if schema_migration_required.is_some() => (
+                AgentErrorKind::SchemaMigrationRequired,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
             _ => database_filesystem_error_payload(error).map_or(
                 (
                     AgentErrorKind::Error,
@@ -5503,7 +5523,7 @@ impl ProjectAtlasMcpServer {
         let payload = McpErrorResponse {
             error: McpErrorPayload {
                 kind,
-                message: error.to_string(),
+                message,
                 refresh_required,
                 init_required,
                 worktree_required,
@@ -5511,6 +5531,7 @@ impl ProjectAtlasMcpServer {
                 project_mismatch,
                 database_filesystem,
                 schema_version_mismatch,
+                schema_migration_required,
                 search_capability,
                 next,
             },
@@ -8017,6 +8038,27 @@ mod tests {
                 && !payload.contains("session_id")
                 && !payload.contains("project_root"),
             "MCP TOON lost typed schema-version details or exposed database context",
+        )?;
+
+        let predecessor = CliError::Service(ServiceError::Db(DbError::SchemaVersion {
+            found: 8,
+            expected: 16,
+        }));
+        let McpToolTextResult(predecessor_result) =
+            ProjectAtlasMcpServer::as_mcp_text(Err(predecessor));
+        let predecessor_payload = predecessor_result.map_err(std::io::Error::other)?;
+        require(
+            predecessor_payload.contains("kind: schema_migration_required")
+                && predecessor_payload.contains("found_schema_version: 8")
+                && predecessor_payload.contains("supported_schema_version: 16")
+                && predecessor_payload.contains("migration_steps_remaining: 8")
+                && predecessor_payload.contains("projectatlas init")
+                && predecessor_payload.contains("atlas_init")
+                && predecessor_payload.contains("same global `--db`/`--config` selection")
+                && predecessor_payload.contains("same MCP server/database binding")
+                && !predecessor_payload.contains("schema_version_mismatch")
+                && !predecessor_payload.contains(crate::SCHEMA_VERSION_MISMATCH_RECOVERY),
+            "MCP omitted the supported-predecessor migration handoff",
         )
     }
 

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -35,11 +35,12 @@ use crate::token_tui::{
 };
 use crate::{
     AgentErrorKind, CliError, DEFAULT_FILE_SUMMARY_LIMIT, DatabaseFilesystemErrorPayload,
-    HarnessConfig, OutputFormat, RootTransition, RuntimeInfoReport, SearchRetrievalModeArg,
-    build_harness_mcp_config_report, build_parity_report, build_root_report, build_runtime_info,
-    controlled_named_output, database_filesystem_error_payload, finalize_coverage_output,
-    render_code_slice, render_file_summary, render_parity_report, render_root_report,
-    render_runtime_info, render_search_report, render_watch_status,
+    HarnessConfig, OutputFormat, RootTransition, RuntimeInfoReport, SchemaVersionMismatchPayload,
+    SearchRetrievalModeArg, build_harness_mcp_config_report, build_parity_report,
+    build_root_report, build_runtime_info, controlled_named_output,
+    database_filesystem_error_payload, finalize_coverage_output, render_code_slice,
+    render_file_summary, render_parity_report, render_root_report, render_runtime_info,
+    render_search_report, render_watch_status, schema_version_mismatch_payload,
 };
 use projectatlas_core::graph::{
     Completeness, ConfidenceClass, CoverageRecord, EntitySelector, ExternalSelector,
@@ -81,7 +82,9 @@ use projectatlas_service::{
     parse_symbol_kind, read_indexed_code_slice_from_source_bounded,
     read_symbol_slice_from_source_bounded, search_indexed_files_with_control,
 };
-use rmcp::handler::server::{router::tool::ToolRouter, wrapper::Parameters};
+use rmcp::handler::server::{
+    router::tool::ToolRouter, tool::IntoCallToolResult, wrapper::Parameters,
+};
 use rmcp::model::{Implementation, ServerCapabilities, ServerInfo};
 use rmcp::schemars;
 use rmcp::service::RequestContext;
@@ -96,6 +99,32 @@ use std::sync::{
 };
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Text response routed through `rmcp`'s native tool-success/tool-error conversion.
+#[derive(Debug, PartialEq, Eq)]
+struct McpToolTextResult(Result<String, String>);
+
+impl std::ops::Deref for McpToolTextResult {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        match &self.0 {
+            Ok(text) | Err(text) => text,
+        }
+    }
+}
+
+impl std::fmt::Display for McpToolTextResult {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self)
+    }
+}
+
+impl IntoCallToolResult for McpToolTextResult {
+    fn into_call_tool_result(self) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+        self.0.into_call_tool_result()
+    }
+}
 
 /// MCP tools required for the agent-first repository-intelligence surface.
 pub(crate) const REQUIRED_MCP_TOOL_NAMES: &[&str] = &[
@@ -1639,6 +1668,9 @@ struct McpErrorPayload {
     /// Content-free database placement details for a rejected `SQLite` profile.
     #[serde(skip_serializing_if = "Option::is_none")]
     database_filesystem: Option<DatabaseFilesystemErrorPayload>,
+    /// Content-free incompatible schema details.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema_version_mismatch: Option<SchemaVersionMismatchPayload>,
     /// Optional retrieval capability state and recovery guidance.
     #[serde(skip_serializing_if = "Option::is_none")]
     search_capability: Option<crate::SearchCapabilityErrorPayload>,
@@ -5338,6 +5370,7 @@ impl ProjectAtlasMcpServer {
 
     /// Encode an MCP error as a structured agent-readable payload.
     fn encode_error_payload(error: &CliError) -> String {
+        let schema_version_mismatch = schema_version_mismatch_payload(error);
         let (
             kind,
             refresh_required,
@@ -5429,6 +5462,17 @@ impl ProjectAtlasMcpServer {
                 }),
                 None,
             ),
+            _ if schema_version_mismatch.is_some() => (
+                AgentErrorKind::SchemaVersionMismatch,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
             _ => database_filesystem_error_payload(error).map_or(
                 (
                     AgentErrorKind::Error,
@@ -5466,6 +5510,7 @@ impl ProjectAtlasMcpServer {
                 verification_incomplete,
                 project_mismatch,
                 database_filesystem,
+                schema_version_mismatch,
                 search_capability,
                 next,
             },
@@ -5481,10 +5526,17 @@ impl ProjectAtlasMcpServer {
     }
 
     /// Convert a command result into an agent-readable TOON MCP text payload.
-    fn as_mcp_text(result: Result<String, CliError>) -> String {
+    fn as_mcp_text(result: Result<String, CliError>) -> McpToolTextResult {
         match result {
-            Ok(text) => text,
-            Err(error) => Self::encode_error_payload(&error),
+            Ok(text) => McpToolTextResult(Ok(text)),
+            Err(error) => {
+                let payload = Self::encode_error_payload(&error);
+                if schema_version_mismatch_payload(&error).is_some() {
+                    McpToolTextResult(Err(payload))
+                } else {
+                    McpToolTextResult(Ok(payload))
+                }
+            }
         }
     }
 }
@@ -5616,7 +5668,7 @@ impl ProjectAtlasMcpServer {
     fn atlas_set_project_path(
         &self,
         Parameters(params): Parameters<AtlasSetProjectPathParams>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = Self::project_state_from_root(Path::new(&params.project_path))?;
             self.set_active_project_state(state.clone())?;
@@ -5629,7 +5681,7 @@ impl ProjectAtlasMcpServer {
         name = "atlas_init",
         description = "Initialize ProjectAtlas project-local config, database, host MCP configs, scan/index, and purpose handoff."
     )]
-    fn atlas_init(&self, Parameters(params): Parameters<AtlasInitParams>) -> String {
+    fn atlas_init(&self, Parameters(params): Parameters<AtlasInitParams>) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.admin_project_root(params.project_path)?;
             let config_path = init_config_path(&state.root, state.config_path.as_deref());
@@ -5659,7 +5711,7 @@ impl ProjectAtlasMcpServer {
         name = "atlas_map",
         description = "Write the explicit compatibility ProjectAtlas map export for older workflows."
     )]
-    fn atlas_map(&self, Parameters(params): Parameters<AtlasMapParams>) -> String {
+    fn atlas_map(&self, Parameters(params): Parameters<AtlasMapParams>) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.admin_project_root(params.project_path)?;
             let report = Self::build_map_report(
@@ -5676,7 +5728,7 @@ impl ProjectAtlasMcpServer {
         name = "atlas_root",
         description = "Show or verify ProjectAtlas root, DB, config, and runtime identity."
     )]
-    fn atlas_root(&self, Parameters(params): Parameters<AtlasRootParams>) -> String {
+    fn atlas_root(&self, Parameters(params): Parameters<AtlasRootParams>) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.admin_project_root(params.project_path)?;
             let report = build_root_report(&state.db_path, state.config_path.as_deref())?;
@@ -5692,7 +5744,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_root_set",
         description = "Bind a repository root, generate project-local MCP configs, and make it active for later MCP calls."
     )]
-    fn atlas_root_set(&self, Parameters(params): Parameters<AtlasRootSetParams>) -> String {
+    fn atlas_root_set(
+        &self,
+        Parameters(params): Parameters<AtlasRootSetParams>,
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let root = canonical_project_root(Path::new(&params.root))?;
             let report = crate::bind_project_root(
@@ -5711,7 +5766,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_config",
         description = "Return the effective ProjectAtlas scan, purpose, and output configuration."
     )]
-    fn atlas_config(&self, Parameters(params): Parameters<AtlasProjectParams>) -> String {
+    fn atlas_config(
+        &self,
+        Parameters(params): Parameters<AtlasProjectParams>,
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.admin_project_root(params.project_path)?;
             let report = effective_config_report(&Self::load_config_for_state(&state)?);
@@ -5724,7 +5782,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_ignore_list",
         description = "List effective ProjectAtlas manual ignore policy and inherited .gitignore status."
     )]
-    fn atlas_ignore_list(&self, Parameters(params): Parameters<AtlasProjectParams>) -> String {
+    fn atlas_ignore_list(
+        &self,
+        Parameters(params): Parameters<AtlasProjectParams>,
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.admin_project_root(params.project_path)?;
             let report = list_ignore_entries(state.config_path.as_deref(), &state.root)?;
@@ -5740,7 +5801,7 @@ impl ProjectAtlasMcpServer {
     fn atlas_ignore_init_gitignore(
         &self,
         Parameters(params): Parameters<AtlasProjectParams>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.admin_project_root(params.project_path)?;
             let report = init_gitignore(state.config_path.as_deref(), &state.root)?;
@@ -5756,7 +5817,7 @@ impl ProjectAtlasMcpServer {
     fn atlas_ignore_add(
         &self,
         Parameters(params): Parameters<AtlasIgnoreMutationParams>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.admin_project_root(params.project_path)?;
             let kind = Self::parse_ignore_kind(params.kind.as_deref(), true)?.ok_or_else(|| {
@@ -5780,7 +5841,7 @@ impl ProjectAtlasMcpServer {
     fn atlas_ignore_remove(
         &self,
         Parameters(params): Parameters<AtlasIgnoreMutationParams>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.admin_project_root(params.project_path)?;
             let kind = Self::parse_ignore_kind(params.kind.as_deref(), false)?;
@@ -5799,7 +5860,7 @@ impl ProjectAtlasMcpServer {
         name = "atlas_scan",
         description = "Scan repository structure, import ProjectAtlas purpose metadata, rebuild symbols, and return a TOON overview."
     )]
-    fn atlas_scan(&self, Parameters(params): Parameters<AtlasScanParams>) -> String {
+    fn atlas_scan(&self, Parameters(params): Parameters<AtlasScanParams>) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let nearest_project = self.nearest_project_enabled(params.nearest_project);
             let background = params.background.unwrap_or(false);
@@ -5856,7 +5917,7 @@ impl ProjectAtlasMcpServer {
         &self,
         params: AtlasProjectParams,
         context: Option<RequestContext<RoleServer>>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.state_for_project_path(params.project_path)?;
             self.with_fresh_string_and_usage_for_request(&state, context, |store, stamp| {
@@ -5887,7 +5948,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasProjectParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         self.atlas_overview_response(params, Some(context))
     }
 
@@ -5900,7 +5961,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasQueryParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         self.atlas_folders_response(params, Some(context))
     }
 
@@ -5909,7 +5970,7 @@ impl ProjectAtlasMcpServer {
         &self,
         params: AtlasQueryParams,
         context: Option<RequestContext<RoleServer>>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.state_for_project_path(params.project_path)?;
             let query = Self::query_or_empty(params.query);
@@ -5942,7 +6003,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasFilesParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         self.atlas_files_response(params, Some(context))
     }
 
@@ -5951,7 +6012,7 @@ impl ProjectAtlasMcpServer {
         &self,
         params: AtlasFilesParams,
         context: Option<RequestContext<RoleServer>>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let nearest_project = self.nearest_project_enabled(params.nearest_project);
             let (state, folder_filter, routed_project) = self.state_and_optional_folder_filter(
@@ -6010,7 +6071,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasQueryParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.state_for_project_path(params.project_path)?;
             let query = Self::query_or_empty(params.query);
@@ -6043,7 +6104,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasOutlineParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let nearest_project = self.nearest_project_enabled(params.nearest_project);
             let resolved = self.state_and_file_key(
@@ -6080,7 +6141,7 @@ impl ProjectAtlasMcpServer {
         &self,
         params: &AtlasFileSummaryParams,
         context: Option<RequestContext<RoleServer>>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let nearest_project = self.nearest_project_enabled(params.nearest_project);
             let resolved = self.state_and_file_key(
@@ -6126,7 +6187,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasFileSummaryParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         self.atlas_file_summary_response(&params, Some(context))
     }
 
@@ -6139,7 +6200,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasSearchParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.state_for_project_path(params.project_path.clone())?;
             self.with_fresh_string_and_usage_controlled_for_request(
@@ -6183,7 +6244,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasSliceParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let nearest_project = self.nearest_project_enabled(params.nearest_project);
             let resolved = self.state_and_file_key(
@@ -6271,7 +6332,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_symbols_build",
         description = "Rebuild ProjectAtlas symbol graphs for indexed files and return a TOON build report."
     )]
-    fn atlas_symbols_build(&self, Parameters(params): Parameters<AtlasScanParams>) -> String {
+    fn atlas_symbols_build(
+        &self,
+        Parameters(params): Parameters<AtlasScanParams>,
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let nearest_project = self.nearest_project_enabled(params.nearest_project);
             let background = params.background.unwrap_or(false);
@@ -6330,7 +6394,7 @@ impl ProjectAtlasMcpServer {
         &self,
         params: &AtlasSymbolsParams,
         context: Option<RequestContext<RoleServer>>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let nearest_project = self.nearest_project_enabled(params.nearest_project);
             let (state, file, routed_project) = self.state_and_optional_file_key(
@@ -6383,7 +6447,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasSymbolsParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         self.atlas_symbols_response(&params, Some(context))
     }
 
@@ -6634,7 +6698,7 @@ impl ProjectAtlasMcpServer {
         &self,
         params: &AtlasSymbolRelationsParams,
         context: Option<RequestContext<RoleServer>>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let (detailed, analysis) = match params
                 .view
@@ -6778,7 +6842,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasSymbolRelationsParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         self.atlas_symbol_relations_response(&params, Some(context))
     }
 
@@ -6791,7 +6855,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasHealthParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.state_for_project_path(params.project_path.clone())?;
             if params.coverage.unwrap_or(false) {
@@ -6859,7 +6923,7 @@ impl ProjectAtlasMcpServer {
     fn atlas_health_resolve(
         &self,
         Parameters(params): Parameters<AtlasHealthResolveParams>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.state_for_project_path(params.project_path)?;
             let store = Self::open_existing_mut_store(&state)?;
@@ -6880,7 +6944,7 @@ impl ProjectAtlasMcpServer {
         name = "atlas_lint",
         description = "Run ProjectAtlas lint checks and return an ok flag, CLI-compatible exit code, and report text."
     )]
-    fn atlas_lint(&self, Parameters(params): Parameters<AtlasLintParams>) -> String {
+    fn atlas_lint(&self, Parameters(params): Parameters<AtlasLintParams>) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.admin_project_root(params.project_path.clone())?;
             let report = Self::lint_report_for_state(&state, &params)?;
@@ -6893,7 +6957,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_token_report",
         description = "Return ProjectAtlas token-savings telemetry for the whole index or one session."
     )]
-    fn atlas_token_report(&self, Parameters(params): Parameters<AtlasTokenParams>) -> String {
+    fn atlas_token_report(
+        &self,
+        Parameters(params): Parameters<AtlasTokenParams>,
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.state_for_project_path(params.project_path.clone())?;
             let store = Self::open_read_store(&state)?;
@@ -6975,7 +7042,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasParityParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.state_for_project_path(params.project_path)?;
             let profile = params
@@ -6992,7 +7059,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_settings",
         description = "Return ProjectAtlas local settings, config, and durable index paths."
     )]
-    fn atlas_settings(&self, Parameters(params): Parameters<AtlasProjectParams>) -> String {
+    fn atlas_settings(
+        &self,
+        Parameters(params): Parameters<AtlasProjectParams>,
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.state_for_project_path(params.project_path)?;
             self.render_settings_with_capabilities(&state)
@@ -7004,7 +7074,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_watch_status",
         description = "Return ProjectAtlas watcher availability and current operating mode."
     )]
-    fn atlas_watch_status(&self, Parameters(params): Parameters<AtlasProjectParams>) -> String {
+    fn atlas_watch_status(
+        &self,
+        Parameters(params): Parameters<AtlasProjectParams>,
+    ) -> McpToolTextResult {
         let state = match self.state_for_project_path(params.project_path) {
             Ok(state) => state,
             Err(error) => return Self::as_mcp_text(Err(error)),
@@ -7023,7 +7096,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_watch_once",
         description = "Run one MCP-safe watcher refresh pass over the repository and rebuild changed symbols, with optional worker, timeout, and text-index size controls."
     )]
-    fn atlas_watch_once(&self, Parameters(params): Parameters<AtlasWatchOnceParams>) -> String {
+    fn atlas_watch_once(
+        &self,
+        Parameters(params): Parameters<AtlasWatchOnceParams>,
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let nearest_project = self.nearest_project_enabled(params.nearest_project);
             let background = params.background.unwrap_or(false);
@@ -7088,7 +7164,7 @@ impl ProjectAtlasMcpServer {
     fn atlas_strip_legacy_purpose(
         &self,
         Parameters(params): Parameters<AtlasStripLegacyParams>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let nearest_project = self.nearest_project_enabled(params.nearest_project);
             let (state, path) =
@@ -7111,7 +7187,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_reset_index",
         description = "Preview or clear ProjectAtlas local SQLite index/cache files for recovery."
     )]
-    fn atlas_reset_index(&self, Parameters(params): Parameters<AtlasResetIndexParams>) -> String {
+    fn atlas_reset_index(
+        &self,
+        Parameters(params): Parameters<AtlasResetIndexParams>,
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.state_for_project_path(params.project_path)?;
             let report = reset_index_files(
@@ -7129,7 +7208,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_mcp_config",
         description = "Return a generated ProjectAtlas MCP config document for mcp-json, codex, claude-code, or opencode hosts."
     )]
-    fn atlas_mcp_config(&self, Parameters(params): Parameters<AtlasMcpConfigParams>) -> String {
+    fn atlas_mcp_config(
+        &self,
+        Parameters(params): Parameters<AtlasMcpConfigParams>,
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.admin_project_root(params.project_path)?;
             let harness = Self::parse_harness_config(params.harness.as_deref())?;
@@ -7152,7 +7234,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_runtime_info",
         description = "Return ProjectAtlas runtime identity, version, capabilities, and compiled MCP tool names."
     )]
-    fn atlas_runtime_info(&self, Parameters(_params): Parameters<AtlasProjectParams>) -> String {
+    fn atlas_runtime_info(
+        &self,
+        Parameters(_params): Parameters<AtlasProjectParams>,
+    ) -> McpToolTextResult {
         let _session_scope = self.session.as_str();
         Self::as_mcp_text(Ok(render_runtime_info(&build_runtime_info())))
     }
@@ -7166,7 +7251,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasSessionBriefParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             if params.compact.unwrap_or(false) {
                 let brief = self.build_compact_session_brief(params, Some(context))?;
@@ -7183,7 +7268,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_task_status",
         description = "Return typed status for a bounded MCP task-progress record."
     )]
-    fn atlas_task_status(&self, Parameters(params): Parameters<AtlasTaskParams>) -> String {
+    fn atlas_task_status(
+        &self,
+        Parameters(params): Parameters<AtlasTaskParams>,
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let status = self.task_status(params.task_id)?;
             Self::encode_named_payload(MCP_PAYLOAD_TASK_STATUS, &status)
@@ -7195,7 +7283,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_task_cancel",
         description = "Request cancellation for a bounded MCP task-progress record."
     )]
-    fn atlas_task_cancel(&self, Parameters(params): Parameters<AtlasTaskParams>) -> String {
+    fn atlas_task_cancel(
+        &self,
+        Parameters(params): Parameters<AtlasTaskParams>,
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let cancel = self.task_cancel(params.task_id)?;
             Self::encode_named_payload(MCP_PAYLOAD_TASK_CANCEL, &cancel)
@@ -7211,7 +7302,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasPurposeQueueParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.state_for_project_path(params.health.project_path.clone())?;
             let query =
@@ -7245,7 +7336,10 @@ impl ProjectAtlasMcpServer {
         name = "atlas_purpose_set",
         description = "Set agent-approved ProjectAtlas purpose metadata for one indexed path."
     )]
-    fn atlas_purpose_set(&self, Parameters(params): Parameters<AtlasPurposeSetParams>) -> String {
+    fn atlas_purpose_set(
+        &self,
+        Parameters(params): Parameters<AtlasPurposeSetParams>,
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let state = self.state_for_project_path(params.project_path)?;
             let store = Self::open_existing_mut_store(&state)?;
@@ -7271,7 +7365,7 @@ impl ProjectAtlasMcpServer {
         &self,
         Parameters(params): Parameters<AtlasPurposeReviewParams>,
         context: RequestContext<RoleServer>,
-    ) -> String {
+    ) -> McpToolTextResult {
         Self::as_mcp_text((|| {
             let apply = params.apply.unwrap_or(false);
             let requests = params
@@ -7902,6 +7996,27 @@ mod tests {
                 && payload.contains("filesystem_type: nfs")
                 && payload.contains("supported local filesystem"),
             "MCP TOON lost typed filesystem details or recovery guidance",
+        )
+    }
+
+    #[test]
+    fn mcp_schema_version_mismatches_are_typed_and_content_free()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let error = CliError::Db(DbError::SchemaVersion {
+            found: 17,
+            expected: 16,
+        });
+        let payload = ProjectAtlasMcpServer::encode_error_payload(&error);
+        require(
+            payload.contains("kind: schema_version_mismatch")
+                && payload.contains("found_schema_version: 17")
+                && payload.contains("supported_schema_version: 16")
+                && payload.contains(env!("CARGO_PKG_VERSION"))
+                && payload.contains("do not reset")
+                && !payload.contains(".projectatlas")
+                && !payload.contains("session_id")
+                && !payload.contains("project_root"),
+            "MCP TOON lost typed schema-version details or exposed database context",
         )
     }
 

--- a/crates/projectatlas-cli/src/token_tui.rs
+++ b/crates/projectatlas-cli/src/token_tui.rs
@@ -366,7 +366,7 @@ pub(crate) fn render_token_dashboard_with_theme(
     session: Option<&str>,
     theme: TokenDashboardTheme,
 ) -> String {
-    let width = dashboard_width().clamp(80, 140) as u16;
+    let width = 140;
     with_token_theme(theme, || {
         render_dashboard_to_ansi_string(width, DASHBOARD_HEIGHT, |frame| {
             render_overview_frame(frame, overview, session);
@@ -3466,8 +3466,7 @@ mod tests {
     }
 
     fn render_overview_buffer(overview: &TokenOverview, session: Option<&str>) -> Buffer {
-        let width = dashboard_width().clamp(80, 140) as u16;
-        render_overview_buffer_at_width(overview, session, width)
+        render_overview_buffer_at_width(overview, session, 140)
     }
 
     fn render_overview_buffer_at_width(

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -2705,6 +2705,82 @@ fn assert_settings_reports_supported_predecessor_without_migration(
     drop(connection);
     let bytes_before = fs::read(&db_path)?;
 
+    let token = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .args(["--format", "json", "--db"])
+        .arg(&db_path)
+        .arg("token")
+        .output()?;
+    let token_error = String::from_utf8_lossy(&token.stderr);
+    let token_error_json: Value = serde_json::from_slice(&token.stderr)?;
+    if token.status.success()
+        || token_error_json
+            .pointer("/error/kind")
+            .and_then(Value::as_str)
+            != Some("schema_migration_required")
+        || token_error_json
+            .pointer("/error/schema_migration_required/found_schema_version")
+            .and_then(Value::as_i64)
+            != Some(8)
+        || token_error_json
+            .pointer("/error/schema_migration_required/supported_schema_version")
+            .and_then(Value::as_i64)
+            != Some(16)
+        || token_error_json
+            .pointer("/error/schema_migration_required/migration_steps_remaining")
+            .and_then(Value::as_u64)
+            != Some(8)
+        || !token_error.contains("projectatlas init")
+        || !token_error.contains("atlas_init")
+        || !token_error.contains("same global `--db`/`--config` selection")
+        || !token_error.contains("same MCP server/database binding")
+        || token_error.contains("schema_version_mismatch")
+        || token_error.contains("unsupported schema version")
+    {
+        return Err(io::Error::other(format!(
+            "token misclassified the supported predecessor {label}: {token_error}"
+        ))
+        .into());
+    }
+
+    let executable = assert_cmd::cargo::cargo_bin("projectatlas");
+    let mut mcp = McpContractSession::spawn(&executable, &repo, &db_path)?;
+    let mcp_result = (|| -> Result<(), Box<dyn Error>> {
+        let token_report = mcp.call_tool("atlas_token_report", &json!({}))?;
+        if !token_report.contains("kind: schema_migration_required")
+            || !token_report.contains("found_schema_version: 8")
+            || !token_report.contains("supported_schema_version: 16")
+            || !token_report.contains("migration_steps_remaining: 8")
+            || !token_report.contains("projectatlas init")
+            || !token_report.contains("atlas_init")
+            || !token_report.contains("same global `--db`/`--config` selection")
+            || !token_report.contains("same MCP server/database binding")
+            || token_report.contains("schema_version_mismatch")
+            || token_report.contains("unsupported schema version")
+        {
+            return Err(io::Error::other(format!(
+                "MCP token report misclassified the supported predecessor {label}: {token_report}"
+            ))
+            .into());
+        }
+        let mcp_settings = mcp.call_tool("atlas_settings", &json!({}))?;
+        for required in [
+            "compatibility: supported_predecessor",
+            "migration_required: true",
+            "migration_supported: true",
+            "migration_steps_remaining: 8",
+        ] {
+            if !mcp_settings.contains(required) {
+                return Err(io::Error::other(format!(
+                    "MCP settings omitted predecessor field {required:?} for {label}: {mcp_settings}"
+                ))
+                .into());
+            }
+        }
+        Ok(())
+    })();
+    complete_mcp_test_after_shutdown(mcp_result, || mcp.shutdown())?;
+
     let output = Command::cargo_bin("projectatlas")?
         .current_dir(&repo)
         .args(["--format", "json", "settings"])
@@ -2752,6 +2828,125 @@ fn assert_settings_reports_supported_predecessor_without_migration(
             "settings migrated or mutated the predecessor database {label}"
         ))
         .into());
+    }
+    Ok(())
+}
+
+#[test]
+fn supported_predecessor_recovery_preserves_explicit_database_selection()
+-> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join(TEST_REPO_DIR);
+    let source_dir = repo.join(SRC_DIR_NAME);
+    let selected_dir = repo.join("selected-state");
+    fs::create_dir_all(&source_dir)?;
+    fs::create_dir_all(&selected_dir)?;
+    fs::write(source_dir.join(LIB_RS_FILE_NAME), "pub fn selected() {}\n")?;
+
+    let cli_db = selected_dir.join("cli.db");
+    let mcp_db = selected_dir.join("mcp.db");
+    let config = selected_dir.join("config.toml");
+    let project_root = normalize_native_path_display(fs::canonicalize(&repo)?);
+    fs::write(
+        &config,
+        format!(
+            "[project]\nroot = \"{}\"\n",
+            project_root.replace('\\', "/")
+        ),
+    )?;
+    for database in [&cli_db, &mcp_db] {
+        let connection = Connection::open(database)?;
+        connection.execute_batch(include_str!(
+            "../../projectatlas-db/tests/fixtures/released-schema-8.sql"
+        ))?;
+        connection.execute(
+            "INSERT INTO metadata(key, value) VALUES ('schema_version', '8')",
+            [],
+        )?;
+        connection.execute(
+            "INSERT INTO metadata(key, value) VALUES ('project_root', ?1)",
+            [&project_root],
+        )?;
+    }
+    let default_db = repo.join(ATLAS_DIR_NAME).join("projectatlas.db");
+
+    let cli_error = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .args(["--format", "json", "--db"])
+        .arg(&cli_db)
+        .arg("--config")
+        .arg(&config)
+        .arg("token")
+        .output()?;
+    let cli_error_text = String::from_utf8_lossy(&cli_error.stderr);
+    if cli_error.status.success()
+        || !cli_error_text.contains("schema_migration_required")
+        || !cli_error_text.contains("same global `--db`/`--config` selection")
+    {
+        return Err(io::Error::other(format!(
+            "CLI recovery did not preserve the explicit database selection: {cli_error_text}"
+        ))
+        .into());
+    }
+    let cli_init = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .args(["--format", "json", "--db"])
+        .arg(&cli_db)
+        .arg("--config")
+        .arg(&config)
+        .args(["init", "--no-scan"])
+        .output()?;
+    if !cli_init.status.success() {
+        return Err(io::Error::other(format!(
+            "CLI recovery failed for the selected database: {}",
+            String::from_utf8_lossy(&cli_init.stderr)
+        ))
+        .into());
+    }
+    if default_db.exists() {
+        return Err(io::Error::other("CLI recovery created the default database").into());
+    }
+
+    let executable = assert_cmd::cargo::cargo_bin("projectatlas");
+    let mut mcp = McpContractSession::spawn(&executable, &repo, &mcp_db)?;
+    let mcp_result = (|| -> Result<(), Box<dyn Error>> {
+        let migration = mcp.call_tool("atlas_token_report", &json!({}))?;
+        if !migration.contains("schema_migration_required")
+            || !migration.contains("same MCP server/database binding")
+        {
+            return Err(io::Error::other(format!(
+                "MCP recovery did not preserve the configured database binding: {migration}"
+            ))
+            .into());
+        }
+        mcp.call_tool("atlas_init", &json!({"no_scan": true}))?;
+        let settings = mcp.call_tool("atlas_settings", &json!({}))?;
+        if !settings.contains("compatibility: current") {
+            return Err(io::Error::other(format!(
+                "MCP recovery did not migrate the configured database: {settings}"
+            ))
+            .into());
+        }
+        Ok(())
+    })();
+    complete_mcp_test_after_shutdown(mcp_result, || mcp.shutdown())?;
+
+    for (adapter, database) in [("CLI", &cli_db), ("MCP", &mcp_db)] {
+        let connection = Connection::open(database)?;
+        let stored_version: String = connection.query_row(
+            "SELECT value FROM metadata WHERE key = 'schema_version'",
+            [],
+            |row| row.get(0),
+        )?;
+        if stored_version != "16" {
+            return Err(io::Error::other(format!(
+                "{adapter} recovery did not migrate the explicitly selected database"
+            ))
+            .into());
+        }
+    }
+    if default_db.exists() {
+        return Err(io::Error::other("MCP recovery created the default database").into());
     }
     Ok(())
 }
@@ -4448,8 +4643,10 @@ fn plugin_installers_require_matching_runtime_version() -> Result<(), Box<dyn Er
         "$inheritedSynchronizedMirrorReady = $stableMirrorReady",
         "$futureProcessPathReady = Set-ProjectAtlasPathPrecedence",
         "$parentCliReady = $inheritedCommandReady -or $inheritedSynchronizedMirrorReady",
-        "$hostRestartRequired = -not $parentCliReady -and $futureProcessPathReady",
-        "ProjectAtlas readiness: runtime_mcp_configs_ready=",
+        "$hostRestartRequired = $verifiedRuntimeReady -and -not $parentCliReady -and $futureProcessPathReady",
+        "ProjectAtlas readiness: runtime_ready=",
+        "generated_mcp_configs_ready=",
+        "runtime_mcp_configs_ready=",
         "installer_cli_ready=",
         "parent_cli_ready=",
         "host_restart_required=",
@@ -4490,9 +4687,10 @@ fn plugin_installers_require_matching_runtime_version() -> Result<(), Box<dyn Er
         r#"Write-ProjectAtlasMcpConfig $claudeMcpConfigPath "claude-code""#,
         r#"Write-ProjectAtlasMcpConfig $opencodeConfigPath "opencode""#,
         "Confirm-ProjectAtlasGeneratedMcpConfig",
-        "Test-ProjectAtlasRuntimeMcpConfigReadiness",
-        "Test-ProjectAtlasRuntime $RuntimePath $ExpectedVersion",
-        "$runtimeMcpConfigsReady = Test-ProjectAtlasRuntimeMcpConfigReadiness",
+        "Test-ProjectAtlasGeneratedMcpConfigReadiness",
+        "$verifiedRuntimeReady = Test-ProjectAtlasRuntime $projectAtlas $ProjectAtlasVersion",
+        "$generatedMcpConfigsReady = Test-ProjectAtlasGeneratedMcpConfigReadiness",
+        "$runtimeMcpConfigsReady = $verifiedRuntimeReady -and $generatedMcpConfigsReady",
         "$probeCleanupSucceeded = -not $probeCleanupFailure",
         "if (-not $probeCleanupSucceeded)",
         "ProjectAtlas generated MCP config verified",
@@ -7009,7 +7207,7 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             .into());
         }
         if !installer_output_text.trim_end().ends_with(
-            "ProjectAtlas readiness: runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=true host_restart_required=false",
+            "ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=true host_restart_required=false",
         ) || installer_output_text.contains("Existing host restart required:")
         {
             return Err(io::Error::other(format!(
@@ -7222,19 +7420,22 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
                 .into());
             }
         }
+        let stable_runtime_diagnostic_path =
+            normalize_native_path_display(fs::canonicalize(&stable_runtime)?).replace('/', "\\");
+        let versioned_runtime_diagnostic_path =
+            normalize_native_path_display(fs::canonicalize(&versioned_runtime)?).replace('/', "\\");
         for required in [
             format!(
-                "ProjectAtlas stale bare command: path={} observed_version=unavailable ready=false",
-                stable_runtime.display()
+                "ProjectAtlas stale bare command: path={stable_runtime_diagnostic_path} observed_version=unavailable ready=false"
             ),
             format!(
                 "verified_runtime={} target_version={}",
-                versioned_runtime.display(),
+                versioned_runtime_diagnostic_path,
                 env!("CARGO_PKG_VERSION")
             ),
             format!(
                 "ProjectAtlas verified absolute runtime command: & '{}' --require-version '{}' --format json runtime-info",
-                versioned_runtime.display(),
+                versioned_runtime_diagnostic_path,
                 env!("CARGO_PKG_VERSION")
             ),
             "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=false"
@@ -7242,7 +7443,7 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             format!(
                 "-ProjectAtlasVersion '{}' -RuntimePath '{}'",
                 env!("CARGO_PKG_VERSION"),
-                versioned_runtime.display()
+                versioned_runtime_diagnostic_path
             ),
             format!(
                 "projectatlas --require-version '{}' token --view tui",
@@ -7258,7 +7459,7 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
         }
         if !stale_output.status.success()
             || !stale_output_text.trim_end().ends_with(
-                "ProjectAtlas readiness: runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=false host_restart_required=false",
+                "ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=false host_restart_required=false",
             )
             || stale_output_text.contains("Existing host restart required:")
             || !stale_output_text.contains("restart alone will not repair it")
@@ -7381,7 +7582,7 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
         );
         if !post_quarantine_output.status.success()
             || !post_quarantine_text.trim_end().ends_with(
-                "ProjectAtlas readiness: runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=true host_restart_required=false",
+                "ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=true host_restart_required=false",
             )
             || post_quarantine_text.contains("Existing host restart required:")
         {
@@ -7475,7 +7676,7 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
         if !converged_output.status.success()
             || !converged_output_text.contains("stable_mirror_ready=true")
             || !converged_output_text.trim_end().ends_with(
-                "ProjectAtlas readiness: runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=true host_restart_required=false",
+                "ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=true host_restart_required=false",
             )
             || converged_output_text.contains("ProjectAtlas stale bare command:")
         {
@@ -7878,7 +8079,7 @@ public static class Program
                 "ProjectAtlas convergence: update_state=complete stable_mirror_ready=true obsolete_mcp_handoff=completed",
             )
             || !installer_output.trim_end().ends_with(
-                "ProjectAtlas readiness: runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=false host_restart_required=false",
+                "ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=false host_restart_required=false",
             )
             || !normalized_installer_output.contains(&expected_path_guidance)
             || normalized_installer_output
@@ -7992,19 +8193,22 @@ public static class Program
             String::from_utf8_lossy(&retry_output.stderr)
         );
         let normalized_retry_text = retry_text.split_whitespace().collect::<Vec<_>>().join(" ");
+        let stable_runtime_diagnostic_path =
+            normalize_native_path_display(fs::canonicalize(&stable_runtime)?).replace('/', "\\");
+        let runtime_diagnostic_path =
+            normalize_native_path_display(fs::canonicalize(&runtime)?).replace('/', "\\");
         for required in [
             format!(
-                "ProjectAtlas stale bare command: path={} observed_version=0.3.26 ready=false",
-                stable_runtime.display()
+                "ProjectAtlas stale bare command: path={stable_runtime_diagnostic_path} observed_version=0.3.26 ready=false"
             ),
             format!(
                 "verified_runtime={} target_version={}",
-                runtime.display(),
+                runtime_diagnostic_path,
                 env!("CARGO_PKG_VERSION")
             ),
             format!(
                 "ProjectAtlas verified absolute runtime command: & '{}' --require-version '{}' --format json runtime-info",
-                runtime.display(),
+                runtime_diagnostic_path,
                 env!("CARGO_PKG_VERSION")
             ),
             "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=false"
@@ -8226,7 +8430,9 @@ public static class Program
     compile_codex_mcp_owner_fixture(&codex_owner_fixture)?;
     let first_child_pid_file = temp.path().join("first-obsolete-mcp.pid");
 
-    let runtime = assert_cmd::cargo::cargo_bin("projectatlas");
+    let runtime_source = assert_cmd::cargo::cargo_bin("projectatlas");
+    let runtime = temp.path().join("projectatlas-current.exe");
+    fs::copy(&runtime_source, &runtime)?;
     let plugin_cache = isolated_home.join(FAKE_CODEX_PLUGIN_CACHE_DIR);
     let plugin_manifest = plugin_cache
         .join(CODEX_PLUGIN_MANIFEST_DIR)
@@ -8290,10 +8496,11 @@ public static class Program
     let fake_codex_log = isolated_home.join(FAKE_CODEX_LOG_FILE);
     let config_drift_trigger = isolated_home.join("drift-generated-config");
     let config_to_drift = atlas_dir.join("projectatlas.mcp.json");
+    let runtime_drift_trigger = isolated_home.join("drift-runtime");
     let fake_codex = isolated_home.join("codex.cmd");
     fs::write(
         &fake_codex,
-        "@echo off\r\necho %*>>\"%PROJECTATLAS_FAKE_CODEX_LOG%\"\r\nif \"%1\"==\"plugin\" if \"%2\"==\"list\" (\r\n  if exist \"%PROJECTATLAS_FAKE_CODEX_CONFIG_DRIFT_TRIGGER%\" (\r\n    echo {}>\"%PROJECTATLAS_FAKE_CODEX_CONFIG_TO_DRIFT%\"\r\n    del /q \"%PROJECTATLAS_FAKE_CODEX_CONFIG_DRIFT_TRIGGER%\"\r\n  )\r\n  type \"%PROJECTATLAS_FAKE_CODEX_PLUGIN_LIST%\"\r\n  exit /b 0\r\n)\r\nif \"%1\"==\"mcp\" if \"%2\"==\"get\" (\r\n  if not exist \"%PROJECTATLAS_FAKE_CODEX_REGISTRY%\" exit /b 1\r\n  type \"%PROJECTATLAS_FAKE_CODEX_REGISTRY%\"\r\n  exit /b 0\r\n)\r\nexit /b 0\r\n",
+        "@echo off\r\necho %*>>\"%PROJECTATLAS_FAKE_CODEX_LOG%\"\r\nif \"%1\"==\"plugin\" if \"%2\"==\"list\" (\r\n  if exist \"%PROJECTATLAS_FAKE_CODEX_RUNTIME_DRIFT_TRIGGER%\" (\r\n    echo invalid>\"%PROJECTATLAS_FAKE_CODEX_RUNTIME_TO_DRIFT%\"\r\n    del /q \"%PROJECTATLAS_FAKE_CODEX_RUNTIME_DRIFT_TRIGGER%\"\r\n  )\r\n  if exist \"%PROJECTATLAS_FAKE_CODEX_CONFIG_DRIFT_TRIGGER%\" (\r\n    echo {}>\"%PROJECTATLAS_FAKE_CODEX_CONFIG_TO_DRIFT%\"\r\n    del /q \"%PROJECTATLAS_FAKE_CODEX_CONFIG_DRIFT_TRIGGER%\"\r\n  )\r\n  type \"%PROJECTATLAS_FAKE_CODEX_PLUGIN_LIST%\"\r\n  exit /b 0\r\n)\r\nif \"%1\"==\"mcp\" if \"%2\"==\"get\" (\r\n  if not exist \"%PROJECTATLAS_FAKE_CODEX_REGISTRY%\" exit /b 1\r\n  type \"%PROJECTATLAS_FAKE_CODEX_REGISTRY%\"\r\n  exit /b 0\r\n)\r\nexit /b 0\r\n",
     )?;
     let stable_runtime_dir = stable_runtime
         .parent()
@@ -8353,6 +8560,11 @@ public static class Program
                 &config_drift_trigger,
             )
             .env("PROJECTATLAS_FAKE_CODEX_CONFIG_TO_DRIFT", &config_to_drift)
+            .env(
+                "PROJECTATLAS_FAKE_CODEX_RUNTIME_DRIFT_TRIGGER",
+                &runtime_drift_trigger,
+            )
+            .env("PROJECTATLAS_FAKE_CODEX_RUNTIME_TO_DRIFT", &runtime)
             .env("PROJECTATLAS_NO_TELEMETRY", "1")
             .output()
     };
@@ -8388,6 +8600,8 @@ public static class Program
         || !no_handoff_drift_text.contains("update_state=partial")
         || !no_handoff_drift_text.contains("obsolete_mcp_handoff=not_required")
         || !no_handoff_drift_text.contains("codex_plugin_ready=true codex_registry_ready=true")
+        || !no_handoff_drift_text.contains("runtime_ready=true")
+        || !no_handoff_drift_text.contains("generated_mcp_configs_ready=false")
         || !no_handoff_drift_text.contains("runtime_mcp_configs_ready=false")
         || !no_handoff_drift_text.contains("rerun this installer")
         || no_handoff_drift_text.contains("integration verified through generated MCP config")
@@ -8398,6 +8612,43 @@ public static class Program
         ))
         .into());
     }
+    let runtime_diagnostic_path =
+        normalize_native_path_display(fs::canonicalize(&runtime)?).replace('/', "\\");
+    fs::write(&runtime_drift_trigger, b"drift")?;
+    let no_handoff_runtime_drift_output = run_installer(&[])?;
+    let no_handoff_runtime_drift_text = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&no_handoff_runtime_drift_output.stdout),
+        String::from_utf8_lossy(&no_handoff_runtime_drift_output.stderr)
+    );
+    let normalized_no_handoff_runtime_drift_text = no_handoff_runtime_drift_text
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if !no_handoff_runtime_drift_output.status.success()
+        || !no_handoff_runtime_drift_text.contains("update_state=partial")
+        || !no_handoff_runtime_drift_text.contains("obsolete_mcp_handoff=not_required")
+        || !no_handoff_runtime_drift_text.contains("runtime_ready=false")
+        || !no_handoff_runtime_drift_text.contains("generated_mcp_configs_ready=true")
+        || !no_handoff_runtime_drift_text.contains("runtime_mcp_configs_ready=false")
+        || !no_handoff_runtime_drift_text.contains("installer_cli_ready=false")
+        || !normalized_no_handoff_runtime_drift_text.contains(&format!(
+            "ProjectAtlas runtime failed final verification: path={runtime_diagnostic_path}"
+        ))
+        || !no_handoff_runtime_drift_text.contains(
+            "ProjectAtlas PATH shadow report skipped because the requested absolute runtime failed final verification",
+        )
+        || no_handoff_runtime_drift_text.contains("ProjectAtlas verified absolute runtime command:")
+        || no_handoff_runtime_drift_text.contains("integration verified through generated MCP config")
+        || no_handoff_runtime_drift_text
+            .contains("The runtime and generated MCP configs are ready")
+    {
+        return Err(io::Error::other(format!(
+            "installer cached runtime readiness before final no-handoff probes:\n{no_handoff_runtime_drift_text}"
+        ))
+        .into());
+    }
+    fs::copy(&runtime_source, &runtime)?;
     fs::remove_file(&stable_runtime)?;
     fs::create_dir(&stable_runtime)?;
     let invalid_mirror_output = run_installer(&[])?;
@@ -8644,11 +8895,24 @@ public static class Program
             String::from_utf8_lossy(&drift_output.stdout),
             String::from_utf8_lossy(&drift_output.stderr)
         );
+        let normalized_drift_text = drift_text.split_whitespace().collect::<Vec<_>>().join(" ");
         if !drift_output.status.success()
             || !drift_text.contains("update_state=partial")
             || !drift_text.contains("obsolete_mcp_handoff=replacement_readiness_changed")
+            || !drift_text.contains("runtime_ready=true")
+            || !drift_text.contains("generated_mcp_configs_ready=false")
             || !drift_text.contains("runtime_mcp_configs_ready=false")
             || !drift_text.contains("rerun this installer")
+            || !normalized_drift_text.contains("ProjectAtlas stale bare command: path=")
+            || !normalized_drift_text.contains("observed_version=0.3.26 ready=false")
+            || !normalized_drift_text
+                .contains(&format!("target_version={}", env!("CARGO_PKG_VERSION")))
+            || !normalized_drift_text.contains("verified_runtime=")
+            || !normalized_drift_text.contains(
+                "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=",
+            )
+            || !normalized_drift_text.contains("--format json runtime-info")
+            || !normalized_drift_text.contains("token --view tui")
             || drift_text.contains("integration verified through generated MCP config")
             || drift_text.contains("The runtime and generated MCP configs are ready")
             || !windows_process_is_alive(&first_obsolete_mcp_pid)?
@@ -8659,6 +8923,49 @@ public static class Program
             ))
             .into());
         }
+        let runtime_diagnostic_path =
+            normalize_native_path_display(fs::canonicalize(&runtime)?).replace('/', "\\");
+        fs::write(&runtime_drift_trigger, b"drift")?;
+        let runtime_drift_output =
+            run_installer(&[first_obsolete_mcp_pid.process_id, first_owner.id()])?;
+        let runtime_drift_text = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&runtime_drift_output.stdout),
+            String::from_utf8_lossy(&runtime_drift_output.stderr)
+        );
+        let normalized_runtime_drift_text = runtime_drift_text
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        if !runtime_drift_output.status.success()
+            || !runtime_drift_text.contains("update_state=partial")
+            || !runtime_drift_text.contains("runtime_ready=false")
+            || !runtime_drift_text.contains("generated_mcp_configs_ready=true")
+            || !runtime_drift_text.contains("runtime_mcp_configs_ready=false")
+            || !normalized_runtime_drift_text.contains("ProjectAtlas stale bare command: path=")
+            || !normalized_runtime_drift_text.contains("observed_version=0.3.26 ready=false")
+            || !normalized_runtime_drift_text
+                .contains(&format!("target_version={}", env!("CARGO_PKG_VERSION")))
+            || !normalized_runtime_drift_text.contains(&format!(
+                "ProjectAtlas requested absolute runtime failed final verification: path={runtime_diagnostic_path}"
+            ))
+            || normalized_runtime_drift_text.contains("verified_runtime=")
+            || normalized_runtime_drift_text
+                .contains("ProjectAtlas verified absolute runtime command:")
+            || normalized_runtime_drift_text.contains(&format!(
+                "-RuntimePath '{runtime_diagnostic_path}'"
+            ))
+            || runtime_drift_text.contains("integration verified through generated MCP config")
+            || runtime_drift_text.contains("The runtime and generated MCP configs are ready")
+            || !windows_process_is_alive(&first_obsolete_mcp_pid)?
+            || first_owner.try_wait()?.is_some()
+        {
+            return Err(io::Error::other(format!(
+                "installer advertised a runtime that failed final verification:\n{runtime_drift_text}"
+            ))
+            .into());
+        }
+        fs::copy(&runtime_source, &runtime)?;
         let (owner, process_id) = spawn_codex_owned_obsolete_mcp(
             &codex_owner_fixture,
             &stable_runtime,
@@ -9061,7 +9368,7 @@ foreach ($functionName in @(
         "Test-ProjectAtlasJsonObject",
         "Test-ProjectAtlasJsonStringArray",
         "Confirm-ProjectAtlasGeneratedMcpConfig",
-        "Test-ProjectAtlasRuntimeMcpConfigReadiness"
+        "Test-ProjectAtlasGeneratedMcpConfigReadiness"
     )) {
     $match = [regex]::Match($installerSource, "(?ms)^function $functionName \{.*?^\}")
     if (-not $match.Success) { throw "Installer function missing: $functionName" }
@@ -9078,44 +9385,27 @@ $digest = Confirm-ProjectAtlasGeneratedMcpConfig `
     $env:PROJECTATLAS_PROJECT_ROOT
 Write-Output "validated_digest=$digest"
 $validatedBytes = [System.IO.File]::ReadAllBytes($env:PROJECTATLAS_GENERATED_CONFIG)
-function Test-ProjectAtlasRuntime { return $script:runtimeReady }
-$script:runtimeReady = $true
 $configPaths = [string[]]@($env:PROJECTATLAS_GENERATED_CONFIG)
 $expectedDigests = [string[]]@($digest)
-if (-not (Test-ProjectAtlasRuntimeMcpConfigReadiness `
-        $env:PROJECTATLAS_RUNTIME `
-        $env:PROJECTATLAS_VERSION `
+if (-not (Test-ProjectAtlasGeneratedMcpConfigReadiness `
         $configPaths `
         $expectedDigests)) {
-    throw "Validated runtime/config bundle was not ready."
+    throw "Validated generated config was not ready."
 }
 [System.IO.File]::WriteAllBytes(
     $env:PROJECTATLAS_GENERATED_CONFIG,
     [System.IO.File]::ReadAllBytes($env:PROJECTATLAS_EXTRA_ARGUMENTS)
 )
-if (Test-ProjectAtlasRuntimeMcpConfigReadiness `
-    $env:PROJECTATLAS_RUNTIME `
-    $env:PROJECTATLAS_VERSION `
+if (Test-ProjectAtlasGeneratedMcpConfigReadiness `
     $configPaths `
     $expectedDigests) {
     throw "Changed generated config was reported ready."
 }
 [System.IO.File]::WriteAllBytes($env:PROJECTATLAS_GENERATED_CONFIG, $validatedBytes)
-$script:runtimeReady = $false
-if (Test-ProjectAtlasRuntimeMcpConfigReadiness `
-    $env:PROJECTATLAS_RUNTIME `
-    $env:PROJECTATLAS_VERSION `
-    $configPaths `
-    $expectedDigests) {
-    throw "Changed runtime readiness was reported ready."
-}
-$script:runtimeReady = $true
 Microsoft.PowerShell.Management\Remove-Item `
     -LiteralPath $env:PROJECTATLAS_GENERATED_CONFIG `
     -Force
-if (Test-ProjectAtlasRuntimeMcpConfigReadiness `
-    $env:PROJECTATLAS_RUNTIME `
-    $env:PROJECTATLAS_VERSION `
+if (Test-ProjectAtlasGeneratedMcpConfigReadiness `
     $configPaths `
     $expectedDigests) {
     throw "Missing generated config was reported ready."
@@ -11179,7 +11469,7 @@ fn windows_release_binary_installer_repairs_stale_mirror_without_registering_it(
         .into());
     }
     if !installer_output_text.trim_end().ends_with(
-        "ProjectAtlas readiness: runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=true host_restart_required=false",
+        "ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=true host_restart_required=false",
     ) || installer_output_text.contains("Existing host restart required:")
     {
         return Err(io::Error::other(format!(
@@ -11282,7 +11572,7 @@ fn windows_release_binary_installer_repairs_stale_mirror_without_registering_it(
     );
     if !stale_parent_install.status.success()
         || !stale_parent_install_text.trim_end().ends_with(
-            "ProjectAtlas readiness: runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=false host_restart_required=false",
+            "ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=false host_restart_required=false",
         )
         || stale_parent_install_text.contains("Existing host restart required:")
         || !stale_parent_install_text.contains("restart alone will not repair it")

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -7572,17 +7572,14 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             String::from_utf8_lossy(&stale_output.stdout),
             String::from_utf8_lossy(&stale_output.stderr)
         );
-        let normalized_stale_output = stale_output_text
-            .split_whitespace()
-            .collect::<Vec<_>>()
-            .join(" ");
+        let normalized_stale_output = stale_output_text.split_whitespace().collect::<String>();
         for required in [
             "ProjectAtlas LocalAppData mirror is locked",
             "verify durable absolute MCP configuration before attempting an exact obsolete-child handoff",
             "process_owner=inspection_failed",
             "ProjectAtlas convergence: update_state=partial stable_mirror_ready=false obsolete_mcp_handoff=inspection_failed",
         ] {
-            if !normalized_stale_output.contains(required) {
+            if !normalized_stale_output.contains(&required.split_whitespace().collect::<String>()) {
                 return Err(io::Error::other(format!(
                     "installer did not provide stale locked-mirror guidance {required:?}\n{stale_output_text}"
                 ))
@@ -7629,7 +7626,7 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
                 env!("CARGO_PKG_VERSION")
             ),
         ] {
-            if !normalized_stale_output.contains(&required) {
+            if !normalized_stale_output.contains(&required.split_whitespace().collect::<String>()) {
                 return Err(io::Error::other(format!(
                     "installer omitted exact stale-command recovery field {required:?}\n{stale_output_text}"
                 ))
@@ -7637,11 +7634,21 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             }
         }
         if !stale_output.status.success()
-            || !stale_output_text.trim_end().ends_with(
-                "ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=false host_restart_required=false",
+            || !normalized_stale_output.ends_with(
+                &"ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=false host_restart_required=false"
+                    .split_whitespace()
+                    .collect::<String>(),
             )
-            || stale_output_text.contains("Existing host restart required:")
-            || !stale_output_text.contains("restart alone will not repair it")
+            || normalized_stale_output.contains(
+                &"Existing host restart required:"
+                    .split_whitespace()
+                    .collect::<String>(),
+            )
+            || !normalized_stale_output.contains(
+                &"restart alone will not repair it"
+                    .split_whitespace()
+                    .collect::<String>(),
+            )
         {
             return Err(io::Error::other(format!(
                 "installer did not report repair-required state for the unchanged stale parent mirror\n{stale_output_text}"
@@ -7655,6 +7662,115 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
         {
             return Err(io::Error::other(format!(
                 "installer terminated the owned stale-mirror lock process: {status}"
+            ))
+            .into());
+        }
+
+        let same_version_shadow = temp
+            .path()
+            .join("machine-shadow-bin")
+            .join("projectatlas.exe");
+        fs::create_dir_all(
+            same_version_shadow
+                .parent()
+                .ok_or_else(|| io::Error::other("same-version shadow parent missing"))?,
+        )?;
+        fs::copy(&versioned_runtime, &same_version_shadow)?;
+        let same_version_path = std::env::join_paths(
+            std::iter::once(
+                same_version_shadow
+                    .parent()
+                    .ok_or_else(|| io::Error::other("same-version shadow parent missing"))?
+                    .to_path_buf(),
+            )
+            .chain(std::env::split_paths(&parent_path)),
+        )?;
+        let compatible_before_same_version_shadow = mcp_database_snapshot(&db)?;
+        let same_version_output = StdCommand::new("powershell")
+            .arg("-NoProfile")
+            .arg("-ExecutionPolicy")
+            .arg("Bypass")
+            .arg("-File")
+            .arg(&standalone_installer)
+            .arg("-ProjectRoot")
+            .arg(&repo)
+            .arg("-RuntimePath")
+            .arg(&versioned_runtime)
+            .env_remove("PROJECTATLAS_VERSION")
+            .env("HOME", &isolated_home)
+            .env("USERPROFILE", &isolated_home)
+            .env("APPDATA", &app_data)
+            .env("LOCALAPPDATA", &local_app_data)
+            .env("PATH", &same_version_path)
+            .env("PROJECTATLAS_SKIP_USER_PATH_UPDATE", "1")
+            .env("PROJECTATLAS_CODEX_COMMAND", &fake_codex)
+            .env("PROJECTATLAS_FAKE_CODEX_LOG", &fake_codex_log)
+            .env("PROJECTATLAS_NO_TELEMETRY", "1")
+            .output()?;
+        let same_version_text = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&same_version_output.stdout),
+            String::from_utf8_lossy(&same_version_output.stderr)
+        );
+        let normalized_same_version_text = same_version_text.split_whitespace().collect::<String>();
+        let same_version_shadow_diagnostic_path =
+            normalize_native_path_display(fs::canonicalize(&same_version_shadow)?)
+                .replace('/', "\\");
+        for required in [
+            format!(
+                "ProjectAtlas stale bare command: path={same_version_shadow_diagnostic_path} observed_version={} ready=false",
+                env!("CARGO_PKG_VERSION")
+            ),
+            format!(
+                "verified_runtime={versioned_runtime_diagnostic_path} target_version={}",
+                env!("CARGO_PKG_VERSION")
+            ),
+            format!(
+                "ProjectAtlas verified absolute runtime command: & '{}' --require-version '{}' --format json runtime-info",
+                versioned_runtime_diagnostic_path,
+                env!("CARGO_PKG_VERSION")
+            ),
+            format!(
+                "ProjectAtlas verified absolute runtime operation: & '{}' '--require-version' '{}' '--db' '{}' '--config' '{}' 'token' '--view' 'tui'",
+                versioned_runtime_diagnostic_path,
+                env!("CARGO_PKG_VERSION"),
+                db_diagnostic_path,
+                config_diagnostic_path
+            ),
+            "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=false"
+                .to_string(),
+            "stable_mirror_ready=false".to_string(),
+            "parent_cli_ready=false".to_string(),
+        ] {
+            if !normalized_same_version_text
+                .contains(&required.split_whitespace().collect::<String>())
+            {
+                return Err(io::Error::other(format!(
+                    "same-version foreign PATH command suppressed recovery field {required:?}\n{same_version_text}"
+                ))
+                .into());
+            }
+        }
+        if !same_version_output.status.success()
+            || mcp_database_snapshot(&db)? != compatible_before_same_version_shadow
+            || temp
+                .path()
+                .join(ATLAS_DIR_NAME)
+                .join("projectatlas.db")
+                .exists()
+        {
+            return Err(io::Error::other(format!(
+                "same-version foreign PATH recovery changed state or failed\n{same_version_text}"
+            ))
+            .into());
+        }
+        if let Some(status) = stale_lock_process
+            .as_mut()
+            .ok_or_else(|| io::Error::other("stale mirror lock process missing"))?
+            .try_wait()?
+        {
+            return Err(io::Error::other(format!(
+                "same-version PATH recovery terminated the unrelated lock owner: {status}"
             ))
             .into());
         }
@@ -7846,6 +7962,7 @@ exit $exitCode
             || !post_quarantine_text.trim_end().ends_with(
                 "ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=true host_restart_required=false",
             )
+            || post_quarantine_text.contains("ProjectAtlas stale bare command:")
             || post_quarantine_text.contains("Existing host restart required:")
         {
             return Err(io::Error::other(format!(
@@ -8327,10 +8444,7 @@ public static class Program
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
-        let normalized_installer_output = installer_output
-            .split_whitespace()
-            .collect::<Vec<_>>()
-            .join(" ");
+        let normalized_installer_output = installer_output.split_whitespace().collect::<String>();
         let expected_path_guidance = format!(
             "Configure {} first on PATH, then rerun this installer if convergence remains partial.",
             runtime
@@ -8344,17 +8458,26 @@ public static class Program
             ))
             .into());
         }
-        if !installer_output.contains("Retired exact obsolete Codex-owned ProjectAtlas MCP process")
-            || !installer_output.contains(
-                "ProjectAtlas convergence: update_state=complete stable_mirror_ready=true obsolete_mcp_handoff=completed",
-            )
-            || !installer_output.trim_end().ends_with(
-                "ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=false host_restart_required=false",
-            )
-            || !normalized_installer_output.contains(&expected_path_guidance)
+        if !normalized_installer_output.contains(
+            &"Retired exact obsolete Codex-owned ProjectAtlas MCP process"
+                .split_whitespace()
+                .collect::<String>(),
+        ) || !normalized_installer_output.contains(
+            &"ProjectAtlas convergence: update_state=complete stable_mirror_ready=true obsolete_mcp_handoff=completed"
+                .split_whitespace()
+                .collect::<String>(),
+        ) || !normalized_installer_output.ends_with(
+            &"ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=false host_restart_required=false"
+                .split_whitespace()
+                .collect::<String>(),
+        ) || !normalized_installer_output.contains(
+            &expected_path_guidance
+                .split_whitespace()
+                .collect::<String>(),
+        )
             || normalized_installer_output
-                .contains("could not prove an exact retireable obsolete MCP owner")
-            || normalized_installer_output.contains("restart the owning host")
+                .contains("couldnotproveanexactretireableobsoleteMCPowner")
+            || normalized_installer_output.contains("restarttheowninghost")
         {
             return Err(io::Error::other(format!(
                 "installer did not report exact complete obsolete MCP convergence:\n{installer_output}"
@@ -8462,7 +8585,7 @@ public static class Program
             String::from_utf8_lossy(&retry_output.stdout),
             String::from_utf8_lossy(&retry_output.stderr)
         );
-        let normalized_retry_text = retry_text.split_whitespace().collect::<Vec<_>>().join(" ");
+        let normalized_retry_text = retry_text.split_whitespace().collect::<String>();
         let stable_runtime_diagnostic_path =
             normalize_native_path_display(fs::canonicalize(&stable_runtime)?).replace('/', "\\");
         let runtime_diagnostic_path =
@@ -8494,7 +8617,7 @@ public static class Program
             "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=false"
                 .to_string(),
         ] {
-            if !normalized_retry_text.contains(&required) {
+            if !normalized_retry_text.contains(&required.split_whitespace().collect::<String>()) {
                 return Err(io::Error::other(format!(
                     "obsolete locked-mirror retry omitted exact diagnostic {required:?}:\n{retry_text}"
                 ))
@@ -8502,8 +8625,10 @@ public static class Program
             }
         }
         if !retry_output.status.success()
-            || !retry_text.contains(
-                "ProjectAtlas convergence: update_state=partial stable_mirror_ready=false obsolete_mcp_handoff=retry_failed codex_plugin_ready=true codex_registry_ready=true",
+            || !normalized_retry_text.contains(
+                &"ProjectAtlas convergence: update_state=partial stable_mirror_ready=false obsolete_mcp_handoff=retry_failed codex_plugin_ready=true codex_registry_ready=true"
+                    .split_whitespace()
+                    .collect::<String>(),
             )
             || !runtime.exists()
             || !atlas_dir.join("projectatlas.mcp.json").exists()
@@ -8903,8 +9028,7 @@ public static class Program
     );
     let normalized_no_handoff_runtime_drift_text = no_handoff_runtime_drift_text
         .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ");
+        .collect::<String>();
     if !no_handoff_runtime_drift_output.status.success()
         || !no_handoff_runtime_drift_text.contains("update_state=partial")
         || !no_handoff_runtime_drift_text.contains("obsolete_mcp_handoff=not_required")
@@ -8912,11 +9036,17 @@ public static class Program
         || !no_handoff_runtime_drift_text.contains("generated_mcp_configs_ready=true")
         || !no_handoff_runtime_drift_text.contains("runtime_mcp_configs_ready=false")
         || !no_handoff_runtime_drift_text.contains("installer_cli_ready=false")
-        || !normalized_no_handoff_runtime_drift_text.contains(&format!(
-            "ProjectAtlas runtime failed final verification: path={runtime_diagnostic_path}"
-        ))
-        || !no_handoff_runtime_drift_text.contains(
-            "ProjectAtlas PATH shadow report skipped because the requested absolute runtime failed final verification",
+        || !normalized_no_handoff_runtime_drift_text.contains(
+            &format!(
+                "ProjectAtlas runtime failed final verification: path={runtime_diagnostic_path}"
+            )
+            .split_whitespace()
+            .collect::<String>(),
+        )
+        || !normalized_no_handoff_runtime_drift_text.contains(
+            &"ProjectAtlas PATH shadow report skipped because the requested absolute runtime failed final verification"
+                .split_whitespace()
+                .collect::<String>(),
         )
         || no_handoff_runtime_drift_text.contains("ProjectAtlas verified absolute runtime command:")
         || no_handoff_runtime_drift_text
@@ -8939,13 +9069,18 @@ public static class Program
         String::from_utf8_lossy(&invalid_mirror_output.stdout),
         String::from_utf8_lossy(&invalid_mirror_output.stderr)
     );
+    let normalized_invalid_mirror_text = invalid_mirror_text.split_whitespace().collect::<String>();
     if !invalid_mirror_output.status.success()
-        || !invalid_mirror_text.contains(
-            "ProjectAtlas convergence: update_state=partial stable_mirror_ready=false obsolete_mcp_handoff=inspection_failed codex_plugin_ready=true codex_registry_ready=true",
+        || !normalized_invalid_mirror_text.contains(
+            &"ProjectAtlas convergence: update_state=partial stable_mirror_ready=false obsolete_mcp_handoff=inspection_failed codex_plugin_ready=true codex_registry_ready=true"
+                .split_whitespace()
+                .collect::<String>(),
         )
-        || !invalid_mirror_text.contains("runtime_mcp_configs_ready=true")
-        || !invalid_mirror_text.contains("Repair the invalid mirror path and rerun this installer")
-        || invalid_mirror_text.contains("Retired exact obsolete Codex-owned ProjectAtlas MCP process")
+        || !normalized_invalid_mirror_text.contains("runtime_mcp_configs_ready=true")
+        || !normalized_invalid_mirror_text
+            .contains("Repairtheinvalidmirrorpathandrerunthisinstaller")
+        || normalized_invalid_mirror_text
+            .contains("RetiredexactobsoleteCodex-ownedProjectAtlasMCPprocess")
         || !stable_runtime.is_dir()
     {
         return Err(io::Error::other(format!(
@@ -8959,7 +9094,7 @@ public static class Program
         "obsolete_mcp_handoff=completed",
         "obsolete_mcp_handoff=retry_failed",
     ] {
-        if invalid_mirror_text.contains(forbidden_state) {
+        if normalized_invalid_mirror_text.contains(forbidden_state) {
             return Err(io::Error::other(format!(
                 "invalid stable mirror entered forbidden handoff state {forbidden_state}:\n{invalid_mirror_text}"
             ))
@@ -11740,6 +11875,8 @@ fn windows_release_binary_installer_repairs_stale_mirror_without_registering_it(
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    let normalized_installer_output_text =
+        installer_output_text.split_whitespace().collect::<String>();
     if !output.status.success() {
         return Err(io::Error::other(format!(
             "release-binary installer failed\n{installer_output_text}"
@@ -11754,9 +11891,15 @@ fn windows_release_binary_installer_repairs_stale_mirror_without_registering_it(
         ))
         .into());
     }
-    if !installer_output_text.trim_end().ends_with(
-        "ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=true host_restart_required=false",
-    ) || installer_output_text.contains("Existing host restart required:")
+    if !normalized_installer_output_text.ends_with(
+        &"ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=true host_restart_required=false"
+            .split_whitespace()
+            .collect::<String>(),
+    ) || normalized_installer_output_text.contains(
+        &"Existing host restart required:"
+            .split_whitespace()
+            .collect::<String>(),
+    )
     {
         return Err(io::Error::other(format!(
             "installer did not report full readiness after synchronizing the unlocked mirror\n{installer_output_text}"
@@ -11856,12 +11999,25 @@ fn windows_release_binary_installer_repairs_stale_mirror_without_registering_it(
         String::from_utf8_lossy(&stale_parent_install.stdout),
         String::from_utf8_lossy(&stale_parent_install.stderr)
     );
+    let normalized_stale_parent_install_text = stale_parent_install_text
+        .split_whitespace()
+        .collect::<String>();
     if !stale_parent_install.status.success()
-        || !stale_parent_install_text.trim_end().ends_with(
-            "ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=false host_restart_required=false",
+        || !normalized_stale_parent_install_text.ends_with(
+            &"ProjectAtlas readiness: runtime_ready=true generated_mcp_configs_ready=true runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=false host_restart_required=false"
+                .split_whitespace()
+                .collect::<String>(),
         )
-        || stale_parent_install_text.contains("Existing host restart required:")
-        || !stale_parent_install_text.contains("restart alone will not repair it")
+        || normalized_stale_parent_install_text.contains(
+            &"Existing host restart required:"
+                .split_whitespace()
+                .collect::<String>(),
+        )
+        || !normalized_stale_parent_install_text.contains(
+            &"restart alone will not repair it"
+                .split_whitespace()
+                .collect::<String>(),
+        )
     {
         return Err(io::Error::other(format!(
             "installer misstated repair requirements when the synchronized mirror was absent from the unchanged parent PATH\n{stale_parent_install_text}"
@@ -11910,7 +12066,11 @@ fn windows_release_binary_installer_repairs_stale_mirror_without_registering_it(
         ))
         .into());
     }
-    if !installer_output_text.contains("Codex MCP registry updated to ProjectAtlas runtime") {
+    if !normalized_installer_output_text.contains(
+        &"Codex MCP registry updated to ProjectAtlas runtime"
+            .split_whitespace()
+            .collect::<String>(),
+    ) {
         return Err(io::Error::other(format!(
             "installer did not report Codex registry repair:\n{installer_output_text}"
         ))

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -91,6 +91,7 @@ const ALTERNATE_ONLY_RS_FILE_NAME: &str = "alternate_only.rs";
 const OUTSIDE_CANARY_FILE_NAME: &str = "outside-canary.txt";
 const PARENT_CANARY_FILE_NAME: &str = "parent-canary.txt";
 const ATLAS_DIR_NAME: &str = ".projectatlas";
+const MISSING_INDEX_DIR_NAME: &str = "missing-index";
 const GITHOOKS_DIR_NAME: &str = ".githooks";
 const ISSUE_TEMPLATE_DIR_NAME: &str = "ISSUE_TEMPLATE";
 const VERSIONS_DIR_NAME: &str = "versions";
@@ -295,6 +296,15 @@ struct McpDatabaseSnapshot {
     generation: u64,
     purpose_revision: u64,
     publication_state: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SqliteCompatibilitySnapshot {
+    database_bytes: Vec<u8>,
+    wal_bytes: Option<Vec<u8>>,
+    sidecars: BTreeSet<String>,
+    schema_objects: Vec<String>,
+    tables: BTreeMap<String, String>,
 }
 
 #[test]
@@ -3729,12 +3739,39 @@ fn implicit_bare_root_refuses_before_opening_a_future_schema_database() -> Resul
     if explicit.status.success() {
         return Err(io::Error::other("explicit future-schema token read succeeded").into());
     }
+    let explicit_error: Value = serde_json::from_slice(&explicit.stderr)?;
+    require_json_string(
+        &explicit_error,
+        &["error", "kind"],
+        "schema_version_mismatch",
+    )?;
+    require_json_usize(
+        &explicit_error,
+        &["error", "schema_version_mismatch", "found_schema_version"],
+        18,
+    )?;
+    require_json_usize(
+        &explicit_error,
+        &[
+            "error",
+            "schema_version_mismatch",
+            "supported_schema_version",
+        ],
+        16,
+    )?;
+    require_json_string(
+        &explicit_error,
+        &["error", "schema_version_mismatch", "runtime_version"],
+        env!("CARGO_PKG_VERSION"),
+    )?;
     let explicit_stderr = String::from_utf8_lossy(&explicit.stderr);
-    if !explicit_stderr.contains("unsupported schema version 18") {
-        return Err(io::Error::other(format!(
-            "explicit database selection hid schema error: {explicit_stderr}"
-        ))
-        .into());
+    for private in [database.display().to_string(), bare.display().to_string()] {
+        if explicit_stderr.contains(&private) {
+            return Err(io::Error::other(format!(
+                "explicit database schema error exposed private path {private}"
+            ))
+            .into());
+        }
     }
     if fs::read(&database)? != database_before {
         return Err(
@@ -6898,6 +6935,10 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             .join("projectatlas")
             .join("scripts")
             .join("install-runtime.ps1");
+        let standalone_installer_dir = temp.path().join("standalone-installer");
+        fs::create_dir_all(&standalone_installer_dir)?;
+        let standalone_installer = standalone_installer_dir.join("install-runtime.ps1");
+        fs::copy(&installer, &standalone_installer)?;
         let output = StdCommand::new("powershell")
             .arg("-NoProfile")
             .arg("-ExecutionPolicy")
@@ -7052,6 +7093,24 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             ))
             .into());
         }
+        let init = StdCommand::new(&versioned_runtime)
+            .current_dir(&repo)
+            .arg("--require-version")
+            .arg(env!("CARGO_PKG_VERSION"))
+            .arg("--format")
+            .arg("json")
+            .arg("--db")
+            .arg(&db)
+            .arg("init")
+            .env("PROJECTATLAS_NO_TELEMETRY", "1")
+            .output()?;
+        if !init.status.success() {
+            return Err(io::Error::other(format!(
+                "versioned runtime could not initialize the locked-mirror fixture: {}",
+                String::from_utf8_lossy(&init.stderr)
+            ))
+            .into());
+        }
 
         let codex_config = read_json_file(&atlas_dir.join("projectatlas.mcp.json"))?;
         let claude_config = read_json_file(&atlas_dir.join("projectatlas.claude.mcp.json"))?;
@@ -7125,13 +7184,12 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             .arg("-ExecutionPolicy")
             .arg("Bypass")
             .arg("-File")
-            .arg(&installer)
+            .arg(&standalone_installer)
             .arg("-ProjectRoot")
             .arg(&repo)
-            .arg("-ProjectAtlasVersion")
-            .arg(format!("v{}", env!("CARGO_PKG_VERSION")))
             .arg("-RuntimePath")
             .arg(&versioned_runtime)
+            .env_remove("PROJECTATLAS_VERSION")
             .env("HOME", &isolated_home)
             .env("USERPROFILE", &isolated_home)
             .env("APPDATA", &app_data)
@@ -7154,12 +7212,46 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
         for required in [
             "ProjectAtlas LocalAppData mirror is locked",
             "verify durable absolute MCP configuration before attempting an exact obsolete-child handoff",
-            "process_owner=no_exact_owner",
-            "ProjectAtlas convergence: update_state=partial stable_mirror_ready=false obsolete_mcp_handoff=no_exact_owner",
+            "process_owner=inspection_failed",
+            "ProjectAtlas convergence: update_state=partial stable_mirror_ready=false obsolete_mcp_handoff=inspection_failed",
         ] {
             if !normalized_stale_output.contains(required) {
                 return Err(io::Error::other(format!(
                     "installer did not provide stale locked-mirror guidance {required:?}\n{stale_output_text}"
+                ))
+                .into());
+            }
+        }
+        for required in [
+            format!(
+                "ProjectAtlas stale bare command: path={} observed_version=unavailable ready=false",
+                stable_runtime.display()
+            ),
+            format!(
+                "verified_runtime={} target_version={}",
+                versioned_runtime.display(),
+                env!("CARGO_PKG_VERSION")
+            ),
+            format!(
+                "ProjectAtlas verified absolute runtime command: & '{}' --require-version '{}' --format json runtime-info",
+                versioned_runtime.display(),
+                env!("CARGO_PKG_VERSION")
+            ),
+            "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=false"
+                .to_string(),
+            format!(
+                "-ProjectAtlasVersion '{}' -RuntimePath '{}'",
+                env!("CARGO_PKG_VERSION"),
+                versioned_runtime.display()
+            ),
+            format!(
+                "projectatlas --require-version '{}' token --view tui",
+                env!("CARGO_PKG_VERSION")
+            ),
+        ] {
+            if !normalized_stale_output.contains(&required) {
+                return Err(io::Error::other(format!(
+                    "installer omitted exact stale-command recovery field {required:?}\n{stale_output_text}"
                 ))
                 .into());
             }
@@ -7183,6 +7275,36 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
         {
             return Err(io::Error::other(format!(
                 "installer terminated the owned stale-mirror lock process: {status}"
+            ))
+            .into());
+        }
+        let compatible_before = mcp_database_snapshot(&db)?;
+        let versioned_token = StdCommand::new(&versioned_runtime)
+            .current_dir(&repo)
+            .arg("--require-version")
+            .arg(env!("CARGO_PKG_VERSION"))
+            .arg("--db")
+            .arg(&db)
+            .args(["token", "--view", "tui"])
+            .env("PROJECTATLAS_NO_TELEMETRY", "1")
+            .output()?;
+        if !versioned_token.status.success() {
+            return Err(io::Error::other(format!(
+                "verified absolute runtime token TUI failed while the stale mirror stayed locked: {}",
+                String::from_utf8_lossy(&versioned_token.stderr)
+            ))
+            .into());
+        }
+        if mcp_database_snapshot(&db)? != compatible_before {
+            return Err(io::Error::other(
+                "verified absolute runtime token TUI changed the compatible locked-mirror database",
+            )
+            .into());
+        }
+        let locked_config_mcp = run_mcp_stdio(&mcp_command, &repo, &mcp_args, &messages)?;
+        if !locked_config_mcp.contains(&expected_server_info) {
+            return Err(io::Error::other(format!(
+                "generated MCP config stopped using the verified runtime while the stale mirror stayed locked: {locked_config_mcp}"
             ))
             .into());
         }
@@ -7318,6 +7440,87 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             "fresh parent sibling",
         )?;
 
+        let mut stale_lock = stale_lock_process
+            .take()
+            .ok_or_else(|| io::Error::other("stale mirror lock process missing before rerun"))?;
+        stale_lock.kill()?;
+        stale_lock.wait()?;
+        let converged_output = StdCommand::new("powershell")
+            .arg("-NoProfile")
+            .arg("-ExecutionPolicy")
+            .arg("Bypass")
+            .arg("-File")
+            .arg(&installer)
+            .arg("-ProjectRoot")
+            .arg(&repo)
+            .arg("-ProjectAtlasVersion")
+            .arg(format!("v{}", env!("CARGO_PKG_VERSION")))
+            .arg("-RuntimePath")
+            .arg(&versioned_runtime)
+            .env("HOME", &isolated_home)
+            .env("USERPROFILE", &isolated_home)
+            .env("APPDATA", &app_data)
+            .env("LOCALAPPDATA", &local_app_data)
+            .env("PATH", &parent_path)
+            .env("PROJECTATLAS_SKIP_USER_PATH_UPDATE", "1")
+            .env("PROJECTATLAS_CODEX_COMMAND", &fake_codex)
+            .env("PROJECTATLAS_FAKE_CODEX_LOG", &fake_codex_log)
+            .env("PROJECTATLAS_NO_TELEMETRY", "1")
+            .output()?;
+        let converged_output_text = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&converged_output.stdout),
+            String::from_utf8_lossy(&converged_output.stderr)
+        );
+        if !converged_output.status.success()
+            || !converged_output_text.contains("stable_mirror_ready=true")
+            || !converged_output_text.trim_end().ends_with(
+                "ProjectAtlas readiness: runtime_mcp_configs_ready=true installer_cli_ready=true parent_cli_ready=true host_restart_required=false",
+            )
+            || converged_output_text.contains("ProjectAtlas stale bare command:")
+        {
+            return Err(io::Error::other(format!(
+                "installer did not converge the stable mirror after its lock was released\n{converged_output_text}"
+            ))
+            .into());
+        }
+        let converged_before = mcp_database_snapshot(&db)?;
+        let bare_token = StdCommand::new("powershell")
+            .current_dir(&repo)
+            .arg("-NoProfile")
+            .arg("-Command")
+            .arg(
+                "$command = Get-Command projectatlas -ErrorAction Stop; Write-Output $command.Source; & projectatlas --require-version $env:PROJECTATLAS_VERSION --format json runtime-info; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; & projectatlas --require-version $env:PROJECTATLAS_VERSION --db $env:PROJECTATLAS_DB token --view tui; exit $LASTEXITCODE",
+            )
+            .env("PATH", &parent_path)
+            .env("PROJECTATLAS_VERSION", env!("CARGO_PKG_VERSION"))
+            .env("PROJECTATLAS_DB", &db)
+            .env("PROJECTATLAS_NO_TELEMETRY", "1")
+            .output()?;
+        let bare_token_stdout = String::from_utf8_lossy(&bare_token.stdout);
+        if !bare_token.status.success() {
+            return Err(io::Error::other(format!(
+                "converged bare runtime/version/token gate failed:\n{bare_token_stdout}\n{}",
+                String::from_utf8_lossy(&bare_token.stderr)
+            ))
+            .into());
+        }
+        let bare_command = bare_token_stdout
+            .lines()
+            .find(|line| !line.trim().is_empty())
+            .ok_or_else(|| io::Error::other("converged bare gate omitted its command path"))?;
+        require_same_executable(
+            bare_command.trim(),
+            &stable_runtime,
+            "converged bare command",
+        )?;
+        if mcp_database_snapshot(&db)? != converged_before {
+            return Err(io::Error::other(
+                "converged bare runtime/token gate changed the compatible database",
+            )
+            .into());
+        }
+
         Ok(())
     })();
 
@@ -7443,6 +7646,15 @@ public static class Program
             .iter()
             .any(|candidate| entry.join(candidate).exists())
         }))?;
+    let stale_parent_path = std::env::join_paths(
+        std::iter::once(
+            stable_runtime
+                .parent()
+                .ok_or_else(|| io::Error::other("stable runtime parent missing"))?
+                .to_path_buf(),
+        )
+        .chain(std::env::split_paths(&parent_path)),
+    )?;
     let fake_codex_log = isolated_home.join(FAKE_CODEX_LOG_FILE);
     let fake_codex = isolated_home.join("codex.cmd");
     let runtime = assert_cmd::cargo::cargo_bin("projectatlas");
@@ -7534,7 +7746,7 @@ public static class Program
         .ok_or_else(|| io::Error::other("installer plugin root missing"))?;
     let installer = temp.path().join("install-runtime-owner-seam.ps1");
     write_installer_with_test_codex_identity_seam(&production_installer, &installer)?;
-    let run_installer = |process_ids: &[u32]| {
+    let run_installer = |process_ids: &[u32], process_path: &OsStr| {
         let mut process_ids = process_ids.to_vec();
         process_ids.push(std::process::id());
         let process_id_allowlist = windows_test_process_id_allowlist(&process_ids)?;
@@ -7554,7 +7766,7 @@ public static class Program
             .env("USERPROFILE", &isolated_home)
             .env("APPDATA", &app_data)
             .env("LOCALAPPDATA", &local_app_data)
-            .env("PATH", &parent_path)
+            .env("PATH", process_path)
             .env("PROJECTATLAS_SKIP_CODEX_PLUGIN_UPDATE", "1")
             .env("PROJECTATLAS_SKIP_USER_PATH_UPDATE", "1")
             .env("PROJECTATLAS_TEST_CODEX_OWNER", &codex_owner_fixture)
@@ -7635,7 +7847,10 @@ public static class Program
             ))
             .into());
         }
-        let output = run_installer(&[obsolete_mcp_pid.process_id, codex_owner.id()])?;
+        let output = run_installer(
+            &[obsolete_mcp_pid.process_id, codex_owner.id()],
+            &parent_path,
+        )?;
         let installer_output = format!(
             "{}\n{}",
             String::from_utf8_lossy(&output.stdout),
@@ -7767,13 +7982,41 @@ public static class Program
             .as_ref()
             .ok_or_else(|| io::Error::other("second Codex owner fixture missing"))?
             .id();
-        let retry_output =
-            run_installer(&[child_pid.process_id, retry_parent_id, direct_child_id])?;
+        let retry_output = run_installer(
+            &[child_pid.process_id, retry_parent_id, direct_child_id],
+            &stale_parent_path,
+        )?;
         let retry_text = format!(
             "{}\n{}",
             String::from_utf8_lossy(&retry_output.stdout),
             String::from_utf8_lossy(&retry_output.stderr)
         );
+        let normalized_retry_text = retry_text.split_whitespace().collect::<Vec<_>>().join(" ");
+        for required in [
+            format!(
+                "ProjectAtlas stale bare command: path={} observed_version=0.3.26 ready=false",
+                stable_runtime.display()
+            ),
+            format!(
+                "verified_runtime={} target_version={}",
+                runtime.display(),
+                env!("CARGO_PKG_VERSION")
+            ),
+            format!(
+                "ProjectAtlas verified absolute runtime command: & '{}' --require-version '{}' --format json runtime-info",
+                runtime.display(),
+                env!("CARGO_PKG_VERSION")
+            ),
+            "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=false"
+                .to_string(),
+        ] {
+            if !normalized_retry_text.contains(&required) {
+                return Err(io::Error::other(format!(
+                    "obsolete locked-mirror retry omitted exact diagnostic {required:?}:\n{retry_text}"
+                ))
+                .into());
+            }
+        }
         if !retry_output.status.success()
             || !retry_text.contains(
                 "ProjectAtlas convergence: update_state=partial stable_mirror_ready=false obsolete_mcp_handoff=retry_failed codex_plugin_ready=true codex_registry_ready=true",
@@ -14801,6 +15044,147 @@ fn packaged_cli_commands_own_their_real_sqlite_effects() -> Result<(), Box<dyn E
         &["file_summary", "file_purpose"],
         "CLI contract watched source.",
     )?;
+
+    Connection::open(&database)?.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    let missing_root = temp.path().join(MISSING_INDEX_DIR_NAME);
+    fs::create_dir(&missing_root)?;
+    let wrong_root = temp.path().join("wrong-owner");
+    let wrong_atlas_dir = wrong_root.join(ATLAS_DIR_NAME);
+    fs::create_dir_all(&wrong_atlas_dir)?;
+    let wrong_database = wrong_atlas_dir.join("projectatlas.db");
+    fs::copy(&database, &wrong_database)?;
+    let wrong_before = sqlite_compatibility_snapshot(&wrong_database)?;
+
+    let writer = Connection::open(&database)?;
+    writer.execute_batch("PRAGMA wal_autocheckpoint = 0")?;
+    let supported_schema_version = writer.query_row(
+        "SELECT CAST(value AS INTEGER) FROM metadata WHERE key = 'schema_version'",
+        [],
+        |row| row.get::<_, i64>(0),
+    )?;
+    let future_schema_version = supported_schema_version
+        .checked_add(1)
+        .ok_or_else(|| io::Error::other("schema version overflowed"))?;
+    writer.execute(
+        "UPDATE metadata SET value = ?1 WHERE key = 'schema_version'",
+        [future_schema_version],
+    )?;
+    let wal_path = sqlite_sidecar_path(&database, "-wal");
+    if !wal_path.is_file() || fs::metadata(&wal_path)?.len() == 0 {
+        return Err(io::Error::other(
+            "packaged schema-mismatch fixture did not retain an active WAL",
+        )
+        .into());
+    }
+    let incompatible_before = sqlite_compatibility_snapshot(&database)?;
+
+    let incompatible_cli = StdCommand::new(&executable)
+        .current_dir(&repo)
+        .arg("--require-version")
+        .arg(env!("CARGO_PKG_VERSION"))
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&database)
+        .arg("overview")
+        .env("PROJECTATLAS_NO_TELEMETRY", "1")
+        .output()?;
+    if incompatible_cli.status.success() {
+        return Err(io::Error::other("packaged CLI opened a newer-schema database").into());
+    }
+    let incompatible_cli_error: Value = serde_json::from_slice(&incompatible_cli.stderr)?;
+    require_schema_version_mismatch(
+        &incompatible_cli_error,
+        future_schema_version,
+        supported_schema_version,
+    )?;
+    let incompatible_cli_text = String::from_utf8_lossy(&incompatible_cli.stderr);
+    for private in [database.display().to_string(), repo.display().to_string()] {
+        if incompatible_cli_text.contains(&private) {
+            return Err(io::Error::other(format!(
+                "packaged CLI schema mismatch exposed private path {private}"
+            ))
+            .into());
+        }
+    }
+    if sqlite_compatibility_snapshot(&database)? != incompatible_before {
+        return Err(io::Error::other(
+            "packaged CLI schema mismatch changed the active-WAL database",
+        )
+        .into());
+    }
+
+    let mut incompatible_session = McpContractSession::spawn(&executable, &repo, &database)?;
+    let incompatible_mcp_result = (|| -> Result<(), Box<dyn Error>> {
+        let mismatch_text = incompatible_session
+            .call_tool_error("atlas_overview", &serde_json::json!({"project_path": repo}))?;
+        let mismatch: Value = toon_format::decode_default(&mismatch_text)?;
+        require_schema_version_mismatch(
+            &mismatch,
+            future_schema_version,
+            supported_schema_version,
+        )?;
+        for private in [database.display().to_string(), repo.display().to_string()] {
+            if mismatch_text.contains(&private) {
+                return Err(io::Error::other(format!(
+                    "packaged MCP schema mismatch exposed private path {private}"
+                ))
+                .into());
+            }
+        }
+
+        let missing_text = incompatible_session.call_tool(
+            "atlas_overview",
+            &serde_json::json!({"project_path": missing_root}),
+        )?;
+        if !missing_text.contains("kind: init_required")
+            || missing_root.join(ATLAS_DIR_NAME).exists()
+        {
+            return Err(io::Error::other(format!(
+                "persistent MCP missing-index control mutated state or lost typed guidance: {missing_text}"
+            ))
+            .into());
+        }
+
+        let wrong_text = incompatible_session.call_tool(
+            "atlas_overview",
+            &serde_json::json!({"project_path": wrong_root}),
+        )?;
+        if !wrong_text.contains("kind: project_mismatch")
+            || wrong_text.contains("kind: schema_version_mismatch")
+            || sqlite_compatibility_snapshot(&wrong_database)? != wrong_before
+        {
+            return Err(io::Error::other(format!(
+                "persistent MCP wrong-root control mutated state or lost typed ownership: {wrong_text}"
+            ))
+            .into());
+        }
+
+        let runtime_text =
+            incompatible_session.call_tool("atlas_runtime_info", &serde_json::json!({}))?;
+        if !runtime_text.contains(env!("CARGO_PKG_VERSION")) {
+            return Err(io::Error::other(
+                "persistent MCP session stopped responding after schema mismatch",
+            )
+            .into());
+        }
+        Ok(())
+    })();
+    complete_mcp_test_after_shutdown(incompatible_mcp_result, || incompatible_session.shutdown())?;
+    if sqlite_compatibility_snapshot(&database)? != incompatible_before {
+        return Err(io::Error::other(
+            "packaged MCP schema mismatch changed the active-WAL database",
+        )
+        .into());
+    }
+    if writer.query_row::<i64, _, _>(
+        "SELECT CAST(value AS INTEGER) FROM metadata WHERE key = 'schema_version'",
+        [],
+        |row| row.get(0),
+    )? != future_schema_version
+    {
+        return Err(io::Error::other("live WAL owner could not read the retained schema").into());
+    }
     Ok(())
 }
 
@@ -15380,7 +15764,7 @@ fn mcp_advertised_tools_own_their_real_sqlite_effects() -> Result<(), Box<dyn Er
         }
     }
 
-    let missing_index_root = temp.path().join("missing-index");
+    let missing_index_root = temp.path().join(MISSING_INDEX_DIR_NAME);
     fs::create_dir(&missing_index_root)?;
     for (name, arguments, expected_error) in [
         (
@@ -24515,20 +24899,41 @@ impl McpContractSession {
 
     /// Call one real MCP tool and return its text payload.
     fn call_tool(&mut self, name: &str, arguments: &Value) -> Result<String, Box<dyn Error>> {
+        self.call_tool_text(name, arguments, false)
+    }
+
+    /// Call one real MCP tool and require a visible tool-level error result.
+    fn call_tool_error(&mut self, name: &str, arguments: &Value) -> Result<String, Box<dyn Error>> {
+        self.call_tool_text(name, arguments, true)
+    }
+
+    /// Call one real MCP tool and require the expected `isError` state.
+    fn call_tool_text(
+        &mut self,
+        name: &str,
+        arguments: &Value,
+        expected_error: bool,
+    ) -> Result<String, Box<dyn Error>> {
         let response = self.request(
             "tools/call",
             &serde_json::json!({"name": name, "arguments": arguments}),
         )?;
-        if response.get("error").is_some()
-            || response
-                .get("result")
-                .and_then(|result| result.get("isError"))
-                .and_then(Value::as_bool)
-                == Some(true)
-        {
-            return Err(
-                io::Error::other(format!("MCP contract tool {name} failed: {response}")).into(),
-            );
+        if response.get("error").is_some() {
+            return Err(io::Error::other(format!(
+                "MCP contract tool {name} returned a protocol error: {response}"
+            ))
+            .into());
+        }
+        let is_error = response
+            .get("result")
+            .and_then(|result| result.get("isError"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if is_error != expected_error {
+            return Err(io::Error::other(format!(
+                "MCP contract tool {name} returned isError={is_error}, expected {expected_error}: {response}"
+            ))
+            .into());
         }
         response
             .get("result")
@@ -25157,12 +25562,13 @@ fn inline_legacy_purpose_review_item_schema(schema: &Value) -> Result<Value, Box
     Ok(schema)
 }
 
-/// Capture bounded logical rows so WAL/page-layout changes do not masquerade as product state.
-fn mcp_database_snapshot(database: &Path) -> Result<McpDatabaseSnapshot, Box<dyn Error>> {
+/// Hash every bounded user-table row through one read-only `SQLite` connection.
+fn sqlite_table_digests(
+    connection: &Connection,
+) -> Result<BTreeMap<String, String>, Box<dyn Error>> {
     const MAX_TABLE_ROWS: usize = 16_384;
     const MAX_TABLE_BYTES: usize = 8 * 1024 * 1024;
 
-    let connection = Connection::open_with_flags(database, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
     let table_names = {
         let mut statement = connection.prepare(
             "SELECT name
@@ -25174,8 +25580,7 @@ fn mcp_database_snapshot(database: &Path) -> Result<McpDatabaseSnapshot, Box<dyn
             .query_map([], |row| row.get::<_, String>(0))?
             .collect::<Result<Vec<_>, _>>()?
     };
-    let mut authoritative = BTreeMap::new();
-    let mut usage = BTreeMap::new();
+    let mut tables = BTreeMap::new();
     for table_name in table_names {
         let quoted_name = format!("\"{}\"", table_name.replace('"', "\"\""));
         let column_count = {
@@ -25239,12 +25644,60 @@ fn mcp_database_snapshot(database: &Path) -> Result<McpDatabaseSnapshot, Box<dyn
             }
         }
         let digest = format!("{row_count}:{}", sha256_hex(&encoded));
-        if table_name.starts_with("usage_") {
-            usage.insert(table_name, digest);
-        } else {
-            authoritative.insert(table_name, digest);
+        tables.insert(table_name, digest);
+    }
+    Ok(tables)
+}
+
+/// Capture durable bytes, schema objects, and all logical rows without checkpointing.
+fn sqlite_compatibility_snapshot(
+    database: &Path,
+) -> Result<SqliteCompatibilitySnapshot, Box<dyn Error>> {
+    let connection = Connection::open_with_flags(database, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let schema_objects = {
+        let mut statement = connection.prepare(
+            "SELECT type, name, tbl_name, COALESCE(sql, '')
+             FROM sqlite_schema
+             WHERE name NOT LIKE 'sqlite_%'
+             ORDER BY type, name",
+        )?;
+        statement
+            .query_map([], |row| {
+                Ok(format!(
+                    "{}\0{}\0{}\0{}",
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    let tables = sqlite_table_digests(&connection)?;
+    drop(connection);
+    let wal_path = sqlite_sidecar_path(database, "-wal");
+    let mut sidecars = BTreeSet::new();
+    for suffix in ["-wal", "-shm"] {
+        if sqlite_sidecar_path(database, suffix).is_file() {
+            sidecars.insert(suffix.to_string());
         }
     }
+    Ok(SqliteCompatibilitySnapshot {
+        database_bytes: fs::read(database)?,
+        wal_bytes: wal_path.is_file().then(|| fs::read(wal_path)).transpose()?,
+        sidecars,
+        schema_objects,
+        tables,
+    })
+}
+
+/// Capture bounded logical rows so WAL/page-layout changes do not masquerade as product state.
+fn mcp_database_snapshot(database: &Path) -> Result<McpDatabaseSnapshot, Box<dyn Error>> {
+    let connection = Connection::open_with_flags(database, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let tables = sqlite_table_digests(&connection)?;
+    let (usage, authoritative) = tables
+        .into_iter()
+        .partition(|(table_name, _)| table_name.starts_with("usage_"));
     drop(connection);
 
     let store = AtlasStore::open_read_only(database)?;
@@ -27490,6 +27943,37 @@ fn require_json_string(value: &Value, path: &[&str], expected: &str) -> Result<(
         ))
         .into())
     }
+}
+
+/// Require the shared privacy-safe CLI/MCP schema mismatch contract.
+fn require_schema_version_mismatch(
+    value: &Value,
+    found: i64,
+    supported: i64,
+) -> Result<(), Box<dyn Error>> {
+    require_json_string(value, &["error", "kind"], "schema_version_mismatch")?;
+    let mismatch = json_at(value, &["error", "schema_version_mismatch"])?;
+    if mismatch.get("found_schema_version").and_then(Value::as_i64) != Some(found)
+        || mismatch
+            .get("supported_schema_version")
+            .and_then(Value::as_i64)
+            != Some(supported)
+    {
+        return Err(io::Error::other(format!(
+            "schema mismatch versions differ: expected found={found} supported={supported}, actual={mismatch}"
+        ))
+        .into());
+    }
+    require_json_string(
+        value,
+        &["error", "schema_version_mismatch", "runtime_version"],
+        env!("CARGO_PKG_VERSION"),
+    )?;
+    require_json_contains(
+        value,
+        &["error", "schema_version_mismatch", "recovery"],
+        "do not reset",
+    )
 }
 
 /// Require a nested JSON string to contain a substring.

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -141,6 +141,12 @@ const NPM_SHIM_DIR: &str = "npm";
 #[cfg(windows)]
 const WINDOWS_SYSTEM32_DIR: &str = "System32";
 #[cfg(windows)]
+const WINDOWS_POWERSHELL_DIR: &str = "WindowsPowerShell";
+#[cfg(windows)]
+const WINDOWS_POWERSHELL_VERSION_DIR: &str = "v1.0";
+#[cfg(windows)]
+const WINDOWS_POWERSHELL_EXECUTABLE: &str = "powershell.exe";
+#[cfg(windows)]
 static WINDOWS_RELEASE_ASSET_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(windows)]
@@ -4631,10 +4637,12 @@ fn plugin_installers_require_matching_runtime_version() -> Result<(), Box<dyn Er
         "PROJECTATLAS_SKIP_USER_PATH_UPDATE",
         "Set-ProjectAtlasProcessPathPrecedence",
         "Test-ProjectAtlasBareCommandResolutionOnPath",
+        "Test-ProjectAtlasPersistedBareCommandResolution",
+        "Get-ProjectAtlasTokenLaunchArguments",
         r#"[Environment]::SetEnvironmentVariable("Path""#,
         r#"[Environment]::GetEnvironmentVariable("Path", "Machine")"#,
-        "$freshProcessPath = @($machinePath, $futureUserPath) -join \";\"",
-        "Test-ProjectAtlasBareCommandResolutionOnPath $freshProcessPath $FilePath",
+        "Test-ProjectAtlasPersistedBareCommandResolution $FilePath",
+        "$futureProcessPathReady = Test-ProjectAtlasPersistedBareCommandResolution $projectAtlas",
         "Confirm-ProjectAtlasBareCommandResolution",
         "Active process resolves bare projectatlas to verified runtime",
         "Restart Codex or the shell",
@@ -5073,8 +5081,18 @@ fn windows_installer_fresh_path_probe_respects_machine_precedence() -> Result<()
     let temp = tempfile::tempdir()?;
     let machine_bin = temp.path().join("machine-bin");
     let user_bin = temp.path().join("user-bin");
+    let empty_bin = temp.path().join("empty-bin");
     fs::create_dir_all(&machine_bin)?;
     fs::create_dir_all(&user_bin)?;
+    fs::create_dir_all(&empty_bin)?;
+    let system_powershell = PathBuf::from(
+        std::env::var_os("SystemRoot")
+            .ok_or_else(|| io::Error::other("SystemRoot is unavailable"))?,
+    )
+    .join(WINDOWS_SYSTEM32_DIR)
+    .join(WINDOWS_POWERSHELL_DIR)
+    .join(WINDOWS_POWERSHELL_VERSION_DIR)
+    .join(WINDOWS_POWERSHELL_EXECUTABLE);
     fs::write(machine_bin.join("projectatlas.cmd"), "@exit /b 0\r\n")?;
     let verified_runtime = user_bin.join("projectatlas.cmd");
     fs::write(&verified_runtime, "@exit /b 0\r\n")?;
@@ -5191,6 +5209,7 @@ $names = @(
     "Split-PathList",
     "Sync-ProjectAtlasRuntimeToLocalAppData",
     "Test-ProjectAtlasBareCommandResolutionOnPath",
+    "Test-ProjectAtlasPersistedBareCommandResolution",
     "Test-ProjectAtlasJsonObject",
     "Test-ProjectAtlasRuntime",
     "Test-Truthy"
@@ -5217,6 +5236,9 @@ if (Test-ProjectAtlasBareCommandResolutionOnPath $machineFirst $env:PROJECTATLAS
 }
 if (-not (Test-ProjectAtlasBareCommandResolutionOnPath $userFirst $env:PROJECTATLAS_TEST_VERIFIED_RUNTIME)) {
     throw "Verified runtime first on PATH was not classified as restart-recoverable"
+}
+if (Test-ProjectAtlasBareCommandResolutionOnPath $env:PROJECTATLAS_TEST_EMPTY_BIN $env:PROJECTATLAS_TEST_VERIFIED_RUNTIME) {
+    throw "PATH without ProjectAtlas was incorrectly classified as restart-recoverable"
 }
 $unicodePayload = Invoke-ProjectAtlasBoundedJsonCommand `
     $env:PROJECTATLAS_TEST_UNICODE_JSON_RUNTIME `
@@ -5335,10 +5357,13 @@ if ($env:PROJECTATLAS_TEST_PERSIST_USER_PATH -eq "1") {
         if (-not (Set-ProjectAtlasPathPrecedence $env:PROJECTATLAS_TEST_VERIFIED_RUNTIME)) {
             throw "Persisted User PATH was not classified as fresh-host ready"
         }
+        if (-not (Test-ProjectAtlasPersistedBareCommandResolution $env:PROJECTATLAS_TEST_VERIFIED_RUNTIME)) {
+            throw "Supplied-runtime mode did not recognize the existing persisted User PATH"
+        }
         $persistedUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
         $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
         $env:Path = @($machinePath, $persistedUserPath) -join ";"
-        $freshChildPath = & powershell -NoProfile -Command `
+        $freshChildPath = & $env:PROJECTATLAS_TEST_SYSTEM_POWERSHELL -NoProfile -Command `
             "(Get-Command projectatlas -ErrorAction Stop).Source"
         if ($LASTEXITCODE -ne 0) {
             throw "Fresh child could not resolve projectatlas from persisted User PATH"
@@ -5516,6 +5541,8 @@ finally {
         .env("PROJECTATLAS_TEST_INSTALLER", installer)
         .env("PROJECTATLAS_TEST_MACHINE_BIN", &machine_bin)
         .env("PROJECTATLAS_TEST_USER_BIN", &user_bin)
+        .env("PROJECTATLAS_TEST_EMPTY_BIN", &empty_bin)
+        .env("PROJECTATLAS_TEST_SYSTEM_POWERSHELL", &system_powershell)
         .env("PROJECTATLAS_TEST_VERIFIED_RUNTIME", &verified_runtime)
         .env("PROJECTATLAS_TEST_HANGING_RUNTIME", &hanging_runtime)
         .env("PROJECTATLAS_TEST_FLOODING_RUNTIME", &flooding_runtime)
@@ -5721,6 +5748,16 @@ fn repository_guidance_keeps_atlas_state_local_and_legacy_export_optional()
             ))
             .into());
         }
+    }
+    let about_claim = "Every file not opened. Every folder not explored. ProjectAtlas guides coding agents with purpose metadata and an intelligent code graph, reducing token costs by over 90%.";
+    let about_qualification = "The \"over 90%\" figure is a workload-specific local estimate from the published audit, not a universal savings guarantee or provider-billing result; see [One Large-Application Audit](#one-large-application-audit).";
+    if readme.matches(about_claim).count() != 1
+        || !readme.contains(&format!("{about_claim}\n\n{about_qualification}"))
+    {
+        return Err(io::Error::other(
+            "README must retain the exact requested About claim once with its adjacent audit qualification",
+        )
+        .into());
     }
     for required in [
         "### Runtime installation and repair",
@@ -7020,6 +7057,138 @@ fn posix_installer_accepts_symlinked_runtime_path() -> Result<(), Box<dyn Error>
 
 #[test]
 #[cfg(windows)]
+fn windows_installer_recovery_operation_preserves_config_selection() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let outside = temp.path().join("outside");
+    fs::create_dir(&outside)?;
+    let runtime = assert_cmd::cargo::cargo_bin("projectatlas");
+    let installer = workspace_root()?
+        .join("plugins")
+        .join("projectatlas")
+        .join("scripts")
+        .join("install-runtime.ps1");
+    let powershell = PathBuf::from(
+        std::env::var_os("SystemRoot")
+            .ok_or_else(|| io::Error::other("SystemRoot is unavailable"))?,
+    )
+    .join(WINDOWS_SYSTEM32_DIR)
+    .join(WINDOWS_POWERSHELL_DIR)
+    .join(WINDOWS_POWERSHELL_VERSION_DIR)
+    .join(WINDOWS_POWERSHELL_EXECUTABLE);
+    let script = temp.path().join("run-token-recovery.ps1");
+    fs::write(
+        &script,
+        r#"$ErrorActionPreference = "Stop"
+$installerSource = Get-Content -Raw -LiteralPath $env:PROJECTATLAS_TEST_INSTALLER
+foreach ($functionName in @(
+        "Convert-ProjectAtlasVersionTag",
+        "Get-ProjectAtlasMcpLaunchArguments",
+        "Get-ProjectAtlasTokenLaunchArguments"
+    )) {
+    $match = [regex]::Match($installerSource, "(?ms)^function $functionName \{.*?^\}")
+    if (-not $match.Success) { throw "Installer function missing: $functionName" }
+    Invoke-Expression $match.Value
+}
+$arguments = @(Get-ProjectAtlasTokenLaunchArguments `
+    $env:PROJECTATLAS_TEST_DB `
+    $env:PROJECTATLAS_TEST_NESTED_CONFIG `
+    $env:PROJECTATLAS_TEST_FLAT_CONFIG `
+    $env:PROJECTATLAS_TEST_VERSION)
+$expected = @(
+    "--require-version", $env:PROJECTATLAS_TEST_VERSION,
+    "--db", $env:PROJECTATLAS_TEST_DB
+)
+if (-not [string]::IsNullOrWhiteSpace($env:PROJECTATLAS_TEST_SELECTED_CONFIG)) {
+    $expected += @("--config", $env:PROJECTATLAS_TEST_SELECTED_CONFIG)
+}
+$expected += @("token", "--view", "tui")
+if (($arguments -join "`0") -cne ($expected -join "`0")) {
+    throw "Unexpected recovery arguments: $($arguments -join ' ')"
+}
+& $env:PROJECTATLAS_TEST_RUNTIME @arguments
+exit $LASTEXITCODE
+"#,
+    )?;
+
+    for layout in ["nested", "flat", "none"] {
+        let repo = temp.path().join(layout);
+        let atlas_dir = repo.join(ATLAS_DIR_NAME);
+        fs::create_dir_all(&atlas_dir)?;
+        let nested_config = atlas_dir.join("config.toml");
+        let flat_config = repo.join("projectatlas.toml");
+        let selected_config = match layout {
+            "nested" => Some(nested_config.as_path()),
+            "flat" => Some(flat_config.as_path()),
+            _ => None,
+        };
+        if let Some(config) = selected_config {
+            fs::write(config, "[project]\nroot = \".\"\n")?;
+        }
+        let db = atlas_dir.join("projectatlas.db");
+        let mut scan = StdCommand::new(&runtime);
+        scan.current_dir(&outside)
+            .args(["--require-version", env!("CARGO_PKG_VERSION")])
+            .args(["--format", "json"])
+            .arg("--db")
+            .arg(&db);
+        if let Some(config) = selected_config {
+            scan.arg("--config").arg(config);
+        }
+        let scan_output = scan.arg("scan").arg(&repo).output()?;
+        if !scan_output.status.success() {
+            return Err(io::Error::other(format!(
+                "{layout} recovery fixture scan failed: {}",
+                String::from_utf8_lossy(&scan_output.stderr)
+            ))
+            .into());
+        }
+        let before = mcp_database_snapshot(&db)?;
+        let output = StdCommand::new(&powershell)
+            .current_dir(&outside)
+            .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+            .arg(&script)
+            .env("PROJECTATLAS_TEST_INSTALLER", &installer)
+            .env("PROJECTATLAS_TEST_RUNTIME", &runtime)
+            .env("PROJECTATLAS_TEST_VERSION", env!("CARGO_PKG_VERSION"))
+            .env("PROJECTATLAS_TEST_DB", &db)
+            .env("PROJECTATLAS_TEST_NESTED_CONFIG", &nested_config)
+            .env("PROJECTATLAS_TEST_FLAT_CONFIG", &flat_config)
+            .env(
+                "PROJECTATLAS_TEST_SELECTED_CONFIG",
+                selected_config.unwrap_or_else(|| Path::new("")),
+            )
+            .env("PROJECTATLAS_NO_TELEMETRY", "1")
+            .output()?;
+        if !output.status.success() {
+            return Err(io::Error::other(format!(
+                "{layout} recovery operation failed:\n{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            ))
+            .into());
+        }
+        if mcp_database_snapshot(&db)? != before {
+            return Err(io::Error::other(format!(
+                "{layout} recovery operation changed the selected database"
+            ))
+            .into());
+        }
+        if outside
+            .join(ATLAS_DIR_NAME)
+            .join("projectatlas.db")
+            .exists()
+        {
+            return Err(io::Error::other(format!(
+                "{layout} recovery operation created an outside default database"
+            ))
+            .into());
+        }
+    }
+    Ok(())
+}
+
+#[test]
+#[cfg(windows)]
 fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is_locked()
 -> Result<(), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
@@ -7424,6 +7593,9 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             normalize_native_path_display(fs::canonicalize(&stable_runtime)?).replace('/', "\\");
         let versioned_runtime_diagnostic_path =
             normalize_native_path_display(fs::canonicalize(&versioned_runtime)?).replace('/', "\\");
+        let db_diagnostic_path = normalize_native_path_display(&db).replace('/', "\\");
+        let config_diagnostic_path =
+            normalize_native_path_display(atlas_dir.join("config.toml")).replace('/', "\\");
         for required in [
             format!(
                 "ProjectAtlas stale bare command: path={stable_runtime_diagnostic_path} observed_version=unavailable ready=false"
@@ -7437,6 +7609,13 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
                 "ProjectAtlas verified absolute runtime command: & '{}' --require-version '{}' --format json runtime-info",
                 versioned_runtime_diagnostic_path,
                 env!("CARGO_PKG_VERSION")
+            ),
+            format!(
+                "ProjectAtlas verified absolute runtime operation: & '{}' '--require-version' '{}' '--db' '{}' '--config' '{}' 'token' '--view' 'tui'",
+                versioned_runtime_diagnostic_path,
+                env!("CARGO_PKG_VERSION"),
+                db_diagnostic_path,
+                config_diagnostic_path
             ),
             "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=false"
                 .to_string(),
@@ -7479,13 +7658,85 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
             ))
             .into());
         }
+        if std::env::var("PROJECTATLAS_TEST_DISPOSABLE_RUNNER").as_deref() == Ok("github-hosted") {
+            let restart_output = StdCommand::new("powershell")
+                .args([
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command",
+                    r#"
+$originalUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$exitCode = 1
+try {
+    $runtimeDir = Split-Path -Parent $env:PROJECTATLAS_TEST_RUNTIME
+    [Environment]::SetEnvironmentVariable("Path", (@($runtimeDir, $originalUserPath) -join ";"), "User")
+    & $env:PROJECTATLAS_TEST_INSTALLER `
+        -ProjectRoot $env:PROJECTATLAS_TEST_ROOT `
+        -ProjectAtlasVersion $env:PROJECTATLAS_TEST_VERSION `
+        -RuntimePath $env:PROJECTATLAS_TEST_RUNTIME
+    $exitCode = $LASTEXITCODE
+}
+finally {
+    [Environment]::SetEnvironmentVariable("Path", $originalUserPath, "User")
+}
+exit $exitCode
+"#,
+                ])
+                .env("PROJECTATLAS_TEST_INSTALLER", &standalone_installer)
+                .env("PROJECTATLAS_TEST_ROOT", &repo)
+                .env(
+                    "PROJECTATLAS_TEST_VERSION",
+                    format!("v{}", env!("CARGO_PKG_VERSION")),
+                )
+                .env("PROJECTATLAS_TEST_RUNTIME", &versioned_runtime)
+                .env("HOME", &isolated_home)
+                .env("USERPROFILE", &isolated_home)
+                .env("APPDATA", &app_data)
+                .env("LOCALAPPDATA", &local_app_data)
+                .env("PATH", &parent_path)
+                .env("PROJECTATLAS_SKIP_USER_PATH_UPDATE", "1")
+                .env("PROJECTATLAS_CODEX_COMMAND", &fake_codex)
+                .env("PROJECTATLAS_FAKE_CODEX_LOG", &fake_codex_log)
+                .env("PROJECTATLAS_FAKE_CODEX_STATE", &fake_codex_state)
+                .env(
+                    "PROJECTATLAS_FAKE_CODEX_REGISTRY_STALE",
+                    &fake_codex_stale_registry,
+                )
+                .env(
+                    "PROJECTATLAS_FAKE_CODEX_REGISTRY_CURRENT",
+                    &fake_codex_current_registry,
+                )
+                .env("PROJECTATLAS_NO_TELEMETRY", "1")
+                .output()?;
+            let restart_text = format!(
+                "{}\n{}",
+                String::from_utf8_lossy(&restart_output.stdout),
+                String::from_utf8_lossy(&restart_output.stderr)
+            );
+            if !restart_output.status.success()
+                || !restart_text.contains(
+                    "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=true",
+                )
+                || !restart_text.contains("Existing host restart required:")
+                || !restart_text.contains("host_restart_required=true")
+                || restart_text.contains("restart alone will not repair it")
+            {
+                return Err(io::Error::other(format!(
+                    "supplied-runtime install did not recognize persisted fresh-host PATH readiness:\n{restart_text}"
+                ))
+                .into());
+            }
+        }
         let compatible_before = mcp_database_snapshot(&db)?;
         let versioned_token = StdCommand::new(&versioned_runtime)
-            .current_dir(&repo)
+            .current_dir(temp.path())
             .arg("--require-version")
             .arg(env!("CARGO_PKG_VERSION"))
             .arg("--db")
             .arg(&db)
+            .arg("--config")
+            .arg(atlas_dir.join("config.toml"))
             .args(["token", "--view", "tui"])
             .env("PROJECTATLAS_NO_TELEMETRY", "1")
             .output()?;
@@ -7499,6 +7750,17 @@ fn windows_release_binary_installer_uses_versioned_runtime_when_stable_mirror_is
         if mcp_database_snapshot(&db)? != compatible_before {
             return Err(io::Error::other(
                 "verified absolute runtime token TUI changed the compatible locked-mirror database",
+            )
+            .into());
+        }
+        if temp
+            .path()
+            .join(ATLAS_DIR_NAME)
+            .join("projectatlas.db")
+            .exists()
+        {
+            return Err(io::Error::other(
+                "verified absolute runtime operation created a default database outside the selected project",
             )
             .into());
         }
@@ -7947,11 +8209,19 @@ public static class Program
         .ok_or_else(|| io::Error::other("installer plugin root missing"))?;
     let installer = temp.path().join("install-runtime-owner-seam.ps1");
     write_installer_with_test_codex_identity_seam(&production_installer, &installer)?;
+    let powershell = PathBuf::from(
+        std::env::var_os("SystemRoot")
+            .ok_or_else(|| io::Error::other("SystemRoot is unavailable"))?,
+    )
+    .join(WINDOWS_SYSTEM32_DIR)
+    .join(WINDOWS_POWERSHELL_DIR)
+    .join(WINDOWS_POWERSHELL_VERSION_DIR)
+    .join(WINDOWS_POWERSHELL_EXECUTABLE);
     let run_installer = |process_ids: &[u32], process_path: &OsStr| {
         let mut process_ids = process_ids.to_vec();
         process_ids.push(std::process::id());
         let process_id_allowlist = windows_test_process_id_allowlist(&process_ids)?;
-        StdCommand::new("powershell")
+        StdCommand::new(&powershell)
             .arg("-NoProfile")
             .arg("-ExecutionPolicy")
             .arg("Bypass")
@@ -7990,7 +8260,7 @@ public static class Program
     };
 
     let run_production_installer = || {
-        StdCommand::new("powershell")
+        StdCommand::new(&powershell)
             .arg("-NoProfile")
             .arg("-ExecutionPolicy")
             .arg("Bypass")
@@ -8197,6 +8467,9 @@ public static class Program
             normalize_native_path_display(fs::canonicalize(&stable_runtime)?).replace('/', "\\");
         let runtime_diagnostic_path =
             normalize_native_path_display(fs::canonicalize(&runtime)?).replace('/', "\\");
+        let db_diagnostic_path = normalize_native_path_display(&db).replace('/', "\\");
+        let config_diagnostic_path =
+            normalize_native_path_display(atlas_dir.join("config.toml")).replace('/', "\\");
         for required in [
             format!(
                 "ProjectAtlas stale bare command: path={stable_runtime_diagnostic_path} observed_version=0.3.26 ready=false"
@@ -8210,6 +8483,13 @@ public static class Program
                 "ProjectAtlas verified absolute runtime command: & '{}' --require-version '{}' --format json runtime-info",
                 runtime_diagnostic_path,
                 env!("CARGO_PKG_VERSION")
+            ),
+            format!(
+                "ProjectAtlas verified absolute runtime operation: & '{}' '--require-version' '{}' '--db' '{}' '--config' '{}' 'token' '--view' 'tui'",
+                runtime_diagnostic_path,
+                env!("CARGO_PKG_VERSION"),
+                db_diagnostic_path,
+                config_diagnostic_path
             ),
             "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=false"
                 .to_string(),
@@ -8639,6 +8919,8 @@ public static class Program
             "ProjectAtlas PATH shadow report skipped because the requested absolute runtime failed final verification",
         )
         || no_handoff_runtime_drift_text.contains("ProjectAtlas verified absolute runtime command:")
+        || no_handoff_runtime_drift_text
+            .contains("ProjectAtlas verified absolute runtime operation:")
         || no_handoff_runtime_drift_text.contains("integration verified through generated MCP config")
         || no_handoff_runtime_drift_text
             .contains("The runtime and generated MCP configs are ready")
@@ -8908,6 +9190,8 @@ public static class Program
             || !normalized_drift_text
                 .contains(&format!("target_version={}", env!("CARGO_PKG_VERSION")))
             || !normalized_drift_text.contains("verified_runtime=")
+            || !normalized_drift_text
+                .contains("ProjectAtlas verified absolute runtime operation: & ")
             || !normalized_drift_text.contains(
                 "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=",
             )
@@ -8952,6 +9236,8 @@ public static class Program
             || normalized_runtime_drift_text.contains("verified_runtime=")
             || normalized_runtime_drift_text
                 .contains("ProjectAtlas verified absolute runtime command:")
+            || normalized_runtime_drift_text
+                .contains("ProjectAtlas verified absolute runtime operation:")
             || normalized_runtime_drift_text.contains(&format!(
                 "-RuntimePath '{runtime_diagnostic_path}'"
             ))
@@ -11243,13 +11529,13 @@ fn windows_installer_without_codex_reports_clean_skip() -> Result<(), Box<dyn Er
     );
     let powershell_dir = system_root
         .join(WINDOWS_SYSTEM32_DIR)
-        .join("WindowsPowerShell")
-        .join("v1.0");
+        .join(WINDOWS_POWERSHELL_DIR)
+        .join(WINDOWS_POWERSHELL_VERSION_DIR);
     let restricted_path = std::env::join_paths([
         system_root.join(WINDOWS_SYSTEM32_DIR),
         powershell_dir.clone(),
     ])?;
-    let output = StdCommand::new(powershell_dir.join("powershell.exe"))
+    let output = StdCommand::new(powershell_dir.join(WINDOWS_POWERSHELL_EXECUTABLE))
         .arg("-NoProfile")
         .arg("-ExecutionPolicy")
         .arg("Bypass")

--- a/crates/projectatlas-db/src/lib.rs
+++ b/crates/projectatlas-db/src/lib.rs
@@ -569,6 +569,30 @@ pub enum DbError {
 }
 
 impl DbError {
+    /// Return a schema version with a complete migration route owned by this runtime.
+    #[must_use]
+    pub fn supported_schema_migration(&self) -> Option<(i64, i64, u32)> {
+        match self {
+            Self::SchemaVersion { found, expected } => schema::migration_steps_remaining(*found)
+                .filter(|steps| *steps > 0)
+                .map(|steps| (*found, *expected, steps)),
+            _ => None,
+        }
+    }
+
+    /// Return a schema version rejected by this runtime's migration inventory.
+    #[must_use]
+    pub fn unsupported_schema_version(&self) -> Option<(i64, i64)> {
+        match self {
+            Self::SchemaVersion { found, expected }
+                if schema::migration_steps_remaining(*found).is_none() =>
+            {
+                Some((*found, *expected))
+            }
+            _ => None,
+        }
+    }
+
     /// Return whether a derived-index write could not proceed without implying
     /// corruption, schema drift, or an identity-contract failure.
     #[must_use]
@@ -7633,6 +7657,65 @@ mod tests {
     use std::fs;
     use std::io;
     use std::time::Instant;
+
+    #[test]
+    fn unsupported_schema_versions_follow_the_migration_inventory() -> Result<(), Box<dyn Error>> {
+        for found in schema::PREVIOUS_SCHEMA_VERSION..=schema::SCHEMA_VERSION {
+            let error = DbError::SchemaVersion {
+                found,
+                expected: schema::SCHEMA_VERSION,
+            };
+            let expected_migration = if found < schema::SCHEMA_VERSION {
+                Some((
+                    found,
+                    schema::SCHEMA_VERSION,
+                    u32::try_from(schema::SCHEMA_VERSION - found)?,
+                ))
+            } else {
+                None
+            };
+            require_eq(
+                &error.supported_schema_migration(),
+                &expected_migration,
+                "admitted schema migration",
+            )?;
+            require_eq(
+                &error.unsupported_schema_version(),
+                &None,
+                "admitted schema version",
+            )?;
+        }
+        for found in [
+            schema::PREVIOUS_SCHEMA_VERSION - 1,
+            schema::SCHEMA_VERSION + 1,
+        ] {
+            let error = DbError::SchemaVersion {
+                found,
+                expected: schema::SCHEMA_VERSION,
+            };
+            require_eq(
+                &error.unsupported_schema_version(),
+                &Some((found, schema::SCHEMA_VERSION)),
+                "unsupported schema version",
+            )?;
+            require_eq(
+                &error.supported_schema_migration(),
+                &None,
+                "unsupported schema migration",
+            )?;
+        }
+        require_eq(
+            &DbError::SchemaVersionMissing.unsupported_schema_version(),
+            &None,
+            "unrelated database error",
+        )?;
+        require_eq(
+            &DbError::SchemaVersionMissing.supported_schema_migration(),
+            &None,
+            "unrelated migration error",
+        )?;
+        Ok(())
+    }
 
     #[test]
     fn stores_nodes_and_overview() -> Result<(), Box<dyn Error>> {

--- a/crates/projectatlas-db/src/lib.rs
+++ b/crates/projectatlas-db/src/lib.rs
@@ -1282,6 +1282,32 @@ const PURPOSE_HEALTH_SPECS: [PurposeHealthSpec; 3] = [
     },
 ];
 
+/// Run one standalone write only while the captured schema and project binding still match.
+fn with_validated_write_transaction<T>(
+    connection: &Connection,
+    expected_root: Option<&str>,
+    expected_identity: Option<ProjectInstanceId>,
+    operation: impl FnOnce(&Connection) -> DbResult<T>,
+) -> DbResult<T> {
+    let transaction =
+        rusqlite::Transaction::new_unchecked(connection, TransactionBehavior::Immediate)?;
+    let result = schema::validate_active_binding(&transaction, expected_root, expected_identity)
+        .and_then(|()| operation(&transaction));
+    match result {
+        Ok(value) => {
+            transaction.commit()?;
+            Ok(value)
+        }
+        Err(operation) => match transaction.rollback() {
+            Ok(()) => Err(operation),
+            Err(rollback) => Err(DbError::TransactionRollback {
+                operation: Box::new(operation),
+                rollback,
+            }),
+        },
+    }
+}
+
 impl AtlasStore {
     /// Reject mutations while this connection owns an ordinary read snapshot.
     fn require_mutation_scope(&self) -> DbResult<()> {
@@ -1318,27 +1344,12 @@ impl AtlasStore {
         if !self.connection.is_autocommit() {
             return operation(&self.connection);
         }
-        let transaction =
-            rusqlite::Transaction::new_unchecked(&self.connection, TransactionBehavior::Immediate)?;
-        let result = schema::validate_active_binding(
-            &transaction,
+        with_validated_write_transaction(
+            &self.connection,
             self.validated_project_root.as_deref(),
             self.validated_project_instance_id,
+            operation,
         )
-        .and_then(|()| operation(&transaction));
-        match result {
-            Ok(value) => {
-                transaction.commit()?;
-                Ok(value)
-            }
-            Err(operation) => match transaction.rollback() {
-                Ok(()) => Err(operation),
-                Err(rollback) => Err(DbError::TransactionRollback {
-                    operation: Box::new(operation),
-                    rollback,
-                }),
-            },
-        }
     }
 
     /// Run telemetry against this store's exact captured database binding.
@@ -5641,39 +5652,28 @@ impl AtlasStore {
             .validated_project_instance_id
             .ok_or(DbError::ProjectInstanceIdentityMissing)?;
         self.with_telemetry_connection(|connection| {
-            let transaction =
-                rusqlite::Transaction::new_unchecked(connection, TransactionBehavior::Immediate)?;
-            let operation = schema::validate_active_binding(
-                &transaction,
+            with_validated_write_transaction(
+                connection,
                 self.validated_project_root.as_deref(),
                 Some(project_instance_id),
-            )
-            .and_then(|()| {
-                telemetry::record_usage_for_project(
-                    &transaction,
-                    project_instance_id,
-                    instance_id,
-                    owner,
-                    event,
-                    policy,
-                    seal_after_record,
-                )
-            });
-            match operation {
-                Ok(()) => transaction.commit().map_err(DbError::from),
-                Err(operation) => match transaction.rollback() {
-                    Ok(()) => Err(operation),
-                    Err(rollback) => Err(DbError::TransactionRollback {
-                        operation: Box::new(operation),
-                        rollback,
-                    }),
+                |transaction| {
+                    telemetry::record_usage_for_project(
+                        transaction,
+                        project_instance_id,
+                        instance_id,
+                        owner,
+                        event,
+                        policy,
+                        seal_after_record,
+                    )
                 },
-            }?;
+            )?;
             // The event is already committed. Passive maintenance remains
             // observable through retention state and must never make callers
             // retry a successfully persisted event.
             drop(telemetry::maintain_after_commit_for_project(
                 connection,
+                self.validated_project_root.as_deref(),
                 project_instance_id,
                 policy,
             ));
@@ -5689,24 +5689,12 @@ impl AtlasStore {
     /// already inactive, or `SQLite` cannot commit the state transition.
     pub fn seal_usage_instance(&self, instance_id: UsageInstanceId) -> DbResult<()> {
         self.with_telemetry_connection(|connection| {
-            let transaction =
-                rusqlite::Transaction::new_unchecked(connection, TransactionBehavior::Immediate)?;
-            let operation = schema::validate_active_binding(
-                &transaction,
+            with_validated_write_transaction(
+                connection,
                 self.validated_project_root.as_deref(),
                 self.validated_project_instance_id,
+                |transaction| telemetry::seal_usage_instance(transaction, instance_id),
             )
-            .and_then(|()| telemetry::seal_usage_instance(&transaction, instance_id));
-            match operation {
-                Ok(()) => transaction.commit().map_err(Into::into),
-                Err(operation) => match transaction.rollback() {
-                    Ok(()) => Err(operation),
-                    Err(rollback) => Err(DbError::TransactionRollback {
-                        operation: Box::new(operation),
-                        rollback,
-                    }),
-                },
-            }
         })
     }
 
@@ -9092,6 +9080,105 @@ mod tests {
             &read_project_root_read_only(&db_path)?,
             &Some(normalize_native_path_display(&root)),
             "WAL-aware read-only project root",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn validated_write_transaction_revalidates_before_operation_and_rolls_back()
+    -> Result<(), Box<dyn Error>> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("repository");
+        fs::create_dir_all(&root)?;
+        let db_path = temp.path().join("projectatlas.db");
+        let store = AtlasStore::open_for_project(&db_path, &root)?;
+        let expected_identity = store
+            .validated_project_instance_id
+            .ok_or(DbError::ProjectInstanceIdentityMissing)?;
+        let sentinel_key = "validated_write_transaction_test";
+
+        with_validated_write_transaction(
+            &store.connection,
+            store.validated_project_root.as_deref(),
+            Some(expected_identity),
+            |connection| set_metadata(connection, sentinel_key, "committed"),
+        )?;
+        require_eq(
+            &store.connection.query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                [sentinel_key],
+                |row| row.get::<_, String>(0),
+            )?,
+            &"committed".to_string(),
+            "validated write positive control",
+        )?;
+
+        let Err(operation_error) = with_validated_write_transaction(
+            &store.connection,
+            store.validated_project_root.as_deref(),
+            Some(expected_identity),
+            |connection| -> DbResult<()> {
+                set_metadata(connection, sentinel_key, "rolled-back")?;
+                Err(DbError::TelemetryIdentityUnavailable)
+            },
+        ) else {
+            return Err(io::Error::other("failing validated write unexpectedly committed").into());
+        };
+        require_eq(
+            &matches!(operation_error, DbError::TelemetryIdentityUnavailable),
+            &true,
+            "validated write operation error",
+        )?;
+        require_eq(
+            &store.connection.query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                [sentinel_key],
+                |row| row.get::<_, String>(0),
+            )?,
+            &"committed".to_string(),
+            "validated write rollback",
+        )?;
+
+        let future_schema = schema::SCHEMA_VERSION + 1;
+        let newer_owner = Connection::open(&db_path)?;
+        newer_owner.execute(
+            "UPDATE metadata SET value = ?2 WHERE key = ?1",
+            params![schema::SCHEMA_VERSION_KEY, future_schema.to_string()],
+        )?;
+        let operation_invoked = Cell::new(false);
+        let Err(binding_error) = with_validated_write_transaction(
+            &store.connection,
+            store.validated_project_root.as_deref(),
+            Some(expected_identity),
+            |connection| {
+                operation_invoked.set(true);
+                set_metadata(connection, sentinel_key, "wrong-schema")
+            },
+        ) else {
+            return Err(io::Error::other("newer schema accepted a validated write").into());
+        };
+        require_eq(
+            &matches!(
+                binding_error,
+                DbError::SchemaVersion { found, expected }
+                    if found == future_schema && expected == schema::SCHEMA_VERSION
+            ),
+            &true,
+            "validated write schema recheck",
+        )?;
+        require_eq(
+            &operation_invoked.get(),
+            &false,
+            "validated write closure invocation",
+        )?;
+        require_eq(
+            &newer_owner.query_row(
+                "SELECT value FROM metadata WHERE key = ?1",
+                [sentinel_key],
+                |row| row.get::<_, String>(0),
+            )?,
+            &"committed".to_string(),
+            "newer-schema sentinel value",
         )?;
         Ok(())
     }

--- a/crates/projectatlas-db/src/lib.rs
+++ b/crates/projectatlas-db/src/lib.rs
@@ -1340,6 +1340,7 @@ impl AtlasStore {
             }
             return Err(DbError::TelemetryPathUnavailable);
         };
+        let _ = schema::preflight(path, self.validated_project_root.as_deref())?;
         let connection = open_writable_connection(
             path,
             OpenFlags::SQLITE_OPEN_READ_WRITE,
@@ -12987,6 +12988,23 @@ mod tests {
     ) -> Result<(), Box<dyn Error>> {
         let mut store = AtlasStore::open(db_path)?;
         store.set_project_root(root)?;
+        populate_schema_compatibility_fixture(&mut store, label)?;
+        set_metadata(
+            &store.connection,
+            SCHEMA_VERSION_KEY,
+            &schema_version.to_string(),
+        )?;
+        store
+            .connection
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")?;
+        Ok(())
+    }
+
+    /// Populate representative source, authored, telemetry, and publication state.
+    pub(crate) fn populate_schema_compatibility_fixture(
+        store: &mut AtlasStore,
+        label: &str,
+    ) -> Result<(), Box<dyn Error>> {
         {
             let mut publication = store.begin_index_publication("untrusted-contract")?;
             write_test_projection(&mut publication, label)?;
@@ -13018,14 +13036,6 @@ mod tests {
             20,
         ))?;
         set_metadata(&store.connection, "custom_setting", "preserved")?;
-        set_metadata(
-            &store.connection,
-            SCHEMA_VERSION_KEY,
-            &schema_version.to_string(),
-        )?;
-        store
-            .connection
-            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")?;
         Ok(())
     }
 

--- a/crates/projectatlas-db/src/schema.rs
+++ b/crates/projectatlas-db/src/schema.rs
@@ -2354,12 +2354,13 @@ mod tests {
     use super::*;
     use crate::{AtlasStore, DbError};
     use projectatlas_core::telemetry::{
-        TokenOverview, TokenTrendPeriod, TokenTrendWindow, UsageEvent,
+        TokenOverview, TokenTrendPeriod, TokenTrendWindow, UsageEvent, usage_from_estimates,
     };
     use rusqlite::types::Value;
     use std::error::Error;
     use std::fs;
     use std::io;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Barrier};
     use std::thread;
 
@@ -2403,6 +2404,238 @@ mod tests {
                 .collect::<Result<Vec<_>, _>>()
         })?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    /// Complete current-schema object and logical-row snapshot used by refusal tests.
+    #[derive(Debug, PartialEq)]
+    struct CurrentSchemaSnapshot {
+        schema_objects: Vec<Vec<Value>>,
+        tables: Vec<(String, Vec<Vec<Value>>)>,
+    }
+
+    /// Read every user table and schema object without checkpointing the live database.
+    fn current_schema_snapshot(
+        connection: &Connection,
+    ) -> Result<CurrentSchemaSnapshot, Box<dyn Error>> {
+        let schema_objects = query_all_values(
+            connection,
+            "SELECT type, name, tbl_name, sql
+             FROM sqlite_master
+             WHERE name NOT LIKE 'sqlite_%'
+             ORDER BY type, name",
+        )?;
+        let table_names = query_all_values(
+            connection,
+            "SELECT name FROM sqlite_master
+             WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+             ORDER BY name",
+        )?;
+        let mut tables = Vec::with_capacity(table_names.len());
+        for row in table_names {
+            let [Value::Text(table_name)] = row.as_slice() else {
+                return Err(io::Error::other(format!(
+                    "sqlite_master returned an invalid table name: {row:?}"
+                ))
+                .into());
+            };
+            let quoted_name = table_name.replace('"', "\"\"");
+            let select = format!("SELECT * FROM \"{quoted_name}\"");
+            let column_count = connection.prepare(&select)?.column_count();
+            let ordering = (1..=column_count)
+                .map(|column| column.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let rows = query_all_values(connection, &format!("{select} ORDER BY {ordering}"))?;
+            tables.push((table_name.clone(), rows));
+        }
+        Ok(CurrentSchemaSnapshot {
+            schema_objects,
+            tables,
+        })
+    }
+
+    #[test]
+    fn newer_schema_active_wal_is_refused_without_mutating_durable_state()
+    -> Result<(), Box<dyn Error>> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("repository");
+        fs::create_dir_all(&root)?;
+        let db_path = temp.path().join("projectatlas.db");
+        let mut store = AtlasStore::open_for_project(&db_path, &root)?;
+        store
+            .connection
+            .execute_batch("PRAGMA wal_autocheckpoint = 0")?;
+        crate::tests::populate_schema_compatibility_fixture(&mut store, "future")?;
+        let navigation_store = AtlasStore::open_read_only_for_project(&db_path, &root)?;
+
+        let future_version = SCHEMA_VERSION + 1;
+        set_metadata(
+            &store.connection,
+            SCHEMA_VERSION_KEY,
+            &future_version.to_string(),
+        )?;
+        let wal_path = sqlite_sidecar_path(&db_path, "-wal");
+        let shm_path = sqlite_sidecar_path(&db_path, "-shm");
+        let wal_before = fs::read(&wal_path)?;
+        if wal_before.is_empty() || !shm_path.is_file() {
+            return Err(io::Error::other(
+                "future-schema fixture did not retain a live WAL and SHM sidecar",
+            )
+            .into());
+        }
+        let database_before = fs::read(&db_path)?;
+        let inventory_before = directory_entry_names(temp.path())?;
+        let snapshot_before = current_schema_snapshot(&store.connection)?;
+        for required_table in [
+            "project_identity",
+            "purposes",
+            "health_resolutions",
+            "usage_events",
+            "nodes",
+            "summaries",
+            "symbols",
+            "file_texts",
+        ] {
+            if !snapshot_before
+                .tables
+                .iter()
+                .any(|(table, rows)| table == required_table && !rows.is_empty())
+            {
+                return Err(io::Error::other(format!(
+                    "future-schema fixture did not populate {required_table}"
+                ))
+                .into());
+            }
+        }
+
+        let Err(error) = AtlasStore::open_for_project(&db_path, &root) else {
+            return Err(io::Error::other("newer schema unexpectedly opened writable").into());
+        };
+        if !matches!(
+            error,
+            DbError::SchemaVersion {
+                found,
+                expected: SCHEMA_VERSION,
+            } if found == future_version
+        ) {
+            return Err(io::Error::other(format!(
+                "newer-schema refusal returned the wrong error: {error}"
+            ))
+            .into());
+        }
+
+        let Err(telemetry_error) = navigation_store.record_usage(&usage_from_estimates(
+            "future-schema-session",
+            "summary",
+            Some("src/lib.rs".to_string()),
+            None,
+            100,
+            20,
+        )) else {
+            return Err(io::Error::other(
+                "newer schema unexpectedly opened writable for telemetry",
+            )
+            .into());
+        };
+        if !matches!(
+            telemetry_error,
+            DbError::SchemaVersion {
+                found,
+                expected: SCHEMA_VERSION,
+            } if found == future_version
+        ) {
+            return Err(io::Error::other(format!(
+                "newer-schema telemetry refusal returned the wrong error: {telemetry_error}"
+            ))
+            .into());
+        }
+
+        if fs::read(&db_path)? != database_before
+            || fs::read(&wal_path)? != wal_before
+            || directory_entry_names(temp.path())? != inventory_before
+        {
+            return Err(io::Error::other(
+                "newer-schema refusal changed database bytes, WAL bytes, or sidecar inventory",
+            )
+            .into());
+        }
+        let snapshot_after = current_schema_snapshot(&store.connection)?;
+        if snapshot_after != snapshot_before {
+            return Err(io::Error::other(
+                "newer-schema refusal changed schema objects or logical database state",
+            )
+            .into());
+        }
+        if read_metadata(&store.connection, SCHEMA_VERSION_KEY)? != Some(future_version.to_string())
+        {
+            return Err(io::Error::other("live owner could not read the retained schema").into());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn newer_schema_preflight_work_is_independent_of_derived_row_count()
+    -> Result<(), Box<dyn Error>> {
+        let small_steps = incompatible_preflight_vm_steps(1)?;
+        let large_steps = incompatible_preflight_vm_steps(10_000)?;
+        if small_steps == 0 || large_steps != small_steps {
+            return Err(io::Error::other(format!(
+                "newer-schema inspection scaled with derived rows: small={small_steps}, large={large_steps}"
+            ))
+            .into());
+        }
+        Ok(())
+    }
+
+    /// Count the actual `SQLite` virtual-machine work used by incompatible preflight.
+    fn incompatible_preflight_vm_steps(row_count: i64) -> Result<usize, Box<dyn Error>> {
+        let store = AtlasStore::in_memory()?;
+        store.connection.execute(
+            "WITH RECURSIVE sequence(value) AS (
+                 VALUES(1)
+                 UNION ALL
+                 SELECT value + 1 FROM sequence WHERE value < ?1
+             )
+             INSERT INTO nodes(path, kind)
+             SELECT printf('src/file-%08d.rs', value), 'file' FROM sequence",
+            [row_count],
+        )?;
+        let inserted = store
+            .connection
+            .query_row("SELECT COUNT(*) FROM nodes", [], |row| row.get::<_, i64>(0))?;
+        if inserted != row_count {
+            return Err(io::Error::other("row-count fixture was not populated").into());
+        }
+        let future_version = SCHEMA_VERSION + 1;
+        set_metadata(
+            &store.connection,
+            SCHEMA_VERSION_KEY,
+            &future_version.to_string(),
+        )?;
+        let vm_steps = Arc::new(AtomicUsize::new(0));
+        let observed_steps = Arc::clone(&vm_steps);
+        store.connection.progress_handler(
+            1,
+            Some(move || {
+                observed_steps.fetch_add(1, Ordering::Relaxed);
+                false
+            }),
+        );
+        let result = inspect_connection(&store.connection, None, false);
+        store.connection.progress_handler(0, None::<fn() -> bool>);
+        let Err(error) = result else {
+            return Err(io::Error::other("newer schema unexpectedly passed inspection").into());
+        };
+        if !matches!(
+            error,
+            DbError::SchemaVersion {
+                found,
+                expected: SCHEMA_VERSION,
+            } if found == future_version
+        ) {
+            return Err(io::Error::other("bounded inspection returned the wrong error").into());
+        }
+        Ok(vm_steps.load(Ordering::Relaxed))
     }
 
     #[test]

--- a/crates/projectatlas-db/src/telemetry.rs
+++ b/crates/projectatlas-db/src/telemetry.rs
@@ -982,19 +982,108 @@ pub(crate) fn seal_project_usage_instances(
 /// Run due post-commit maintenance only for the adapter's captured project identity.
 pub(crate) fn maintain_after_commit_for_project(
     connection: &Connection,
+    expected_root: Option<&str>,
     project: ProjectInstanceId,
     policy: TelemetryRetentionPolicy,
 ) -> DbResult<()> {
+    maintain_after_commit_for_project_with_checkpoint(
+        connection,
+        expected_root,
+        project,
+        policy,
+        |connection| Ok(passive_checkpoint_state(connection)),
+    )
+}
+
+/// Run due maintenance with an explicit passive-checkpoint boundary.
+fn maintain_after_commit_for_project_with_checkpoint(
+    connection: &Connection,
+    expected_root: Option<&str>,
+    project: ProjectInstanceId,
+    policy: TelemetryRetentionPolicy,
+    checkpoint: impl FnOnce(&Connection) -> DbResult<TelemetryCheckpointState>,
+) -> DbResult<()> {
     crate::project_identity::require_bound_project_identity(connection, project)?;
     let policy = policy.validate()?;
-    let writes = connection.query_row(
-        "SELECT writes_since_checkpoint FROM usage_retention_state WHERE singleton = 1",
-        [],
-        |row| row.get::<_, i64>(0),
+    let checkpoint_start_writes = count_usize(
+        "writes_since_checkpoint",
+        connection.query_row(
+            "SELECT writes_since_checkpoint FROM usage_retention_state WHERE singleton = 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?,
     )?;
-    if count_usize("writes_since_checkpoint", writes)? < policy.checkpoint_write_interval {
+    if checkpoint_start_writes < policy.checkpoint_write_interval {
         return Ok(());
     }
+    crate::schema::validate_active_binding(connection, expected_root, Some(project))?;
+    let checkpoint_data_version =
+        connection.query_row("PRAGMA data_version", [], |row| row.get::<_, i64>(0))?;
+    let state = checkpoint(connection)?;
+    crate::with_validated_write_transaction(
+        connection,
+        expected_root,
+        Some(project),
+        |transaction| {
+            let current_data_version =
+                transaction.query_row("PRAGMA data_version", [], |row| row.get::<_, i64>(0))?;
+            let current_writes = count_usize(
+                "writes_since_checkpoint",
+                transaction.query_row(
+                    "SELECT writes_since_checkpoint
+                     FROM usage_retention_state WHERE singleton = 1",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )?,
+            )?;
+            let retained_writes = writes_after_checkpoint_attempt(
+                state,
+                checkpoint_start_writes,
+                current_writes,
+                current_data_version == checkpoint_data_version,
+            );
+            let now = now_epoch_seconds()?;
+            let (raw_rows, raw_bytes, old_raw) = raw_pressure(transaction, policy, now)?;
+            let retention_pending = raw_rows > policy.max_raw_rows
+                || raw_bytes > policy.max_raw_logical_bytes
+                || old_raw > 0
+                || retention_counter(transaction, RetentionCounter::InstanceRows)?
+                    > policy.max_retained_instances
+                || retention_counter(transaction, RetentionCounter::LabelRows)?
+                    > policy.max_retained_labels
+                || retention_counter(transaction, RetentionCounter::DailyRows)?
+                    > policy.max_daily_rows
+                || retention_counter(transaction, RetentionCounter::LabelTombstoneRows)?
+                    > policy.max_label_tombstones
+                || retention_counter(transaction, RetentionCounter::InstanceTombstoneRows)?
+                    > policy.max_instance_tombstones
+                || aged_maintenance_pending(transaction, policy, now)?;
+            let completed = state == TelemetryCheckpointState::Completed;
+            transaction.execute(
+                "UPDATE usage_retention_state
+                 SET writes_since_checkpoint = ?1,
+                     last_checkpoint_epoch = ?2,
+                     checkpoint_state = ?3,
+                     maintenance_pending = ?4
+                 WHERE singleton = 1",
+                params![
+                    to_i64("writes_since_checkpoint", retained_writes)?,
+                    now,
+                    state.as_str(),
+                    i64::from(
+                        !completed
+                            || retention_pending
+                            || retained_writes >= policy.checkpoint_write_interval
+                    ),
+                ],
+            )?;
+            Ok(())
+        },
+    )
+}
+
+/// Run one passive checkpoint and classify its bounded `SQLite` result.
+fn passive_checkpoint_state(connection: &Connection) -> TelemetryCheckpointState {
     let result = connection.query_row("PRAGMA wal_checkpoint(PASSIVE)", [], |row| {
         Ok((
             row.get::<_, i64>(0)?,
@@ -1002,44 +1091,27 @@ pub(crate) fn maintain_after_commit_for_project(
             row.get::<_, i64>(2)?,
         ))
     });
-    let state = match result {
+    match result {
         Ok((0, log_frames, checkpointed_frames)) if checkpointed_frames == log_frames => {
             TelemetryCheckpointState::Completed
         }
         Ok(_) => TelemetryCheckpointState::Busy,
         Err(_) => TelemetryCheckpointState::Error,
-    };
-    crate::project_identity::require_bound_project_identity(connection, project)?;
-    let now = now_epoch_seconds()?;
-    let (raw_rows, raw_bytes, old_raw) = raw_pressure(connection, policy, now)?;
-    let retention_pending = raw_rows > policy.max_raw_rows
-        || raw_bytes > policy.max_raw_logical_bytes
-        || old_raw > 0
-        || retention_counter(connection, RetentionCounter::InstanceRows)?
-            > policy.max_retained_instances
-        || retention_counter(connection, RetentionCounter::LabelRows)? > policy.max_retained_labels
-        || retention_counter(connection, RetentionCounter::DailyRows)? > policy.max_daily_rows
-        || retention_counter(connection, RetentionCounter::LabelTombstoneRows)?
-            > policy.max_label_tombstones
-        || retention_counter(connection, RetentionCounter::InstanceTombstoneRows)?
-            > policy.max_instance_tombstones
-        || aged_maintenance_pending(connection, policy, now)?;
-    let completed = state == TelemetryCheckpointState::Completed;
-    connection.execute(
-        "UPDATE usage_retention_state
-         SET writes_since_checkpoint = ?1,
-             last_checkpoint_epoch = ?2,
-             checkpoint_state = ?3,
-             maintenance_pending = ?4
-         WHERE singleton = 1",
-        params![
-            if completed { 0 } else { writes },
-            now,
-            state.as_str(),
-            i64::from(!completed || retention_pending),
-        ],
-    )?;
-    Ok(())
+    }
+}
+
+/// Preserve writes that committed after a checkpoint attempt began.
+const fn writes_after_checkpoint_attempt(
+    state: TelemetryCheckpointState,
+    checkpoint_start_writes: usize,
+    current_writes: usize,
+    data_version_unchanged: bool,
+) -> usize {
+    if matches!(state, TelemetryCheckpointState::Completed) && data_version_unchanged {
+        current_writes.saturating_sub(checkpoint_start_writes)
+    } else {
+        current_writes
+    }
 }
 
 /// Return content-free bounded telemetry state.
@@ -5146,7 +5218,12 @@ mod tests {
 
             let lookalike = database.temp.path().join("usage-telemetry-spill.db");
             std::fs::write(&lookalike, b"not owned by ProjectAtlas")?;
-            maintain_after_commit_for_project(&database.connection, database.project, policy)?;
+            maintain_after_commit_for_project(
+                &database.connection,
+                None,
+                database.project,
+                policy,
+            )?;
             assert_eq!(std::fs::read(lookalike)?, b"not owned by ProjectAtlas");
             Ok(())
         })();
@@ -5396,7 +5473,113 @@ mod tests {
     }
 
     #[test]
-    fn production_store_checkpoint_retries_after_a_held_reader_and_rejects_stale_binding() {
+    fn checkpoint_finalization_preserves_writes_committed_after_attempt() {
+        assert_eq!(
+            writes_after_checkpoint_attempt(
+                TelemetryCheckpointState::Completed,
+                1_024,
+                1_025,
+                true,
+            ),
+            1
+        );
+        assert_eq!(
+            writes_after_checkpoint_attempt(
+                TelemetryCheckpointState::Completed,
+                1_024,
+                1_025,
+                false,
+            ),
+            1_025
+        );
+        assert_eq!(
+            writes_after_checkpoint_attempt(TelemetryCheckpointState::Busy, 1_024, 1_025, true,),
+            1_025
+        );
+        assert_eq!(
+            writes_after_checkpoint_attempt(TelemetryCheckpointState::Error, 1_024, 1_025, true,),
+            1_025
+        );
+    }
+
+    #[test]
+    fn overlapping_checkpoint_finalizers_preserve_later_event_debt() {
+        let result = (|| -> Result<(), Box<dyn Error>> {
+            let database = production_database()?;
+            let policy = TelemetryRetentionPolicy::default();
+            let first = AtlasStore::open_for_project(&database.database_path, &database.root)?;
+            let second = AtlasStore::open_for_project(&database.database_path, &database.root)?;
+            let event_writer =
+                AtlasStore::open_for_project(&database.database_path, &database.root)?;
+            let first_instance = instance(91)?;
+            let second_instance = instance(92)?;
+            let first_event = event("checkpoint-overlap-first", 100, 10);
+            let second_event = event("checkpoint-overlap-second", 100, 10);
+            database.store.connection.execute(
+                "UPDATE usage_retention_state
+                 SET writes_since_checkpoint = ?1 WHERE singleton = 1",
+                [to_i64(
+                    "checkpoint_write_interval",
+                    policy.checkpoint_write_interval,
+                )?],
+            )?;
+
+            maintain_after_commit_for_project_with_checkpoint(
+                &first.connection,
+                first.validated_project_root.as_deref(),
+                database.project,
+                policy,
+                |connection| {
+                    let state = passive_checkpoint_state(connection);
+                    record_transaction(
+                        &event_writer.connection,
+                        database.project,
+                        first_instance,
+                        UsageInstanceOwner::McpProcess,
+                        &first_event,
+                        policy,
+                        false,
+                    )?;
+                    maintain_after_commit_for_project_with_checkpoint(
+                        &second.connection,
+                        second.validated_project_root.as_deref(),
+                        database.project,
+                        policy,
+                        |connection| {
+                            let state = passive_checkpoint_state(connection);
+                            record_transaction(
+                                &event_writer.connection,
+                                database.project,
+                                second_instance,
+                                UsageInstanceOwner::McpProcess,
+                                &second_event,
+                                policy,
+                                false,
+                            )?;
+                            Ok(state)
+                        },
+                    )?;
+                    Ok(state)
+                },
+            )?;
+
+            let retention = database.store.telemetry_retention_state()?;
+            assert_eq!(
+                retention.writes_since_checkpoint,
+                policy.checkpoint_write_interval + 2,
+                "overlapping checkpoint finalizers erased later event debt"
+            );
+            assert!(retention.maintenance_pending);
+            Ok(())
+        })();
+        assert!(
+            result.is_ok(),
+            "overlapping checkpoint test failed: {result:?}"
+        );
+    }
+
+    #[test]
+    fn production_store_checkpoint_retries_and_rejects_stale_schema_or_binding() {
         let result = (|| -> Result<(), Box<dyn Error>> {
             let database = production_database()?;
             let runtime = instance(90)?;
@@ -5429,6 +5612,7 @@ mod tests {
             )?;
             maintain_after_commit_for_project(
                 &database.store.connection,
+                database.store.validated_project_root.as_deref(),
                 database.project,
                 policy,
             )?;
@@ -5442,6 +5626,7 @@ mod tests {
             reader.finish_index_read_snapshot()?;
             maintain_after_commit_for_project(
                 &database.store.connection,
+                database.store.validated_project_root.as_deref(),
                 database.project,
                 policy,
             )?;
@@ -5451,6 +5636,121 @@ mod tests {
                 TelemetryCheckpointState::Completed
             );
             assert_eq!(completed.writes_since_checkpoint, 0);
+
+            database.store.connection.execute(
+                "UPDATE usage_retention_state
+                 SET writes_since_checkpoint = ?1 WHERE singleton = 1",
+                [to_i64(
+                    "checkpoint_write_interval",
+                    policy.checkpoint_write_interval,
+                )?],
+            )?;
+            let newer_owner = Connection::open(&database.database_path)?;
+            let future_schema = crate::schema::SCHEMA_VERSION + 1;
+            newer_owner.execute(
+                "UPDATE metadata SET value = ?2 WHERE key = ?1",
+                params![crate::schema::SCHEMA_VERSION_KEY, future_schema.to_string()],
+            )?;
+            let wal_path = crate::schema::sqlite_sidecar_path(&database.database_path, "-wal");
+            let wal_before = fs::read(&wal_path)?;
+            let maintenance_before = database.store.telemetry_retention_state()?;
+            let Err(error) = maintain_after_commit_for_project(
+                &database.store.connection,
+                database.store.validated_project_root.as_deref(),
+                database.project,
+                policy,
+            ) else {
+                return Err(std::io::Error::other(
+                    "post-commit maintenance accepted a newer schema",
+                )
+                .into());
+            };
+            assert!(matches!(
+                error,
+                DbError::SchemaVersion { found, expected }
+                    if found == future_schema && expected == crate::schema::SCHEMA_VERSION
+            ));
+            assert_eq!(
+                database.store.telemetry_retention_state()?,
+                maintenance_before,
+                "newer-schema maintenance refusal changed retention state"
+            );
+            assert_eq!(
+                fs::read(&wal_path)?,
+                wal_before,
+                "newer-schema maintenance refusal checkpointed the WAL"
+            );
+            assert_eq!(
+                newer_owner.query_row(
+                    "SELECT value FROM metadata WHERE key = ?1",
+                    [crate::schema::SCHEMA_VERSION_KEY],
+                    |row| row.get::<_, String>(0),
+                )?,
+                future_schema.to_string(),
+                "newer-schema owner stopped observing its schema"
+            );
+            newer_owner.execute(
+                "UPDATE metadata SET value = ?2 WHERE key = ?1",
+                params![
+                    crate::schema::SCHEMA_VERSION_KEY,
+                    crate::schema::SCHEMA_VERSION.to_string()
+                ],
+            )?;
+
+            database.store.connection.execute(
+                "UPDATE usage_retention_state
+                 SET writes_since_checkpoint = ?1 WHERE singleton = 1",
+                [to_i64(
+                    "checkpoint_write_interval",
+                    policy.checkpoint_write_interval,
+                )?],
+            )?;
+            let transition_before = database.store.telemetry_retention_state()?;
+            let Err(error) = maintain_after_commit_for_project_with_checkpoint(
+                &database.store.connection,
+                database.store.validated_project_root.as_deref(),
+                database.project,
+                policy,
+                |connection| {
+                    let state = passive_checkpoint_state(connection);
+                    newer_owner.execute(
+                        "UPDATE metadata SET value = ?2 WHERE key = ?1",
+                        params![crate::schema::SCHEMA_VERSION_KEY, future_schema.to_string()],
+                    )?;
+                    Ok(state)
+                },
+            ) else {
+                return Err(std::io::Error::other(
+                    "maintenance finalized after a schema transition at the checkpoint boundary",
+                )
+                .into());
+            };
+            assert!(matches!(
+                error,
+                DbError::SchemaVersion { found, expected }
+                    if found == future_schema && expected == crate::schema::SCHEMA_VERSION
+            ));
+            assert_eq!(
+                database.store.telemetry_retention_state()?,
+                transition_before,
+                "checkpoint-boundary schema transition changed retention state"
+            );
+            assert_eq!(
+                newer_owner.query_row(
+                    "SELECT value FROM metadata WHERE key = ?1",
+                    [crate::schema::SCHEMA_VERSION_KEY],
+                    |row| row.get::<_, String>(0),
+                )?,
+                future_schema.to_string(),
+                "checkpoint-boundary refusal changed the concurrent owner's schema"
+            );
+            newer_owner.execute(
+                "UPDATE metadata SET value = ?2 WHERE key = ?1",
+                params![
+                    crate::schema::SCHEMA_VERSION_KEY,
+                    crate::schema::SCHEMA_VERSION.to_string()
+                ],
+            )?;
 
             let old_project = database.project;
             let captured = database.store.captured_project_binding()?;
@@ -5467,8 +5767,12 @@ mod tests {
                     .revalidate_captured_project_binding()
                     .is_err()
             );
-            let stale =
-                maintain_after_commit_for_project(&database.store.connection, old_project, policy);
+            let stale = maintain_after_commit_for_project(
+                &database.store.connection,
+                database.store.validated_project_root.as_deref(),
+                old_project,
+                policy,
+            );
             assert!(stale.is_err());
             Ok(())
         })();

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -262,6 +262,17 @@ The Codex parent is never terminated. A failed post-retirement retry reports
 `retry_failed` and preserves the versioned runtime plus project-local configs;
 any bundle that cannot be reverified is reported unready with rerun guidance.
 
+When the stable mirror stays locked but the versioned runtime and generated
+configs remain verified, final output names the captured stale bare-command
+path and its observed version (or `unavailable`), the verified absolute runtime
+and target version, and whether restarting the environment-owning host can
+repair command resolution. Use the emitted absolute runtime command until the
+lock owner exits or releases the mirror, then rerun the emitted installer
+command. From the reported project root, require both the bare-command
+version gate and `projectatlas --require-version <target> token --view tui`
+before declaring convergence. Restart never makes the locked mirror ready by
+itself, and this recovery path adds no process-termination authority.
+
 Local installer fixtures prove the selection, identity, readiness, failure, and
 retry-reporting contracts, but do not prove the real Codex parent/child
 lifecycle. Release acceptance for this handoff additionally requires an

--- a/openspec/changes/reject-incompatible-schema-before-write/.openspec.yaml
+++ b/openspec/changes/reject-incompatible-schema-before-write/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/reject-incompatible-schema-before-write/design.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/design.md
@@ -1,0 +1,82 @@
+## Context
+
+`projectatlas-db` already owns schema compatibility in `schema::preflight`. Every normal writable store open routes through `AtlasStore::open_with_binding_requirement`, which runs that read-only preflight before `open_writable_connection` can select create flags, establish WAL, configure write pragmas, run DDL, or enter migration. A stale v0.3.26 mirror violated this ordering, while the current source has the right ownership boundary but lacks a durable newer-schema/active-WAL regression and typed public adapter contract.
+
+The database is project-local SQLite accessed through `rusqlite`. Its authored purposes, health resolutions, telemetry, project identity, metadata, and schema objects are durable authority; derived index state is rebuildable, but incompatibility refusal is not authorized to mutate either class. CLI and MCP errors already share `AgentErrorKind` and related payload types in the CLI crate. The Windows installer already distinguishes verified versioned-runtime/config readiness from stable-mirror, parent, and bare-command readiness after `handoff-obsolete-mcp-runtime`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep the single read-only schema preflight ahead of every writable SQLite open and every schema mutation path.
+- Prove a current runtime refuses a database stamped with a newer schema without changing database bytes, WAL bytes, schema objects, metadata, or authored rows, including while a live connection retains uncheckpointed WAL state.
+- Give CLI and MCP the same machine-readable `schema_version_mismatch` kind and content-free version fields.
+- Prove the contract through the packaged CLI and real stdio MCP server, not only direct database calls.
+- Make locked-mirror Windows output identify the resolved stale path/version, the verified runtime path/target version, and the exact safe verify/use/rerun sequence.
+
+**Non-Goals:**
+
+- Adding a schema object, schema version, migration, query index, crate, dependency, trait, framework, command, or MCP tool.
+- Making an immutable released v0.3.26 executable safe retroactively.
+- Opening, repairing, checkpointing, resetting, replacing, or downgrading a newer database after refusal.
+- Changing SQLite transaction ownership or the existing installer handoff/termination authority.
+- Duplicating `handoff-obsolete-mcp-runtime` task 4.1 or treating a local fixture as real installed-Codex process-handoff proof.
+- Adding a diagram for an ownership flow that remains unchanged.
+
+## Decisions
+
+### Keep refusal in the existing database-open owner
+
+Retain `schema::preflight` as the sole compatibility classifier and `AtlasStore::open_with_binding_requirement` as the shared writable-open gate. A future schema remains a closed `DbError::SchemaVersion { found, expected }` result before `open_writable_connection`; sibling CLI and MCP callers do not receive their own schema guards.
+
+Adding adapter-local prechecks was rejected because another caller could still reach writable SQLite first. Adding a trait, migration framework, or second connection owner was rejected because variability is closed and the existing concrete enum/function boundary already expresses it.
+
+### Prove zero mutation with a live newer-schema WAL fixture
+
+Build a real temporary current-schema database, populate representative authored and derived rows, switch it to WAL with automatic checkpointing disabled, and stamp its metadata to `SCHEMA_VERSION + 1` through the fixture's owning live connection. Keep that connection open so the newer version and fixture writes remain in an active WAL. Before and after a rejected normal writable store open, capture:
+
+- main database and WAL bytes plus sidecar presence;
+- complete table/index/view/trigger inventory and schema-version metadata;
+- project identity, authored purposes, health resolutions, telemetry, and representative derived rows.
+
+The failure must be `DbError::SchemaVersion` with the exact found/supported versions. The test must not checkpoint merely to make byte comparison convenient. The existing compatible-current and admitted-predecessor migration tests remain the positive controls; missing/malformed metadata and schema-shape fixtures remain failure controls.
+
+A SQL mock was rejected because it cannot prove SQLite open flags, WAL behavior, or durable bytes. Requiring `-shm` bytes to remain identical was rejected because SQLite reader-lock bookkeeping is transient rather than durable database mutation; the durable database/WAL bytes and logical state are the contract.
+
+### Reuse one typed schema-mismatch payload in CLI and MCP
+
+Extend the existing shared agent error vocabulary with `AgentErrorKind::SchemaVersionMismatch` and one serializable payload containing `found_schema_version`, `supported_schema_version`, and the current `runtime_version`. A single extractor from `CliError::Db(DbError::SchemaVersion { .. })` supplies both CLI JSON/TOON rendering and MCP error encoding. The stable serialized kind is `schema_version_mismatch`.
+
+The payload and human message contain only bounded numeric versions and the public runtime version. They omit database paths, project roots, metadata values, SQL, and authored content. String matching in each adapter was rejected because it would duplicate classification and could expose unrelated error context.
+
+### Verify the released adapter boundary
+
+Use the repository's official packaged-runtime construction in an isolated destination, verify the artifact's exact runtime version, and run both a representative CLI command and a real stdio MCP initialize/tool call against the newer-schema fixture. Both adapters must return the shared typed refusal, exit or remain usable according to their existing protocol, and leave the database/WAL snapshot unchanged. Direct database tests remain the fast owning checks; packaged coverage protects feature, resource, and adapter wiring.
+
+### Specialize the existing Windows partial-convergence guidance
+
+Reuse the installer's captured effective inherited command, bounded version probe, verified versioned runtime, target version, stable-mirror state, and existing readiness booleans. When the effective bare command is an obsolete locked mirror, emit deterministic diagnostics that name:
+
+- the exact resolved stale executable and observed version;
+- the exact verified absolute runtime and target version;
+- an absolute-runtime verification/use command that does not depend on stale PATH;
+- the unlock-or-exit, installer-rerun, and bare-command verification steps required before declaring convergence.
+
+The installer continues to report partial success while the verified versioned runtime and generated absolute MCP configs remain usable. It must not claim the stale bare command is ready, imply that a child-shell restart updates an unchanged parent, broaden process termination, or absorb the separate #411 real-host handoff gate.
+
+## Risks / Trade-offs
+
+- **A regression asserts only the error and misses preceding DDL** -> retain byte snapshots plus complete logical schema and durable-row comparisons around the normal writable open.
+- **WAL coverage accidentally checkpoints away the failure topology** -> keep the fixture writer open, disable automatic checkpointing, require a non-empty WAL, and compare it without checkpointing.
+- **CLI and MCP drift to different error fields** -> derive both payloads from one typed extractor and assert exact JSON/TOON and stdio MCP shapes.
+- **Packaged proof silently runs a workspace binary** -> verify and invoke the isolated installed artifact by absolute path and assert its exact runtime version before the refusal checks.
+- **Installer guidance names the target but not the command that remains stale** -> assert exact stale and verified paths/versions in the locked-mirror E2E output.
+- **The preflight becomes row-count dependent** -> keep inspection to bounded schema/metadata reads and compare representative small and large fixtures with SQLite progress/profile evidence and zero write/WAL growth.
+
+## Migration Plan
+
+Ship the regression, typed adapter payload, packaged smoke, and Windows diagnostics together in the next bugfix release. There is no database migration or data rewrite. Rollback is the prior runtime/installer; a refused newer database remains untouched and usable by its owning newer release. On Windows, the versioned runtime and absolute generated MCP configs remain the recovery path until the obsolete mirror unlocks and an installer rerun synchronizes and verifies the bare command.
+
+## Open Questions
+
+None.

--- a/openspec/changes/reject-incompatible-schema-before-write/design.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/design.md
@@ -45,7 +45,7 @@ A SQL mock was rejected because it cannot prove SQLite open flags, WAL behavior,
 
 ### Reuse one typed schema-mismatch payload in CLI and MCP
 
-Extend the existing shared agent error vocabulary with `AgentErrorKind::SchemaVersionMismatch` and one serializable payload containing `found_schema_version`, `supported_schema_version`, and the current `runtime_version`. A single extractor from `CliError::Db(DbError::SchemaVersion { .. })` supplies both CLI JSON/TOON rendering and MCP error encoding. The stable serialized kind is `schema_version_mismatch`.
+Extend the existing shared agent error vocabulary with `AgentErrorKind::SchemaVersionMismatch` and one serializable payload containing `found_schema_version`, `supported_schema_version`, and the current `runtime_version`. The database-owned migration inventory distinguishes admitted predecessors from unsupported versions before shared extractors supply both CLI JSON/TOON rendering and MCP error encoding. An admitted predecessor that reaches a current-only read returns `schema_migration_required`, the bounded remaining-step count, and the existing `projectatlas init` / `atlas_init` migration owner while explicitly preserving the same CLI `--db`/`--config` selection or MCP server/database binding; the stable incompatible-schema kind remains `schema_version_mismatch`.
 
 The payload and human message contain only bounded numeric versions and the public runtime version. They omit database paths, project roots, metadata values, SQL, and authored content. String matching in each adapter was rejected because it would duplicate classification and could expose unrelated error context.
 
@@ -55,7 +55,7 @@ Use the repository's official packaged-runtime construction in an isolated desti
 
 ### Specialize the existing Windows partial-convergence guidance
 
-Reuse the installer's captured effective inherited command, bounded version probe, verified versioned runtime, target version, stable-mirror state, and existing readiness booleans. When the effective bare command is an obsolete locked mirror, emit deterministic diagnostics that name:
+Reuse the installer's captured effective inherited command, bounded version probe, verified versioned runtime, target version, stable-mirror state, and existing readiness booleans. Keep the final runtime probe separate from generated-config digest readiness so config-only drift retains the verified absolute-runtime recovery while runtime drift cannot advertise that path as verified. When the effective bare command is an obsolete locked mirror, emit deterministic diagnostics that name:
 
 - the exact resolved stale executable and observed version;
 - the exact verified absolute runtime and target version;

--- a/openspec/changes/reject-incompatible-schema-before-write/design.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/design.md
@@ -2,6 +2,8 @@
 
 `projectatlas-db` already owns schema compatibility in `schema::preflight`. Every normal writable store open routes through `AtlasStore::open_with_binding_requirement`, which runs that read-only preflight before `open_writable_connection` can select create flags, establish WAL, configure write pragmas, run DDL, or enter migration. A stale v0.3.26 mirror violated this ordering, while the current source has the right ownership boundary but lacks a durable newer-schema/active-WAL regression and typed public adapter contract.
 
+Read-only navigation stores record telemetry through a separate short-lived writable connection. Event and seal DML already validate schema, root, and project identity inside their immediate transactions. Post-commit checkpoint maintenance previously checked only project identity before an autocommit singleton update, leaving that ancillary write outside the same invariant.
+
 The database is project-local SQLite accessed through `rusqlite`. Its authored purposes, health resolutions, telemetry, project identity, metadata, and schema objects are durable authority; derived index state is rebuildable, but incompatibility refusal is not authorized to mutate either class. CLI and MCP errors already share `AgentErrorKind` and related payload types in the CLI crate. The Windows installer already distinguishes verified versioned-runtime/config readiness from stable-mirror, parent, and bare-command readiness after `handoff-obsolete-mcp-runtime`.
 
 ## Goals / Non-Goals
@@ -9,6 +11,7 @@ The database is project-local SQLite accessed through `rusqlite`. Its authored p
 **Goals:**
 
 - Keep the single read-only schema preflight ahead of every writable SQLite open and every schema mutation path.
+- Keep every ancillary telemetry DML operation behind schema/root/identity validation in its owning immediate transaction.
 - Prove a current runtime refuses a database stamped with a newer schema without changing database bytes, WAL bytes, schema objects, metadata, or authored rows, including while a live connection retains uncheckpointed WAL state.
 - Give CLI and MCP the same machine-readable `schema_version_mismatch` kind and content-free version fields.
 - Prove the contract through the packaged CLI and real stdio MCP server, not only direct database calls.
@@ -19,7 +22,7 @@ The database is project-local SQLite accessed through `rusqlite`. Its authored p
 - Adding a schema object, schema version, migration, query index, crate, dependency, trait, framework, command, or MCP tool.
 - Making an immutable released v0.3.26 executable safe retroactively.
 - Opening, repairing, checkpointing, resetting, replacing, or downgrading a newer database after refusal.
-- Changing SQLite transaction ownership or the existing installer handoff/termination authority.
+- Changing SQLite transaction ownership outside the ancillary telemetry maintenance write or changing existing installer handoff/termination authority.
 - Duplicating `handoff-obsolete-mcp-runtime` task 4.1 or treating a local fixture as real installed-Codex process-handoff proof.
 - Adding a diagram for an ownership flow that remains unchanged.
 
@@ -30,6 +33,14 @@ The database is project-local SQLite accessed through `rusqlite`. Its authored p
 Retain `schema::preflight` as the sole compatibility classifier and `AtlasStore::open_with_binding_requirement` as the shared writable-open gate. A future schema remains a closed `DbError::SchemaVersion { found, expected }` result before `open_writable_connection`; sibling CLI and MCP callers do not receive their own schema guards.
 
 Adding adapter-local prechecks was rejected because another caller could still reach writable SQLite first. Adding a trait, migration framework, or second connection owner was rejected because variability is closed and the existing concrete enum/function boundary already expresses it.
+
+### Revalidate ancillary telemetry at the write transaction
+
+Keep telemetry's read-only compatibility preflight before its short-lived writable open, then use one private concrete helper for `BEGIN IMMEDIATE`, exact schema/root/project-identity validation, DML, and commit-or-lossless-rollback. Event recording and instance sealing reuse that helper. Due post-commit maintenance prechecks the binding before its passive checkpoint and revalidates inside the final immediate transaction that recomputes bounded retention pressure and updates `usage_retention_state`. The maintenance connection captures SQLite's connection-local `data_version` before checkpointing. Finalization subtracts the checkpoint-start counter only when that witness is unchanged; any other connection commit, including an overlapping checkpoint finalizer, conservatively preserves the complete current count. Busy or failed attempts also preserve the complete current count.
+
+SQLite cannot run a passive checkpoint while the same connection holds a writer transaction. The precheck prevents knowingly checkpointing a binding that is already incompatible, but it is not an atomic reservation across the checkpoint statement. A concurrent transition may make the checkpoint busy or may have compatible WAL frames processed by SQLite before the final transaction detects the changed binding. This passive engine maintenance is intentionally schema-independent; the stronger atomic invariant applies to ProjectAtlas DDL and DML, and the final maintenance DML always revalidates under its writer reservation.
+
+An extra deferred validation immediately after writable open was rejected because it would finish before the later writer transaction and would not make validation plus DML atomic. A trait, pool, retry loop, or transaction framework was rejected because the operation set is closed and the existing concrete connection owner is sufficient.
 
 ### Prove zero mutation with a live newer-schema WAL fixture
 
@@ -72,6 +83,8 @@ The installer continues to report partial success while the verified versioned r
 - **Packaged proof silently runs a workspace binary** -> verify and invoke the isolated installed artifact by absolute path and assert its exact runtime version before the refusal checks.
 - **Installer guidance names the target but not the command that remains stale** -> assert exact stale and verified paths/versions in the locked-mirror E2E output.
 - **The preflight becomes row-count dependent** -> keep inspection to bounded schema/metadata reads and compare representative small and large fixtures with SQLite progress/profile evidence and zero write/WAL growth.
+- **Post-commit telemetry maintenance crosses a schema transition** -> refuse an already-stale binding before checkpointing, treat the passive checkpoint as schema-independent engine maintenance, and revalidate under the same immediate transaction as the singleton update.
+- **A concurrent event or checkpoint finalizer commits after the checkpoint starts** -> compare the maintenance connection's `data_version` inside the final writer transaction; subtract the checkpoint-start count only when no other connection committed, otherwise preserve the complete current counter.
 
 ## Migration Plan
 

--- a/openspec/changes/reject-incompatible-schema-before-write/proposal.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+A stale ProjectAtlas runtime can damage compatibility by opening a database owned by a newer release for writes before rejecting its schema version. The current read-only preflight must become a durable cross-version contract, with zero-mutation and packaged-runtime proof plus actionable Windows recovery when a locked stable mirror still resolves to obsolete code.
+
+## What Changes
+
+- Preserve one database-owned, read-only schema identity/version preflight before writable open, WAL activation, DDL, repair, index creation, or migration.
+- Return a shared typed `schema_version_mismatch` classification through CLI and MCP adapters with found and supported versions but no private path or database contents.
+- Add real SQLite regressions, including an active WAL, that compare durable database state and sidecars before and after a newer-schema refusal.
+- Exercise the same refusal through packaged CLI and stdio MCP entry points so source-only tests cannot mask release-artifact drift.
+- When Windows retains a locked obsolete stable mirror, report the exact stale command and observed version, identify the verified absolute runtime and target version, and give explicit verify/use/rerun recovery without claiming the stale bare command is ready.
+
+## Capabilities
+
+### New Capabilities
+
+- `schema-compatibility-preflight`: Defines non-mutating cross-version schema refusal and the shared typed CLI/MCP contract, including SQLite WAL and packaged-runtime proof.
+- `windows-stale-runtime-recovery`: Defines exact Windows path/version diagnostics and bounded operator recovery when a locked stable mirror remains obsolete.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- The existing `projectatlas-db` schema/open boundary and released-schema fixtures.
+- Existing CLI and MCP error adapters, packaged-runtime smoke coverage, and Windows installer diagnostics/tests.
+- No schema version bump, migration, table, index, crate, dependency, trait, framework, command, or MCP tool is added.
+
+## Non-Goals
+
+- Backporting or republishing an immutable older release artifact.
+- Resetting, replacing, downgrading, checkpointing, or otherwise repairing a newer database after refusal.
+- Terminating ProjectAtlas, Codex, terminal, or unrelated processes.
+- Duplicating or claiming `handoff-obsolete-mcp-runtime` task 4.1 real-host process-handoff proof.
+- Adding architecture diagrams when the existing database-open and installer ownership flow does not change.
+
+## Status
+
+Ready for implementation in the v0.4.x bugfix-only release scope after its dependency work lands.

--- a/openspec/changes/reject-incompatible-schema-before-write/proposal.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/proposal.md
@@ -5,6 +5,7 @@ A stale ProjectAtlas runtime can damage compatibility by opening a database owne
 ## What Changes
 
 - Preserve one database-owned, read-only schema identity/version preflight before writable open, WAL activation, DDL, repair, index creation, or migration.
+- Revalidate schema, root, and project identity inside the same immediate transaction as every ancillary telemetry DML operation, including post-commit maintenance.
 - Return a shared typed `schema_version_mismatch` classification through CLI and MCP adapters with found and supported versions but no private path or database contents.
 - Add real SQLite regressions, including an active WAL, that compare durable database state and sidecars before and after a newer-schema refusal.
 - Exercise the same refusal through packaged CLI and stdio MCP entry points so source-only tests cannot mask release-artifact drift.

--- a/openspec/changes/reject-incompatible-schema-before-write/specs/schema-compatibility-preflight/spec.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/specs/schema-compatibility-preflight/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: Schema compatibility is classified before writable access
+ProjectAtlas SHALL inspect an existing database through the database-owned read-only preflight before opening it writable, enabling or changing WAL, configuring write pragmas, executing DDL or repair, creating indexes, or applying migrations. Every normal CLI and MCP path that can acquire a writable store SHALL use this shared open boundary.
+
+#### Scenario: Current database opens normally
+- **WHEN** the selected project database has the exact schema version and valid ownership supported by the runtime
+- **THEN** preflight admits it and the existing writable-open behavior continues without schema-specific adapter logic
+
+#### Scenario: Supported predecessor is upgraded through the existing owner
+- **WHEN** preflight classifies a valid released predecessor represented by the centralized migration inventory
+- **THEN** ProjectAtlas SHALL defer establishing the write profile and applying the existing ordered migrations to the subsequent database-owned writable transaction
+
+#### Scenario: Newer database is refused before writable open
+- **WHEN** the durable schema version is newer than the runtime supports
+- **THEN** ProjectAtlas returns a typed version mismatch before any writable connection, WAL change, DDL, repair, index creation, or migration
+
+#### Scenario: Existing database has missing or malformed version metadata
+- **WHEN** read-only preflight cannot classify the durable schema version safely
+- **THEN** ProjectAtlas fails closed without creating, repairing, migrating, or otherwise mutating the database
+
+#### Scenario: Database is genuinely absent
+- **WHEN** preflight proves the selected database does not exist
+- **THEN** ProjectAtlas SHALL classify it as fresh and SHALL create it only through the subsequent existing fresh-database path
+
+#### Scenario: Selected project root does not own the database
+- **WHEN** preflight finds a valid schema whose durable project identity belongs to another root
+- **THEN** ProjectAtlas returns the existing typed project mismatch and does not migrate, rebind, create, or mutate either project's index
+
+### Requirement: Newer-schema refusal preserves complete durable state
+ProjectAtlas SHALL leave the main database, WAL contents, schema objects, schema metadata, project identity, authored state, telemetry, and derived rows unchanged after refusing a newer schema. The refusal SHALL remain non-mutating when the newer schema and committed fixture writes are present in an active uncheckpointed WAL retained by another live connection.
+
+#### Scenario: Newer schema is present in an active WAL
+- **WHEN** a live SQLite connection retains a non-empty uncheckpointed WAL containing a valid fixture stamped one version newer than the runtime
+- **THEN** a normal writable ProjectAtlas open returns the version mismatch without checkpointing or changing the main database bytes, WAL bytes, or sidecar inventory
+
+#### Scenario: Newer database contains durable and derived rows
+- **WHEN** the incompatible database contains project identity, authored purposes, health resolutions, telemetry, metadata, and representative derived rows
+- **THEN** refusal leaves every captured row and table, index, view, and trigger definition unchanged
+
+#### Scenario: Concurrent owner remains usable
+- **WHEN** the live fixture connection remains open while ProjectAtlas refuses the incompatible database
+- **THEN** that owner can still read its unchanged committed state and ProjectAtlas does not acquire a writer transaction or alter checkpoint state
+
+### Requirement: CLI and MCP share a privacy-safe mismatch contract
+ProjectAtlas SHALL serialize incompatible schema errors from the shared typed database error as `schema_version_mismatch` in both CLI agent output and MCP tool errors. The payload SHALL include `found_schema_version`, `supported_schema_version`, and `runtime_version`, and SHALL NOT include database paths, project roots, SQL, metadata values, or authored content.
+
+#### Scenario: CLI agent output encounters a newer schema
+- **WHEN** a JSON or TOON CLI command opens a newer project database
+- **THEN** it returns `schema_version_mismatch` with the exact found, supported, and runtime versions and no private database content
+
+#### Scenario: MCP tool encounters a newer schema
+- **WHEN** a real stdio MCP session initializes and a tool addresses a newer project database through explicit `project_path`
+- **THEN** the tool error returns the same kind and version fields as the CLI while the MCP session remains protocol-correct
+
+#### Scenario: MCP addresses a missing index
+- **WHEN** an MCP tool addresses a project root with no project-local database
+- **THEN** it returns the existing typed initialization handoff and does not create an index implicitly
+
+#### Scenario: MCP addresses another project's index
+- **WHEN** an MCP tool's explicit `project_path` would select an index owned by another root
+- **THEN** it returns the existing typed project mismatch rather than a schema mismatch and performs no implicit migration, rebind, or mutation
+
+### Requirement: Packaged adapters preserve incompatible-schema refusal
+The official packaged ProjectAtlas runtime SHALL preserve the same preflight ordering and typed refusal as workspace code. Release verification SHALL invoke the isolated packaged executable by absolute path, verify its exact runtime version, and exercise both a representative CLI command and real stdio MCP tool call against a newer-schema active-WAL fixture.
+
+#### Scenario: Packaged CLI refuses a newer database
+- **WHEN** the exact packaged runtime executes a representative CLI command against the fixture
+- **THEN** it returns the shared typed mismatch and leaves the complete database/WAL snapshot unchanged
+
+#### Scenario: Packaged MCP refuses a newer database
+- **WHEN** the exact packaged runtime serves stdio MCP and a tool addresses the fixture
+- **THEN** it returns the shared typed mismatch without adapter fallback, implicit initialization, or database mutation
+
+### Requirement: Incompatible preflight remains bounded by schema metadata
+Newer-schema classification SHALL remain a bounded schema/metadata operation whose CPU, memory, SQLite reads, and elapsed work do not scale with authored or derived row cardinality. It SHALL perform no database or WAL writes.
+
+#### Scenario: Small and representative large databases are refused
+- **WHEN** focused profiling compares the same newer schema with small and representative large row populations
+- **THEN** observed work remains bounded by schema metadata, performs no table-sized scan or row decode, and produces no database/WAL growth

--- a/openspec/changes/reject-incompatible-schema-before-write/specs/schema-compatibility-preflight/spec.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/specs/schema-compatibility-preflight/spec.md
@@ -27,6 +27,26 @@ ProjectAtlas SHALL inspect an existing database through the database-owned read-
 - **WHEN** preflight finds a valid schema whose durable project identity belongs to another root
 - **THEN** ProjectAtlas returns the existing typed project mismatch and does not migrate, rebind, create, or mutate either project's index
 
+#### Scenario: Ancillary telemetry writer observes a transition after preflight
+- **WHEN** a short-lived telemetry writer opens after preflight and another runtime has changed the schema, project root, or project identity
+- **THEN** ProjectAtlas begins an immediate transaction, revalidates the exact captured binding inside that transaction, and refuses event, seal, or maintenance DML before invoking it
+
+#### Scenario: Post-commit telemetry maintenance becomes due
+- **WHEN** a committed event reaches the passive-checkpoint interval
+- **THEN** ProjectAtlas refuses a binding that is already stale before checkpointing, treats the passive checkpoint as schema-independent SQLite engine maintenance, then revalidates and updates bounded maintenance state inside one short immediate transaction without making the already-committed event retryable
+
+#### Scenario: Schema transition races passive checkpoint maintenance
+- **WHEN** another runtime changes the binding after the maintenance precheck but before the passive checkpoint completes
+- **THEN** ProjectAtlas may observe SQLite's passive checkpoint result, but it revalidates and refuses all subsequent ProjectAtlas DML under the final writer transaction while preserving the concurrent owner's committed state
+
+#### Scenario: Telemetry write commits after checkpoint start
+- **WHEN** another telemetry event increments the durable write counter after a checkpoint attempt starts
+- **THEN** completed-checkpoint finalization subtracts the count observed before the attempt only when the maintenance connection's SQLite data-version witness is unchanged; any other connection commit, busy checkpoint, or failed checkpoint preserves the complete current count so no later write is erased
+
+#### Scenario: Successful checkpoint finalizers overlap
+- **WHEN** two connections complete overlapping passive checkpoint attempts and either finalizer or another telemetry event commits before the stale finalizer updates retention state
+- **THEN** the changed SQLite data-version witness makes the stale finalizer preserve the complete current write counter instead of subtracting from a different counter generation
+
 ### Requirement: Newer-schema refusal preserves complete durable state
 ProjectAtlas SHALL leave the main database, WAL contents, schema objects, schema metadata, project identity, authored state, telemetry, and derived rows unchanged after refusing a newer schema. The refusal SHALL remain non-mutating when the newer schema and committed fixture writes are present in an active uncheckpointed WAL retained by another live connection.
 

--- a/openspec/changes/reject-incompatible-schema-before-write/specs/schema-compatibility-preflight/spec.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/specs/schema-compatibility-preflight/spec.md
@@ -53,6 +53,10 @@ ProjectAtlas SHALL serialize incompatible schema errors from the shared typed da
 - **WHEN** a real stdio MCP session initializes and a tool addresses a newer project database through explicit `project_path`
 - **THEN** the tool error returns the same kind and version fields as the CLI while the MCP session remains protocol-correct
 
+#### Scenario: Current-only adapter encounters an admitted predecessor
+- **WHEN** a CLI or MCP read requires the current schema but the database has a released predecessor represented by the centralized migration inventory
+- **THEN** ProjectAtlas returns a content-free `schema_migration_required` handoff with the found version, supported version, remaining migration steps, and the existing safe `init` migration action through the same CLI `--db`/`--config` selection or MCP server/database binding instead of calling the schema unsupported or creating the default database
+
 #### Scenario: MCP addresses a missing index
 - **WHEN** an MCP tool addresses a project root with no project-local database
 - **THEN** it returns the existing typed initialization handoff and does not create an index implicitly

--- a/openspec/changes/reject-incompatible-schema-before-write/specs/windows-stale-runtime-recovery/spec.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/specs/windows-stale-runtime-recovery/spec.md
@@ -11,6 +11,10 @@ When Windows cannot synchronize an obsolete locked stable mirror, the ProjectAtl
 - **WHEN** the inherited executable is locked or present but its bounded version probe cannot produce a trustworthy version
 - **THEN** the installer reports the exact path with version unavailable, does not claim the command current, and keeps convergence partial
 
+#### Scenario: Same-version foreign PATH command is not ready
+- **WHEN** inherited PATH selects an executable at neither the verified runtime path nor the synchronized stable-mirror path, even though its bounded probe reports the target version
+- **THEN** the installer reports that exact command and version as unready, emits verified-runtime recovery guidance, and derives restart applicability from exact fresh-process command resolution
+
 #### Scenario: Bare command already resolves to the verified target
 - **WHEN** the inherited command and version exactly match the verified runtime target
 - **THEN** the installer does not emit stale-command recovery guidance

--- a/openspec/changes/reject-incompatible-schema-before-write/specs/windows-stale-runtime-recovery/spec.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/specs/windows-stale-runtime-recovery/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Locked stale command diagnostics identify both runtimes
+When Windows cannot synchronize an obsolete locked stable mirror, the ProjectAtlas installer SHALL report the exact bare-command executable selected by the inherited environment, its observed runtime version, the verified absolute versioned runtime, and the requested target version. It SHALL keep stable-mirror, versioned-runtime/config, installer-CLI, parent-CLI, and restart readiness truthful and distinct.
+
+#### Scenario: Locked stable mirror remains obsolete
+- **WHEN** the inherited bare command resolves to a locked stable mirror whose bounded version probe reports an older ProjectAtlas version
+- **THEN** installer output names that exact stale path/version and the verified absolute path/target version, reports the bare command unready, and preserves usable versioned-runtime and generated-config readiness
+
+#### Scenario: Stale version cannot be observed safely
+- **WHEN** the inherited executable is locked or present but its bounded version probe cannot produce a trustworthy version
+- **THEN** the installer reports the exact path with version unavailable, does not claim the command current, and keeps convergence partial
+
+#### Scenario: Bare command already resolves to the verified target
+- **WHEN** the inherited command and version exactly match the verified runtime target
+- **THEN** the installer does not emit stale-command recovery guidance
+
+### Requirement: Recovery uses the verified runtime until mirror convergence
+Locked-mirror guidance SHALL give an exact absolute-runtime verification/use command that does not depend on inherited PATH, state whether a fresh host restart can repair command resolution, and require unlock or observed exit followed by installer rerun and bare-command verification before claiming stable-mirror convergence.
+
+#### Scenario: Versioned runtime is ready while mirror is locked
+- **WHEN** the stable mirror remains obsolete but the versioned runtime and generated Codex, Claude Code, and OpenCode MCP configs pass final verification
+- **THEN** the installer directs the operator to the exact absolute runtime and keeps those integrations usable without claiming the stale bare command is ready
+
+#### Scenario: Fresh environment will resolve the verified runtime
+- **WHEN** the persisted effective fresh-process PATH selects the verified runtime but the unchanged parent still resolves the stale mirror
+- **THEN** guidance requires restarting the environment-owning Windows host, not merely one child shell, and gives the post-restart bare-command version gate
+
+#### Scenario: Restart alone cannot repair command resolution
+- **WHEN** the effective fresh-process PATH still selects a stale command
+- **THEN** guidance requires correcting or unlocking that exact command and rerunning the installer instead of promising restart recovery
+
+#### Scenario: Mirror unlocks and installer reruns
+- **WHEN** the lock owner exits or releases the stable mirror and the installer is rerun
+- **THEN** the installer synchronizes and verifies the mirror, the bare command reports the target version, and the bare token TUI opens the existing compatible database without reset or replacement
+
+### Requirement: Diagnostic recovery does not broaden handoff authority
+The #410 diagnostic and recovery path SHALL reuse the existing bounded probes, mirror synchronization, readiness classification, and #411 process-handoff authority. It SHALL NOT introduce name-wide termination, terminate Codex or unrelated processes, or count local locked-mirror diagnostics as completion of the separate real installed-Codex handoff release gate.
+
+#### Scenario: Lock owner is not authorized for exact handoff
+- **WHEN** the stale mirror remains locked by a process outside the existing exact handoff authority
+- **THEN** that process remains alive and the installer emits path/version recovery guidance with partial convergence
+
+#### Scenario: Local recovery regression passes
+- **WHEN** an isolated Windows test proves stale diagnostics, absolute-runtime use, unlock, rerun, and bare-command convergence
+- **THEN** #410 platform coverage passes without marking `handoff-obsolete-mcp-runtime` task 4.1 complete

--- a/openspec/changes/reject-incompatible-schema-before-write/tasks.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/tasks.md
@@ -5,7 +5,7 @@
 
 ## 2. Database-Owned Compatibility Boundary
 
-- [x] 2.1 Trace every normal writable store caller through `schema::preflight` and `AtlasStore::open_with_binding_requirement`; retain the single read-only gate before writable open, WAL policy, write pragmas, DDL, repair, index creation, and migration, changing only that shared owner if the failing regression exposes a gap.
+- [x] 2.1 Trace every normal writable store caller through `schema::preflight` and `AtlasStore::open_with_binding_requirement`, plus every ancillary telemetry writer through preflight and the shared validated write transaction; retain the read-only gate before writable open, WAL policy, write pragmas, DDL, repair, index creation, and migration.
 - [x] 2.2 Prove newer-schema refusal returns the exact typed database version error while the live WAL owner remains usable and all captured database/WAL bytes, schema objects, metadata, authored state, telemetry, and derived rows remain unchanged without checkpointing.
 - [x] 2.3 Retain positive current-schema and admitted-predecessor behavior and cover malformed/missing version metadata, incompatible schema shape, wrong-root ownership, and genuinely missing-database classification without implicit creation, rebind, repair, or migration.
 

--- a/openspec/changes/reject-incompatible-schema-before-write/tasks.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/tasks.md
@@ -12,13 +12,13 @@
 ## 3. Shared CLI and MCP Contract
 
 - [x] 3.1 Add the shared `schema_version_mismatch` agent error kind and one typed payload/extractor for found schema, supported schema, and runtime versions; reuse it from CLI JSON/TOON and MCP encoding without paths, roots, SQL, metadata values, or authored content.
-- [x] 3.2 Cover exact CLI JSON/TOON mismatch fields plus human diagnostics, privacy-negative assertions, and unchanged behavior for compatible, missing-index, wrong-root, malformed, and non-schema failures.
+- [x] 3.2 Cover exact CLI JSON/TOON mismatch fields plus human diagnostics, privacy-negative assertions, an actionable supported-predecessor migration handoff that preserves explicit CLI and MCP database selection, and unchanged behavior for current, missing-index, wrong-root, malformed, and non-schema failures.
 - [x] 3.3 Exercise a real stdio MCP initialize/tool exchange with explicit `project_path` against the newer active-WAL database, a missing index, and a wrong-root index; assert typed mismatch/init/project errors, protocol-correct failure, no implicit mutation, and subsequent MCP session behavior.
 
 ## 4. Windows Locked-Mirror Recovery
 
 - [x] 4.1 Extend the existing installer partial-convergence output using its bounded probes and captured readiness state to report the exact stale bare-command path/observed version, verified absolute runtime/target version, absolute verification/use command, restart applicability, and unlock/rerun/bare-command gate without broadening #411 handoff authority.
-- [x] 4.2 On Windows, cover obsolete locked mirror, unavailable stale-version probe, already-current command, fresh-PATH shadowing, non-retireable lock-owner survival, verified versioned-runtime/generated-config use while locked, unlock plus installer rerun, target bare-command version, and bare token TUI success against the unchanged compatible database; do not claim `handoff-obsolete-mcp-runtime` task 4.1.
+- [x] 4.2 On Windows, cover obsolete locked mirror, unavailable stale-version probe, already-current command, fresh-PATH shadowing, non-retireable lock-owner survival, config-only and runtime drift, verified versioned-runtime/generated-config use while locked, unlock plus installer rerun, target bare-command version, and bare token TUI success against the unchanged compatible database; do not claim `handoff-obsolete-mcp-runtime` task 4.1.
 
 ## 5. Packaged, Performance, and Release Verification
 

--- a/openspec/changes/reject-incompatible-schema-before-write/tasks.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/tasks.md
@@ -17,8 +17,8 @@
 
 ## 4. Windows Locked-Mirror Recovery
 
-- [x] 4.1 Extend the existing installer partial-convergence output using its bounded probes and captured readiness state to report the exact stale bare-command path/observed version, verified absolute runtime/target version, absolute verification/use command, restart applicability, and unlock/rerun/bare-command gate without broadening #411 handoff authority.
-- [x] 4.2 On Windows, cover obsolete locked mirror, unavailable stale-version probe, already-current command, fresh-PATH shadowing, non-retireable lock-owner survival, config-only and runtime drift, verified versioned-runtime/generated-config use while locked, unlock plus installer rerun, target bare-command version, and bare token TUI success against the unchanged compatible database; do not claim `handoff-obsolete-mcp-runtime` task 4.1.
+- [ ] 4.1 Extend the existing installer partial-convergence output using its bounded probes and captured readiness state to report the exact stale bare-command path/observed version, verified absolute runtime/target version, absolute verification/use command, restart applicability, and unlock/rerun/bare-command gate without broadening #411 handoff authority.
+- [ ] 4.2 On Windows, cover obsolete locked mirror, unavailable stale-version probe, already-current command, fresh-PATH shadowing, non-retireable lock-owner survival, config-only and runtime drift, verified versioned-runtime/generated-config use while locked, unlock plus installer rerun, target bare-command version, and bare token TUI success against the unchanged compatible database; do not claim `handoff-obsolete-mcp-runtime` task 4.1.
 
 ## 5. Packaged, Performance, and Release Verification
 

--- a/openspec/changes/reject-incompatible-schema-before-write/tasks.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/tasks.md
@@ -17,12 +17,12 @@
 
 ## 4. Windows Locked-Mirror Recovery
 
-- [ ] 4.1 Extend the existing installer partial-convergence output using its bounded probes and captured readiness state to report the exact stale bare-command path/observed version, verified absolute runtime/target version, absolute verification/use command, restart applicability, and unlock/rerun/bare-command gate without broadening #411 handoff authority.
-- [ ] 4.2 On Windows, cover obsolete locked mirror, unavailable stale-version probe, already-current command, fresh-PATH shadowing, non-retireable lock-owner survival, config-only and runtime drift, verified versioned-runtime/generated-config use while locked, unlock plus installer rerun, target bare-command version, and bare token TUI success against the unchanged compatible database; do not claim `handoff-obsolete-mcp-runtime` task 4.1.
+- [x] 4.1 Extend the existing installer partial-convergence output using its bounded probes and captured readiness state to report the exact stale bare-command path/observed version, verified absolute runtime/target version, absolute verification/use command, restart applicability, and unlock/rerun/bare-command gate without broadening #411 handoff authority.
+- [x] 4.2 On Windows, cover obsolete locked mirror, unavailable stale-version probe, already-current command, fresh-PATH shadowing, non-retireable lock-owner survival, config-only and runtime drift, verified versioned-runtime/generated-config use while locked, unlock plus installer rerun, target bare-command version, and bare token TUI success against the unchanged compatible database; do not claim `handoff-obsolete-mcp-runtime` task 4.1.
 
 ## 5. Packaged, Performance, and Release Verification
 
 - [x] 5.1 Construct and install the official packaged runtime in an isolated destination, verify its exact version and absolute path, and prove both packaged CLI and real stdio MCP return the shared typed refusal with the complete active-WAL snapshot unchanged.
 - [x] 5.2 Profile newer-schema refusal on small and representative large row populations; confirm CPU, memory, SQLite reads, and elapsed work remain bounded by schema metadata with no table-sized scan, database/WAL write, checkpoint, or persistent growth.
 - [x] 5.3 With explicit 20-minute process timeouts, run `cargo fmt --check`, `cargo check --workspace --all-targets --all-features`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`, `cargo test --doc --all-features`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, plus focused database, CLI/MCP, packaged-runtime, and Windows installer tests.
-- [ ] 5.4 Run strict OpenSpec validation, `.github/scripts/issue-checklists.py`, applicable release/package gates, and authenticated live review-thread/Codex/Dependabot feedback reconciliation before task, issue, PR, or release transition.
+- [x] 5.4 Run strict OpenSpec validation, `.github/scripts/issue-checklists.py`, applicable release/package gates, and authenticated live review-thread/Codex/Dependabot feedback reconciliation before task, issue, PR, or release transition.

--- a/openspec/changes/reject-incompatible-schema-before-write/tasks.md
+++ b/openspec/changes/reject-incompatible-schema-before-write/tasks.md
@@ -1,0 +1,28 @@
+## 1. Change Control and Failing Regression
+
+- [x] 1.1 Map `reject-incompatible-schema-before-write` to GitHub issue #410, mirror this checklist in the issue, and keep every implementation task unchecked until its complete behavior and owning tests pass.
+- [x] 1.2 Add one real newer-schema fixture with representative project identity, authored purposes, health resolutions, telemetry, derived rows, and an active uncheckpointed WAL; capture main/WAL bytes, sidecar inventory, schema objects, metadata, and durable rows so the normal writable open reproduces any mutation before typed refusal.
+
+## 2. Database-Owned Compatibility Boundary
+
+- [x] 2.1 Trace every normal writable store caller through `schema::preflight` and `AtlasStore::open_with_binding_requirement`; retain the single read-only gate before writable open, WAL policy, write pragmas, DDL, repair, index creation, and migration, changing only that shared owner if the failing regression exposes a gap.
+- [x] 2.2 Prove newer-schema refusal returns the exact typed database version error while the live WAL owner remains usable and all captured database/WAL bytes, schema objects, metadata, authored state, telemetry, and derived rows remain unchanged without checkpointing.
+- [x] 2.3 Retain positive current-schema and admitted-predecessor behavior and cover malformed/missing version metadata, incompatible schema shape, wrong-root ownership, and genuinely missing-database classification without implicit creation, rebind, repair, or migration.
+
+## 3. Shared CLI and MCP Contract
+
+- [x] 3.1 Add the shared `schema_version_mismatch` agent error kind and one typed payload/extractor for found schema, supported schema, and runtime versions; reuse it from CLI JSON/TOON and MCP encoding without paths, roots, SQL, metadata values, or authored content.
+- [x] 3.2 Cover exact CLI JSON/TOON mismatch fields plus human diagnostics, privacy-negative assertions, and unchanged behavior for compatible, missing-index, wrong-root, malformed, and non-schema failures.
+- [x] 3.3 Exercise a real stdio MCP initialize/tool exchange with explicit `project_path` against the newer active-WAL database, a missing index, and a wrong-root index; assert typed mismatch/init/project errors, protocol-correct failure, no implicit mutation, and subsequent MCP session behavior.
+
+## 4. Windows Locked-Mirror Recovery
+
+- [x] 4.1 Extend the existing installer partial-convergence output using its bounded probes and captured readiness state to report the exact stale bare-command path/observed version, verified absolute runtime/target version, absolute verification/use command, restart applicability, and unlock/rerun/bare-command gate without broadening #411 handoff authority.
+- [x] 4.2 On Windows, cover obsolete locked mirror, unavailable stale-version probe, already-current command, fresh-PATH shadowing, non-retireable lock-owner survival, verified versioned-runtime/generated-config use while locked, unlock plus installer rerun, target bare-command version, and bare token TUI success against the unchanged compatible database; do not claim `handoff-obsolete-mcp-runtime` task 4.1.
+
+## 5. Packaged, Performance, and Release Verification
+
+- [x] 5.1 Construct and install the official packaged runtime in an isolated destination, verify its exact version and absolute path, and prove both packaged CLI and real stdio MCP return the shared typed refusal with the complete active-WAL snapshot unchanged.
+- [x] 5.2 Profile newer-schema refusal on small and representative large row populations; confirm CPU, memory, SQLite reads, and elapsed work remain bounded by schema metadata with no table-sized scan, database/WAL write, checkpoint, or persistent growth.
+- [x] 5.3 With explicit 20-minute process timeouts, run `cargo fmt --check`, `cargo check --workspace --all-targets --all-features`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`, `cargo test --doc --all-features`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`, plus focused database, CLI/MCP, packaged-runtime, and Windows installer tests.
+- [ ] 5.4 Run strict OpenSpec validation, `.github/scripts/issue-checklists.py`, applicable release/package gates, and authenticated live review-thread/Codex/Dependabot feedback reconciliation before task, issue, PR, or release transition.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -43,6 +43,7 @@
     },
     "prefer-worktree-guidance-before-database-preflight": 412,
     "publish-rustdoc-readme-links": 300,
+    "reject-incompatible-schema-before-write": 410,
     "report-installer-host-restart": 383,
     "resolve-configured-module-aliases": 385,
     "reuse-release-proof-by-inputs": 366,

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -3356,7 +3356,7 @@ else {
 $lockedStaleCommandRecoveryRequired = -not $stableMirrorReady `
     -and $staleBareCommandPath `
     -and -not [string]::IsNullOrWhiteSpace($targetRuntimeVersion) `
-    -and $staleBareCommandVersion -ne $targetRuntimeVersion
+    -and -not $parentCliReady
 if ($lockedStaleCommandRecoveryRequired) {
     $observedVersion = if ($staleBareCommandVersion) { $staleBareCommandVersion } else { "unavailable" }
     $quotedInstaller = "'" + (Get-NormalizedPathEntry $PSCommandPath).Replace("'", "''") + "'"

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -2308,16 +2308,13 @@ function Confirm-ProjectAtlasGeneratedMcpConfig {
     return (Get-ProjectAtlasSha256FromBytes $configBytes)
 }
 
-function Test-ProjectAtlasRuntimeMcpConfigReadiness {
+function Test-ProjectAtlasGeneratedMcpConfigReadiness {
     param(
-        [string]$RuntimePath,
-        [string]$ExpectedVersion,
         [string[]]$ConfigPaths,
         [string[]]$ExpectedSha256
     )
     try {
-        if (-not (Test-ProjectAtlasRuntime $RuntimePath $ExpectedVersion) `
-            -or $ConfigPaths.Count -eq 0 `
+        if ($ConfigPaths.Count -eq 0 `
             -or $ConfigPaths.Count -ne $ExpectedSha256.Count) {
             return $false
         }
@@ -3249,27 +3246,29 @@ if (-not $stableMirrorSynchronized) {
         }
     }
 }
-$stableMirrorReady = $stableMirrorSynchronized `
-    -and (Test-ProjectAtlasRuntime $stableMirrorPath $ProjectAtlasVersion)
-$inheritedCommandReady = -not [string]::IsNullOrWhiteSpace($effectiveInheritedProjectAtlasPath) `
+$inheritedCommandMatchesRuntime = -not [string]::IsNullOrWhiteSpace($effectiveInheritedProjectAtlasPath) `
     -and (Get-NormalizedPathEntry $effectiveInheritedProjectAtlasPath) -eq $verifiedRuntimePath
-$inheritedSynchronizedMirrorReady = $stableMirrorReady `
-    -and -not [string]::IsNullOrWhiteSpace($effectiveInheritedProjectAtlasPath) `
+$inheritedCommandMatchesMirror = -not [string]::IsNullOrWhiteSpace($effectiveInheritedProjectAtlasPath) `
     -and (Get-NormalizedPathEntry $effectiveInheritedProjectAtlasPath) -eq $stableMirrorPath
 $installerProjectAtlasCommand = Get-Command projectatlas -ErrorAction SilentlyContinue | Select-Object -First 1
 $installerProjectAtlasPath = if ($installerProjectAtlasCommand) { $installerProjectAtlasCommand.Source } else { $null }
-$installerCliReady = -not [string]::IsNullOrWhiteSpace($installerProjectAtlasPath) `
+$installerCommandMatchesRuntime = -not [string]::IsNullOrWhiteSpace($installerProjectAtlasPath) `
     -and (Get-NormalizedPathEntry $installerProjectAtlasPath) -eq $verifiedRuntimePath
-$parentCliReady = $inheritedCommandReady -or $inheritedSynchronizedMirrorReady
-$hostRestartRequired = -not $parentCliReady -and $futureProcessPathReady
-$hostRepairRequired = -not $parentCliReady -and -not $futureProcessPathReady
 $codexPluginReady = Test-ProjectAtlasCodexPluginReady $ProjectAtlasVersion
 $codexRegistryReady = Test-ProjectAtlasCodexMcpRegistryReady $projectAtlas $ProjectAtlasVersion $dbPath $projectConfigPath $flatConfigPath
-$runtimeMcpConfigsReady = Test-ProjectAtlasRuntimeMcpConfigReadiness `
-    $projectAtlas `
-    $ProjectAtlasVersion `
+$generatedMcpConfigsReady = Test-ProjectAtlasGeneratedMcpConfigReadiness `
     ([string[]]@($mcpConfigPath, $claudeMcpConfigPath, $opencodeConfigPath)) `
     ([string[]]@($mcpConfigSha256, $claudeMcpConfigSha256, $opencodeConfigSha256))
+$verifiedRuntimeReady = Test-ProjectAtlasRuntime $projectAtlas $ProjectAtlasVersion
+$stableMirrorReady = $stableMirrorSynchronized `
+    -and (Test-ProjectAtlasRuntime $stableMirrorPath $ProjectAtlasVersion)
+$inheritedCommandReady = $verifiedRuntimeReady -and $inheritedCommandMatchesRuntime
+$inheritedSynchronizedMirrorReady = $stableMirrorReady -and $inheritedCommandMatchesMirror
+$installerCliReady = $verifiedRuntimeReady -and $installerCommandMatchesRuntime
+$parentCliReady = $inheritedCommandReady -or $inheritedSynchronizedMirrorReady
+$hostRestartRequired = $verifiedRuntimeReady -and -not $parentCliReady -and $futureProcessPathReady
+$hostRepairRequired = $verifiedRuntimeReady -and -not $parentCliReady -and -not $futureProcessPathReady
+$runtimeMcpConfigsReady = $verifiedRuntimeReady -and $generatedMcpConfigsReady
 $integrationVerificationRequired = $handoffState -ne "not_required" -or $codexIntegrationManaged
 $updateState = if ($runtimeMcpConfigsReady `
         -and $stableMirrorReady `
@@ -3279,10 +3278,20 @@ $updateState = if ($runtimeMcpConfigsReady `
 else {
     "partial"
 }
-Write-ProjectAtlasPathShadowReport $projectAtlas $ProjectAtlasVersion
+if ($verifiedRuntimeReady) {
+    Write-ProjectAtlasPathShadowReport $projectAtlas $ProjectAtlasVersion
+}
+else {
+    Write-Warning "ProjectAtlas PATH shadow report skipped because the requested absolute runtime failed final verification."
+}
 Write-ProjectAtlasWorkflowPinReport $ProjectRoot $ProjectAtlasVersion
 
-Write-Output "ProjectAtlas runtime installed and verified: $projectAtlas"
+if ($verifiedRuntimeReady) {
+    Write-Output "ProjectAtlas runtime installed and verified: $projectAtlas"
+}
+else {
+    Write-Warning "ProjectAtlas runtime failed final verification: path=$verifiedRuntimePath target_version=$(Convert-ProjectAtlasVersionTag $ProjectAtlasVersion). Rerun this installer with a valid matching runtime."
+}
 Write-Output "ProjectAtlas update preserved project state under $atlasDir; use reset-index --apply for explicit state cleanup."
 Write-Output "Project-local MCP config written: $mcpConfigPath"
 Write-Output "Project-local Claude Code MCP config written: $claudeMcpConfigPath"
@@ -3293,11 +3302,16 @@ $runtimeMcpConfigGuidance = if ($runtimeMcpConfigsReady) {
     "The runtime and generated MCP configs are ready through the verified absolute runtime."
 }
 else {
-    Write-Warning "ProjectAtlas runtime or generated MCP config readiness changed before final reporting; rerun this installer."
+    if (-not $verifiedRuntimeReady) {
+        Write-Warning "ProjectAtlas runtime readiness changed before final reporting; generated MCP configs are not usable until the runtime is reverified."
+    }
+    else {
+        Write-Warning "ProjectAtlas generated MCP config readiness changed before final reporting; rerun this installer."
+    }
     "The installed runtime and generated MCP configs could not be reverified; rerun this installer."
 }
 $targetRuntimeVersion = Convert-ProjectAtlasVersionTag $ProjectAtlasVersion
-if ([string]::IsNullOrWhiteSpace($targetRuntimeVersion) -and $runtimeMcpConfigsReady) {
+if ([string]::IsNullOrWhiteSpace($targetRuntimeVersion)) {
     $targetRuntimeVersion = Convert-ProjectAtlasVersionTag (Get-ProjectAtlasRuntimeVersion $verifiedRuntimePath)
 }
 $staleBareCommandPath = if (-not $stableMirrorReady `
@@ -3307,29 +3321,37 @@ $staleBareCommandPath = if (-not $stableMirrorReady `
 else {
     $null
 }
-$staleBareCommandVersion = if ($runtimeMcpConfigsReady -and $staleBareCommandPath) {
+$staleBareCommandVersion = if ($staleBareCommandPath) {
     Get-ProjectAtlasRuntimeVersion $staleBareCommandPath
 }
 else {
     $null
 }
-$lockedStaleCommandRecoveryRequired = $runtimeMcpConfigsReady `
-    -and -not $stableMirrorReady `
+$lockedStaleCommandRecoveryRequired = -not $stableMirrorReady `
     -and $staleBareCommandPath `
     -and -not [string]::IsNullOrWhiteSpace($targetRuntimeVersion) `
     -and $staleBareCommandVersion -ne $targetRuntimeVersion
 if ($lockedStaleCommandRecoveryRequired) {
     $observedVersion = if ($staleBareCommandVersion) { $staleBareCommandVersion } else { "unavailable" }
-    $quotedRuntime = "'" + $verifiedRuntimePath.Replace("'", "''") + "'"
     $quotedInstaller = "'" + (Get-NormalizedPathEntry $PSCommandPath).Replace("'", "''") + "'"
     $quotedProjectRoot = "'" + $ProjectRoot.Replace("'", "''") + "'"
     $quotedReleaseVersion = "'" + $targetRuntimeVersion.Replace("'", "''") + "'"
     $quotedRuntimeVersion = "'" + $targetRuntimeVersion.Replace("'", "''") + "'"
-    Write-Warning "ProjectAtlas stale bare command: path=$staleBareCommandPath observed_version=$observedVersion ready=false; verified_runtime=$verifiedRuntimePath target_version=$targetRuntimeVersion."
-    Write-Output "ProjectAtlas verified absolute runtime command: & $quotedRuntime --require-version $quotedRuntimeVersion --format json runtime-info"
-    Write-Warning "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=$($hostRestartRequired.ToString().ToLowerInvariant()). Wait for the lock owner to exit or release $stableMirrorPath; then rerun & $quotedInstaller -ProjectRoot $quotedProjectRoot -ProjectAtlasVersion $quotedReleaseVersion -RuntimePath $quotedRuntime. From $ProjectRoot, require both bare-command gates before declaring convergence: projectatlas --require-version $quotedRuntimeVersion --format json runtime-info; projectatlas --require-version $quotedRuntimeVersion token --view tui."
+    if ($verifiedRuntimeReady) {
+        $quotedRuntime = "'" + $verifiedRuntimePath.Replace("'", "''") + "'"
+        Write-Warning "ProjectAtlas stale bare command: path=$staleBareCommandPath observed_version=$observedVersion ready=false; verified_runtime=$verifiedRuntimePath target_version=$targetRuntimeVersion."
+        Write-Output "ProjectAtlas verified absolute runtime command: & $quotedRuntime --require-version $quotedRuntimeVersion --format json runtime-info"
+        Write-Warning "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=$($hostRestartRequired.ToString().ToLowerInvariant()). Wait for the lock owner to exit or release $stableMirrorPath; then rerun & $quotedInstaller -ProjectRoot $quotedProjectRoot -ProjectAtlasVersion $quotedReleaseVersion -RuntimePath $quotedRuntime. From $ProjectRoot, require both bare-command gates before declaring convergence: projectatlas --require-version $quotedRuntimeVersion --format json runtime-info; projectatlas --require-version $quotedRuntimeVersion token --view tui."
+    }
+    else {
+        Write-Warning "ProjectAtlas stale bare command: path=$staleBareCommandPath observed_version=$observedVersion ready=false; target_version=$targetRuntimeVersion."
+        Write-Warning "ProjectAtlas requested absolute runtime failed final verification: path=$verifiedRuntimePath target_version=$targetRuntimeVersion. Restore or replace that runtime and rerun & $quotedInstaller -ProjectRoot $quotedProjectRoot -ProjectAtlasVersion $quotedReleaseVersion; do not use it through -RuntimePath until verification succeeds."
+    }
 }
-if ($hostRestartRequired) {
+if (-not $verifiedRuntimeReady) {
+    Write-Warning "Existing host recovery cannot use or advertise the requested absolute runtime until final runtime verification succeeds. $runtimeMcpConfigGuidance"
+}
+elseif ($hostRestartRequired) {
     Write-Warning "Existing host restart required: the inherited bare 'projectatlas' command remains stale, but the verified runtime is first on the persisted fresh-process PATH. Restart the environment-owning Windows launcher or terminal session, then start a new Codex or shell; restarting only a child of an unchanged launcher can retain stale PATH. $runtimeMcpConfigGuidance"
 }
 elseif ($hostRepairRequired) {
@@ -3341,4 +3363,4 @@ elseif ($hostRepairRequired) {
     }
 }
 Write-Output "ProjectAtlas convergence: update_state=$updateState stable_mirror_ready=$($stableMirrorReady.ToString().ToLowerInvariant()) obsolete_mcp_handoff=$handoffState codex_plugin_ready=$($codexPluginReady.ToString().ToLowerInvariant()) codex_registry_ready=$($codexRegistryReady.ToString().ToLowerInvariant())"
-Write-Output "ProjectAtlas readiness: runtime_mcp_configs_ready=$($runtimeMcpConfigsReady.ToString().ToLowerInvariant()) installer_cli_ready=$($installerCliReady.ToString().ToLowerInvariant()) parent_cli_ready=$($parentCliReady.ToString().ToLowerInvariant()) host_restart_required=$($hostRestartRequired.ToString().ToLowerInvariant())"
+Write-Output "ProjectAtlas readiness: runtime_ready=$($verifiedRuntimeReady.ToString().ToLowerInvariant()) generated_mcp_configs_ready=$($generatedMcpConfigsReady.ToString().ToLowerInvariant()) runtime_mcp_configs_ready=$($runtimeMcpConfigsReady.ToString().ToLowerInvariant()) installer_cli_ready=$($installerCliReady.ToString().ToLowerInvariant()) parent_cli_ready=$($parentCliReady.ToString().ToLowerInvariant()) host_restart_required=$($hostRestartRequired.ToString().ToLowerInvariant())"

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -3296,6 +3296,39 @@ else {
     Write-Warning "ProjectAtlas runtime or generated MCP config readiness changed before final reporting; rerun this installer."
     "The installed runtime and generated MCP configs could not be reverified; rerun this installer."
 }
+$targetRuntimeVersion = Convert-ProjectAtlasVersionTag $ProjectAtlasVersion
+if ([string]::IsNullOrWhiteSpace($targetRuntimeVersion) -and $runtimeMcpConfigsReady) {
+    $targetRuntimeVersion = Convert-ProjectAtlasVersionTag (Get-ProjectAtlasRuntimeVersion $verifiedRuntimePath)
+}
+$staleBareCommandPath = if (-not $stableMirrorReady `
+        -and -not [string]::IsNullOrWhiteSpace($effectiveInheritedProjectAtlasPath)) {
+    Get-NormalizedPathEntry $effectiveInheritedProjectAtlasPath
+}
+else {
+    $null
+}
+$staleBareCommandVersion = if ($runtimeMcpConfigsReady -and $staleBareCommandPath) {
+    Get-ProjectAtlasRuntimeVersion $staleBareCommandPath
+}
+else {
+    $null
+}
+$lockedStaleCommandRecoveryRequired = $runtimeMcpConfigsReady `
+    -and -not $stableMirrorReady `
+    -and $staleBareCommandPath `
+    -and -not [string]::IsNullOrWhiteSpace($targetRuntimeVersion) `
+    -and $staleBareCommandVersion -ne $targetRuntimeVersion
+if ($lockedStaleCommandRecoveryRequired) {
+    $observedVersion = if ($staleBareCommandVersion) { $staleBareCommandVersion } else { "unavailable" }
+    $quotedRuntime = "'" + $verifiedRuntimePath.Replace("'", "''") + "'"
+    $quotedInstaller = "'" + (Get-NormalizedPathEntry $PSCommandPath).Replace("'", "''") + "'"
+    $quotedProjectRoot = "'" + $ProjectRoot.Replace("'", "''") + "'"
+    $quotedReleaseVersion = "'" + $targetRuntimeVersion.Replace("'", "''") + "'"
+    $quotedRuntimeVersion = "'" + $targetRuntimeVersion.Replace("'", "''") + "'"
+    Write-Warning "ProjectAtlas stale bare command: path=$staleBareCommandPath observed_version=$observedVersion ready=false; verified_runtime=$verifiedRuntimePath target_version=$targetRuntimeVersion."
+    Write-Output "ProjectAtlas verified absolute runtime command: & $quotedRuntime --require-version $quotedRuntimeVersion --format json runtime-info"
+    Write-Warning "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=$($hostRestartRequired.ToString().ToLowerInvariant()). Wait for the lock owner to exit or release $stableMirrorPath; then rerun & $quotedInstaller -ProjectRoot $quotedProjectRoot -ProjectAtlasVersion $quotedReleaseVersion -RuntimePath $quotedRuntime. From $ProjectRoot, require both bare-command gates before declaring convergence: projectatlas --require-version $quotedRuntimeVersion --format json runtime-info; projectatlas --require-version $quotedRuntimeVersion token --view tui."
+}
 if ($hostRestartRequired) {
     Write-Warning "Existing host restart required: the inherited bare 'projectatlas' command remains stale, but the verified runtime is first on the persisted fresh-process PATH. Restart the environment-owning Windows launcher or terminal session, then start a new Codex or shell; restarting only a child of an unchanged launcher can retain stale PATH. $runtimeMcpConfigGuidance"
 }

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -1924,6 +1924,15 @@ function Test-ProjectAtlasBareCommandResolutionOnPath {
     }
 }
 
+function Test-ProjectAtlasPersistedBareCommandResolution {
+    param(
+        [string]$VerifiedPath
+    )
+    $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    return (Test-ProjectAtlasBareCommandResolutionOnPath (@($machinePath, $userPath) -join ";") $VerifiedPath)
+}
+
 function Set-ProjectAtlasPathPrecedence {
     param(
         [string]$FilePath
@@ -1945,9 +1954,7 @@ function Set-ProjectAtlasPathPrecedence {
     $userEntries = @($userEntries | Where-Object { (Get-NormalizedPathEntry $_) -ne $normalizedRuntimeDir })
     $futureUserPath = (@($runtimeDir) + $userEntries) -join ";"
     [Environment]::SetEnvironmentVariable("Path", $futureUserPath, "User")
-    $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
-    $freshProcessPath = @($machinePath, $futureUserPath) -join ";"
-    return (Test-ProjectAtlasBareCommandResolutionOnPath $freshProcessPath $FilePath)
+    return (Test-ProjectAtlasPersistedBareCommandResolution $FilePath)
 }
 
 function Confirm-ProjectAtlasBareCommandResolution {
@@ -2084,6 +2091,22 @@ function Get-ProjectAtlasMcpLaunchArguments {
         $launchArgs += @("--config", $FlatConfigPath)
     }
     $launchArgs += "mcp"
+    return $launchArgs
+}
+
+function Get-ProjectAtlasTokenLaunchArguments {
+    param(
+        [string]$DbPath,
+        [string]$ProjectConfigPath,
+        [string]$FlatConfigPath,
+        [string]$ExpectedVersion
+    )
+    $launchArgs = @(Get-ProjectAtlasMcpLaunchArguments $DbPath $ProjectConfigPath $FlatConfigPath $ExpectedVersion)
+    if ($launchArgs.Count -eq 0) {
+        return @()
+    }
+    $launchArgs[$launchArgs.Count - 1] = "token"
+    $launchArgs += @("--view", "tui")
     return $launchArgs
 }
 
@@ -3154,6 +3177,9 @@ Quarantine-ProjectAtlasStaleShims $projectAtlas $ProjectAtlasVersion
 if (-not $RuntimePath) {
     $futureProcessPathReady = Set-ProjectAtlasPathPrecedence $projectAtlas
 }
+else {
+    $futureProcessPathReady = Test-ProjectAtlasPersistedBareCommandResolution $projectAtlas
+}
 $effectiveInheritedProjectAtlasPath = $inheritedProjectAtlasPath
 if ([string]::IsNullOrWhiteSpace($effectiveInheritedProjectAtlasPath) -or -not (Test-Path -LiteralPath $effectiveInheritedProjectAtlasPath)) {
     $installerProcessPath = $env:Path
@@ -3339,12 +3365,15 @@ if ($lockedStaleCommandRecoveryRequired) {
     $quotedRuntimeVersion = "'" + $targetRuntimeVersion.Replace("'", "''") + "'"
     if ($verifiedRuntimeReady) {
         $quotedRuntime = "'" + $verifiedRuntimePath.Replace("'", "''") + "'"
-        Write-Warning "ProjectAtlas stale bare command: path=$staleBareCommandPath observed_version=$observedVersion ready=false; verified_runtime=$verifiedRuntimePath target_version=$targetRuntimeVersion."
+        $tokenArguments = @(Get-ProjectAtlasTokenLaunchArguments $dbPath $projectConfigPath $flatConfigPath $targetRuntimeVersion)
+        $quotedTokenArguments = ($tokenArguments | ForEach-Object { "'" + ([string]$_).Replace("'", "''") + "'" }) -join " "
+        Write-Output "ProjectAtlas stale bare command: path=$staleBareCommandPath observed_version=$observedVersion ready=false; verified_runtime=$verifiedRuntimePath target_version=$targetRuntimeVersion."
         Write-Output "ProjectAtlas verified absolute runtime command: & $quotedRuntime --require-version $quotedRuntimeVersion --format json runtime-info"
+        Write-Output "ProjectAtlas verified absolute runtime operation: & $quotedRuntime $quotedTokenArguments"
         Write-Warning "ProjectAtlas locked-mirror recovery: restart_can_repair_command_resolution=$($hostRestartRequired.ToString().ToLowerInvariant()). Wait for the lock owner to exit or release $stableMirrorPath; then rerun & $quotedInstaller -ProjectRoot $quotedProjectRoot -ProjectAtlasVersion $quotedReleaseVersion -RuntimePath $quotedRuntime. From $ProjectRoot, require both bare-command gates before declaring convergence: projectatlas --require-version $quotedRuntimeVersion --format json runtime-info; projectatlas --require-version $quotedRuntimeVersion token --view tui."
     }
     else {
-        Write-Warning "ProjectAtlas stale bare command: path=$staleBareCommandPath observed_version=$observedVersion ready=false; target_version=$targetRuntimeVersion."
+        Write-Output "ProjectAtlas stale bare command: path=$staleBareCommandPath observed_version=$observedVersion ready=false; target_version=$targetRuntimeVersion."
         Write-Warning "ProjectAtlas requested absolute runtime failed final verification: path=$verifiedRuntimePath target_version=$targetRuntimeVersion. Restore or replace that runtime and rerun & $quotedInstaller -ProjectRoot $quotedProjectRoot -ProjectAtlasVersion $quotedReleaseVersion; do not use it through -RuntimePath until verification succeeds."
     }
 }


### PR DESCRIPTION
Closes #410

## Summary

- retain the database-owned read-only schema preflight before both primary and telemetry writable connections
- return one privacy-safe `schema_version_mismatch` contract through CLI JSON/TOON and real stdio MCP tool errors
- prove active-WAL refusal leaves database bytes, WAL bytes, sidecars, schema objects, authored state, telemetry, and derived state unchanged
- make Windows locked-mirror recovery name the stale command/version, verified runtime/version, and exact unlock/rerun/bare-command gates
- add packaged-runtime and row-count-independent performance proof, keep wide TUI reference tests deterministic, and add the requested About sentence unchanged

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-features --locked`
- `cargo test --doc --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked`
- `COLUMNS=80` deterministic overview/reference regressions
- strict OpenSpec validation, issue-checklist parity, PowerShell AST parse, strict-string and dependency policy gates
- isolated official-package CLI plus persistent stdio MCP active-WAL proof
- Windows locked-mirror/unlock/rerun/bare-command installer proof
- 1-row vs 1,000,000-row refusal profile with identical SQLite VM steps and reads

## Review state

Three independent Rust/database/release-gate reviews found no actionable blocker on the implementation. All OpenSpec tasks are complete; exact-head local and hosted gates pass on Linux, Windows, macOS x64, and macOS arm64, all review threads are resolved, and Codex reported no major issues on 7c8e22f.
