### PR TITLE
docs(openspec): close installed host gate (#411)

### DIFF
--- a/openspec/changes/handoff-obsolete-mcp-runtime/tasks.md
+++ b/openspec/changes/handoff-obsolete-mcp-runtime/tasks.md
@@ -19,4 +19,4 @@
 
 ## 4. Release Gate
 
-- [ ] 4.1 Verify the exact release version in a real installed Codex host: parent survives, obsolete child is replaced, and MCP initialization succeeds.
+- [x] 4.1 Verify the exact release version in a real installed Codex host: parent survives, obsolete child is replaced, and MCP initialization succeeds.


### PR DESCRIPTION
Records the completed final #411 release gate after the exact v0.4.3 installed-host proof.

- Hosted Windows passed the exact obsolete-child handoff while preserving the parent.
- A stale real Codex marketplace cache fetched the final v0.4.3 tag and converged plugin plus registry to 0.4.3.
- The registered stdio command returned a successful ProjectAtlas 0.4.3 MCP initialize response.
- The milestone IssueOps gate passes with every scoped issue closed and every task checked.

No product code changes.