### PR TITLE
test(release): stabilize MCP scan publication contract

### DIFF
--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -19536,6 +19536,10 @@ fn mcp_advertised_tools_own_their_real_sqlite_effects() -> Result<(), Box<dyn Er
                 repo.join(SRC_DIR_NAME).join(SCANNED_RS_FILE_NAME),
                 "pub fn scanned_contract() {}\n",
             )?,
+            "atlas_scan" => fs::write(
+                repo.join(SRC_DIR_NAME).join(SCANNED_RS_FILE_NAME),
+                "pub fn rescanned_contract() {}\n",
+            )?,
             "atlas_file_summary" => fs::write(
                 repo.join(SRC_DIR_NAME).join(LIB_RS_FILE_NAME),
                 "pub fn indexed() {\n    helper();\n}\n\nfn helper() {}\n\npub fn dirty_contract() {}\n",


### PR DESCRIPTION
## Why\n\nThe v0.4.4 prepublish installer proof passed on Windows and both macOS targets but exposed a Linux-only false failure in the packaged MCP SQLite-effects contract.\n\nThe tlas_scan case expected a complete source-publication advance without changing its source fixture first. On Linux, an unchanged scan correctly skipped unchanged table rewrites, so the contract failed even though the packaged 0.4.4 runtime and installer had succeeded.\n\n## What changed\n\n- mutate the existing src/scanned.rs fixture immediately before the tlas_scan call\n- keep symbol cardinality stable so downstream shared assertions remain unchanged\n- leave production behavior, release packaging, and the v0.4.4 token-impact contract untouched\n\n## Verification\n\n- focused packaged MCP SQLite-effects E2E passed three consecutive runs\n- full guarded pre-push suite passed\n- cargo fmt --check\n- workspace Clippy\n- ProjectAtlas scan/lint\n- independent Rust/source review: no findings\n\nRelated to #439\n