### PR TITLE
chore(release): align v0.4.4 checklist gate

### DIFF
--- a/openspec/changes/distinguish-average-maximum-token-impact/tasks.md
+++ b/openspec/changes/distinguish-average-maximum-token-impact/tasks.md
@@ -19,4 +19,6 @@
 
 - [x] 4.1 Run focused tests, `cargo fmt --check`, workspace check/Clippy/tests/doc-tests/rustdoc, ProjectAtlas lint, OpenSpec strict validation, IssueOps checklist validation, diff checks, and affected packaging/compatibility/release gates with explicit timeouts.
 - [x] 4.2 Render and visually inspect the real token TUI at desktop, common, and narrow terminal widths in dark, light, and terminal themes; fix overlap, truncation, hierarchy, contrast, or misleading formula presentation.
-- [ ] 4.3 Reconcile every live review thread and automated finding against the behavior-relevant source, configuration, dependency, artifact, and workflow inputs; merge only after hosted gates and packaged proof succeed, then publish and independently verify the v0.4.4 release, artifacts, installer, runtime, plugin, and MCP identity before closing and archiving the change.
+- [x] 4.3 Reconcile every live review thread and automated finding against the behavior-relevant source, configuration, dependency, artifact, and workflow inputs; merge only after hosted gates and packaged prepublication proof succeed, then synchronize the completed checklist and close issue #439 before dispatching the release workflow with `prepublish_only: false`.
+
+Archive condition: Keep this OpenSpec change unarchived until the release workflow has published v0.4.4 and a separate post-publication verification confirms the GitHub release, platform artifacts and checksums, installer behavior, runtime version, plugin version, and MCP identity.


### PR DESCRIPTION
## Why\n\nThe v0.4.4 release gate requires every milestone issue to be closed and every mapped OpenSpec task to be checked before publication. The previous task 4.3 wording also required publication before issue closure, creating a circular ordering requirement.\n\n## What changed\n\n- scope task 4.3 to completed prepublication readiness and the required issue-close transition\n- keep independent post-publication verification as an explicit non-checkbox OpenSpec archive condition\n- leave the release gate, product code, telemetry, TUI, packaging, and issue mapping unchanged\n\n## Proof already complete\n\n- PR #442 exact-head CI: 31206959824\n- clean optional-parser proof: 31206973400\n- all-platform packaged prepublication release proof: 31209870512\n- live IssueOps mirror: 11 local / 11 remote / 11 checked\n- strict OpenSpec validation and ProjectAtlas lint\n- independent release-order review: no diff finding\n\nCloses the release-readiness transition for #439.\n