### PR TITLE
feat(release): add release candidate promotion

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -19,6 +19,8 @@ cargo deny --locked --all-features check -D warnings
 cargo test --workspace --all-features --locked
 cargo test --doc --workspace --all-features --locked
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked
+npm ci --ignore-scripts --prefix .github/mermaid-parser
+npm audit --omit=dev --audit-level=moderate --prefix .github/mermaid-parser
 python3 .github/scripts/issue-checklists.py --self-test
 python3 .github/scripts/test-optional-parser-proof-inputs.py
 command -v gh >/dev/null 2>&1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: cargo
     directory: /
-    target-branch: dev
+    target-branch: main
     schedule:
       interval: weekly
     groups:
@@ -13,6 +13,6 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
-    target-branch: dev
+    target-branch: main
     schedule:
       interval: weekly

--- a/.github/mermaid-parser/package-lock.json
+++ b/.github/mermaid-parser/package-lock.json
@@ -1,0 +1,1684 @@
+{
+  "name": "mermaid-parser",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "jsdom": "27.4.0",
+        "mermaid": "11.16.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "license": "MIT"
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.1.tgz",
+      "integrity": "sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
+    },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/.github/mermaid-parser/package.json
+++ b/.github/mermaid-parser/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+  },
+  "dependencies": {
+    "jsdom": "27.4.0",
+    "mermaid": "11.16.1"
+  }
+}

--- a/.github/mermaid-parser/validate.mjs
+++ b/.github/mermaid-parser/validate.mjs
@@ -1,0 +1,20 @@
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>");
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.Option = dom.window.Option;
+const { default: mermaid } = await import("mermaid");
+
+let source = "";
+for await (const chunk of process.stdin) {
+  source += chunk;
+}
+
+mermaid.initialize({ startOnLoad: false });
+try {
+  await mermaid.parse(source);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,6 @@ Use `Closes #NNN` only when this pull request completes the issue.
 - [ ] `cargo test --workspace --all-features --locked` and stable workspace doctests clean.
 - [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked` clean.
 - [ ] Tests updated or added where behavior changed.
-- [ ] All active OpenSpec changes are mapped in `openspec/issue-map.json`, linked issue task sections exactly mirror local task text and state, and `.github/scripts/issue-checklists.py` passes. Full issue and milestone completion is required only when closing or releasing, not for every incremental `dev` slice.
+- [ ] All active OpenSpec changes are mapped in `openspec/issue-map.json`, linked issue task sections exactly mirror local task text and state, and `.github/scripts/issue-checklists.py` passes. Full issue and milestone completion is required only when closing or releasing, not for every incremental pull request.
 - [ ] README, Markdown docs, and GitHub Pages/rustdoc-facing content are updated or confirmed current for this change.
 - [ ] PR text contains no private or internal-only details (release notes are generated from PR text).

--- a/.github/scripts/issue-checklists.py
+++ b/.github/scripts/issue-checklists.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from urllib.parse import unquote, urlsplit
 
@@ -21,6 +24,11 @@ HEADING_RE = re.compile(r"(?m)^(#{1,6})\s+(.+?)\s*$")
 TASK_SECTION_HEADING_RE = re.compile(r"^(\d+(?:\.\d+)*)\.\s+")
 HTML_COMMENT_RE = re.compile(r"(?s)<!--.*?(?:-->|$)")
 FENCE_RE = re.compile(r"^[ ]{0,3}(`{3,}|~{3,})")
+ARCHITECTURE_NA_RE = re.compile(r"(?is)^N/A:\s*(\S(?:.*\S)?)$")
+ARCHITECTURE_ACCEPTANCE_TASK = (
+    "Review the final implementation against the architecture diagrams, update the "
+    "diagrams or implementation until they agree, or reconfirm the reasoned N/A."
+)
 MARKDOWN_LINK_RE = re.compile(
     r"\[(?:[^\[\]\n]|\[[^\[\]\n]*\])+\]"
     r"\(\s*<?([^)>\s]+)>?"
@@ -91,6 +99,18 @@ REQUIRED_OPEN_ISSUE_HEADINGS = (
     "non-goals",
     "pre-mortem",
 )
+RELEASE_MILESTONE_RE = re.compile(
+    r"^v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)-00$"
+)
+REQUIRED_PROPOSAL_HEADINGS = {"why", "what changes", "capabilities", "impact"}
+REQUIRED_DESIGN_HEADINGS = {
+    "goals / non-goals",
+    "decisions",
+    "risks / trade-offs",
+    "migration plan",
+    "dependencies / cross-issue impact",
+    "open questions",
+}
 
 
 @dataclass(frozen=True)
@@ -212,23 +232,160 @@ def github_heading_slug(heading: str) -> str:
     ).replace(" ", "-")
 
 
+def markdown_headings(text: str) -> list[tuple[str, int, int, int]]:
+    """Return visible headings as fragment, level, start, and end offsets."""
+
+    masked = HTML_COMMENT_RE.sub(
+        lambda match: "".join(
+            character if character in "\r\n" else " " for character in match.group(0)
+        ),
+        text or "",
+    )
+    headings: list[tuple[str, int, int, int]] = []
+    next_suffix: dict[str, int] = {}
+    used: set[str] = set()
+    fence_character = ""
+    fence_length = 0
+    offset = 0
+    for line in masked.splitlines(keepends=True):
+        fence = FENCE_RE.match(line)
+        if fence_character:
+            marker = fence.group(1) if fence else ""
+            if (
+                marker
+                and marker[0] == fence_character
+                and len(marker) >= fence_length
+                and not line[fence.end() :].strip()
+            ):
+                fence_character = ""
+                fence_length = 0
+        elif fence:
+            marker = fence.group(1)
+            fence_character = marker[0]
+            fence_length = len(marker)
+        else:
+            heading = HEADING_RE.match(line)
+            if heading:
+                base = github_heading_slug(heading.group(2))
+                if base:
+                    suffix = next_suffix.get(base, 0)
+                    fragment = base if suffix == 0 else f"{base}-{suffix}"
+                    while fragment in used:
+                        suffix += 1
+                        fragment = f"{base}-{suffix}"
+                    used.add(fragment)
+                    next_suffix[base] = suffix + 1
+                    headings.append(
+                        (
+                            fragment,
+                            len(heading.group(1)),
+                            offset + heading.start(),
+                            offset + heading.end(),
+                        )
+                    )
+        offset += len(line)
+    return headings
+
+
 def markdown_heading_fragments(text: str) -> set[str]:
     """Return rendered heading fragments, including GitHub duplicate suffixes."""
 
-    fragments: set[str] = set()
-    next_suffix: dict[str, int] = {}
-    for heading in HEADING_RE.finditer(visible_markdown(text)):
-        base = github_heading_slug(heading.group(2))
-        if not base:
+    return {fragment for fragment, _, _, _ in markdown_headings(text)}
+
+
+def markdown_heading_section(text: str, fragment: str) -> str | None:
+    """Return the raw Markdown body owned by one rendered heading fragment."""
+
+    headings = markdown_headings(text)
+    for index, (candidate, level, _, end) in enumerate(headings):
+        if candidate != fragment:
             continue
-        suffix = next_suffix.get(base, 0)
-        fragment = base if suffix == 0 else f"{base}-{suffix}"
-        while fragment in fragments:
-            suffix += 1
-            fragment = f"{base}-{suffix}"
-        fragments.add(fragment)
-        next_suffix[base] = suffix + 1
-    return fragments
+        section_end = len(text)
+        for _, later_level, later_start, _ in headings[index + 1 :]:
+            if later_level <= level:
+                section_end = later_start
+                break
+        return text[end:section_end]
+    return None
+
+
+def mermaid_diagram_blocks(section: str) -> list[str]:
+    """Return structurally eligible fenced Mermaid diagram bodies."""
+
+    diagrams: list[str] = []
+    fence_character = ""
+    fence_length = 0
+    mermaid = False
+    body: list[str] = []
+    for line in section.splitlines():
+        fence = FENCE_RE.match(line)
+        if fence_character:
+            marker = fence.group(1) if fence else ""
+            if (
+                marker
+                and marker[0] == fence_character
+                and len(marker) >= fence_length
+                and not line[fence.end() :].strip()
+            ):
+                if mermaid:
+                    meaningful = [
+                        value
+                        for value in (candidate.strip() for candidate in body)
+                        if value and not value.startswith("%%")
+                    ]
+                    if meaningful[:1] == ["---"]:
+                        try:
+                            frontmatter_end = meaningful.index("---", 1)
+                        except ValueError:
+                            meaningful = []
+                        else:
+                            meaningful = meaningful[frontmatter_end + 1 :]
+                    if len(meaningful) > 1:
+                        diagrams.append("\n".join(body))
+                fence_character = ""
+                fence_length = 0
+                mermaid = False
+                body = []
+            elif mermaid:
+                body.append(line)
+        elif fence:
+            marker = fence.group(1)
+            fence_character = marker[0]
+            fence_length = len(marker)
+            mermaid = line[fence.end() :].strip().casefold() == "mermaid"
+    return diagrams
+
+
+@lru_cache(maxsize=64)
+def mermaid_syntax_is_valid(diagram: str) -> bool:
+    """Validate one diagram with the repository-locked Mermaid parser."""
+
+    node = shutil.which("node")
+    validator = Path(__file__).resolve().parents[1] / "mermaid-parser" / "validate.mjs"
+    mermaid_package = validator.parent / "node_modules" / "mermaid" / "package.json"
+    if node is None or not mermaid_package.is_file():
+        raise RuntimeError(
+            "IssueOps Mermaid validation requires `npm ci --ignore-scripts --prefix "
+            ".github/mermaid-parser`"
+        )
+    try:
+        result = subprocess.run(
+            [node, str(validator)],
+            input=f"{diagram}\n",
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        return False
+    return result.returncode == 0
+
+
+def contains_mermaid_diagram(section: str) -> bool:
+    """Return whether a fenced Mermaid block is structurally and syntactically real."""
+
+    return any(mermaid_syntax_is_valid(diagram) for diagram in mermaid_diagram_blocks(section))
 
 
 def parse_tasks(text: str) -> list[tuple[bool, str]]:
@@ -392,7 +549,7 @@ def issue_payload(repo: str, number: int) -> dict[str, object]:
             "-R",
             repo,
             "--json",
-            "body,title,state,url",
+            "body,title,state,url,number,labels,milestone",
         ]
     )
     if not isinstance(payload, dict):
@@ -431,9 +588,167 @@ def heading_section(
     return text[heading.end() : end].strip()
 
 
+def named_markdown_section(text: str, name: str) -> str | None:
+    """Return one uniquely named visible Markdown section."""
+
+    visible = visible_markdown(text)
+    headings = list(HEADING_RE.finditer(visible))
+    matches = [
+        index
+        for index, heading in enumerate(headings)
+        if clean(heading.group(2)).casefold() == name.casefold()
+    ]
+    if len(matches) != 1:
+        return None
+    return heading_section(visible, headings, matches[0])
+
+
+def required_markdown_section_failures(
+    text: str, names: set[str], document: str
+) -> list[str]:
+    """Require one non-empty visible section for every named heading."""
+
+    visible = visible_markdown(text)
+    headings = list(HEADING_RE.finditer(visible))
+    failures: list[str] = []
+    for name in sorted(names):
+        matches = [
+            index
+            for index, heading in enumerate(headings)
+            if clean(heading.group(2)).casefold() == name
+        ]
+        if len(matches) != 1:
+            failures.append(
+                f"{document} section {name!r} must appear exactly once; found {len(matches)}"
+            )
+            continue
+        body = heading_section(visible, headings, matches[0])
+        if not clean(HEADING_RE.sub("", body)):
+            failures.append(f"{document} section {name!r} must not be empty")
+    return failures
+
+
+def openspec_readiness_failures(root: Path, change: str) -> list[str]:
+    """Validate the bounded artifacts required before milestone planning."""
+
+    change_root = root / "openspec" / "changes" / change
+    failures: list[str] = []
+    documents: dict[str, str] = {}
+    for name in ("proposal.md", "design.md"):
+        path = change_root / name
+        try:
+            documents[name] = path.read_text(encoding="utf-8")
+        except OSError:
+            failures.append(f"{change} is not implementation-ready: missing readable {name}")
+    proposal = documents.get("proposal.md")
+    if proposal is not None:
+        failures.extend(
+            f"{change} {failure}"
+            for failure in required_markdown_section_failures(
+                proposal, REQUIRED_PROPOSAL_HEADINGS, "proposal"
+            )
+        )
+    design = documents.get("design.md")
+    if design is not None:
+        failures.extend(
+            f"{change} {failure}"
+            for failure in required_markdown_section_failures(
+                design, REQUIRED_DESIGN_HEADINGS, "design"
+            )
+        )
+        dependencies = named_markdown_section(design, "dependencies / cross-issue impact")
+        if dependencies is not None and not (
+            re.search(r"#\d+", dependencies)
+            or ARCHITECTURE_NA_RE.fullmatch(dependencies.strip())
+        ):
+            failures.append(
+                f"{change} design must name cross-issue dependencies or use a reasoned N/A"
+            )
+        open_questions = named_markdown_section(design, "open questions")
+        if open_questions is not None and clean(open_questions).casefold() not in {
+            "none",
+            "none.",
+        }:
+            failures.append(f"{change} still has unresolved open questions")
+    specs_root = change_root / "specs"
+    specs = sorted(specs_root.glob("*/spec.md")) if specs_root.is_dir() else []
+    if not specs:
+        failures.append(f"{change} is not implementation-ready: no delta spec")
+    for spec in specs:
+        try:
+            text = visible_markdown(spec.read_text(encoding="utf-8"))
+        except OSError:
+            failures.append(f"{change} has an unreadable delta spec: {spec}")
+            continue
+        if re.search(r"(?m)^### Requirement:\s+\S", text) is None:
+            failures.append(f"{change} delta spec has no requirement: {spec}")
+        if re.search(r"(?m)^#### Scenario:\s+\S", text) is None:
+            failures.append(f"{change} delta spec has no scenario: {spec}")
+    try:
+        _, tasks = local_tasks(root, change)
+    except SystemExit as error:
+        failures.append(str(error))
+    else:
+        contract_tasks = [task for task in tasks if task_id(task).startswith("1.")]
+        if not contract_tasks or any(not checked for checked, _ in contract_tasks):
+            failures.append(
+                f"{change} contract/specification tasks must be present and checked before milestone planning"
+            )
+    return failures
+
+
+def planned_issue_failures(
+    issue: dict[str, object],
+    issue_map: dict[str, tuple[Owner, ...]],
+    root: Path,
+) -> list[str]:
+    """Validate one open issue when it is assigned to a release milestone."""
+
+    if str(issue.get("state", "")).upper() != "OPEN":
+        return []
+    milestone = issue.get("milestone")
+    if not isinstance(milestone, dict):
+        return []
+    title = milestone.get("title")
+    if not isinstance(title, str) or RELEASE_MILESTONE_RE.fullmatch(title) is None:
+        return []
+    number = positive_issue(issue.get("number"), "issue number")
+    issue_to_change = {
+        owner.issue: change for change, owners in issue_map.items() for owner in owners
+    }
+    failures: list[str] = []
+    change = issue_to_change.get(number)
+    if change is None:
+        failures.append(
+            f"#{number} cannot be planned in {title}: no local OpenSpec mapping"
+        )
+        return failures
+    labels = issue.get("labels")
+    status_labels = {
+        label.get("name")
+        for label in (labels if isinstance(labels, list) else [])
+        if isinstance(label, dict)
+        and isinstance(label.get("name"), str)
+        and str(label.get("name")).startswith("status:")
+    }
+    if status_labels != {"status:ready"}:
+        failures.append(
+            f"#{number} cannot be planned in {title}: expected only status:ready, found "
+            f"{', '.join(sorted(status_labels)) or 'no status label'}"
+        )
+    failures.extend(openspec_readiness_failures(root, change))
+    return failures
+
+
 def architecture_diagram_link_failures(section: str, repo: str, root: Path) -> list[str]:
     """Validate durable local architecture-document links for one issue section."""
 
+    if ARCHITECTURE_NA_RE.fullmatch(section.strip()):
+        return []
+    if re.match(r"(?is)^\s*N/?A\b", section):
+        return [
+            "'architecture diagrams' N/A decision must use 'N/A: <reason>' with a non-empty reason"
+        ]
     matches = list(MARKDOWN_LINK_RE.finditer(section))
     urls = [match.group(1) for match in matches]
     if not urls:
@@ -506,18 +821,22 @@ def architecture_diagram_link_failures(section: str, repo: str, root: Path) -> l
             )
         else:
             try:
-                fragments = markdown_heading_fragments(
-                    candidate.read_text(encoding="utf-8")
-                )
+                document = candidate.read_text(encoding="utf-8")
             except OSError as error:
                 failures.append(
                     f"architecture diagram link {url!r} documentation could not be read: {error}"
                 )
                 continue
             fragment = unquote(parsed.fragment)
-            if fragment not in fragments:
+            diagram_section = markdown_heading_section(document, fragment)
+            if diagram_section is None:
                 failures.append(
                     f"architecture diagram link {url!r} has no matching GitHub-style heading fragment"
+                )
+            elif not contains_mermaid_diagram(diagram_section):
+                failures.append(
+                    f"architecture diagram link {url!r} must target a section containing a non-empty "
+                    "fenced Mermaid block accepted by the locked syntax parser"
                 )
     return failures
 
@@ -543,6 +862,14 @@ def issue_contract_failures(
     headings = list(HEADING_RE.finditer(visible_body))
     normalized = [clean(heading.group(2)).lower() for heading in headings]
     failures: list[str] = []
+    final_task = (
+        TASK_ID_RE.sub("", expected_tasks[-1][1], count=1) if expected_tasks else ""
+    )
+    if clean(final_task).casefold() != ARCHITECTURE_ACCEPTANCE_TASK.casefold():
+        failures.append(
+            "final OpenSpec task must be the architecture acceptance task: "
+            f"{ARCHITECTURE_ACCEPTANCE_TASK}"
+        )
     positions: list[int] = []
     for required in REQUIRED_OPEN_ISSUE_HEADINGS:
         matches = [index for index, value in enumerate(normalized) if value == required]
@@ -687,14 +1014,23 @@ def first_task_difference(
 
 
 def check_openspec_tasks(
-    repo: str, root: Path, issue_map: dict[str, tuple[Owner, ...]]
+    repo: str,
+    root: Path,
+    issue_map: dict[str, tuple[Owner, ...]],
+    planned_issue: int | None = None,
 ) -> list[str]:
     failures: list[str] = []
     for change, owners in sorted(issue_map.items()):
+        if planned_issue is not None and all(
+            owner.issue != planned_issue for owner in owners
+        ):
+            continue
         path, tasks = local_tasks(root, change)
         for owner, expected in owner_slices(path, tasks, owners):
-            issue = issue_payload(repo, owner.issue)
-            remote = issue_checklist_tasks(issue)
+            if planned_issue is not None and owner.issue != planned_issue:
+                continue
+            payload = issue_payload(repo, owner.issue)
+            remote = issue_checklist_tasks(payload)
             print(
                 f"#{owner.issue} {change}: local {len(expected)} / "
                 f"remote {len(remote)} / checked "
@@ -705,9 +1041,9 @@ def check_openspec_tasks(
                     f"#{owner.issue} does not exactly mirror {path}: "
                     f"{first_task_difference(expected, remote)}"
                 )
-            for failure in issue_contract_failures(issue, expected, repo, root):
+            for failure in issue_contract_failures(payload, expected, repo, root):
                 failures.append(f"#{owner.issue} issue contract {failure}")
-            if issue.get("state") == "CLOSED" and any(
+            if payload.get("state") == "CLOSED" and any(
                 not checked for checked, _ in remote
             ):
                 failures.append(f"#{owner.issue} is closed but still has unchecked tasks")
@@ -858,7 +1194,7 @@ def self_test() -> None:
 
 ## 2. Implementation
 
-- [ ] 2.1 Same-level task subsection
+- [ ] 2.1 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
 
 ## 2. Acceptance Criteria
 
@@ -870,7 +1206,10 @@ def self_test() -> None:
 """
     expected = [
         (True, "1.1 Anchored task"),
-        (False, "2.1 Same-level task subsection"),
+        (
+            False,
+            "2.1 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.",
+        ),
     ]
     assert parse_section_tasks(issue_body, heading_matches_openspec_tasks) == expected
     issue_contract = """
@@ -895,7 +1234,7 @@ Mitigations:
 ## 1. Review
 - [x] 1.1 Anchored task
 ## 2. Implementation
-- [ ] 2.1 Same-level task subsection
+- [ ] 2.1 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
 """
     self_test_root = Path(__file__).resolve().parents[2]
 
@@ -905,6 +1244,91 @@ Mitigations:
         return issue_contract_failures(issue, tasks, "owner/repo", self_test_root)
 
     assert contract_failures({"state": "OPEN", "body": issue_contract}, expected) == []
+    na_contract = issue_contract.replace(
+        "- [System architecture](https://github.com/owner/repo/blob/dev/docs/projectatlas-3-architecture.md#architecture-views)",
+        "N/A: This change has no architecture impact.",
+    )
+    assert contract_failures({"state": "OPEN", "body": na_contract}, expected) == []
+    unexplained_na = na_contract.replace(
+        "N/A: This change has no architecture impact.", "N/A"
+    )
+    assert any(
+        "N/A decision" in failure
+        for failure in contract_failures(
+            {"state": "OPEN", "body": unexplained_na}, expected
+        )
+    )
+    invalid_na = na_contract.replace(
+        "N/A: This change has no architecture impact.",
+        "NA: This change has no architecture impact.",
+    )
+    assert any(
+        "N/A decision" in failure
+        for failure in contract_failures(
+            {"state": "OPEN", "body": invalid_na}, expected
+        )
+    )
+    invalid_na_delimiter = na_contract.replace(
+        "N/A: This change has no architecture impact.",
+        "N/A - This change has no architecture impact.",
+    )
+    assert any(
+        "N/A decision" in failure
+        for failure in contract_failures(
+            {"state": "OPEN", "body": invalid_na_delimiter}, expected
+        )
+    )
+    assert contains_mermaid_diagram("```mermaid\nflowchart LR\nA --> B\n```")
+    assert contains_mermaid_diagram(
+        "```mermaid\n---\ntitle: Typed graph\n---\nerDiagram\nA ||--o{ B : owns\n```"
+    )
+    assert contains_mermaid_diagram(
+        "```mermaid\nkanban\n  column1[Backlog]\n    task1[Add feature]\n```"
+    )
+    assert not contains_mermaid_diagram(
+        "```mermaid\nflowchart LR\nthis is not valid mermaid ???\n```"
+    )
+    assert not contains_mermaid_diagram("```mermaid\nThis is only prose.\n```")
+    assert not contains_mermaid_diagram("```mermaid\nflowchart LR\n```")
+    assert not contains_mermaid_diagram("```mermaid\n---\ntitle: Missing close\nflowchart LR\n```")
+    assert not contains_mermaid_diagram("```python\nflowchart LR\n```")
+    assert not contains_mermaid_diagram("```mermaid\n```")
+    with tempfile.TemporaryDirectory() as temporary:
+        architecture_root = Path(temporary)
+        docs = architecture_root / "docs"
+        docs.mkdir()
+        architecture = docs / "architecture.md"
+        link = (
+            "[Target](https://github.com/owner/repo/blob/dev/docs/"
+            "architecture.md#target-view)"
+        )
+        architecture.write_text(
+            "## Target View\n\n```mermaid\n%% comment\nflowchart LR\nA --> B\n```\n"
+            "\n## Later View\n\n```mermaid\nflowchart LR\nB --> C\n```\n",
+            encoding="utf-8",
+        )
+        assert architecture_diagram_link_failures(link, "owner/repo", architecture_root) == []
+        architecture.write_text(
+            "## Target View\n\nArchitecture prose only.\n"
+            "\n## Later View\n\n```mermaid\nflowchart LR\nB --> C\n```\n",
+            encoding="utf-8",
+        )
+        assert any(
+            "fenced Mermaid block" in failure
+            for failure in architecture_diagram_link_failures(
+                link, "owner/repo", architecture_root
+            )
+        )
+        architecture.write_text(
+            "## Target View\n\n```mermaid\nflowchart LR\nA --> B\n",
+            encoding="utf-8",
+        )
+        assert any(
+            "fenced Mermaid block" in failure
+            for failure in architecture_diagram_link_failures(
+                link, "owner/repo", architecture_root
+            )
+        )
     exact_head_contract = issue_contract.replace(
         "Explain the need.", "Require exact-head proof."
     )
@@ -1024,12 +1448,18 @@ Mitigations:
         "- [ ] Keep the contract synchronized.",
         "- [x] Keep the contract synchronized.",
     ).replace(
-        "- [ ] 2.1 Same-level task subsection",
-        "- [x] 2.1 Same-level task subsection",
+        "- [ ] 2.1 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.",
+        "- [x] 2.1 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.",
     )
     assert contract_failures(
         {"state": "OPEN", "body": completed_contract},
-        [(True, "1.1 Anchored task"), (True, "2.1 Same-level task subsection")],
+        [
+            (True, "1.1 Anchored task"),
+            (
+                True,
+                "2.1 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.",
+            ),
+        ],
     ) == []
     missing_scope = issue_contract.replace("## Release Scope", "## Delivery")
     assert any(
@@ -1044,6 +1474,13 @@ Mitigations:
         for failure in contract_failures({"state": "OPEN", "body": unknown_task}, expected)
     )
     assert contract_failures({"state": "CLOSED", "body": ""}, expected) == []
+    wrong_final = [expected[0], (False, "2.1 Finish ordinary tests.")]
+    assert any(
+        "final OpenSpec task must be the architecture acceptance task" in failure
+        for failure in contract_failures(
+            {"state": "OPEN", "body": issue_contract}, wrong_final
+        )
+    )
     missing_architecture_link = issue_contract.replace(
         "- [System architecture](https://github.com/owner/repo/blob/dev/docs/projectatlas-3-architecture.md#architecture-views)",
         "Architecture will be documented later.",
@@ -1231,6 +1668,121 @@ Mitigations:
         assert "owned by both one and one" in str(error)
     else:
         raise AssertionError("repeated issue ownership within one change was accepted")
+    ready_issue = {
+        "number": 448,
+        "state": "OPEN",
+        "milestone": {"title": "v6.7.8-00"},
+        "labels": [{"name": "status:ready"}],
+    }
+    backlog_issue = {**ready_issue, "labels": [{"name": "status:backlog"}]}
+    assert any(
+        "expected only status:ready" in failure
+        for failure in planned_issue_failures(
+            backlog_issue, {"missing-readiness-change": (Owner(448),)}, self_test_root
+        )
+    )
+    assert any(
+        "no local OpenSpec mapping" in failure
+        for failure in planned_issue_failures(ready_issue, {}, self_test_root)
+    )
+    assert any(
+        "missing readable proposal.md" in failure
+        for failure in openspec_readiness_failures(
+            self_test_root, "missing-readiness-change"
+        )
+    )
+    with tempfile.TemporaryDirectory() as temporary:
+        readiness_root = Path(temporary)
+        change = readiness_root / "openspec" / "changes" / "ready-change"
+        (change / "specs" / "capability").mkdir(parents=True)
+        (change / "proposal.md").write_text(
+            "## Why\nNeed it.\n## What Changes\nChange it.\n"
+            "## Capabilities\nOne.\n## Impact\nBounded.\n",
+            encoding="utf-8",
+        )
+        design = (
+            "## Goals / Non-Goals\nGoal.\n## Decisions\nDecide.\n"
+            "## Risks / Trade-offs\nRisk.\n## Migration Plan\nMigrate.\n"
+            "## Dependencies / Cross-Issue Impact\nIssue #123 owns the input.\n"
+            "## Open Questions\nNone.\n"
+        )
+        (change / "design.md").write_text(design, encoding="utf-8")
+        (change / "specs" / "capability" / "spec.md").write_text(
+            "## ADDED Requirements\n### Requirement: Ready contract\nIt SHALL work.\n"
+            "#### Scenario: Positive\n- **WHEN** ready\n- **THEN** proceed\n",
+            encoding="utf-8",
+        )
+        (change / "tasks.md").write_text(
+            "## 1. Contract\n- [x] 1.1 Specify the contract.\n"
+            "## 2. Acceptance\n- [ ] 2.1 Review the final implementation against the "
+            "architecture diagrams, update the diagrams or implementation until they "
+            "agree, or reconfirm the reasoned N/A.\n",
+            encoding="utf-8",
+        )
+        assert openspec_readiness_failures(readiness_root, "ready-change") == []
+        assert planned_issue_failures(
+            ready_issue, {"ready-change": (Owner(448),)}, readiness_root
+        ) == []
+        empty_proposal = (
+            "## Why\n\n## What Changes\nChange it.\n"
+            "## Capabilities\nOne.\n## Impact\nBounded.\n"
+        )
+        (change / "proposal.md").write_text(empty_proposal, encoding="utf-8")
+        assert any(
+            "proposal section 'why' must not be empty" in failure
+            for failure in openspec_readiness_failures(
+                readiness_root, "ready-change"
+            )
+        )
+        (change / "proposal.md").write_text(
+            "## Why\nNeed it.\n## Why\nNeed it twice.\n"
+            "## What Changes\nChange it.\n## Capabilities\nOne.\n"
+            "## Impact\nBounded.\n",
+            encoding="utf-8",
+        )
+        assert any(
+            "proposal section 'why' must appear exactly once" in failure
+            for failure in openspec_readiness_failures(
+                readiness_root, "ready-change"
+            )
+        )
+        (change / "proposal.md").write_text(
+            "## Why\nNeed it.\n## What Changes\nChange it.\n"
+            "## Capabilities\nOne.\n## Impact\nBounded.\n",
+            encoding="utf-8",
+        )
+        (change / "design.md").write_text(
+            design.replace("None.", "Which owner is responsible?"), encoding="utf-8"
+        )
+        assert any(
+            "unresolved open questions" in failure
+            for failure in openspec_readiness_failures(
+                readiness_root, "ready-change"
+            )
+        )
+        (change / "design.md").write_text(
+            design.replace(
+                "Issue #123 owns the input.", "Dependencies will be decided later."
+            ),
+            encoding="utf-8",
+        )
+        assert any(
+            "must name cross-issue dependencies" in failure
+            for failure in openspec_readiness_failures(
+                readiness_root, "ready-change"
+            )
+        )
+        (change / "design.md").write_text(design, encoding="utf-8")
+        (change / "tasks.md").write_text(
+            "## 1. Contract\n- [ ] 1.1 Specify the contract.\n",
+            encoding="utf-8",
+        )
+        assert any(
+            "contract/specification tasks" in failure
+            for failure in openspec_readiness_failures(
+                readiness_root, "ready-change"
+            )
+        )
     print("issue checklist self-test passed")
 
 
@@ -1240,6 +1792,7 @@ def main() -> None:
     parser.add_argument("--root", default=".")
     parser.add_argument("--issue-map", default="openspec/issue-map.json")
     parser.add_argument("--milestone", action="append", default=[])
+    parser.add_argument("--planned-issue", type=int)
     parser.add_argument("--skip-openspec", action="store_true")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
@@ -1254,7 +1807,17 @@ def main() -> None:
     failures: list[str] = []
     issue_map = load_issue_map(args.issue_map)
     if not args.skip_openspec:
-        failures.extend(check_openspec_tasks(args.repo, root, issue_map))
+        failures.extend(
+            check_openspec_tasks(
+                args.repo, root, issue_map, planned_issue=args.planned_issue
+            )
+        )
+    if args.planned_issue is not None:
+        failures.extend(
+            planned_issue_failures(
+                issue_payload(args.repo, args.planned_issue), issue_map, root
+            )
+        )
     mapped_issues = mapped_issue_numbers(issue_map)
     for milestone in args.milestone:
         failures.extend(check_milestone_complete(args.repo, milestone, mapped_issues))

--- a/.github/scripts/release-notes.py
+++ b/.github/scripts/release-notes.py
@@ -8,6 +8,8 @@ import sys
 from datetime import datetime
 from html.parser import HTMLParser
 
+from release_version import parse_release_version
+
 
 def run(args, check=True):
     process = subprocess.run(args, capture_output=True, text=True)
@@ -38,20 +40,19 @@ def note_title(text):
 SECTIONS = ("New Features", "Bug Fixes", "Chores")
 
 
-def semver_key(tag):
-    match = re.fullmatch(r"v([0-9]+)\.([0-9]+)\.([0-9]+)", tag or "")
-    return tuple(int(part) for part in match.groups()) if match else None
-
-
 def previous_tag_from(tags, version):
-    current = semver_key(version)
-    if current is None:
+    try:
+        current = parse_release_version(version, source="release")
+    except ValueError:
         return ""
     candidates = []
     for tag in tags:
-        key = semver_key(tag)
-        if key and key < current:
-            candidates.append((key, tag))
+        try:
+            candidate = parse_release_version(tag, source="release")
+        except ValueError:
+            continue
+        if not candidate.is_prerelease and candidate.numbers < current.numbers:
+            candidates.append((candidate.numbers, tag))
     return max(candidates)[1] if candidates else ""
 
 
@@ -354,8 +355,12 @@ def self_test():
     assert section_for("fix: reject stale paths", [], "feat(index): publish graph") == "Bug Fixes"
     assert merged_after("2026-07-05T18:59:26Z", 1783277965)
     assert not merged_after("2026-07-05T18:59:26Z", 1783277966)
-    assert previous_tag_from(["v0.3.15", "v0.3.16"], "v0.3.17") == "v0.3.16"
-    assert previous_tag_from(["v0.3.15", "v0.3.16", "v0.3.17"], "v0.3.17") == "v0.3.16"
+    tags = ["v4.8.8", "v4.8.9", "v4.9.0-rc1", "v4.9.0-rc2"]
+    assert previous_tag_from(tags, "v4.9.0-rc1") == "v4.8.9"
+    assert previous_tag_from(tags, "v4.9.0-rc3") == "v4.8.9"
+    assert previous_tag_from(tags, "v4.9.0") == "v4.8.9"
+    assert previous_tag_from(["v4.8.8", "v4.8.9"], "v4.9.0") == "v4.8.9"
+    assert previous_tag_from(["v4.9.0"], "v4.9.0") == ""
     print("release notes self-test passed")
 
 

--- a/.github/scripts/release_version.py
+++ b/.github/scripts/release_version.py
@@ -7,6 +7,8 @@ import argparse
 import json
 import os
 import re
+import subprocess
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -141,6 +143,33 @@ def latest_published_rc(payload: object, stable: ReleaseVersion) -> ReleaseVersi
     return max(candidates, key=lambda candidate: candidate.rc_number or 0, default=None)
 
 
+def require_prior_rc_ancestor(
+    prior_rc: ReleaseVersion, head: str, *, repo: Path = Path(".")
+) -> None:
+    """Require the selected published RC to be an ancestor of the stable head."""
+    result = subprocess.run(
+        [
+            "git",
+            "merge-base",
+            "--is-ancestor",
+            f"{prior_rc.tag}^{{commit}}",
+            f"{head}^{{commit}}",
+        ],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return
+    if result.returncode == 1:
+        raise ValueError(
+            f"published RC {prior_rc.tag} is not an ancestor of stable head {head}"
+        )
+    detail = result.stderr.strip() or result.stdout.strip() or "git merge-base failed"
+    raise ValueError(f"could not verify published RC ancestry: {detail}")
+
+
 def self_test() -> None:
     """Exercise generic stable, RC, development, and malformed inputs."""
     stable = parse_release_version("v1.2.3", source="release")
@@ -221,6 +250,37 @@ def self_test() -> None:
     else:
         raise AssertionError("prior RC lookup accepted an RC target")
 
+    with tempfile.TemporaryDirectory(prefix="projectatlas-release-version-") as temp_dir:
+        repo = Path(temp_dir)
+
+        def git(*arguments: str) -> str:
+            return subprocess.run(
+                ["git", *arguments],
+                cwd=repo,
+                text=True,
+                capture_output=True,
+                check=True,
+            ).stdout.strip()
+
+        git("init", "--quiet")
+        git("config", "user.name", "ProjectAtlas release self-test")
+        git("config", "user.email", "release-self-test@example.invalid")
+        git("config", "commit.gpgsign", "false")
+        git("config", "tag.gpgsign", "false")
+        git("config", "core.hooksPath", ".git/disabled-hooks")
+        git("commit", "--quiet", "--allow-empty", "--message", "candidate")
+        git("tag", prior.tag)
+        git("commit", "--quiet", "--allow-empty", "--message", "stable")
+        require_prior_rc_ancestor(prior, git("rev-parse", "HEAD"), repo=repo)
+        git("checkout", "--quiet", "--orphan", "divergent")
+        git("commit", "--quiet", "--allow-empty", "--message", "divergent")
+        try:
+            require_prior_rc_ancestor(prior, git("rev-parse", "HEAD"), repo=repo)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("divergent stable head accepted published RC ancestry")
+
     invalid = (
         ("1.2.3", "release"),
         ("v1.2.3", "workspace"),
@@ -261,6 +321,7 @@ def main() -> None:
     parser.add_argument("--source", choices=("release", "workspace"), default="release")
     parser.add_argument("--github-output", type=Path)
     parser.add_argument("--require-prior-rc-from", type=Path)
+    parser.add_argument("--require-prior-rc-ancestor-of")
     parser.add_argument("--resolve-expected-latest", action="store_true")
     parser.add_argument("--latest-before")
     parser.add_argument("--release-exists", action="store_true")
@@ -294,6 +355,12 @@ def main() -> None:
             parser.error(str(error))
     elif args.latest_before is not None or args.release_exists:
         parser.error("Latest-state inputs require --resolve-expected-latest")
+    if (args.require_prior_rc_from is None) != (
+        args.require_prior_rc_ancestor_of is None
+    ):
+        parser.error(
+            "--require-prior-rc-from and --require-prior-rc-ancestor-of must be used together"
+        )
     if args.require_prior_rc_from is not None:
         if version is None:
             parser.error("development versions cannot require a prior RC")
@@ -306,6 +373,10 @@ def main() -> None:
             parser.error(
                 f"stable release {version.tag} requires a published prerelease for the same base version"
             )
+        try:
+            require_prior_rc_ancestor(prior_rc, args.require_prior_rc_ancestor_of)
+        except (OSError, ValueError) as error:
+            parser.error(str(error))
         outputs["prior_rc_tag"] = prior_rc.tag
     output_path = args.github_output or (Path(path) if (path := os.environ.get("GITHUB_OUTPUT")) else None)
     if output_path is not None:

--- a/.github/scripts/release_version.py
+++ b/.github/scripts/release_version.py
@@ -81,6 +81,24 @@ def github_outputs(version: ReleaseVersion | None) -> dict[str, str]:
     }
 
 
+def expected_latest_tag(
+    version: ReleaseVersion, *, release_exists: bool, latest_before: str | None
+) -> str:
+    """Return the required post-publication Latest tag, failing closed for repairs."""
+    if not version.is_prerelease and not release_exists:
+        return version.tag
+    if not latest_before:
+        raise ValueError(
+            "an RC or release repair requires the current Latest stable release"
+        )
+    latest = parse_release_version(latest_before, source="release")
+    if latest.is_prerelease:
+        raise ValueError(
+            f"GitHub Latest is not a canonical stable ProjectAtlas tag: {latest_before}"
+        )
+    return latest.tag
+
+
 def release_records(payload: object) -> list[dict[str, object]]:
     """Normalize one raw or ``gh api --paginate --slurp`` release response."""
     if not isinstance(payload, list):
@@ -153,6 +171,34 @@ def self_test() -> None:
     assert classify_workspace_version("7.8.9-dev.12") is None
     assert github_outputs(None) == {"eligible": "false"}
     assert github_outputs(candidate)["is_prerelease"] == "true"
+    assert (
+        expected_latest_tag(stable, release_exists=False, latest_before=None)
+        == stable.tag
+    )
+    assert (
+        expected_latest_tag(candidate, release_exists=False, latest_before="v1.2.3")
+        == "v1.2.3"
+    )
+    assert (
+        expected_latest_tag(stable, release_exists=True, latest_before="v1.2.2")
+        == "v1.2.2"
+    )
+    for target, release_exists, latest_before in (
+        (candidate, False, None),
+        (stable, True, None),
+        (candidate, True, "v1.2.3-rc1"),
+        (stable, True, "nightly"),
+    ):
+        try:
+            expected_latest_tag(
+                target,
+                release_exists=release_exists,
+                latest_before=latest_before,
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("invalid Latest release state was accepted")
     releases = [
         [
             {"tag_name": "v10.20.30-rc2", "draft": False, "prerelease": True},
@@ -215,6 +261,9 @@ def main() -> None:
     parser.add_argument("--source", choices=("release", "workspace"), default="release")
     parser.add_argument("--github-output", type=Path)
     parser.add_argument("--require-prior-rc-from", type=Path)
+    parser.add_argument("--resolve-expected-latest", action="store_true")
+    parser.add_argument("--latest-before")
+    parser.add_argument("--release-exists", action="store_true")
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
     if args.self_test:
@@ -232,6 +281,19 @@ def main() -> None:
     except ValueError as error:
         parser.error(str(error))
     outputs = github_outputs(version)
+    if args.resolve_expected_latest:
+        if version is None:
+            parser.error("development versions cannot resolve release Latest state")
+        try:
+            outputs["expected_latest"] = expected_latest_tag(
+                version,
+                release_exists=args.release_exists,
+                latest_before=args.latest_before,
+            )
+        except ValueError as error:
+            parser.error(str(error))
+    elif args.latest_before is not None or args.release_exists:
+        parser.error("Latest-state inputs require --resolve-expected-latest")
     if args.require_prior_rc_from is not None:
         if version is None:
             parser.error("development versions cannot require a prior RC")

--- a/.github/scripts/release_version.py
+++ b/.github/scripts/release_version.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Classify ProjectAtlas stable and release-candidate versions for CI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+NUMBER = r"(?:0|[1-9][0-9]*)"
+VERSION_PATTERN = re.compile(
+    rf"(?P<prefix>v?)(?P<major>{NUMBER})\.(?P<minor>{NUMBER})\."
+    rf"(?P<patch>{NUMBER})(?:-rc(?P<rc>[1-9][0-9]*))?"
+)
+DEVELOPMENT_PATTERN = re.compile(rf"{NUMBER}\.{NUMBER}\.{NUMBER}-dev\.{NUMBER}")
+
+
+@dataclass(frozen=True)
+class ReleaseVersion:
+    """One validated stable or release-candidate version."""
+
+    numbers: tuple[int, int, int]
+    package_version: str
+    tag: str
+    stable_version: str
+    stable_tag: str
+    milestone: str
+    is_prerelease: bool
+    rc_number: int | None
+
+
+def parse_release_version(value: str, *, source: str) -> ReleaseVersion:
+    """Parse a release tag or workspace package version, failing closed."""
+    if source not in {"release", "workspace"}:
+        raise ValueError(f"unsupported version source: {source}")
+    match = VERSION_PATTERN.fullmatch(value)
+    expected_prefix = "v" if source == "release" else ""
+    if match is None or match.group("prefix") != expected_prefix:
+        expected = "vMAJOR.MINOR.PATCH[-rcN]" if source == "release" else "MAJOR.MINOR.PATCH[-rcN]"
+        raise ValueError(f"version must match {expected} with canonical positive rcN")
+    numbers = tuple(int(match.group(name)) for name in ("major", "minor", "patch"))
+    stable_version = ".".join(str(part) for part in numbers)
+    rc = match.group("rc")
+    package_version = stable_version + (f"-rc{rc}" if rc else "")
+    stable_tag = f"v{stable_version}"
+    return ReleaseVersion(
+        numbers=numbers,
+        package_version=package_version,
+        tag=f"v{package_version}",
+        stable_version=stable_version,
+        stable_tag=stable_tag,
+        milestone=f"{stable_tag}-00",
+        is_prerelease=rc is not None,
+        rc_number=int(rc) if rc else None,
+    )
+
+
+def classify_workspace_version(value: str) -> ReleaseVersion | None:
+    """Return an eligible release or ``None`` for the supported development form."""
+    if DEVELOPMENT_PATTERN.fullmatch(value):
+        return None
+    return parse_release_version(value, source="workspace")
+
+
+def github_outputs(version: ReleaseVersion | None) -> dict[str, str]:
+    """Build validated GitHub Actions outputs for one classification."""
+    if version is None:
+        return {"eligible": "false"}
+    return {
+        "eligible": "true",
+        "package_version": version.package_version,
+        "tag": version.tag,
+        "stable_version": version.stable_version,
+        "stable_tag": version.stable_tag,
+        "milestone": version.milestone,
+        "is_prerelease": str(version.is_prerelease).lower(),
+    }
+
+
+def release_records(payload: object) -> list[dict[str, object]]:
+    """Normalize one raw or ``gh api --paginate --slurp`` release response."""
+    if not isinstance(payload, list):
+        raise ValueError("GitHub releases response must be a list")
+    if payload and all(isinstance(page, list) for page in payload):
+        values = [record for page in payload for record in page]
+    elif any(isinstance(page, list) for page in payload):
+        raise ValueError("GitHub releases response mixes pages and records")
+    else:
+        values = payload
+    if any(not isinstance(record, dict) for record in values):
+        raise ValueError("GitHub releases response contains a non-object record")
+    return values
+
+
+def latest_published_rc(payload: object, stable: ReleaseVersion) -> ReleaseVersion | None:
+    """Return the highest published RC for one stable base version."""
+    if stable.is_prerelease:
+        raise ValueError("prior RC lookup requires a stable release version")
+    candidates: list[ReleaseVersion] = []
+    for record in release_records(payload):
+        tag = record.get("tag_name")
+        draft = record.get("draft")
+        prerelease = record.get("prerelease")
+        if not isinstance(tag, str) or not isinstance(draft, bool) or not isinstance(
+            prerelease, bool
+        ):
+            raise ValueError("GitHub release record has invalid tag or classification fields")
+        try:
+            candidate = parse_release_version(tag, source="release")
+        except ValueError:
+            continue
+        if (
+            not draft
+            and prerelease
+            and candidate.is_prerelease
+            and candidate.stable_tag == stable.stable_tag
+        ):
+            candidates.append(candidate)
+    return max(candidates, key=lambda candidate: candidate.rc_number or 0, default=None)
+
+
+def self_test() -> None:
+    """Exercise generic stable, RC, development, and malformed inputs."""
+    stable = parse_release_version("v1.2.3", source="release")
+    assert stable.package_version == "1.2.3"
+    assert stable.stable_tag == "v1.2.3"
+    assert stable.milestone == "v1.2.3-00"
+    assert stable.numbers == (1, 2, 3)
+    assert not stable.is_prerelease
+    assert stable.rc_number is None
+    assert github_outputs(stable) == {
+        "eligible": "true",
+        "package_version": "1.2.3",
+        "tag": "v1.2.3",
+        "stable_version": "1.2.3",
+        "stable_tag": "v1.2.3",
+        "milestone": "v1.2.3-00",
+        "is_prerelease": "false",
+    }
+
+    candidate = classify_workspace_version("10.20.30-rc12")
+    assert candidate is not None
+    assert candidate.tag == "v10.20.30-rc12"
+    assert candidate.stable_version == "10.20.30"
+    assert candidate.milestone == "v10.20.30-00"
+    assert candidate.is_prerelease
+    assert candidate.rc_number == 12
+    assert classify_workspace_version("7.8.9-dev.0") is None
+    assert classify_workspace_version("7.8.9-dev.12") is None
+    assert github_outputs(None) == {"eligible": "false"}
+    assert github_outputs(candidate)["is_prerelease"] == "true"
+    releases = [
+        [
+            {"tag_name": "v10.20.30-rc2", "draft": False, "prerelease": True},
+            {"tag_name": "v10.20.30-rc9", "draft": False, "prerelease": True},
+            {"tag_name": "v10.20.30-rc20", "draft": True, "prerelease": True},
+        ],
+        [
+            {"tag_name": "v10.20.30", "draft": False, "prerelease": False},
+            {"tag_name": "v10.20.31-rc99", "draft": False, "prerelease": True},
+            {"tag_name": "nightly", "draft": False, "prerelease": True},
+        ],
+    ]
+    prior = latest_published_rc(releases, parse_release_version("v10.20.30", source="release"))
+    assert prior is not None and prior.tag == "v10.20.30-rc9"
+    assert latest_published_rc([], stable) is None
+    try:
+        latest_published_rc(releases, candidate)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("prior RC lookup accepted an RC target")
+
+    invalid = (
+        ("1.2.3", "release"),
+        ("v1.2.3", "workspace"),
+        ("v01.2.3", "release"),
+        ("v1.02.3", "release"),
+        ("v1.2.03", "release"),
+        ("v1.2.3-rc0", "release"),
+        ("v1.2.3-rc01", "release"),
+        ("v1.2.3-rc.1", "release"),
+        ("v1.2.3-beta1", "release"),
+        ("v1.2.3+build", "release"),
+        ("v1.2.3\n", "release"),
+    )
+    for value, source in invalid:
+        try:
+            parse_release_version(value, source=source)
+        except ValueError:
+            continue
+        raise AssertionError(f"invalid {source} version was accepted: {value!r}")
+    for value in ("7.8.9.dev1", "7.8.9-dev", "7.8.9-dev.01", "v7.8.9-dev.1"):
+        try:
+            classify_workspace_version(value)
+        except ValueError:
+            continue
+        raise AssertionError(f"invalid workspace development version was accepted: {value!r}")
+    try:
+        parse_release_version("v1.2.3", source="unknown")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("unknown version source was accepted")
+
+
+def main() -> None:
+    """Classify one version or run the bounded self-test."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version", nargs="?")
+    parser.add_argument("--source", choices=("release", "workspace"), default="release")
+    parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--require-prior-rc-from", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        print("release version self-test passed")
+        return
+    if args.version is None:
+        parser.error("version is required")
+    try:
+        version = (
+            classify_workspace_version(args.version)
+            if args.source == "workspace"
+            else parse_release_version(args.version, source="release")
+        )
+    except ValueError as error:
+        parser.error(str(error))
+    outputs = github_outputs(version)
+    if args.require_prior_rc_from is not None:
+        if version is None:
+            parser.error("development versions cannot require a prior RC")
+        try:
+            payload = json.loads(args.require_prior_rc_from.read_text(encoding="utf-8"))
+            prior_rc = latest_published_rc(payload, version)
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            parser.error(str(error))
+        if prior_rc is None:
+            parser.error(
+                f"stable release {version.tag} requires a published prerelease for the same base version"
+            )
+        outputs["prior_rc_tag"] = prior_rc.tag
+    output_path = args.github_output or (Path(path) if (path := os.environ.get("GITHUB_OUTPUT")) else None)
+    if output_path is not None:
+        with output_path.open("a", encoding="utf-8", newline="\n") as output:
+            for name, value in outputs.items():
+                output.write(f"{name}={value}\n")
+    for name, value in outputs.items():
+        print(f"{name}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test-optional-parser-proof-inputs.py
+++ b/.github/scripts/test-optional-parser-proof-inputs.py
@@ -3,11 +3,67 @@
 
 import runpy
 import subprocess
+import sys
+import tempfile
 import unittest
 from pathlib import Path
 
 
 class OptionalParserProofInputsTests(unittest.TestCase):
+    def test_handoff_accepts_equivalent_merge_squash_and_rebase_trees(self) -> None:
+        policy = Path(__file__).with_name("optional-parser-proof-inputs.py")
+        with tempfile.TemporaryDirectory() as temporary:
+            repository = Path(temporary)
+
+            def git(*arguments: str) -> str:
+                result = subprocess.run(
+                    ["git", *arguments],
+                    cwd=repository,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                return result.stdout.strip()
+
+            git("init", "--initial-branch=main")
+            git("config", "user.name", "ProjectAtlas test")
+            git("config", "user.email", "projectatlas@example.invalid")
+            (repository / "source.txt").write_text("base\n", encoding="utf-8")
+            git("add", "source.txt")
+            git("commit", "-m", "base")
+            base = git("rev-parse", "HEAD")
+            git("checkout", "-b", "proof")
+            (repository / "source.txt").write_text("candidate\n", encoding="utf-8")
+            git("commit", "-am", "candidate")
+            proof = git("rev-parse", "HEAD")
+
+            for mode in ("merge", "squash", "rebase"):
+                with self.subTest(mode=mode):
+                    git("checkout", "-B", f"main-{mode}", base)
+                    if mode == "merge":
+                        git("merge", "--no-ff", "--no-edit", "proof")
+                    elif mode == "squash":
+                        git("merge", "--squash", "proof")
+                        git("commit", "-m", "squash candidate")
+                    else:
+                        git("cherry-pick", proof)
+                    promotion = git("rev-parse", "HEAD")
+                    result = subprocess.run(
+                        [
+                            sys.executable,
+                            str(policy),
+                            "--base",
+                            proof,
+                            "--head",
+                            promotion,
+                        ],
+                        cwd=repository,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_metadata_reuses_proof_and_every_other_input_invalidates(self) -> None:
         classify = runpy.run_path(
             Path(__file__).with_name("optional-parser-proof-inputs.py")

--- a/.github/scripts/verify-main-atlas-seed-release-assets.py
+++ b/.github/scripts/verify-main-atlas-seed-release-assets.py
@@ -105,6 +105,27 @@ def validate_hosted_seed_assets(
     return hosted_assets
 
 
+def repair_upload_assets(source: Path, immutable_names: list[str]) -> list[Path]:
+    """Return regular staged assets that are not immutable hosted seed objects."""
+
+    entries = sorted(source.iterdir(), key=lambda entry: entry.name)
+    if any(not entry.is_file() or entry.is_symlink() for entry in entries):
+        raise ValueError("release repair assets must be regular, non-symlink files")
+    if (
+        len(immutable_names) != len(set(immutable_names))
+        or any(not name or "/" in name or "\\" in name for name in immutable_names)
+    ):
+        raise ValueError("immutable hosted seed asset names must be unique leaf names")
+    staged_names = {entry.name for entry in entries}
+    missing = set(immutable_names) - staged_names
+    if missing:
+        raise ValueError(
+            f"immutable hosted seed asset is absent from staged release assets: {min(missing)}"
+        )
+    immutable = set(immutable_names)
+    return [entry for entry in entries if entry.name not in immutable]
+
+
 def self_test() -> None:
     """Cover absence, stable/RC identity, and malformed inventory failure."""
     with tempfile.TemporaryDirectory() as temporary:
@@ -220,6 +241,26 @@ def self_test() -> None:
         else:
             raise AssertionError("mismatched hosted seed pair was accepted")
 
+        hosted_manifest.write_bytes(b".manifest.json")
+        (staged / "projectatlas-v9.8.7-rc12-linux.tar.gz").write_bytes(b"package")
+        (staged / "SHA256SUMS").write_bytes(b"checksums")
+        assert [asset.name for asset in repair_upload_assets(
+            staged, [hosted_archive.name]
+        )] == [
+            "SHA256SUMS",
+            f"{basename}.manifest.json",
+            "projectatlas-v9.8.7-rc12-linux.tar.gz",
+        ]
+        assert [asset.name for asset in repair_upload_assets(
+            staged, [hosted_archive.name, hosted_manifest.name]
+        )] == ["SHA256SUMS", "projectatlas-v9.8.7-rc12-linux.tar.gz"]
+        try:
+            repair_upload_assets(staged, ["missing-seed.tar.zst"])
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("missing immutable hosted seed asset was ignored")
+
 
 def main() -> None:
     """Validate optional seed assets and write their leaf names when requested."""
@@ -228,11 +269,32 @@ def main() -> None:
     parser.add_argument("--release-tag")
     parser.add_argument("--list-file", type=Path)
     parser.add_argument("--staged-source", type=Path)
+    parser.add_argument("--repair-upload-source", type=Path)
+    parser.add_argument("--immutable-list-file", type=Path)
+    parser.add_argument("--upload-list-file", type=Path)
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
     if args.self_test:
         self_test()
         print("main Atlas seed release-asset self-test passed")
+        return
+    if args.repair_upload_source is not None:
+        if args.immutable_list_file is None or args.upload_list_file is None:
+            parser.error(
+                "--repair-upload-source requires --immutable-list-file and --upload-list-file"
+            )
+        try:
+            immutable_names = args.immutable_list_file.read_text(
+                encoding="utf-8"
+            ).splitlines()
+            uploads = repair_upload_assets(args.repair_upload_source, immutable_names)
+            args.upload_list_file.write_text(
+                "".join(f"{asset}\n" for asset in uploads), encoding="utf-8"
+            )
+        except (OSError, ValueError) as error:
+            parser.error(str(error))
+        for asset in uploads:
+            print(asset)
         return
     if args.source is None or args.release_tag is None:
         parser.error("--source and --release-tag are required")

--- a/.github/scripts/verify-main-atlas-seed-release-assets.py
+++ b/.github/scripts/verify-main-atlas-seed-release-assets.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Discover an optional exact-version ProjectAtlas main Atlas seed asset pair."""
+
+from __future__ import annotations
+
+import argparse
+import filecmp
+import re
+import tempfile
+from pathlib import Path
+
+from release_version import parse_release_version
+
+
+ASSET_PREFIX = "projectatlas-main-atlas-seed-"
+SNAPSHOT_DIGEST = r"[0-9a-f]{64}"
+
+
+def seed_candidates(source: Path) -> list[Path]:
+    """Return the bounded regular seed-prefixed inventory."""
+
+    candidates = sorted(
+        (entry for entry in source.iterdir() if entry.name.startswith(ASSET_PREFIX)),
+        key=lambda entry: entry.name,
+    )
+    if not candidates:
+        return []
+    if any(not entry.is_file() or entry.is_symlink() for entry in candidates):
+        raise ValueError("main Atlas seed assets must be regular, non-symlink files")
+    return candidates
+
+
+def discover_seed_assets(source: Path, release_tag: str) -> list[Path]:
+    """Return one validated archive/manifest pair, or an empty list when absent."""
+    version = parse_release_version(release_tag, source="release")
+    candidates = seed_candidates(source)
+    if not candidates:
+        return []
+
+    basename_pattern = re.compile(
+        rf"{re.escape(ASSET_PREFIX + version.tag)}-(?P<digest>{SNAPSHOT_DIGEST})"
+    )
+    pairs: dict[str, set[str]] = {}
+    for candidate in candidates:
+        suffix = next(
+            (value for value in (".tar.zst", ".manifest.json") if candidate.name.endswith(value)),
+            None,
+        )
+        if suffix is None:
+            raise ValueError(f"unexpected main Atlas seed asset: {candidate.name}")
+        basename = candidate.name[: -len(suffix)]
+        match = basename_pattern.fullmatch(basename)
+        if match is None:
+            raise ValueError(
+                f"main Atlas seed asset does not preserve exact release tag {version.tag}: "
+                f"{candidate.name}"
+            )
+        pairs.setdefault(match.group("digest"), set()).add(suffix)
+
+    if len(pairs) != 1:
+        raise ValueError("main Atlas seed assets must contain exactly one snapshot digest")
+    digest, suffixes = next(iter(pairs.items()))
+    expected_suffixes = {".tar.zst", ".manifest.json"}
+    if suffixes != expected_suffixes or len(candidates) != 2:
+        raise ValueError("main Atlas seed archive and manifest must form one complete pair")
+    basename = f"{ASSET_PREFIX}{version.tag}-{digest}"
+    return [source / f"{basename}{suffix}" for suffix in (".tar.zst", ".manifest.json")]
+
+
+def validate_hosted_seed_assets(
+    hosted: Path, staged: Path, release_tag: str
+) -> list[Path]:
+    """Validate immutable hosted assets, including one-member upload recovery."""
+
+    hosted_candidates = seed_candidates(hosted)
+    if not hosted_candidates:
+        return []
+    staged_assets = discover_seed_assets(staged, release_tag)
+    if len(hosted_candidates) == 1:
+        if not staged_assets:
+            raise ValueError(
+                "a partial hosted main Atlas seed requires the complete staged pair"
+            )
+        staged_by_name = {asset.name: asset for asset in staged_assets}
+        candidate = hosted_candidates[0]
+        staged_candidate = staged_by_name.get(candidate.name)
+        if staged_candidate is None or not filecmp.cmp(
+            candidate, staged_candidate, shallow=False
+        ):
+            raise ValueError(
+                f"partial hosted main Atlas seed asset differs: {candidate.name}"
+            )
+        return hosted_candidates
+
+    hosted_assets = discover_seed_assets(hosted, release_tag)
+    if staged_assets:
+        staged_by_name = {asset.name: asset for asset in staged_assets}
+        if [asset.name for asset in hosted_assets] != [
+            asset.name for asset in staged_assets
+        ] or any(
+            not filecmp.cmp(asset, staged_by_name[asset.name], shallow=False)
+            for asset in hosted_assets
+        ):
+            raise ValueError("hosted main Atlas seed pair differs from the staged pair")
+    return hosted_assets
+
+
+def self_test() -> None:
+    """Cover absence, stable/RC identity, and malformed inventory failure."""
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        assert discover_seed_assets(root, "v1.2.3") == []
+
+        digest = "a" * 64
+        stable_basename = f"{ASSET_PREFIX}v1.2.3-{digest}"
+        for suffix in (".tar.zst", ".manifest.json"):
+            (root / f"{stable_basename}{suffix}").write_bytes(suffix.encode("ascii"))
+        assert [path.name for path in discover_seed_assets(root, "v1.2.3")] == [
+            f"{stable_basename}.tar.zst",
+            f"{stable_basename}.manifest.json",
+        ]
+        try:
+            discover_seed_assets(root, "v1.2.3-rc1")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("stable seed assets were accepted for an RC")
+
+        for path in tuple(root.iterdir()):
+            path.unlink()
+        rc_basename = f"{ASSET_PREFIX}v9.8.7-rc12-{'b' * 64}"
+        archive = root / f"{rc_basename}.tar.zst"
+        manifest = root / f"{rc_basename}.manifest.json"
+        archive.write_bytes(b"archive")
+        manifest.write_text("{}\n", encoding="utf-8")
+        assert len(discover_seed_assets(root, "v9.8.7-rc12")) == 2
+
+        manifest.unlink()
+        try:
+            discover_seed_assets(root, "v9.8.7-rc12")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("incomplete seed asset pair was accepted")
+
+        archive.unlink()
+        malformed = root / f"{ASSET_PREFIX}v9.8.7-rc12-not-a-digest.tar.zst"
+        malformed.write_bytes(b"archive")
+        try:
+            discover_seed_assets(root, "v9.8.7-rc12")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("malformed seed asset was accepted")
+
+        malformed.unlink()
+        for suffix in (".tar.zst", ".manifest.json"):
+            (root / f"{rc_basename}{suffix}").write_bytes(b"pair")
+        second_basename = f"{ASSET_PREFIX}v9.8.7-rc12-{'c' * 64}"
+        for suffix in (".tar.zst", ".manifest.json"):
+            (root / f"{second_basename}{suffix}").write_bytes(b"second")
+        try:
+            discover_seed_assets(root, "v9.8.7-rc12")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("multiple seed snapshot digests were accepted")
+
+        for path in tuple(root.iterdir()):
+            path.unlink()
+        non_regular = root / f"{ASSET_PREFIX}v9.8.7-rc12-{'d' * 64}.tar.zst"
+        non_regular.mkdir()
+        try:
+            discover_seed_assets(root, "v9.8.7-rc12")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("non-regular seed asset was accepted")
+
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        staged = root / "staged"
+        hosted = root / "hosted"
+        missing_staged = root / "missing-staged"
+        staged.mkdir()
+        hosted.mkdir()
+        missing_staged.mkdir()
+        basename = f"{ASSET_PREFIX}v9.8.7-rc12-{'e' * 64}"
+        for suffix in (".tar.zst", ".manifest.json"):
+            (staged / f"{basename}{suffix}").write_bytes(suffix.encode("ascii"))
+        hosted_archive = hosted / f"{basename}.tar.zst"
+        hosted_archive.write_bytes(b".tar.zst")
+        try:
+            validate_hosted_seed_assets(
+                hosted, missing_staged, "v9.8.7-rc12"
+            )
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("partial hosted seed was accepted without a staged pair")
+        assert [asset.name for asset in validate_hosted_seed_assets(
+            hosted, staged, "v9.8.7-rc12"
+        )] == [hosted_archive.name]
+        hosted_archive.write_bytes(b"mismatch")
+        try:
+            validate_hosted_seed_assets(hosted, staged, "v9.8.7-rc12")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("mismatched partial hosted seed asset was accepted")
+        hosted_archive.write_bytes(b".tar.zst")
+        hosted_manifest = hosted / f"{basename}.manifest.json"
+        hosted_manifest.write_bytes(b".manifest.json")
+        assert len(validate_hosted_seed_assets(hosted, staged, "v9.8.7-rc12")) == 2
+        hosted_manifest.write_bytes(b"mismatch")
+        try:
+            validate_hosted_seed_assets(hosted, staged, "v9.8.7-rc12")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("mismatched hosted seed pair was accepted")
+
+
+def main() -> None:
+    """Validate optional seed assets and write their leaf names when requested."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path)
+    parser.add_argument("--release-tag")
+    parser.add_argument("--list-file", type=Path)
+    parser.add_argument("--staged-source", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        print("main Atlas seed release-asset self-test passed")
+        return
+    if args.source is None or args.release_tag is None:
+        parser.error("--source and --release-tag are required")
+    try:
+        assets = (
+            validate_hosted_seed_assets(
+                args.source, args.staged_source, args.release_tag
+            )
+            if args.staged_source is not None
+            else discover_seed_assets(args.source, args.release_tag)
+        )
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+    names = [asset.name for asset in assets]
+    if args.list_file is not None:
+        args.list_file.write_text("".join(f"{name}\n" for name in names), encoding="utf-8")
+    for name in names:
+        print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/verify-optional-parser-release-assets.py
+++ b/.github/scripts/verify-optional-parser-release-assets.py
@@ -12,6 +12,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from release_version import parse_release_version
+
 
 TARGETS = (
     "x86_64-unknown-linux-gnu",
@@ -48,10 +50,7 @@ def stage_release_assets(
     cargo_lock: Path,
 ) -> list[Path]:
     """Validate a clean handoff and stage versioned release assets."""
-    require(
-        re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", release_version) is not None,
-        "release version must match vMAJOR.MINOR.PATCH",
-    )
+    version = parse_release_version(release_version, source="release").package_version
     require(re.fullmatch(r"[0-9a-f]{40}", revision) is not None, "invalid run revision")
     expected_files = {PROOF_NAME}
     for target in TARGETS:
@@ -66,7 +65,6 @@ def stage_release_assets(
     require(actual_files == expected_files, "clean handoff file inventory differs")
 
     proof = load_object(source / PROOF_NAME)
-    version = release_version.removeprefix("v")
     require(proof.get("schema_version") == 2, "unsupported aggregate proof schema")
     require(proof.get("pack_id") == PACK_ID, "aggregate proof pack differs")
     require(proof.get("projectatlas_version") == version, "aggregate proof version differs")
@@ -181,6 +179,8 @@ def self_test() -> None:
         cargo_lock = root / "Cargo.lock"
         cargo_lock.write_bytes(b"locked\n")
         revision = "a" * 40
+        package_version = "6.7.8-rc2"
+        release_tag = f"v{package_version}"
         common = {
             "accepted_manifest_sha256": "b" * 64,
             "capability_set_digest": "c" * 64,
@@ -198,8 +198,8 @@ def self_test() -> None:
                     "platform": target,
                     "candidate": {
                         "projectatlas_revision": revision,
-                        "cargo_package_version": "0.4.0",
-                        "intended_release_version": "0.4.0",
+                        "cargo_package_version": package_version,
+                        "intended_release_version": package_version,
                         "cargo_lock_sha256": digest(cargo_lock),
                         "source_state": "clean",
                     },
@@ -248,21 +248,49 @@ def self_test() -> None:
                 {
                     "schema_version": 2,
                     "pack_id": PACK_ID,
-                    "projectatlas_version": "0.4.0",
+                    "projectatlas_version": package_version,
                     **common,
                     "platforms": platforms,
                 }
             ),
             encoding="utf-8",
         )
-        staged = stage_release_assets(source, output, "v0.4.0", revision, cargo_lock)
+        staged = stage_release_assets(source, output, release_tag, revision, cargo_lock)
         require(len(staged) == 3 and all(path.is_file() for path in staged), "self-test staging failed")
+        require(
+            all(release_tag in path.name for path in staged),
+            "self-test staging truncated the RC tag",
+        )
+        try:
+            stage_release_assets(source, root / "mismatch-output", "v6.7.8", revision, cargo_lock)
+        except ValueError:
+            pass
+        else:
+            raise RuntimeError("mismatched release identity passed validation")
+        stable_version = "6.7.8"
+        for fixture in source.glob("*.json"):
+            fixture.write_text(
+                fixture.read_text(encoding="utf-8").replace(
+                    package_version, stable_version
+                ),
+                encoding="utf-8",
+            )
+        stable_tag = f"v{stable_version}"
+        stable_staged = stage_release_assets(
+            source, root / "stable-output", stable_tag, revision, cargo_lock
+        )
+        require(
+            len(stable_staged) == 3
+            and all(stable_tag in path.name and "-rc" not in path.name for path in stable_staged),
+            "stable release-asset compatibility failed",
+        )
         (source / f"projectatlas-{PACK_ID}-{TARGETS[0]}.tar.zst").write_bytes(b"tampered")
         try:
-            stage_release_assets(source, root / "tampered-output", "v0.4.0", revision, cargo_lock)
+            stage_release_assets(source, root / "tampered-output", stable_tag, revision, cargo_lock)
         except ValueError:
-            return
-        raise RuntimeError("tampered archive passed validation")
+            pass
+        else:
+            raise RuntimeError("tampered archive passed validation")
 
 
 def main() -> None:

--- a/.github/workflows/03-auto-release.yml
+++ b/.github/workflows/03-auto-release.yml
@@ -36,22 +36,25 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Check release eligibility
+      - name: Classify release version
         id: release
         run: |
-          if [[ "${{ steps.version.outputs.version }}" == *".dev"* ]]; then
-            echo "eligible=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "eligible=true" >> "$GITHUB_OUTPUT"
-          fi
+          python3 .github/scripts/release_version.py --self-test
+          python3 .github/scripts/release_version.py \
+            "${{ steps.version.outputs.version }}" \
+            --source workspace \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Fetch tags
         run: git fetch --tags
 
       - name: Check tag
         id: tag
+        if: steps.release.outputs.eligible == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
-          if git tag -l "v${{ steps.version.outputs.version }}" | grep -q .; then
+          if git tag -l "$RELEASE_TAG" | grep -q .; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -64,9 +67,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          promotion_sha="$(git rev-parse HEAD^2)"
-          if [[ "$(git rev-parse 'HEAD^{tree}')" != "$(git rev-parse "$promotion_sha^{tree}")" ]]; then
-            echo "Main promotion tree differs from its verified dev parent" >&2
+          promotion_sha="$(git rev-parse 'HEAD^{commit}')"
+          if [[ "$promotion_sha" != "$GITHUB_SHA" ]]; then
+            echo "Auto-release checkout differs from the exact main push" >&2
             exit 1
           fi
           parser_pack_run_id="$(
@@ -83,5 +86,5 @@ jobs:
         run: |
           gh workflow run release.yml \
             --ref main \
-            --field version="v${{ steps.version.outputs.version }}" \
+            --field version="${{ steps.release.outputs.tag }}" \
             --field parser_pack_run_id="${{ steps.parser_pack.outputs.run_id }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          npm ci --ignore-scripts --prefix .github/mermaid-parser
+          npm audit --omit=dev --audit-level=moderate --prefix .github/mermaid-parser
           python3 .github/scripts/issue-checklists.py --self-test
           python3 .github/scripts/test-optional-parser-proof-inputs.py
           python3 .github/scripts/issue-checklists.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,10 @@ jobs:
         timeout-minutes: 10
         run: cargo test --locked -p projectatlas-cli plugin_installer_writes_real_harness_configs --test e2e
 
+      - name: Installer RC pin E2E
+        timeout-minutes: 5
+        run: cargo test --locked -p projectatlas-cli installer_workflow_pin_reports_preserve_exact_rc_identity --test e2e
+
       - name: Plugin update E2E
         timeout-minutes: 5
         run: cargo test --locked -p projectatlas-cli plugin_update_replaces_stale_runtime_configs_and_launches_new_mcp --test e2e

--- a/.github/workflows/issueops.yml
+++ b/.github/workflows/issueops.yml
@@ -1,0 +1,39 @@
+name: 00-IssueOps
+
+on:
+  issues:
+    types: [opened, edited, reopened, labeled, unlabeled, milestoned]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Open issue number to validate for release-milestone readiness"
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  planned-issue:
+    name: planned-issue-readiness
+    if: github.event_name == 'workflow_dispatch' || github.event.issue.milestone != null
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Validate IssueOps contract
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue }}
+        run: |
+          npm ci --ignore-scripts --prefix .github/mermaid-parser
+          npm audit --omit=dev --audit-level=moderate --prefix .github/mermaid-parser
+          python3 .github/scripts/issue-checklists.py --self-test
+          python3 .github/scripts/issue-checklists.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --root . \
+            --issue-map openspec/issue-map.json \
+            --planned-issue "$ISSUE_NUMBER"

--- a/.github/workflows/optional-parser-pack.yml
+++ b/.github/workflows/optional-parser-pack.yml
@@ -18,7 +18,7 @@ on:
           - x86_64-unknown-linux-gnu
           - x86_64-pc-windows-msvc
   pull_request:
-    branches: [dev]
+    branches: [main]
     types: [labeled]
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -844,6 +844,7 @@ jobs:
       - name: Revalidate exact main head before release mutation
         run: |
           set -euo pipefail
+          python3 .github/scripts/release-notes.py > release-notes.md
           git fetch --force origin main:refs/remotes/origin/main
           head_commit="$(git rev-parse HEAD^{commit})"
           main_commit="$(git rev-parse refs/remotes/origin/main^{commit})"
@@ -855,7 +856,6 @@ jobs:
       - name: Create GitHub release
         run: |
           set -euo pipefail
-          python3 .github/scripts/release-notes.py > release-notes.md
           if [[ "${PROJECTATLAS_RELEASE_EXISTS:-false}" == "true" ]]; then
             python3 .github/scripts/verify-main-atlas-seed-release-assets.py \
               --repair-upload-source release-assets \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -717,6 +717,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       EXPECTED_RELEASE_PRERELEASE: ${{ needs.verify.outputs.is_prerelease }}
+      EXPECTED_STABLE_TAG: ${{ needs.verify.outputs.stable_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -856,18 +857,35 @@ jobs:
       - name: Create GitHub release
         run: |
           set -euo pipefail
+          require_stable_tag_absent_for_rc() {
+            if [[ "$EXPECTED_RELEASE_PRERELEASE" != "true" ]]; then
+              return
+            fi
+            if git ls-remote --exit-code --tags origin "refs/tags/$EXPECTED_STABLE_TAG" > /dev/null; then
+              echo "Cannot publish an RC after stable tag $EXPECTED_STABLE_TAG exists" >&2
+              exit 1
+            else
+              status=$?
+              if [[ "$status" -ne 2 ]]; then
+                echo "Could not verify that stable tag $EXPECTED_STABLE_TAG is absent" >&2
+                exit "$status"
+              fi
+            fi
+          }
           if [[ "${PROJECTATLAS_RELEASE_EXISTS:-false}" == "true" ]]; then
             python3 .github/scripts/verify-main-atlas-seed-release-assets.py \
               --repair-upload-source release-assets \
               --immutable-list-file "$RUNNER_TEMP/projectatlas-hosted-main-atlas-seed-assets.txt" \
               --upload-list-file "$RUNNER_TEMP/projectatlas-release-repair-assets.txt"
             mapfile -t upload_assets < "$RUNNER_TEMP/projectatlas-release-repair-assets.txt"
+            require_stable_tag_absent_for_rc
             gh release upload "$RELEASE_VERSION" "${upload_assets[@]}" --clobber
           else
             classification=()
             if [[ "$EXPECTED_RELEASE_PRERELEASE" == "true" ]]; then
               classification+=(--prerelease --latest=false)
             fi
+            require_stable_tag_absent_for_rc
             gh release create "$RELEASE_VERSION" release-assets/* \
               --target "$GITHUB_SHA" \
               --title "$RELEASE_VERSION" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. v0.3.0)"
+        description: "Stable or release-candidate version (for example v1.2.3 or v1.2.3-rc1)"
         required: true
         type: string
       prepublish_only:
@@ -31,13 +31,97 @@ env:
   RELEASE_VERSION: ${{ inputs.version }}
   RUSTUP_TOOLCHAIN: "1.93.1"
 
+concurrency:
+  group: projectatlas-release-${{ inputs.version }}
+  cancel-in-progress: false
+
 jobs:
   verify:
     name: verify
     runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.release_version.outputs.package_version }}
+      release_tag: ${{ steps.release_version.outputs.tag }}
+      stable_tag: ${{ steps.release_version.outputs.stable_tag }}
+      milestone: ${{ steps.release_version.outputs.milestone }}
+      is_prerelease: ${{ steps.release_version.outputs.is_prerelease }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify release version
+        id: release_version
+        run: |
+          python3 .github/scripts/release_version.py --self-test
+          python3 .github/scripts/release_version.py \
+            "$RELEASE_VERSION" \
+            --source release \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Verify workspace version
+        env:
+          EXPECTED_PACKAGE_VERSION: ${{ steps.release_version.outputs.package_version }}
+        run: |
+          version="$(awk -F'"' '
+            /^\[workspace.package\]/ { in_workspace_package = 1; next }
+            /^\[/ { if (in_workspace_package) exit }
+            in_workspace_package && /^version = / { print $2; exit }
+          ' Cargo.toml)"
+          if [[ -z "$version" ]]; then
+            echo "Could not read workspace package version from Cargo.toml" >&2
+            exit 1
+          fi
+          if [[ "$version" != "$EXPECTED_PACKAGE_VERSION" ]]; then
+            echo "Cargo.toml version $version does not match requested $EXPECTED_PACKAGE_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Enforce RC-first promotion
+        if: ${{ !inputs.prepublish_only }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_IS_PRERELEASE: ${{ steps.release_version.outputs.is_prerelease }}
+          EXPECTED_STABLE_TAG: ${{ steps.release_version.outputs.stable_tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$EXPECTED_IS_PRERELEASE" == "true" ]]; then
+            if git rev-parse "$EXPECTED_STABLE_TAG^{commit}" >/dev/null 2>&1; then
+              echo "Cannot publish an RC after stable tag $EXPECTED_STABLE_TAG exists" >&2
+              exit 1
+            fi
+            exit 0
+          fi
+          releases="$RUNNER_TEMP/projectatlas-github-releases.json"
+          gh api --paginate "/repos/$GITHUB_REPOSITORY/releases?per_page=100" --slurp > "$releases"
+          prior_rc_tag="$(
+            python3 .github/scripts/release_version.py \
+              "$RELEASE_VERSION" \
+              --source release \
+              --require-prior-rc-from "$releases" |
+              sed -n 's/^prior_rc_tag=//p'
+          )"
+          if [[ -z "$prior_rc_tag" ]] || ! git rev-parse "$prior_rc_tag^{commit}" >/dev/null 2>&1; then
+            echo "Published RC tag was not found in the release checkout: $prior_rc_tag" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$prior_rc_tag^{commit}" HEAD; then
+            echo "Published RC $prior_rc_tag is not an ancestor of the stable release head" >&2
+            exit 1
+          fi
+
+      - name: Require exact main head for publication
+        if: ${{ !inputs.prepublish_only }}
+        run: |
+          set -euo pipefail
+          git fetch --force origin main:refs/remotes/origin/main
+          head_commit="$(git rev-parse HEAD^{commit})"
+          main_commit="$(git rev-parse refs/remotes/origin/main^{commit})"
+          if [[ "$head_commit" != "$GITHUB_SHA" || "$head_commit" != "$main_commit" ]]; then
+            echo "Release publication requires the exact origin/main head" >&2
+            exit 1
+          fi
 
       - name: Setup Rust
         run: |
@@ -81,13 +165,19 @@ jobs:
         run: python3 .github/scripts/release-notes.py --self-test
 
       - name: Issue checklist self-test
-        run: python3 .github/scripts/issue-checklists.py --self-test
+        run: |
+          npm ci --ignore-scripts --prefix .github/mermaid-parser
+          npm audit --omit=dev --audit-level=moderate --prefix .github/mermaid-parser
+          python3 .github/scripts/issue-checklists.py --self-test
 
       - name: Optional-parser proof-input unit test
         run: python3 .github/scripts/test-optional-parser-proof-inputs.py
 
       - name: Optional-parser release-asset self-test
         run: python3 .github/scripts/verify-optional-parser-release-assets.py --self-test
+
+      - name: Main Atlas seed release-asset self-test
+        run: python3 .github/scripts/verify-main-atlas-seed-release-assets.py --self-test
 
       - name: MCP composition integrity
         run: python3 docs/benchmarks/harness/mcp_composition.py --self-test
@@ -98,28 +188,6 @@ jobs:
       - name: Published benchmark measurement locks
         run: python3 .github/scripts/verify-published-benchmark-locks.py
 
-      - name: Verify version
-        run: |
-          requested="$RELEASE_VERSION"
-          if [[ ! "$requested" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Release version must match vMAJOR.MINOR.PATCH" >&2
-            exit 1
-          fi
-          requested="${requested#v}"
-          version="$(awk -F'"' '
-            /^\[workspace.package\]/ { in_workspace_package = 1; next }
-            /^\[/ { if (in_workspace_package) exit }
-            in_workspace_package && /^version = / { print $2; exit }
-          ' Cargo.toml)"
-          if [[ -z "$version" ]]; then
-            echo "Could not read workspace package version from Cargo.toml" >&2
-            exit 1
-          fi
-          if [[ "$version" != "$requested" ]]; then
-            echo "Cargo.toml version $version does not match requested $requested" >&2
-            exit 1
-          fi
-
       - name: Release issue checklist gate
         if: ${{ !inputs.prepublish_only }}
         env:
@@ -127,7 +195,7 @@ jobs:
         run: |
           python3 .github/scripts/issue-checklists.py \
             --repo "$GITHUB_REPOSITORY" \
-            --milestone "${RELEASE_VERSION}-00"
+            --milestone "${{ steps.release_version.outputs.milestone }}"
 
   package-unix:
     name: package ${{ matrix.label }}
@@ -244,10 +312,6 @@ jobs:
       - name: Package
         shell: pwsh
         run: |
-          if ($env:RELEASE_VERSION -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+$') {
-            Write-Error "Release version must match vMAJOR.MINOR.PATCH"
-            exit 1
-          }
           $archive = "projectatlas-$($env:RELEASE_VERSION)-x86_64-pc-windows-msvc.zip"
           New-Item -ItemType Directory -Force -Path "dist/projectatlas" | Out-Null
           Copy-Item "target/release/projectatlas.exe" "dist/projectatlas/"
@@ -651,7 +715,10 @@ jobs:
     name: publish
     if: ${{ !inputs.prepublish_only }}
     needs:
-      [prepublish-installer-smoke-unix, prepublish-installer-smoke-windows, parser-pack-assets]
+      - verify
+      - prepublish-installer-smoke-unix
+      - prepublish-installer-smoke-windows
+      - parser-pack-assets
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -659,6 +726,7 @@ jobs:
       pull-requests: read
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      EXPECTED_RELEASE_PRERELEASE: ${{ needs.verify.outputs.is_prerelease }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -674,15 +742,37 @@ jobs:
 
       - name: Prepare release assets
         run: |
-          if [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Release version must match vMAJOR.MINOR.PATCH" >&2
-            exit 1
-          fi
+          set -euo pipefail
           git fetch --tags
+          latest_before="$(gh api "/repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name 2>/dev/null || true)"
           release_exists=false
-          if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
+          release_json="$RUNNER_TEMP/projectatlas-release.json"
+          if gh release view "$RELEASE_VERSION" --json tagName,isDraft,isPrerelease,assets > "$release_json" 2>/dev/null; then
             release_exists=true
+            if ! jq -e \
+              --arg tag "$RELEASE_VERSION" \
+              --argjson prerelease "$EXPECTED_RELEASE_PRERELEASE" \
+              '.tagName == $tag and .isDraft == false and .isPrerelease == $prerelease' \
+              "$release_json" > /dev/null; then
+              echo "Existing release is draft, has the wrong tag, or has the wrong prerelease classification" >&2
+              exit 1
+            fi
             echo "Release $RELEASE_VERSION already exists; continuing asset repair publish."
+          fi
+          if [[ "$EXPECTED_RELEASE_PRERELEASE" == "true" || "$release_exists" == "true" ]]; then
+            if [[ -z "$latest_before" ]]; then
+              echo "Cannot publish an RC or repair a release without observing the current Latest stable release" >&2
+              exit 1
+            fi
+            latest_is_prerelease="$({
+              python3 .github/scripts/release_version.py \
+                "$latest_before" \
+                --source release
+            } | sed -n 's/^is_prerelease=//p')"
+            if [[ "$latest_is_prerelease" != "false" ]]; then
+              echo "GitHub Latest is not a canonical stable ProjectAtlas tag: $latest_before" >&2
+              exit 1
+            fi
           fi
           if git rev-parse "$RELEASE_VERSION^{commit}" >/dev/null 2>&1; then
             tag_commit="$(git rev-parse "$RELEASE_VERSION^{commit}")"
@@ -701,6 +791,41 @@ jobs:
             exit 1
           fi
           echo "PROJECTATLAS_RELEASE_EXISTS=$release_exists" >> "$GITHUB_ENV"
+          echo "PROJECTATLAS_LATEST_BEFORE=$latest_before" >> "$GITHUB_ENV"
+          python3 .github/scripts/verify-main-atlas-seed-release-assets.py \
+            --source release-assets \
+            --release-tag "$RELEASE_VERSION" \
+            --list-file "$RUNNER_TEMP/projectatlas-main-atlas-seed-assets.txt"
+          : > "$RUNNER_TEMP/projectatlas-hosted-main-atlas-seed-assets.txt"
+          if [[ "$release_exists" == "true" ]]; then
+            hosted_seed_dir="$RUNNER_TEMP/projectatlas-hosted-main-seed"
+            mkdir -p "$hosted_seed_dir"
+            hosted_seed_count="$(
+              jq '[.assets[].name | select(startswith("projectatlas-main-atlas-seed-"))] | length' \
+                "$release_json"
+            )"
+            if [[ "$hosted_seed_count" -gt 0 ]]; then
+              gh release download "$RELEASE_VERSION" \
+                --pattern 'projectatlas-main-atlas-seed-*' \
+                --dir "$hosted_seed_dir"
+              python3 .github/scripts/verify-main-atlas-seed-release-assets.py \
+                --source "$hosted_seed_dir" \
+                --staged-source release-assets \
+                --release-tag "$RELEASE_VERSION" \
+                --list-file "$RUNNER_TEMP/projectatlas-hosted-main-atlas-seed-assets.txt"
+              if [[ "$(wc -l < "$RUNNER_TEMP/projectatlas-hosted-main-atlas-seed-assets.txt")" -ne "$hosted_seed_count" ]]; then
+                echo "Existing release contains duplicate or non-regular main Atlas seed assets" >&2
+                exit 1
+              fi
+              if [[ ! -s "$RUNNER_TEMP/projectatlas-main-atlas-seed-assets.txt" ]]; then
+                while IFS= read -r seed_asset; do
+                  cp "$hosted_seed_dir/$seed_asset" "release-assets/$seed_asset"
+                done < "$RUNNER_TEMP/projectatlas-hosted-main-atlas-seed-assets.txt"
+                cp "$RUNNER_TEMP/projectatlas-hosted-main-atlas-seed-assets.txt" \
+                  "$RUNNER_TEMP/projectatlas-main-atlas-seed-assets.txt"
+              fi
+            fi
+          fi
           (
             cd release-assets
             mapfile -d '' assets < <(find . -maxdepth 1 -type f -name "projectatlas-${RELEASE_VERSION}-*" -printf '%f\0' | sort -z)
@@ -708,22 +833,101 @@ jobs:
               echo "No release archives matched projectatlas-${RELEASE_VERSION}-*" >&2
               exit 1
             fi
+            mapfile -t seed_assets < "$RUNNER_TEMP/projectatlas-main-atlas-seed-assets.txt"
+            assets+=("${seed_assets[@]}")
+            declare -A expected_assets=()
+            for asset in "${assets[@]}"; do
+              expected_assets["$asset"]=1
+            done
+            mapfile -d '' inventory < <(find . -mindepth 1 -maxdepth 1 -printf '%f\0' | sort -z)
+            if [[ ${#inventory[@]} -ne ${#expected_assets[@]} ]]; then
+              echo "Release artifact inventory contains an unexpected, duplicate, or non-regular entry" >&2
+              exit 1
+            fi
+            for entry in "${inventory[@]}"; do
+              if [[ -z "${expected_assets[$entry]+present}" ]]; then
+                echo "Unexpected release artifact: $entry" >&2
+                exit 1
+              fi
+            done
             : > SHA256SUMS
             for asset in "${assets[@]}"; do
               sha256sum "$asset" >> SHA256SUMS
             done
           )
 
+      - name: Revalidate exact main head before release mutation
+        run: |
+          set -euo pipefail
+          git fetch --force origin main:refs/remotes/origin/main
+          head_commit="$(git rev-parse HEAD^{commit})"
+          main_commit="$(git rev-parse refs/remotes/origin/main^{commit})"
+          if [[ "$head_commit" != "$GITHUB_SHA" || "$head_commit" != "$main_commit" ]]; then
+            echo "Release mutation requires the exact current origin/main head" >&2
+            exit 1
+          fi
+
       - name: Create GitHub release
         run: |
+          set -euo pipefail
           python3 .github/scripts/release-notes.py > release-notes.md
           if [[ "${PROJECTATLAS_RELEASE_EXISTS:-false}" == "true" ]]; then
-            gh release upload "$RELEASE_VERSION" release-assets/* --clobber
+            declare -A immutable_hosted_seed=()
+            while IFS= read -r seed_asset; do
+              immutable_hosted_seed["$seed_asset"]=1
+            done < "$RUNNER_TEMP/projectatlas-hosted-main-atlas-seed-assets.txt"
+            upload_assets=()
+            while IFS= read -r -d '' asset; do
+              name="$(basename "$asset")"
+              if [[ -z "${immutable_hosted_seed[$name]+present}" ]]; then
+                upload_assets+=("$asset")
+              fi
+            done < <(find release-assets -maxdepth 1 -type f -print0)
+            gh release upload "$RELEASE_VERSION" "${upload_assets[@]}" --clobber
           else
+            classification=()
+            if [[ "$EXPECTED_RELEASE_PRERELEASE" == "true" ]]; then
+              classification+=(--prerelease --latest=false)
+            fi
             gh release create "$RELEASE_VERSION" release-assets/* \
               --target "$GITHUB_SHA" \
               --title "$RELEASE_VERSION" \
-              --notes-file release-notes.md
+              --notes-file release-notes.md \
+              "${classification[@]}"
+          fi
+
+      - name: Verify hosted release state
+        run: |
+          set -euo pipefail
+          release_json="$RUNNER_TEMP/projectatlas-published-release.json"
+          gh release view "$RELEASE_VERSION" --json tagName,isDraft,isPrerelease > "$release_json"
+          jq -e \
+            --arg tag "$RELEASE_VERSION" \
+            --argjson prerelease "$EXPECTED_RELEASE_PRERELEASE" \
+            '.tagName == $tag and .isDraft == false and .isPrerelease == $prerelease' \
+            "$release_json" > /dev/null
+          git fetch --tags --force
+          tag_commit="$(git rev-parse "$RELEASE_VERSION^{commit}")"
+          head_commit="$(git rev-parse "$GITHUB_SHA^{commit}")"
+          if [[ "$tag_commit" != "$head_commit" ]]; then
+            echo "Published tag points to $tag_commit, not workflow head $head_commit" >&2
+            exit 1
+          fi
+          expected_latest="$RELEASE_VERSION"
+          if [[ "$EXPECTED_RELEASE_PRERELEASE" == "true" || "${PROJECTATLAS_RELEASE_EXISTS:-false}" == "true" ]]; then
+            expected_latest="${PROJECTATLAS_LATEST_BEFORE:-}"
+          fi
+          latest_after=""
+          for attempt in 1 2 3 4 5 6; do
+            latest_after="$(gh api "/repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name 2>/dev/null || true)"
+            if [[ "$latest_after" == "$expected_latest" ]]; then
+              break
+            fi
+            sleep 5
+          done
+          if [[ "$latest_after" != "$expected_latest" ]]; then
+            echo "GitHub Latest is '$latest_after', expected '$expected_latest'" >&2
+            exit 1
           fi
 
   installer-smoke-unix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -759,21 +759,16 @@ jobs:
             fi
             echo "Release $RELEASE_VERSION already exists; continuing asset repair publish."
           fi
-          if [[ "$EXPECTED_RELEASE_PRERELEASE" == "true" || "$release_exists" == "true" ]]; then
-            if [[ -z "$latest_before" ]]; then
-              echo "Cannot publish an RC or repair a release without observing the current Latest stable release" >&2
-              exit 1
-            fi
-            latest_is_prerelease="$({
-              python3 .github/scripts/release_version.py \
-                "$latest_before" \
-                --source release
-            } | sed -n 's/^is_prerelease=//p')"
-            if [[ "$latest_is_prerelease" != "false" ]]; then
-              echo "GitHub Latest is not a canonical stable ProjectAtlas tag: $latest_before" >&2
-              exit 1
-            fi
+          latest_policy=(--resolve-expected-latest --latest-before "$latest_before")
+          if [[ "$release_exists" == "true" ]]; then
+            latest_policy+=(--release-exists)
           fi
+          expected_latest="$({
+            python3 .github/scripts/release_version.py \
+              "$RELEASE_VERSION" \
+              --source release \
+              "${latest_policy[@]}"
+          } | sed -n 's/^expected_latest=//p')"
           if git rev-parse "$RELEASE_VERSION^{commit}" >/dev/null 2>&1; then
             tag_commit="$(git rev-parse "$RELEASE_VERSION^{commit}")"
             head_commit="$(git rev-parse HEAD)"
@@ -791,7 +786,7 @@ jobs:
             exit 1
           fi
           echo "PROJECTATLAS_RELEASE_EXISTS=$release_exists" >> "$GITHUB_ENV"
-          echo "PROJECTATLAS_LATEST_BEFORE=$latest_before" >> "$GITHUB_ENV"
+          echo "PROJECTATLAS_EXPECTED_LATEST=$expected_latest" >> "$GITHUB_ENV"
           python3 .github/scripts/verify-main-atlas-seed-release-assets.py \
             --source release-assets \
             --release-tag "$RELEASE_VERSION" \
@@ -872,17 +867,11 @@ jobs:
           set -euo pipefail
           python3 .github/scripts/release-notes.py > release-notes.md
           if [[ "${PROJECTATLAS_RELEASE_EXISTS:-false}" == "true" ]]; then
-            declare -A immutable_hosted_seed=()
-            while IFS= read -r seed_asset; do
-              immutable_hosted_seed["$seed_asset"]=1
-            done < "$RUNNER_TEMP/projectatlas-hosted-main-atlas-seed-assets.txt"
-            upload_assets=()
-            while IFS= read -r -d '' asset; do
-              name="$(basename "$asset")"
-              if [[ -z "${immutable_hosted_seed[$name]+present}" ]]; then
-                upload_assets+=("$asset")
-              fi
-            done < <(find release-assets -maxdepth 1 -type f -print0)
+            python3 .github/scripts/verify-main-atlas-seed-release-assets.py \
+              --repair-upload-source release-assets \
+              --immutable-list-file "$RUNNER_TEMP/projectatlas-hosted-main-atlas-seed-assets.txt" \
+              --upload-list-file "$RUNNER_TEMP/projectatlas-release-repair-assets.txt"
+            mapfile -t upload_assets < "$RUNNER_TEMP/projectatlas-release-repair-assets.txt"
             gh release upload "$RELEASE_VERSION" "${upload_assets[@]}" --clobber
           else
             classification=()
@@ -913,10 +902,7 @@ jobs:
             echo "Published tag points to $tag_commit, not workflow head $head_commit" >&2
             exit 1
           fi
-          expected_latest="$RELEASE_VERSION"
-          if [[ "$EXPECTED_RELEASE_PRERELEASE" == "true" || "${PROJECTATLAS_RELEASE_EXISTS:-false}" == "true" ]]; then
-            expected_latest="${PROJECTATLAS_LATEST_BEFORE:-}"
-          fi
+          expected_latest="${PROJECTATLAS_EXPECTED_LATEST:?}"
           latest_after=""
           for attempt in 1 2 3 4 5 6; do
             latest_after="$(gh api "/repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name 2>/dev/null || true)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,21 +95,11 @@ jobs:
           fi
           releases="$RUNNER_TEMP/projectatlas-github-releases.json"
           gh api --paginate "/repos/$GITHUB_REPOSITORY/releases?per_page=100" --slurp > "$releases"
-          prior_rc_tag="$(
-            python3 .github/scripts/release_version.py \
-              "$RELEASE_VERSION" \
-              --source release \
-              --require-prior-rc-from "$releases" |
-              sed -n 's/^prior_rc_tag=//p'
-          )"
-          if [[ -z "$prior_rc_tag" ]] || ! git rev-parse "$prior_rc_tag^{commit}" >/dev/null 2>&1; then
-            echo "Published RC tag was not found in the release checkout: $prior_rc_tag" >&2
-            exit 1
-          fi
-          if ! git merge-base --is-ancestor "$prior_rc_tag^{commit}" HEAD; then
-            echo "Published RC $prior_rc_tag is not an ancestor of the stable release head" >&2
-            exit 1
-          fi
+          python3 .github/scripts/release_version.py \
+            "$RELEASE_VERSION" \
+            --source release \
+            --require-prior-rc-from "$releases" \
+            --require-prior-rc-ancestor-of "$GITHUB_SHA"
 
       - name: Require exact main head for publication
         if: ${{ !inputs.prepublish_only }}
@@ -987,6 +977,80 @@ jobs:
           require(Path(command[0]).resolve() == runtime, "opencode command path mismatch")
           require_args(command[1:])
           require(Path(opencode["cwd"]).resolve() == root, "opencode cwd mismatch")
+          PY
+
+      - name: Holistic release-candidate E2E
+        if: matrix.label == 'linux-x64-posix' && contains(env.RELEASE_VERSION, '-rc')
+        timeout-minutes: 5
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          release_json="$RUNNER_TEMP/projectatlas-release-e2e.json"
+          gh release view "$RELEASE_VERSION" --json tagName,isDraft,isPrerelease > "$release_json"
+          jq -e --arg tag "$RELEASE_VERSION" \
+            '.tagName == $tag and .isDraft == false and .isPrerelease == true' \
+            "$release_json" > /dev/null
+          latest_tag="$(gh api "/repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)"
+          if [[ "$latest_tag" == "$RELEASE_VERSION" ]]; then
+            echo "Release candidate $RELEASE_VERSION unexpectedly became GitHub Latest" >&2
+            exit 1
+          fi
+          python3 .github/scripts/release_version.py "$latest_tag" --source release |
+            grep -Fx 'is_prerelease=false' > /dev/null
+
+          project_root="$RUNNER_TEMP/projectatlas-release-e2e"
+          runtime="$HOME/.local/bin/projectatlas"
+          mkdir -p "$project_root/src"
+          printf '%s\n' 'pub fn release_e2e_marker() {}' > "$project_root/src/lib.rs"
+          (
+            cd "$project_root"
+            PROJECTATLAS_NO_TELEMETRY=1 "$runtime" --require-version "$RELEASE_VERSION" init
+            PROJECTATLAS_NO_TELEMETRY=1 "$runtime" --require-version "$RELEASE_VERSION" watch --once
+          )
+          PROJECT_ROOT="$project_root" python3 <<'PY'
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+
+          root = Path(os.environ["PROJECT_ROOT"]).resolve()
+          config = json.loads((root / ".projectatlas" / "projectatlas.mcp.json").read_text(encoding="utf-8"))
+          server = config["mcpServers"]["projectatlas"]
+          messages = [
+              {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "projectatlas-release-e2e", "version": "0.1.0"}}},
+              {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+              {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "atlas_session_brief", "arguments": {"project_path": str(root), "query": "release_e2e_marker", "compact": True}},
+              {"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "atlas_slice", "arguments": {"project_path": str(root), "file": "src/lib.rs", "start_line": 1, "end_line": 1}}},
+          ]
+          completed = subprocess.run(
+              [server["command"], *server["args"]],
+              cwd=server.get("cwd", root),
+              env={**os.environ, "PROJECTATLAS_NO_TELEMETRY": "1"},
+              input="\n".join(json.dumps(message) for message in messages) + "\n",
+              text=True,
+              capture_output=True,
+              timeout=30,
+              check=False,
+          )
+          if completed.returncode != 0:
+              raise SystemExit(f"release MCP exited {completed.returncode}: {completed.stderr}")
+          responses = {
+              response["id"]: response
+              for line in completed.stdout.splitlines()
+              if (response := json.loads(line)).get("id") is not None
+          }
+
+          def tool_text(request_id):
+              result = responses.get(request_id, {}).get("result", {})
+              if result.get("isError"):
+                  raise SystemExit(f"MCP request {request_id} failed: {result}")
+              return "\n".join(block.get("text", "") for block in result.get("content", []))
+
+          brief = tool_text(2)
+          source = tool_text(3)
+          if "index_status: available" not in brief or "release_e2e_marker" not in source:
+              raise SystemExit(f"release MCP contract incomplete:\n{brief}\n{source}")
           PY
 
   installer-smoke-windows:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ If you spot a bug or have a suggestion, please open an issue with clear reproduc
 
 ## Internal workflow
 
-- Feature work lands on `dev`.
-- Releases are merged from `dev` into `main` via PR.
-- Ensure `dev` includes the latest `main` changes before releasing.
+- Feature work uses short-lived branches targeting `main`.
+- Keep change branches current with `main` before merge.
+- Release candidates and stable releases publish only from the exact verified `main` head.
 - Update the Cargo workspace version in `Cargo.toml` when preparing a release.
 - Release tags must match the Cargo version, for example `v0.3.1`.
 - Use the `02-Release` workflow for release publication; it validates the Rust workspace, builds Linux/macOS/Windows archives, creates the tag, and uploads the artifacts to the GitHub Release.

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -5196,6 +5196,7 @@ fn plugin_installers_require_matching_runtime_version() -> Result<(), Box<dyn Er
         .into());
     }
     for required in [
+        "installer_workflow_pin_reports_preserve_exact_rc_identity",
         "plugin_update_skips_non_official_codex_marketplace",
         "plugin_update_leaves_current_codex_marketplace_untouched",
         "plugin_update_repairs_current_codex_plugin_with_stale_source_manifest",
@@ -6995,7 +6996,8 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
         "continuing asset repair publish",
         "--prerelease --latest=false",
         "EXPECTED_RELEASE_PRERELEASE",
-        "PROJECTATLAS_LATEST_BEFORE",
+        "PROJECTATLAS_EXPECTED_LATEST",
+        "--resolve-expected-latest",
         "Verify hosted release state",
         "verify-main-atlas-seed-release-assets.py",
         "Enforce RC-first promotion",
@@ -7014,10 +7016,8 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
         "projectatlas-main-atlas-seed-*",
         "--staged-source release-assets",
         "Existing release contains duplicate or non-regular main Atlas seed assets",
-        "immutable_hosted_seed",
-        "if [[ \"$EXPECTED_RELEASE_PRERELEASE\" == \"true\" || \"${PROJECTATLAS_RELEASE_EXISTS:-false}\" == \"true\" ]]; then",
-        "if [[ \"$EXPECTED_RELEASE_PRERELEASE\" == \"true\" || \"$release_exists\" == \"true\" ]]; then",
-        "Cannot publish an RC or repair a release without observing the current Latest stable release",
+        "--repair-upload-source release-assets",
+        "projectatlas-release-repair-assets.txt",
     ] {
         if !release_workflow.contains(required) {
             return Err(io::Error::other(format!(
@@ -7036,6 +7036,7 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
         "is_prerelease",
         "rc_number",
         "latest_published_rc",
+        "expected_latest_tag",
     ] {
         if !release_version_policy.contains(required) {
             return Err(io::Error::other(format!(
@@ -7050,6 +7051,7 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
         "\".manifest.json\"",
         "exact release tag",
         "validate_hosted_seed_assets",
+        "repair_upload_assets",
     ] {
         if !seed_asset_policy.contains(required) {
             return Err(io::Error::other(format!(
@@ -11710,6 +11712,112 @@ fn write_fake_codex_projectatlas_integration(
         )?;
     }
     Ok((marketplace_root, plugin_source, installed_cache))
+}
+
+#[test]
+fn installer_workflow_pin_reports_preserve_exact_rc_identity() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join(TEST_REPO_DIR);
+    let workflow_dir = repo.join(".github").join("workflows");
+    fs::create_dir_all(&workflow_dir)?;
+    fs::write(
+        workflow_dir.join("pins.yml"),
+        "https://github.com/styler-ai/ProjectAtlas/releases/download/v1.2.3-rc12/current\n\
+https://github.com/styler-ai/ProjectAtlas/releases/download/v1.2.2/stale-stable\n\
+https://github.com/styler-ai/ProjectAtlas/releases/download/v1.2.3-rc2/stale-rc\n\
+https://github.com/example/ProjectAtlas/releases/download/v9.9.9/unrelated\n",
+    )?;
+    let workspace = workspace_root()?;
+    let output = if cfg!(windows) {
+        let installer = fs::read_to_string(
+            workspace
+                .join("plugins")
+                .join("projectatlas")
+                .join("scripts")
+                .join("install-runtime.ps1"),
+        )?;
+        let convert_start = installer
+            .find("function Convert-ProjectAtlasVersionTag {")
+            .ok_or_else(|| io::Error::other("PowerShell version conversion function missing"))?;
+        let convert_end = installer[convert_start..]
+            .find("function Initialize-ProjectAtlasRuntimeProbe")
+            .map(|offset| convert_start + offset)
+            .ok_or_else(|| io::Error::other("PowerShell version conversion boundary missing"))?;
+        let report_start = installer
+            .find("function Write-ProjectAtlasWorkflowPinReport {")
+            .ok_or_else(|| io::Error::other("PowerShell workflow-pin report function missing"))?;
+        let report_end = installer[report_start..]
+            .find("function Get-ReleaseRuntimeInstallPath")
+            .map(|offset| report_start + offset)
+            .ok_or_else(|| io::Error::other("PowerShell workflow-pin report boundary missing"))?;
+        let script = temp.path().join("workflow-pin-report.ps1");
+        fs::write(
+            &script,
+            format!(
+                "$ErrorActionPreference = 'Stop'\n{}\n{}\nWrite-ProjectAtlasWorkflowPinReport $env:PROJECTATLAS_FIXTURE_ROOT 'v1.2.3-rc12'\n",
+                &installer[convert_start..convert_end],
+                &installer[report_start..report_end]
+            ),
+        )?;
+        StdCommand::new("powershell")
+            .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+            .arg(script)
+            .env("PROJECTATLAS_FIXTURE_ROOT", &repo)
+            .output()?
+    } else {
+        let installer = fs::read_to_string(
+            workspace
+                .join("plugins")
+                .join("projectatlas")
+                .join("scripts")
+                .join("install-runtime.sh"),
+        )?;
+        let version_start = installer
+            .find("expected_runtime_version() {")
+            .ok_or_else(|| io::Error::other("POSIX version conversion function missing"))?;
+        let version_end = installer[version_start..]
+            .find("is_projectatlas_runtime() {")
+            .map(|offset| version_start + offset)
+            .ok_or_else(|| io::Error::other("POSIX version conversion boundary missing"))?;
+        let report_start = installer
+            .find("report_projectatlas_workflow_pins() {")
+            .ok_or_else(|| io::Error::other("POSIX workflow-pin report function missing"))?;
+        let report_end = installer[report_start..]
+            .find("download_release_file() {")
+            .map(|offset| report_start + offset)
+            .ok_or_else(|| io::Error::other("POSIX workflow-pin report boundary missing"))?;
+        let script = temp.path().join("workflow-pin-report.sh");
+        fs::write(
+            &script,
+            format!(
+                "set -eu\nprojectatlas_version=v1.2.3-rc12\nprojectatlas_bin=\n{}\n{}\nproject_root=$PROJECTATLAS_FIXTURE_ROOT\nreport_projectatlas_workflow_pins\n",
+                &installer[version_start..version_end],
+                &installer[report_start..report_end]
+            ),
+        )?;
+        StdCommand::new("sh")
+            .arg(script)
+            .env("PROJECTATLAS_FIXTURE_ROOT", &repo)
+            .output()?
+    };
+    let report = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if !output.status.success()
+        || !report.contains("uses v1.2.2; expected v1.2.3-rc12")
+        || !report.contains("uses v1.2.3-rc2; expected v1.2.3-rc12")
+        || report.contains("uses v1.2.3-rc12;")
+        || report.contains("uses v1.2.3;")
+        || report.contains("v9.9.9")
+    {
+        return Err(io::Error::other(format!(
+            "installer workflow-pin report did not preserve exact RC identity:\n{report}"
+        ))
+        .into());
+    }
+    Ok(())
 }
 
 #[test]

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -11864,16 +11864,17 @@ https://github.com/example/ProjectAtlas/releases/download/v9.9.9/unrelated\n",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    let normalized_report = report.split_whitespace().collect::<Vec<_>>().join(" ");
     if !output.status.success()
-        || !report.contains("uses v1.2.2; expected v1.2.3-rc12")
-        || !report.contains("uses v1.2.3-rc2; expected v1.2.3-rc12")
-        || !report.contains("uses v1.2.3-rc12evil; expected v1.2.3-rc12")
-        || !report.contains("uses v1.2.3evil; expected v1.2.3-rc12")
-        || report.contains("uses v1.2.3-rc12;")
-        || report.contains("uses v1.2.3;")
-        || report.contains("PROJECTATLAS_VERSION")
-        || report.contains("inputs.version")
-        || report.contains("v9.9.9")
+        || !normalized_report.contains("uses v1.2.2; expected v1.2.3-rc12")
+        || !normalized_report.contains("uses v1.2.3-rc2; expected v1.2.3-rc12")
+        || !normalized_report.contains("uses v1.2.3-rc12evil; expected v1.2.3-rc12")
+        || !normalized_report.contains("uses v1.2.3evil; expected v1.2.3-rc12")
+        || normalized_report.contains("uses v1.2.3-rc12;")
+        || normalized_report.contains("uses v1.2.3;")
+        || normalized_report.contains("PROJECTATLAS_VERSION")
+        || normalized_report.contains("inputs.version")
+        || normalized_report.contains("v9.9.9")
     {
         return Err(io::Error::other(format!(
             "installer workflow-pin report did not preserve exact RC identity:\n{report}"

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -99,6 +99,7 @@ const ISSUE_TEMPLATE_DIR_NAME: &str = "ISSUE_TEMPLATE";
 const VERSIONS_DIR_NAME: &str = "versions";
 const PRE_PUSH_HOOK_FILE_NAME: &str = "pre-push";
 const TS_CONFIG_FILE_NAME: &str = "tsconfig.json";
+const PACKAGE_JSON_FILE_NAME: &str = "package.json";
 const GIT_REPOSITORY_ENVIRONMENT_VARIABLES: &[&str] = &[
     "GIT_ALTERNATE_OBJECT_DIRECTORIES",
     "GIT_CONFIG",
@@ -7178,7 +7179,7 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
     let workflows = github.join("workflows");
     let issueops = fs::read_to_string(github.join("scripts").join("issue-checklists.py"))?;
     let mermaid_parser = github.join("mermaid-parser");
-    let mermaid_package = fs::read_to_string(mermaid_parser.join("package.json"))?;
+    let mermaid_package = fs::read_to_string(mermaid_parser.join(PACKAGE_JSON_FILE_NAME))?;
     let mermaid_lock = fs::read_to_string(mermaid_parser.join("package-lock.json"))?;
     let ci = fs::read_to_string(workflows.join("ci.yml"))?;
     let release = fs::read_to_string(workflows.join("release.yml"))?;
@@ -21932,7 +21933,7 @@ fn structural_summaries_cover_declarative_files_and_projectatlas_inputs()
         "# ProjectAtlas Demo\n\n## Install\n## Usage\n",
     )?;
     fs::write(
-        repo.join("package.json"),
+        repo.join(PACKAGE_JSON_FILE_NAME),
         r#"{"name":"demo","scripts":{"test":"vitest"},"dependencies":{"react":"1.0.0"}}"#,
     )?;
     fs::write(
@@ -22022,7 +22023,7 @@ fn structural_summaries_cover_declarative_files_and_projectatlas_inputs()
     require_json_string(&readme_summary, &["summary_status"], "ok")?;
     require_json_string(&readme_summary, &["file_purpose_status"], "suggested")?;
 
-    let package_summary = json_summary_command(&repo, &db, "package.json")?;
+    let package_summary = json_summary_command(&repo, &db, PACKAGE_JSON_FILE_NAME)?;
     require_json_string(
         &package_summary,
         &["content_summary"],

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -11750,6 +11750,9 @@ https://github.com/styler-ai/ProjectAtlas/releases/download/v1.2.2/stale-stable\
 https://github.com/styler-ai/ProjectAtlas/releases/download/v1.2.3-rc2/stale-rc\n\
 https://github.com/styler-ai/ProjectAtlas/releases/download/v1.2.3-rc12evil/malformed-rc\n\
 https://github.com/styler-ai/ProjectAtlas/releases/download/v1.2.3evil/malformed-stable\n\
+https://github.com/styler-ai/ProjectAtlas/releases/download/v$PROJECTATLAS_VERSION/dynamic-variable\n\
+https://github.com/styler-ai/ProjectAtlas/releases/download/v${PROJECTATLAS_VERSION}/dynamic-braced\n\
+https://github.com/styler-ai/ProjectAtlas/releases/download/${{ inputs.version }}/dynamic-expression\n\
 https://github.com/example/ProjectAtlas/releases/download/v9.9.9/unrelated\n",
     )?;
     let workspace = workspace_root()?;
@@ -11837,6 +11840,8 @@ https://github.com/example/ProjectAtlas/releases/download/v9.9.9/unrelated\n",
         || !report.contains("uses v1.2.3evil; expected v1.2.3-rc12")
         || report.contains("uses v1.2.3-rc12;")
         || report.contains("uses v1.2.3;")
+        || report.contains("PROJECTATLAS_VERSION")
+        || report.contains("inputs.version")
         || report.contains("v9.9.9")
     {
         return Err(io::Error::other(format!(

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -7116,6 +7116,23 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
             .into());
         }
     }
+    let notes = publish
+        .find("python3 .github/scripts/release-notes.py > release-notes.md")
+        .ok_or_else(|| io::Error::other("release notes generation is missing"))?;
+    let revalidation = publish
+        .find("git fetch --force origin main:refs/remotes/origin/main")
+        .ok_or_else(|| io::Error::other("exact-main revalidation is missing"))?;
+    for mutation in ["gh release upload", "gh release create"] {
+        let mutation = publish
+            .find(mutation)
+            .ok_or_else(|| io::Error::other(format!("release mutation {mutation:?} is missing")))?;
+        if notes >= revalidation || revalidation >= mutation {
+            return Err(io::Error::other(
+                "release notes must precede exact-main revalidation and every release mutation",
+            )
+            .into());
+        }
+    }
     for required in [
         "parser_pack_run_id:",
         "parser-pack-assets:",

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -5189,6 +5189,22 @@ fn plugin_installers_require_matching_runtime_version() -> Result<(), Box<dyn Er
             .into());
         }
     }
+    let unix_installer_smoke = workflow_job_block(&release_workflow, "installer-smoke-unix")?;
+    for required in [
+        "Holistic release-candidate E2E",
+        "contains(env.RELEASE_VERSION, '-rc')",
+        "atlas_session_brief",
+        "atlas_slice",
+        "index_status: available",
+        "release_e2e_marker",
+    ] {
+        if !unix_installer_smoke.contains(required) {
+            return Err(io::Error::other(format!(
+                "hosted release-candidate E2E is missing contract {required:?}"
+            ))
+            .into());
+        }
+    }
     let e2e_smoke = workflow_job_block(&ci_workflow, "e2e-smoke")?;
     if !e2e_smoke.contains("plugin_update_replaces_stale_runtime_configs_and_launches_new_mcp") {
         return Err(io::Error::other(
@@ -6985,6 +7001,12 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
         )
         .into());
     }
+    if release_workflow.contains("git merge-base --is-ancestor") {
+        return Err(io::Error::other(
+            "release workflow must route RC ancestry through release_version.py",
+        )
+        .into());
+    }
     for required in [
         "gh release create \"$RELEASE_VERSION\"",
         "gh release upload \"$RELEASE_VERSION\" \"${upload_assets[@]}\" --clobber",
@@ -7003,7 +7025,7 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
         "verify-main-atlas-seed-release-assets.py",
         "Enforce RC-first promotion",
         "--require-prior-rc-from",
-        "git merge-base --is-ancestor",
+        "--require-prior-rc-ancestor-of",
         "Cannot publish an RC after stable tag",
         "projectatlas-release-${{ inputs.version }}",
         "cancel-in-progress: false",
@@ -11726,6 +11748,8 @@ fn installer_workflow_pin_reports_preserve_exact_rc_identity() -> Result<(), Box
         "https://github.com/styler-ai/ProjectAtlas/releases/download/v1.2.3-rc12/current\n\
 https://github.com/styler-ai/ProjectAtlas/releases/download/v1.2.2/stale-stable\n\
 https://github.com/styler-ai/ProjectAtlas/releases/download/v1.2.3-rc2/stale-rc\n\
+https://github.com/styler-ai/ProjectAtlas/releases/download/v1.2.3-rc12evil/malformed-rc\n\
+https://github.com/styler-ai/ProjectAtlas/releases/download/v1.2.3evil/malformed-stable\n\
 https://github.com/example/ProjectAtlas/releases/download/v9.9.9/unrelated\n",
     )?;
     let workspace = workspace_root()?;
@@ -11809,6 +11833,8 @@ https://github.com/example/ProjectAtlas/releases/download/v9.9.9/unrelated\n",
     if !output.status.success()
         || !report.contains("uses v1.2.2; expected v1.2.3-rc12")
         || !report.contains("uses v1.2.3-rc2; expected v1.2.3-rc12")
+        || !report.contains("uses v1.2.3-rc12evil; expected v1.2.3-rc12")
+        || !report.contains("uses v1.2.3evil; expected v1.2.3-rc12")
         || report.contains("uses v1.2.3-rc12;")
         || report.contains("uses v1.2.3;")
         || report.contains("v9.9.9")

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -7019,6 +7019,7 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
         "continuing asset repair publish",
         "--prerelease --latest=false",
         "EXPECTED_RELEASE_PRERELEASE",
+        "EXPECTED_STABLE_TAG: ${{ needs.verify.outputs.stable_tag }}",
         "PROJECTATLAS_EXPECTED_LATEST",
         "--resolve-expected-latest",
         "Verify hosted release state",
@@ -7108,6 +7109,8 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
         "Revalidate exact main head before release mutation",
         "Release mutation requires the exact current origin/main head",
         "git fetch --force origin main:refs/remotes/origin/main",
+        "git ls-remote --exit-code --tags origin \"refs/tags/$EXPECTED_STABLE_TAG\"",
+        "Could not verify that stable tag $EXPECTED_STABLE_TAG is absent",
     ] {
         if !publish.contains(required) {
             return Err(io::Error::other(format!(
@@ -7129,6 +7132,17 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
         if notes >= revalidation || revalidation >= mutation {
             return Err(io::Error::other(
                 "release notes must precede exact-main revalidation and every release mutation",
+            )
+            .into());
+        }
+    }
+    for guarded_mutation in [
+        "require_stable_tag_absent_for_rc\n            gh release upload",
+        "require_stable_tag_absent_for_rc\n            gh release create",
+    ] {
+        if !publish.contains(guarded_mutation) {
+            return Err(io::Error::other(
+                "each release mutation must immediately recheck the remote stable tag",
             )
             .into());
         }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -6382,8 +6382,10 @@ fn repository_guidance_keeps_atlas_state_local_and_legacy_export_optional()
             .into());
         }
     }
-    if !auto_release_workflow.contains("promotion_sha=\"$(git rev-parse HEAD^2)\"")
+    if !auto_release_workflow.contains("promotion_sha=\"$(git rev-parse 'HEAD^{commit}')\"")
+        || !auto_release_workflow.contains("[[ \"$promotion_sha\" != \"$GITHUB_SHA\" ]]")
         || !auto_release_workflow.contains("--ref main")
+        || auto_release_workflow.contains("HEAD^2")
     {
         return Err(io::Error::other("auto-release must preserve promotion identity").into());
     }
@@ -6620,6 +6622,18 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
     let release_workflow = fs::read_to_string(workflow_dir.join("release.yml"))?;
     let auto_release_workflow =
         fs::read_to_string(workflow_dir.join(AUTO_RELEASE_WORKFLOW_FILE_NAME))?;
+    let release_version_policy = fs::read_to_string(
+        workspace_root
+            .join(".github")
+            .join("scripts")
+            .join("release_version.py"),
+    )?;
+    let seed_asset_policy = fs::read_to_string(
+        workspace_root
+            .join(".github")
+            .join("scripts")
+            .join("verify-main-atlas-seed-release-assets.py"),
+    )?;
     let optional_parser_handoff_resolver = fs::read_to_string(
         workspace_root
             .join(".github")
@@ -6767,7 +6781,7 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
     for (ecosystem, update) in [("cargo", cargo_update), ("github-actions", actions_update)] {
         for (field, actual, expected) in [
             ("directory", update["directory"].as_str(), "/"),
-            ("target-branch", update["target-branch"].as_str(), "dev"),
+            ("target-branch", update["target-branch"].as_str(), "main"),
             (
                 "schedule.interval",
                 update["schedule"]["interval"].as_str(),
@@ -6971,7 +6985,7 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
     }
     for required in [
         "gh release create \"$RELEASE_VERSION\"",
-        "gh release upload \"$RELEASE_VERSION\" release-assets/* --clobber",
+        "gh release upload \"$RELEASE_VERSION\" \"${upload_assets[@]}\" --clobber",
         "--target \"$GITHUB_SHA\"",
         "PROJECTATLAS_RELEASE_EXISTS",
         "SHA256SUMS",
@@ -6979,10 +6993,67 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
         "already points to",
         "exists without a GitHub release; continuing recovery publish",
         "continuing asset repair publish",
+        "--prerelease --latest=false",
+        "EXPECTED_RELEASE_PRERELEASE",
+        "PROJECTATLAS_LATEST_BEFORE",
+        "Verify hosted release state",
+        "verify-main-atlas-seed-release-assets.py",
+        "Enforce RC-first promotion",
+        "--require-prior-rc-from",
+        "git merge-base --is-ancestor",
+        "Cannot publish an RC after stable tag",
+        "projectatlas-release-${{ inputs.version }}",
+        "cancel-in-progress: false",
+        "Require exact main head for publication",
+        "Revalidate exact main head before release mutation",
+        "git fetch --force origin main:refs/remotes/origin/main",
+        "refs/remotes/origin/main^{commit}",
+        "Release publication requires the exact origin/main head",
+        "projectatlas-main-atlas-seed",
+        "projectatlas-hosted-main-atlas-seed-assets.txt",
+        "projectatlas-main-atlas-seed-*",
+        "--staged-source release-assets",
+        "Existing release contains duplicate or non-regular main Atlas seed assets",
+        "immutable_hosted_seed",
+        "if [[ \"$EXPECTED_RELEASE_PRERELEASE\" == \"true\" || \"${PROJECTATLAS_RELEASE_EXISTS:-false}\" == \"true\" ]]; then",
+        "if [[ \"$EXPECTED_RELEASE_PRERELEASE\" == \"true\" || \"$release_exists\" == \"true\" ]]; then",
+        "Cannot publish an RC or repair a release without observing the current Latest stable release",
     ] {
         if !release_workflow.contains(required) {
             return Err(io::Error::other(format!(
                 "release workflow is missing recoverable publish/checksum guard {required:?}"
+            ))
+            .into());
+        }
+    }
+    for required in [
+        "ReleaseVersion",
+        "VERSION_PATTERN",
+        "DEVELOPMENT_PATTERN",
+        "-dev.",
+        "stable_tag",
+        "milestone",
+        "is_prerelease",
+        "rc_number",
+        "latest_published_rc",
+    ] {
+        if !release_version_policy.contains(required) {
+            return Err(io::Error::other(format!(
+                "release version policy is missing closed classifier field {required:?}"
+            ))
+            .into());
+        }
+    }
+    for required in [
+        "projectatlas-main-atlas-seed-",
+        "\".tar.zst\"",
+        "\".manifest.json\"",
+        "exact release tag",
+        "validate_hosted_seed_assets",
+    ] {
+        if !seed_asset_policy.contains(required) {
+            return Err(io::Error::other(format!(
+                "main Atlas seed release hook is missing exact-pair guard {required:?}"
             ))
             .into());
         }
@@ -7009,6 +7080,18 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
         }
     }
     for required in [
+        "Revalidate exact main head before release mutation",
+        "Release mutation requires the exact current origin/main head",
+        "git fetch --force origin main:refs/remotes/origin/main",
+    ] {
+        if !publish.contains(required) {
+            return Err(io::Error::other(format!(
+                "release publish job omitted exact-main mutation guard {required:?}"
+            ))
+            .into());
+        }
+    }
+    for required in [
         "parser_pack_run_id:",
         "parser-pack-assets:",
         "optional-parser-pack-release-assets",
@@ -7028,6 +7111,7 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
     }
     for required in [
         "github.event_name == 'workflow_dispatch' && inputs.clean_construction && inputs.target == 'all'",
+        "pull_request:\n    branches: [main]",
         "optional-parser-pack-release-assets",
         "cargo-layer-$target.json",
         "projectatlas-broad-parser-$target.tar.zst",
@@ -7040,7 +7124,8 @@ fn repository_delivery_and_dependency_policy_is_enforced() -> Result<(), Box<dyn
         }
     }
     for required in [
-        "git rev-parse HEAD^2",
+        "git rev-parse 'HEAD^{commit}'",
+        "Auto-release checkout differs from the exact main push",
         "resolve-optional-parser-handoff.py",
         "--field parser_pack_run_id=",
     ] {
@@ -7090,8 +7175,12 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
     let github = workspace_root.join(".github");
     let workflows = github.join("workflows");
     let issueops = fs::read_to_string(github.join("scripts").join("issue-checklists.py"))?;
+    let mermaid_parser = github.join("mermaid-parser");
+    let mermaid_package = fs::read_to_string(mermaid_parser.join("package.json"))?;
+    let mermaid_lock = fs::read_to_string(mermaid_parser.join("package-lock.json"))?;
     let ci = fs::read_to_string(workflows.join("ci.yml"))?;
     let release = fs::read_to_string(workflows.join("release.yml"))?;
+    let issueops_workflow = fs::read_to_string(workflows.join("issueops.yml"))?;
     let hook = fs::read_to_string(
         workspace_root
             .join(GITHOOKS_DIR_NAME)
@@ -7123,6 +7212,35 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
             .join("tasks.md"),
     )?;
 
+    if !mermaid_package.contains(r#""jsdom": "27.4.0""#)
+        || !mermaid_package.contains(r#""mermaid": "11.16.1""#)
+        || !mermaid_lock.contains(r#""node_modules/jsdom""#)
+        || !mermaid_lock.contains(r#""node_modules/mermaid""#)
+        || !mermaid_lock.contains(r#""version": "11.16.1""#)
+    {
+        return Err(io::Error::other(
+            "IssueOps Mermaid syntax validation must use one exact lockfile-owned parser",
+        )
+        .into());
+    }
+    for (name, workflow) in [
+        ("CI", ci.as_str()),
+        ("release", release.as_str()),
+        ("IssueOps", issueops_workflow.as_str()),
+    ] {
+        for command in [
+            "npm ci --ignore-scripts --prefix .github/mermaid-parser",
+            "npm audit --omit=dev --audit-level=moderate --prefix .github/mermaid-parser",
+        ] {
+            if !workflow.contains(command) {
+                return Err(io::Error::other(format!(
+                    "{name} workflow omitted locked Mermaid parser gate {command:?}"
+                ))
+                .into());
+            }
+        }
+    }
+
     for required in [
         "validate_unique_issue_ownership",
         "owner_slices",
@@ -7131,6 +7249,15 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
         "milestone_issue_failures",
         "REQUIRED_OPEN_ISSUE_HEADINGS",
         "architecture_diagram_link_failures",
+        "contains_mermaid_diagram",
+        "mermaid_syntax_is_valid",
+        "mermaid-parser",
+        "len(meaningful) > 1",
+        "ARCHITECTURE_ACCEPTANCE_TASK",
+        "planned_issue_failures",
+        "openspec_readiness_failures",
+        "required_markdown_section_failures",
+        "planned_issue=args.planned_issue",
         "MITIGATION_RE",
         "issue_contract_failures",
     ] {
@@ -7140,6 +7267,12 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
             ))
             .into());
         }
+    }
+    if issueops.contains("MERMAID_DECLARATION_RE") {
+        return Err(io::Error::other(
+            "IssueOps must let the locked Mermaid parser own diagram-family admission",
+        )
+        .into());
     }
     if !issue_map.contains(r#""schema_version": 2"#)
         || !issue_map.contains(r#""enforce-rust-test-quality-gates": 309"#)
@@ -7194,6 +7327,8 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
         "cargo test --doc --workspace --all-features --locked",
         "RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --all-features --locked",
         "cargo deny --locked --all-features check -D warnings",
+        "npm ci --ignore-scripts --prefix .github/mermaid-parser",
+        "npm audit --omit=dev --audit-level=moderate --prefix .github/mermaid-parser",
         "issue-checklists.py --self-test",
         "test-optional-parser-proof-inputs.py",
     ] {
@@ -7233,7 +7368,7 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
         )
         .into());
     }
-    if !release.contains("--milestone \"${RELEASE_VERSION}-00\"")
+    if !release.contains("--milestone \"${{ steps.release_version.outputs.milestone }}\"")
         || !release.contains("cargo fmt --all --check")
         || !release.contains(
             "cargo test --locked -p projectatlas-cli --all-features task_errors_classify_only_typed_cancellation_as_canceled",
@@ -7244,6 +7379,20 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
             "release must retain milestone completion, ordinary gates, and a non-publishing package-proof mode",
         )
         .into());
+    }
+    for required in [
+        "types: [opened, edited, reopened, labeled, unlabeled, milestoned]",
+        "--planned-issue \"$ISSUE_NUMBER\"",
+        "timeout-minutes: 5",
+        "contents: read",
+        "issues: read",
+    ] {
+        if !issueops_workflow.contains(required) {
+            return Err(io::Error::other(format!(
+                "issue-event IssueOps workflow is missing readiness guard {required:?}"
+            ))
+            .into());
+        }
     }
     let prepublish_input = release
         .split("      prepublish_only:")
@@ -7270,6 +7419,31 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
         )
         .into());
     }
+    let rc_first_gate = release
+        .split("      - name: Enforce RC-first promotion")
+        .nth(1)
+        .and_then(|tail| tail.split("\n      - name:").next())
+        .ok_or_else(|| io::Error::other("release omitted the RC-first promotion step"))?;
+    if !rc_first_gate.contains(prepublish_guard) {
+        return Err(io::Error::other(
+            "hosted RC-first admission must not block non-publishing package proof",
+        )
+        .into());
+    }
+    let exact_main_gate = release
+        .split("      - name: Require exact main head for publication")
+        .nth(1)
+        .and_then(|tail| tail.split("\n      - name:").next())
+        .ok_or_else(|| io::Error::other("release omitted the exact-main publication step"))?;
+    if !exact_main_gate.contains(prepublish_guard)
+        || !exact_main_gate.contains("git fetch --force origin main:refs/remotes/origin/main")
+        || !exact_main_gate.contains("refs/remotes/origin/main^{commit}")
+    {
+        return Err(io::Error::other(
+            "exact-main publication admission must preserve branch prepublication proof",
+        )
+        .into());
+    }
     let publish_job = release
         .split("\n  publish:\n")
         .nth(1)
@@ -7278,10 +7452,10 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
         .split("    steps:")
         .next()
         .ok_or_else(|| io::Error::other("release publish job omitted its header"))?;
-    if !publish_header.contains(prepublish_guard) || release.matches(prepublish_guard).count() != 2
+    if !publish_header.contains(prepublish_guard) || release.matches(prepublish_guard).count() != 4
     {
         return Err(io::Error::other(
-            "prepublish-only guard must own exactly the checklist step and publish job",
+            "prepublish-only guard must own exactly the RC-first, exact-main, checklist, and publish boundaries",
         )
         .into());
     }
@@ -7309,7 +7483,7 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
         "packaged-contract-runner-${{ matrix.suffix }}",
         "packaged-contract-runner-x86_64-pc-windows-msvc",
         "PROJECTATLAS_MCP_CONTRACT_EXECUTABLE",
-        "[prepublish-installer-smoke-unix, prepublish-installer-smoke-windows, parser-pack-assets]",
+        "      - verify\n      - prepublish-installer-smoke-unix\n      - prepublish-installer-smoke-windows\n      - parser-pack-assets",
         "pattern: projectatlas-*",
     ] {
         if !release.contains(required) {
@@ -11563,7 +11737,7 @@ fn plugin_update_replaces_stale_runtime_configs_and_launches_new_mcp() -> Result
     fs::write(
         workflow_dir.join("ci.yml"),
         format!(
-            "jobs:\n  smoke:\n    steps:\n      - run: curl -fsSL https://github.com/styler-ai/ProjectAtlas/releases/download/v0.0.1/projectatlas-v0.0.1-x86_64-unknown-linux-gnu.tar.gz -o projectatlas.tar.gz\n      - run: curl -fsSL https://github.com/styler-ai/ProjectAtlas/releases/download/{expected_release_tag}/projectatlas-{expected_release_tag}-x86_64-unknown-linux-gnu.tar.gz -o projectatlas-current.tar.gz\n      - run: curl -fsSL https://github.com/example/ProjectAtlas/releases/download/v9.9.9/projectatlas-v9.9.9-x86_64-unknown-linux-gnu.tar.gz -o projectatlas-fork.tar.gz\n"
+            "jobs:\n  smoke:\n    steps:\n      - run: curl -fsSL https://github.com/styler-ai/ProjectAtlas/releases/download/v0.0.1/projectatlas-v0.0.1-x86_64-unknown-linux-gnu.tar.gz -o projectatlas.tar.gz\n      - run: curl -fsSL https://github.com/styler-ai/ProjectAtlas/releases/download/v0.0.2-rc12/projectatlas-v0.0.2-rc12-x86_64-unknown-linux-gnu.tar.gz -o projectatlas-rc.tar.gz\n      - run: curl -fsSL https://github.com/styler-ai/ProjectAtlas/releases/download/{expected_release_tag}/projectatlas-{expected_release_tag}-x86_64-unknown-linux-gnu.tar.gz -o projectatlas-current.tar.gz\n      - run: curl -fsSL https://github.com/example/ProjectAtlas/releases/download/v9.9.9/projectatlas-v9.9.9-x86_64-unknown-linux-gnu.tar.gz -o projectatlas-fork.tar.gz\n"
         ),
     )?;
     fs::write(
@@ -11812,12 +11986,47 @@ fn plugin_update_replaces_stale_runtime_configs_and_launches_new_mcp() -> Result
     }
     if !installer_output_text.contains("Stale ProjectAtlas workflow release pin")
         || !installer_output_text.contains("v0.0.1")
+        || !installer_output_text.contains("v0.0.2-rc12")
         || !installer_output_text.contains(&expected_release_tag)
     {
         return Err(io::Error::other(format!(
             "plugin update installer did not report stale downstream workflow release pins:\n{installer_output_text}"
         ))
         .into());
+    }
+    let stale_pin_lines = installer_output_text
+        .lines()
+        .filter(|line| line.contains("Stale ProjectAtlas workflow release pin"))
+        .collect::<Vec<_>>();
+    if stale_pin_lines
+        .iter()
+        .any(|line| line.contains(&format!("uses {expected_release_tag};")))
+    {
+        return Err(io::Error::other(format!(
+            "plugin update installer reported its exact current workflow release pin as stale:\n{installer_output_text}"
+        ))
+        .into());
+    }
+    if stale_pin_lines
+        .iter()
+        .any(|line| line.contains("uses v0.0.2;"))
+    {
+        return Err(io::Error::other(format!(
+            "plugin update installer truncated a stale RC workflow release pin:\n{installer_output_text}"
+        ))
+        .into());
+    }
+    if let Some((stable_version, _)) = env!("CARGO_PKG_VERSION").split_once("-rc") {
+        let truncated_tag = format!("v{stable_version}");
+        if stale_pin_lines
+            .iter()
+            .any(|line| line.contains(&format!("uses {truncated_tag};")))
+        {
+            return Err(io::Error::other(format!(
+                "plugin update installer truncated its exact RC workflow release pin:\n{installer_output_text}"
+            ))
+            .into());
+        }
     }
     if installer_output_text.contains("v9.9.9") {
         return Err(io::Error::other(format!(

--- a/docs/projectatlas-3-architecture.md
+++ b/docs/projectatlas-3-architecture.md
@@ -2204,6 +2204,19 @@ flowchart TB
     Create -->|stable| Stable[Create non-draft stable release]
     RC --> VerifyRC[Verify prerelease metadata and tag head;<br/>previous stable remains Latest]
     Stable --> VerifyStable[Verify stable metadata and tag head;<br/>promoted stable becomes Latest]
+    VerifyRepair --> PlatformSmokes[Start hosted installer smoke lanes]
+    VerifyRC --> PlatformSmokes
+    VerifyStable --> PlatformSmokes
+    PlatformSmokes --> Linux[Install exact hosted release on Linux]
+    PlatformSmokes --> MacOS[Install exact hosted release on<br/>macOS x64 and arm64]
+    PlatformSmokes --> Windows[Install exact hosted release on Windows]
+    Linux --> Candidate{Release candidate?}
+    Candidate -->|no| LinuxReady[Linux lane succeeds]
+    Candidate -->|yes| AgentE2E[Index a real project and verify<br/>fresh brief and source through stdio MCP]
+    AgentE2E --> LinuxReady
+    LinuxReady --> Complete[All hosted lanes succeed;<br/>release workflow succeeds]
+    MacOS --> Complete
+    Windows --> Complete
 ```
 
 The optional-pack workflow may reuse only sanitized Cargo dependency build state.

--- a/docs/projectatlas-3-architecture.md
+++ b/docs/projectatlas-3-architecture.md
@@ -1475,21 +1475,33 @@ and usage telemetry. Interfaces call the same core APIs.
 
 Recommended layers:
 
-```text
-projectatlas-core
-  owns domain models and service traits
+```mermaid
+flowchart TB
+    Core[projectatlas-core<br/>domain models and service traits]
+    subgraph Engines[Responsibility-owned engines]
+        DB[projectatlas-db<br/>storage and publication]
+        FS[projectatlas-fs<br/>ignore-aware scanning]
+        Service[projectatlas-service<br/>shared query services]
+        Symbols[projectatlas-symbols<br/>language and relation parsing]
+    end
+    Runtime[projectatlas-cli runtime<br/>shared orchestration]
+    CLI[CLI adapter<br/>humans and CI]
+    MCP[MCP adapter<br/>agents and harnesses]
+    Future[Future adapters<br/>only when separately justified]
 
-projectatlas-db/projectatlas-fs/projectatlas-service/projectatlas-symbols
-  implement storage, scanning, shared query services, and parsing
-
-projectatlas-cli
-  human and CI command adapter plus shared runtime orchestration module
-
-projectatlas-cli::mcp
-  current agent/harness adapter over the same runtime module
-
-future adapters
-  language server, daemon, or editor extensions only when separately justified
+    CLI --> Runtime
+    MCP --> Runtime
+    Future -.-> Runtime
+    Runtime --> DB
+    Runtime --> FS
+    Runtime --> Service
+    Runtime --> Symbols
+    DB --> Core
+    FS --> Core
+    Service --> DB
+    Service --> Symbols
+    Service --> Core
+    Symbols --> Core
 ```
 
 CLI is the best first implementation target because it is deterministic, easy
@@ -2102,6 +2114,41 @@ workflows. Those paths retain focused harness unit tests and artifact-integrity
 checks, but an input-incompatible campaign publication becomes historical or
 unavailable instead of triggering a run. Only an explicit user request starts a
 full campaign.
+
+Release promotion has one version-derived path for stable and candidate tags.
+Both use the same stable milestone and cumulative notes baseline, but GitHub
+publication keeps candidates explicitly outside Latest. The release adapter may
+consume a clean-main Atlas seed archive and manifest created by the separately
+owned seed producer; it validates their exact tag-bound names and checksums both,
+without creating or opening the immutable seed.
+
+```mermaid
+flowchart TB
+    subgraph Admission[Version-derived release admission]
+        Main[Exact origin/main candidate head] --> Serial[One in-flight workflow per requested tag]
+        Serial --> Classify{Classify workspace version}
+        Classify -->|development| Stop[No release dispatch]
+        Classify -->|malformed| Fail[Fail closed]
+        Classify -->|stable or rcN| Handoff[Verify clean parser handoff compatibility]
+        Handoff --> Milestone[Gate shared stable milestone]
+        Milestone --> Kind{Derived release kind}
+        Kind -->|rcN| RCGuard[Refuse when stable tag exists]
+        Kind -->|stable| PriorRC[Require highest published rcN<br/>as an ancestor of final head]
+    end
+    RCGuard --> Stage[Validate assets and checksum every file]
+    PriorRC --> Stage
+    Stage --> Existing{Existing release?}
+    Existing -->|yes| Repair[Validate exact metadata and tag head;<br/>repair replaceable assets;<br/>preserve immutable seed and captured Latest]
+    Existing -->|no| Create{Create requested release kind}
+    Seed[Optional clean-main seed producer] -. exact-tag archive and manifest .-> Stage
+    Prior[Greatest preceding stable tag] --> Notes[Cumulative notes for new releases]
+    Notes -. new releases only .-> Create
+    Repair --> VerifyRepair[Verify repaired metadata, tag head,<br/>and unchanged Latest]
+    Create -->|rcN| RC[Create non-draft prerelease<br/>Latest disabled]
+    Create -->|stable| Stable[Create non-draft stable release]
+    RC --> VerifyRC[Verify prerelease metadata and tag head;<br/>previous stable remains Latest]
+    Stable --> VerifyStable[Verify stable metadata and tag head;<br/>promoted stable becomes Latest]
+```
 
 The optional-pack workflow may reuse only sanitized Cargo dependency build state.
 An exact key binds the target, Rust and native toolchains, Cargo lockfile and

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -40,6 +40,8 @@ cargo test --doc --workspace --all-features --locked
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked
 cargo run --locked -p projectatlas-lints --bin cargo-projectatlas-lints -- strict-strings
 cargo deny --locked --all-features check -D warnings
+npm ci --ignore-scripts --prefix .github/mermaid-parser
+npm audit --omit=dev --audit-level=moderate --prefix .github/mermaid-parser
 python3 .github/scripts/issue-checklists.py --self-test
 python3 .github/scripts/test-optional-parser-proof-inputs.py
 python3 .github/scripts/issue-checklists.py --repo "$(gh repo view --json nameWithOwner --jq .nameWithOwner)" --root . --issue-map openspec/issue-map.json
@@ -70,7 +72,7 @@ For a bounded manual update or Dependabot review:
 4. Check the repository Rust toolchain and the dependency's MSRV, default and added features, license, advisories, registry or Git source, duplicate paths, upstream changelog, and breaking changes.
 5. Run the focused repository-policy E2E test, the dependency inventory and deny commands above, and the ordinary locked workspace gates.
 
-Weekly Cargo and GitHub Actions Dependabot updates target `dev`; only Cargo minor and patch updates are grouped, majors remain separate, and no repository automation merges them. Configuration merged only into `dev` is validated but does not become hosted-active until the later normal verified integration into the default branch. GitHub may originate a security-update pull request against the default branch; leave it unmerged until the same dependency change has been routed through and proven on `dev`.
+Weekly Cargo and GitHub Actions Dependabot updates target `main`; only Cargo minor and patch updates are grouped, majors remain separate, and no repository automation merges them. Dependency pull requests follow the same review and locked workspace gates as other changes. Obsolete automated pull requests against the retired `dev` release line are explicitly closed or superseded rather than merged into a release milestone as cleanup.
 
 ## Lean implementation and IssueOps
 
@@ -79,12 +81,14 @@ ProjectAtlas uses the implementation loop that produced v0.3.26:
 1. Implement a meaningful compiling behavior slice.
 2. Add or update the smallest focused unit, integration, E2E, smoke, or validation test appropriate to the risk. One coherent test may cover several related tasks.
 3. Run the ordinary locked Rust/workspace gates.
-4. Commit and integrate significant working slices into `dev`.
+4. Commit and integrate significant working slices into `main` through reviewed pull requests.
 5. Use normal CI and review, then synchronize the local OpenSpec checklist with its mapped GitHub issue.
 
 Task completion does not require unique test identifiers, task-level verification plans or ledgers, commit receipts, rendered evidence comments, hosted links per checkbox, or post-merge issue sealing. When useful, keep one compact shared behavior-coverage row in the issue with clickable owning test definitions and the passed test command. One test may cover several tasks, and several tests may jointly cover one coherent task. GitHub Actions already records normal hosted outcomes.
 
-Open mapped issues keep the concise v0.3.26 #305 planning shape: `Why`, `What Changes`, `Capabilities`, `Architecture Diagrams`, `Release Scope`, `Non-Goals`, `Pre-Mortem`, and one authoritative OpenSpec task section. `Architecture Diagrams` contains at least one durable HTTPS link to a versioned `dev/docs/*.md` view in this repository; reuse an existing architecture document when the change does not need a new one, and do not substitute `N/A`, a commit/SHA permalink, an external repository, or a duplicate PDF. The pre-mortem lists likely failures and visible mitigation checkboxes. Each mitigation ends with its owning task IDs, for example `(OpenSpec tasks: 2.1, 4.3)`, and is checked exactly when all referenced tasks are checked. This reuses the implementation checklist; it does not create mitigation-specific tests, receipts, or evidence artifacts.
+Open mapped issues keep the concise v0.3.26 #305 planning shape: `Why`, `What Changes`, `Capabilities`, `Architecture Diagrams`, `Release Scope`, `Non-Goals`, `Pre-Mortem`, and one authoritative OpenSpec task section. `Architecture Diagrams` either contains a durable HTTPS link to a versioned `dev/docs/*.md#heading` view in this repository or records exactly `N/A: <reason>` as a conscious no-architecture-change decision. Every linked heading's own section must contain a closed fenced `mermaid` block that passes the repository-locked Mermaid syntax parser; a heading, prose, empty or declaration-only fence, or invalid Mermaid does not satisfy the gate. The final OpenSpec task compares the completed implementation with those diagrams and updates either side until they agree, or reconfirms the reasoned `N/A`. The pre-mortem lists likely failures and visible mitigation checkboxes. Each mitigation ends with its owning task IDs, for example `(OpenSpec tasks: 2.1, 4.3)`, and is checked exactly when all referenced tasks are checked. This reuses the implementation checklist; it does not create mitigation-specific tests, receipts, or evidence artifacts.
+
+Assign an open issue to a canonical `vMAJOR.MINOR.PATCH-00` release milestone only when it has exactly `status:ready`, a local OpenSpec mapping, exactly one non-empty copy of every required proposal and design section, complete delta-spec/task artifacts, explicit dependency and cross-issue impact, no unresolved open questions, checked contract tasks, synchronized issue sections, architecture evidence, and the final reconciliation task. The issue-event IssueOps workflow enforces this implementation-ready boundary. Release-time milestone completion remains the stricter all-issues-closed gate.
 
 Ordinary pull requests require exact local/GitHub checklist synchronization but do not require the whole release milestone to be complete. Full milestone checklist completion is a release-only gate. SHA-pinned Actions, locked Cargo commands, least privilege, parser/package/signature/digest validation, release checksums, and other executable integrity controls remain independent of task bookkeeping.
 
@@ -111,15 +115,15 @@ Commit identity is provenance, not a general test invalidation key. After a comm
 
 ## Branching
 
-- `dev` for active development.
-- `main` for stable releases only.
-- Merge `dev` -> `main` via pull request after CI is green.
-- Ensure `dev` includes the latest `main` changes before releasing.
+- Open change branches and pull requests against `main`; `main` is the active integration and release authority.
+- Retain `dev` only while durable historical links or an explicit migration require it; dependency and release automation do not target it.
 - Update the Cargo workspace version in `Cargo.toml`.
-- Pushes to `main` create a GitHub release when the Cargo version is release-eligible.
-- The auto-release workflow generates GitHub release notes from merged PRs.
-- Release archives are published with a `SHA256SUMS` asset. Verify manually with `sha256sum -c SHA256SUMS` or `shasum -a 256 -c SHA256SUMS` from a directory containing the downloaded archives.
-- If a publish run fails after creating a tag or leaves a GitHub release with missing or stale assets, rerun the release workflow for the same version. The publish job recovers when the existing tag points at the current commit, creates the missing release when needed, and uploads release assets with replacement enabled for repair runs.
+- Pushes to `main` automatically dispatch a release for an exact stable `MAJOR.MINOR.PATCH` or candidate `MAJOR.MINOR.PATCH-rcN` workspace version when the tag is absent and the clean optional-parser handoff is input-compatible with the exact pushed commit. Merge-commit, squash, and rebase histories use that same commit-bound rule. Canonical Cargo development versions `MAJOR.MINOR.PATCH-dev.N` do not dispatch; malformed versions fail closed.
+- Publish at least `-rc1` before promoting a release series to its final stable version. The release gate refuses a final version unless the highest published non-draft RC for the same base version is an ancestor of the final head, and refuses a late RC after that stable tag exists. RCs are non-draft GitHub prereleases created with Latest disabled, so GitHub Latest stays on the preceding stable release. The final stable release is a normal release and becomes Latest.
+- Keep exact hosted tag/release/Latest verification in the release operation after all mapped milestone implementation issues are closed. Implementation checklists prove generic policy and prepublication packages; they must not require the hosted release whose prepublication milestone gate they block.
+- Release notes for every RC and the final stable promotion use the preceding stable tag as their baseline. Later candidates and the final notes therefore remain cumulative across the entire release series without duplicating an RC as the history baseline.
+- Release archives are published with a `SHA256SUMS` asset. If the clean-main seed producer supplies the optional exact-tag `projectatlas-main-atlas-seed-<tag>-<snapshot-digest>.tar.zst` and matching `.manifest.json`, release staging validates the pair and checksums both without opening or modifying the seed. Verify downloaded assets with `sha256sum -c SHA256SUMS` or `shasum -a 256 -c SHA256SUMS`.
+- If a publish run fails after creating a tag or leaves a GitHub release with missing or stale assets, rerun the release workflow for the same exact version. Repair is accepted only when the existing non-draft release classification and tag head match the derived stable/RC policy; replaceable assets may then be repaired without moving the tag or changing classification, while validated immutable seed assets are never clobbered. If interruption left exactly one seed-pair member, recovery also requires the complete staged pair and exact byte equality, then uploads only the missing companion. The workflow rechecks release metadata, exact head, and requires the previously captured Latest release to remain unchanged during repair.
 
 ## CI behavior
 

--- a/openspec/changes/persist-agent-project-context/tasks.md
+++ b/openspec/changes/persist-agent-project-context/tasks.md
@@ -46,3 +46,4 @@
 - [ ] 7.2 After the complete #314 surface is implemented, run line coverage and mutation once, close real gaps or document justified exclusions, and do not create per-task coverage/mutation campaigns.
 - [ ] 7.3 Run bounded final reviews for architecture/crate ownership, Rust skill and pattern fit, OpenSpec task truth, shared-test adequacy, privacy/root/migration safety, streamlined MCP usefulness, and whether the result materially improves agent recovery without an eighth crate.
 - [ ] 7.4 Synchronize completed OpenSpec/GitHub task states, verify the issue checklist gate and packaged documentation, and close #314 only after the implementation is merged and the complete issue checks pass.
+- [ ] 7.5 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/changes/release-candidates-and-pr-cleanup/.openspec.yaml
+++ b/openspec/changes/release-candidates-and-pr-cleanup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/release-candidates-and-pr-cleanup/design.md
+++ b/openspec/changes/release-candidates-and-pr-cleanup/design.md
@@ -1,0 +1,105 @@
+## Context
+
+`03-Auto-Release` reads the Cargo workspace version on each push to `main` and historically tried to exclude a non-SemVer `.dev` spelling. `02-Release` currently validates only stable `vMAJOR.MINOR.PATCH`, derives the checklist milestone by appending `-00` to that raw tag, and creates a normal GitHub release. Those decisions are duplicated workflow policy and cannot represent `v0.4.5-rc1` without either rejecting it, looking for `v0.4.5-rc1-00`, or replacing the stable Latest release.
+
+The repository already uses Python standard-library policy scripts with `--self-test` entrypoints in CI. Release jobs run on Ubuntu with Python and authenticated `gh`; no product runtime or database change is needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep one exact stable/RC admission and milestone-classification rule across auto-dispatch and publication.
+- Make GitHub release classification explicit, idempotent, and verified after publication.
+- Keep RC and final release notes cumulative from the preceding stable release for any release series.
+- Preserve exact prerelease identity through parser assets and installer downstream-pin checks.
+- Preserve the full existing package, parser-pack, installer, exact-head, and stable-release contracts.
+- Stop automated dependency PRs from targeting the retired `dev` release line.
+
+**Non-Goals:**
+
+- General SemVer prerelease parsing, arbitrary channels, or a reusable versioning framework.
+- Any Rust crate, API, schema, index, MCP, or product-runtime change.
+- Publishing final `v0.4.5`, changing the default branch, deleting `dev` while public links still depend on it, or admitting routine dependency upgrades to v0.4.5.
+
+## Decisions
+
+### Use one small standard-library policy script
+
+Add one repository-owned Python script that accepts either a workspace version or `v`-prefixed release tag, recognizes only stable and `-rcN` with `N >= 1`, derives the normalized tag, base version, stable milestone, prerelease boolean, and publication eligibility, and writes validated GitHub step outputs. The same importable classifier is reused by release-note and optional-parser scripts. It owns a generic self-test table for stable, RC, development, and malformed inputs; no release number is embedded as policy.
+
+This reuses the repository's existing CI-script pattern and avoids duplicated shell regular expressions across two workflows and several jobs. A Rust helper, dependency, action, or generic SemVer abstraction would add a build/runtime boundary for policy used only by GitHub Actions.
+
+### Derive classification, never accept a manual prerelease flag
+
+`02-Release` derives prerelease state and `vMAJOR.MINOR.PATCH-00` from the requested version. Manual callers cannot independently select stable/prerelease state or an RC-specific milestone. `03-Auto-Release` uses the same classifier; stable and RC versions are eligible, canonical Cargo `MAJOR.MINOR.PATCH-dev.N` versions are explicitly ineligible, and other forms fail closed.
+
+### Verify existing and newly created GitHub release state
+
+Publication runs are serialized by the exact requested version, and publishing—not branch-safe prepublication proof—requires the workflow checkout to equal both the event SHA and current `origin/main`. The publish job repeats that check immediately before its first release mutation so a long package build cannot publish a head that `main` has since passed. Before asset repair, an existing release must have the exact requested tag, be non-draft, have the expected prerelease boolean, and resolve to the workflow head. Before publication, the workflow captures the current Latest stable tag. A new RC is created with `--prerelease --latest=false`; a new stable release is created without prerelease flags. After create or repair, the workflow re-reads the release record and tag head. New RCs and every repair require GitHub's `/releases/latest` endpoint to identify a canonical stable ProjectAtlas tag and remain exactly on that captured tag; only a newly created stable release is required to become Latest.
+
+This keeps repair idempotent without silently changing classification. The endpoint check verifies the user-visible repository contract rather than assuming GitHub's create semantics.
+
+### Make RC-first promotion executable
+
+Publication of an RC fails when the corresponding stable tag already exists. Publication of a final stable release queries every GitHub release page, selects the highest canonical non-draft prerelease with the same stable base, requires its tag to exist in the checkout, and proves that candidate tag is an ancestor of the final head. Prepublish-only package proof remains usable without hosted state because it cannot create a release. This makes “RC first” a version-agnostic admission rule instead of guidance or a `0.4.5` special case.
+
+Automatic handoff resolution compares prior clean parser proof with the exact pushed `main` commit. It does not assume a second merge parent, so the repository's allowed merge-commit, squash, and rebase histories share the same input-equivalence rule. The labeled optional-parser proof trigger follows pull requests to `main`.
+
+### Use the preceding stable tag as the promotion-series notes baseline
+
+Release notes ignore RC tags when selecting history. An RC and the final stable release both select the greatest stable tag lower than their base version, then summarize that stable tag through the candidate head. Later RCs therefore remain cumulative, and the final stable notes include every change introduced during all RCs. This is computed from arbitrary accepted version tuples rather than a hard-coded current release number.
+
+### Carry the exact accepted version through release artifacts and installer pins
+
+Optional-parser verification uses the shared classifier and requires proof/package identity plus filenames to retain the complete accepted tag. The existing POSIX and PowerShell installer pin scanners recognize the same optional `-rcN` suffix, so a workflow correctly pinned to an installed RC is not reported stale. No product-runtime version abstraction is added.
+
+The release adapter also owns a read-only discovery hook for the separately produced clean-main Atlas seed. Absence is valid until that producer participates in the release handoff. If any `projectatlas-main-atlas-seed-` asset is present locally or on a repair target, the hook requires one regular archive and manifest with the shared basename `projectatlas-main-atlas-seed-<exact-tag>-<snapshot-digest>`, rejects malformed, other-version, or multi-digest inventories, and includes the complete pair in `SHA256SUMS`. Byte-identical hosted seed assets are retained rather than clobbered; any mismatch fails before release mutation. An interrupted first upload may leave one hosted member only when a retry supplies the complete validated pair and that member has the expected exact name and bytes; the retry uploads only the missing companion. The hook never creates, opens writable, hydrates, or interprets the seed; those responsibilities remain with the seed producer and runtime owned by issue #430.
+
+### Retarget automation without merging dependency scope
+
+Dependabot targets `main`. Existing automated PRs against `dev` are closed with an explicit disposition after review-thread inspection; their branches may be removed once GitHub confirms closure. No dependency version is changed in this issue.
+
+### Make architecture evidence executable IssueOps policy
+
+Reuse the existing IssueOps architecture-link validator. An open mapped issue may either provide repository-local `dev/docs/*.md#heading` links or write exactly `N/A: <reason>` with a non-empty reason. Every linked heading owns a section through the next same-or-higher heading; that section must contain a closed `mermaid` fence whose body passes the repository-locked canonical Mermaid syntax parser. Headings, prose, declaration-only, empty, syntactically invalid Mermaid, and other code fences do not satisfy the contract. CI installs the parser once from its lockfile without install scripts; the validator starts only the local parse API, not a browser renderer or runtime download.
+
+The final task in every mapped OpenSpec checklist uses one standard acceptance sentence requiring the finished implementation and architecture diagrams to agree, or the reasoned `N/A` to be reconfirmed. Syntax is machine-checked by the locked parser; visual communication and semantic truth remain the final acceptance review rather than a separate evidence ledger.
+
+### Gate milestone planning at the issue transition
+
+The issue-event workflow runs the same IssueOps validator when an open issue is assigned to or edited within a canonical release milestone. Planning requires exactly `status:ready`, a local OpenSpec mapping, proposal/design/delta-spec/tasks artifacts, the standard design sections, explicit dependencies or a reasoned `N/A`, resolved open questions, at least one requirement and scenario, and checked `1.x` contract/specification tasks. The ordinary mapped-issue pass continues to enforce synchronized tasks, the concise issue shape, architecture evidence, and final reconciliation task. Release-time milestone completion remains the stricter all-issues-closed gate.
+
+This checks the transition that creates planned scope without scanning unrelated future milestones on every source pull request or adding a separate validation service.
+
+## Risks / Trade-offs
+
+- **GitHub changes Latest behavior** -> Verify both release metadata and the live Latest endpoint; fail publication if the invariant is not true.
+- **A typo on `main` silently skips a release** -> Only canonical Cargo `MAJOR.MINOR.PATCH-dev.N` is a supported ineligible state; other unsupported versions fail the auto-release job.
+- **Repair uploads assets to a misclassified release** -> Compare exact tag head and prerelease state before upload.
+- **Concurrent repair runs interleave mutable assets and checksums** -> Serialize the workflow by exact requested version without cancelling an in-flight repair.
+- **A manual publish runs from stale or non-main source** -> Require the event SHA, checkout commit, and fetched `origin/main` commit to match before publication.
+- **A stable version bypasses candidate validation or an RC appears after final** -> Require the highest published same-base RC on the stable head, and refuse RC publication once the stable tag exists.
+- **RC notes omit earlier candidate work or include all repository history** -> Select the prior stable tag by parsed version and ignore RC tags as baselines.
+- **RC asset or downstream pin identity is truncated** -> Reuse the classifier in parser verification and test the existing installer scanners with exact RC pins.
+- **A partial or wrong-version stable-main seed is published** -> Fail release staging when any discovered seed-prefixed inventory is not one exact-tag archive/manifest pair, and checksum both validated files.
+- **The policy script becomes a version framework** -> Keep the accepted grammar fixed to stable and `-rcN`, expose only workflow outputs, and use no dependency.
+- **Retargeted dependency PRs expand v0.4.5** -> Keep them outside the milestone and close/defer them until after the RC scope.
+- **Architecture sections contain prose or stale diagrams** -> Require a real Mermaid declaration or reasoned `N/A`, then make final implementation-to-diagram reconciliation the last OpenSpec task.
+- **IssueOps accepts Mermaid-looking prose or downloads an unpinned parser** -> Parse every candidate with the lockfile-owned Mermaid package installed once with scripts disabled.
+- **An aspirational issue is assigned to a release before its design is usable** -> Fail the issue-event gate unless its mapped artifacts, contract tasks, dependencies, open questions, and readiness label satisfy the implementation-ready contract.
+
+## Migration Plan
+
+1. Land the classifier, cumulative release-note selection, parser/installer and optional seed-asset compatibility checks, focused self-tests, workflow integration, Dependabot retarget, IssueOps mapping, and release guidance on `main` before setting the workspace version to `0.4.5-rc1`.
+2. Close obsolete `dev`-targeted automated PRs and prune only their closed or merged heads.
+3. Let `03-Auto-Release` dispatch `02-Release` when the verified v0.4.5 candidate reaches `main`.
+4. After every milestone implementation issue is closed, run the separate release operation and confirm the candidate is a prerelease at the exact head while `/releases/latest` remains on the preceding stable release.
+5. Roll back by reverting the workflow/policy change before any later tag; an already published RC remains a prerelease and does not require deleting or rewriting release history.
+
+## Dependencies / Cross-Issue Impact
+
+Issue #448 owns release and IssueOps policy. It does not implement #430 worktree continuity or #440 classified documentation navigation, but it prevents either issue from remaining planned in a release milestone until its own mapped OpenSpec and cross-issue handoff are implementation-ready.
+
+## Open Questions
+
+None.

--- a/openspec/changes/release-candidates-and-pr-cleanup/proposal.md
+++ b/openspec/changes/release-candidates-and-pr-cleanup/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+ProjectAtlas cannot currently publish `v0.4.5-rc1` truthfully: the release workflow rejects RC tags and would create any accepted version as a normal release, allowing a candidate to displace `v0.4.4` as GitHub Latest. The same repository state still routes Dependabot to the obsolete `dev` line, creating failed PR clutter outside the focused v0.4.5 scope.
+
+## What Changes
+
+- Accept exactly stable `vMAJOR.MINOR.PATCH` and release-candidate `vMAJOR.MINOR.PATCH-rcN` inputs, with `N >= 1`.
+- Derive the owning stable `vMAJOR.MINOR.PATCH-00` milestone for both stable and RC releases.
+- Create and repair RC releases only with GitHub prerelease metadata, and verify an RC never becomes the Latest stable release.
+- Refuse a final stable publication until a non-draft RC of the same base version is published on its history, and refuse a late RC after that base version's stable tag exists.
+- Preserve existing stable publication, exact-head, parser-pack handoff, package, installer, and recovery behavior.
+- Keep automatic release dispatch for stable and RC workspace versions while excluding development or unsupported prerelease versions.
+- Generate every RC and final stable release note set cumulatively from the preceding stable tag, so promotion never drops work introduced during an RC.
+- Preserve the complete RC suffix in optional-parser release assets and downstream workflow pin checks.
+- Accept an optional clean-main Atlas seed archive/manifest pair from its separately owned producer, require the exact release tag in both content-addressed filenames, and checksum both without creating or opening the seed.
+- Retarget Dependabot to `main` and disposition obsolete automated PRs against `dev` without admitting dependency upgrades to v0.4.5.
+- Hard-gate each open mapped issue so `Architecture Diagrams` either links to a real Mermaid diagram in the named local documentation section or records a reasoned `N/A`, and require the final OpenSpec task to reconcile that decision with the finished implementation.
+- Reject release-milestone planning unless the open issue is `status:ready`, mapped to complete OpenSpec proposal/design/delta-spec/tasks artifacts, has checked contract tasks, resolved open questions, and explicitly records cross-issue impact.
+- Document and test a version-agnostic prerelease-to-stable promotion contract; `0.4.5` is release proof, not policy embedded in reusable logic.
+- Non-goals: arbitrary prerelease channels, hard-coded release-series policy, a versioning framework or release-version dependency, a separate release service, a new long-lived release branch model, the final v0.4.5 publication, or routine dependency upgrades in v0.4.5.
+
+This change is ready for implementation as issue #448 in the v0.4.5 milestone.
+
+## Capabilities
+
+### New Capabilities
+
+- `release-candidate-promotion`: Stable and RC version admission, GitHub prerelease/Latest classification, milestone routing, recovery validation, automatic dispatch, and current-branch dependency-update routing.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `.github/workflows/release.yml` and `.github/workflows/03-auto-release.yml`
+- One small repository-owned, version-agnostic release classifier shared by workflows, release notes, and optional-parser verification
+- `.github/scripts/release-notes.py`, optional-parser and optional main-seed release-asset validation, and installer downstream-pin checks
+- `.github/dependabot.yml`
+- Release architecture/guidance, IssueOps architecture/readiness validation, its issue-event workflow, and IssueOps mapping
+- One repository-locked Mermaid parser used only by IssueOps syntax validation
+- GitHub releases, the Latest endpoint, milestones, and obsolete automated PR heads
+- No Rust product API, crate boundary, database schema, runtime behavior, or product dependency

--- a/openspec/changes/release-candidates-and-pr-cleanup/specs/release-candidate-promotion/spec.md
+++ b/openspec/changes/release-candidates-and-pr-cleanup/specs/release-candidate-promotion/spec.md
@@ -1,0 +1,208 @@
+## ADDED Requirements
+
+### Requirement: Release versions have one bounded stable or RC contract
+The release system SHALL accept exactly `vMAJOR.MINOR.PATCH` stable tags and `vMAJOR.MINOR.PATCH-rcN` release-candidate tags where each numeric component is canonical decimal notation and RC `N` is a positive decimal integer without leading zeroes. It SHALL derive the same classification from an unprefixed Cargo workspace version, treat exactly `MAJOR.MINOR.PATCH-dev.N` with canonical non-negative `N` as publication-ineligible development state, operate for any accepted version tuple without hard-coded release-series values, and reject every other prerelease spelling.
+
+#### Scenario: Stable version is accepted
+- **WHEN** the classifier receives `0.4.5` or `v0.4.5`
+- **THEN** it reports normalized tag `v0.4.5`, stable classification, and publication eligibility
+
+#### Scenario: Release candidate is accepted
+- **WHEN** the classifier receives `0.4.5-rc1` or `v0.4.5-rc1`
+- **THEN** it reports normalized tag `v0.4.5-rc1`, prerelease classification, and publication eligibility
+
+#### Scenario: Development version is not published
+- **WHEN** automatic release classification receives canonical Cargo workspace version `1.2.3-dev.1`
+- **THEN** it reports publication ineligible without dispatching a release
+
+#### Scenario: Unsupported version fails closed
+- **WHEN** the classifier receives `v0.4.5-rc0`, `v0.4.5-rc01`, `v0.4.5-beta1`, build metadata, missing components, or extra text
+- **THEN** it returns a nonzero error and no release outputs
+
+### Requirement: Stable and RC releases share the stable milestone
+The release system MUST derive `vMAJOR.MINOR.PATCH-00` as the owning IssueOps milestone for both the stable tag and every RC of that version.
+
+#### Scenario: RC milestone routing
+- **WHEN** `v0.4.5-rc1` enters the release checklist gate
+- **THEN** the gate validates milestone `v0.4.5-00` rather than an RC-named milestone
+
+#### Scenario: Stable milestone compatibility
+- **WHEN** `v0.4.5` enters the release checklist gate
+- **THEN** the gate continues to validate milestone `v0.4.5-00`
+
+### Requirement: GitHub publication preserves prerelease and Latest truth
+The release workflow SHALL serialize runs by exact requested version, SHALL publish only from the exact current `origin/main` head, SHALL create RC tags as non-draft GitHub prereleases with explicit Latest exclusion, and SHALL create stable tags as non-draft normal releases. A stable publication MUST require a previously published non-draft RC of the same base version on the stable head, and an RC publication MUST be refused after the same base version's stable tag exists. After create or repair it MUST verify the exact release tag, draft state, prerelease classification, tag head, and repository Latest endpoint before reporting publication success.
+
+#### Scenario: Same-version publication is serialized
+- **WHEN** two create or repair runs request the same exact stable or RC version
+- **THEN** the later run waits without cancelling the in-flight run and cannot interleave its archives or checksums
+
+#### Scenario: Non-main or stale publication is refused
+- **WHEN** a publishing workflow checkout differs from its event SHA or current `origin/main`
+- **THEN** publication fails before creating, repairing, or tagging a release while branch prepublication proof remains available
+
+#### Scenario: Final stable release requires a prior RC
+- **WHEN** a stable release is requested without any published non-draft RC of the same base version on its history
+- **THEN** publication fails before creating or repairing the stable release
+
+#### Scenario: Stable promotion follows the highest published RC
+- **WHEN** several RC releases exist for the same base version
+- **THEN** the highest canonical RC tag must exist and be an ancestor of the stable release head
+
+#### Scenario: RC after final is refused
+- **WHEN** an RC is requested after the same base version's stable tag already exists
+- **THEN** publication fails without creating or repairing the RC
+
+#### Scenario: RC publication keeps the previous stable release Latest
+- **WHEN** `v0.4.5-rc1` is created or repaired while `v0.4.4` is the current stable release
+- **THEN** the RC record is marked prerelease and GitHub's Latest endpoint does not identify `v0.4.5-rc1`
+
+#### Scenario: RC publication preserves the exact previous Latest stable tag
+- **WHEN** an RC is created or repaired and the workflow captured the current Latest tag before publication
+- **THEN** GitHub's Latest endpoint remains exactly that captured tag after publication
+
+#### Scenario: New stable publication becomes Latest
+- **WHEN** final `v0.4.5` is newly created after its milestone is complete
+- **THEN** the release record is not prerelease and GitHub's Latest endpoint identifies `v0.4.5`
+
+#### Scenario: Existing release repair preserves Latest
+- **WHEN** an existing stable or RC release is repaired while another stable release is the captured Latest release
+- **THEN** GitHub's Latest endpoint remains exactly on that captured release
+
+#### Scenario: Repair requires an observable canonical Latest release
+- **WHEN** an RC publication or existing-release repair cannot observe a canonical stable tag from GitHub's Latest endpoint before mutation
+- **THEN** publication fails before creating, repairing, or uploading release assets
+
+#### Scenario: Existing release classification mismatch is refused
+- **WHEN** asset repair finds an existing release whose prerelease state differs from the version-derived state
+- **THEN** the workflow fails before uploading or replacing assets
+
+#### Scenario: Draft recovery target is refused
+- **WHEN** asset repair finds an existing draft release for the requested tag
+- **THEN** the workflow fails before uploading or replacing assets
+
+#### Scenario: Existing tag head mismatch remains refused
+- **WHEN** create or repair finds the requested tag at a commit other than the workflow head
+- **THEN** the workflow fails without moving the tag or mutating the release
+
+#### Scenario: Prepublication milestone gating remains acyclic
+- **WHEN** a mapped implementation issue is validated before release publication
+- **THEN** its tasks require generic and prepublication proof only, while exact hosted-release verification remains a separate post-closure release operation
+
+### Requirement: Automatic release dispatch preserves verified handoff behavior
+`03-Auto-Release` SHALL dispatch `02-Release` for a new eligible stable or RC workspace version only after the clean optional-parser handoff is input-compatible with the exact pushed `main` commit. It SHALL not dispatch a supported development version or an already tagged version.
+
+#### Scenario: New RC dispatch
+- **WHEN** `0.4.5-rc1` lands on `main`, its tag is absent, and the exact parser-pack handoff is valid
+- **THEN** auto-release dispatches `02-Release` with version `v0.4.5-rc1` and the verified handoff run ID
+
+#### Scenario: Stable dispatch compatibility
+- **WHEN** a stable workspace version lands under the same verified conditions
+- **THEN** auto-release preserves the existing stable dispatch behavior
+
+#### Scenario: Allowed integration histories share one handoff rule
+- **WHEN** an eligible version reaches `main` through an allowed merge commit, squash merge, or rebase merge
+- **THEN** auto-release compares clean parser proof with the exact pushed commit without requiring a second parent
+
+#### Scenario: Ineligible or existing version does not dispatch
+- **WHEN** the workspace version is the supported development form or its normalized tag already exists
+- **THEN** auto-release does not resolve a handoff or dispatch publication
+
+### Requirement: Release notes remain cumulative through candidate promotion
+For any accepted release series, the release-note generator MUST use the greatest preceding stable tag as its history baseline and MUST ignore RC tags as baselines. Every RC and the final stable release in that series SHALL therefore include all changes since the preceding stable release.
+
+#### Scenario: First RC uses the preceding stable release
+- **WHEN** the first RC of a release series is generated after a preceding stable tag
+- **THEN** its notes cover the preceding stable tag through the RC head rather than all repository history
+
+#### Scenario: Later RC remains cumulative
+- **WHEN** a later RC is generated and earlier RC tags exist for the same series
+- **THEN** its notes still use the preceding stable tag and include changes from the earlier RCs
+
+#### Scenario: Final promotion includes all RC work
+- **WHEN** the final stable release is generated after one or more RC tags for the same series
+- **THEN** its notes use the preceding stable tag and include every change introduced during the RC sequence
+
+#### Scenario: Existing stable-to-stable behavior remains compatible
+- **WHEN** a stable release is generated without any RC tags in its series
+- **THEN** its notes continue to use the preceding stable tag
+
+### Requirement: Release artifact identity remains exact
+Optional-parser release verification and installer downstream-pin checks MUST preserve and compare the complete accepted version tag, including an `-rcN` suffix when present. Release staging SHALL accept an optional immutable clean-main Atlas seed only as a complete archive/manifest pair whose shared content-addressed basename contains that same exact tag, and SHALL include both files in release checksums without taking ownership of seed creation or hydration.
+
+#### Scenario: RC parser assets retain exact identity
+- **WHEN** an optional-parser package and proof are staged for an RC
+- **THEN** their declared version and filenames retain the complete RC tag and a stable proof cannot be relabeled as that RC
+
+#### Scenario: Exact RC workflow pin is current
+- **WHEN** an installed RC inspects a downstream ProjectAtlas workflow pinned to its complete RC tag
+- **THEN** neither the POSIX nor PowerShell installer reports that exact pin as stale
+
+#### Scenario: Stale and unrelated pins remain classified correctly
+- **WHEN** downstream files contain an older ProjectAtlas tag and a tag belonging to another repository
+- **THEN** the older ProjectAtlas tag is reported stale and the unrelated repository tag is ignored
+
+#### Scenario: Exact stable or RC seed pair is included
+- **WHEN** the separately owned producer supplies `projectatlas-main-atlas-seed-<tag>-<snapshot-digest>.tar.zst` and the matching `.manifest.json` for the requested stable or RC tag
+- **THEN** release staging accepts both immutable files and records a SHA-256 checksum for each
+
+#### Scenario: Seed production remains optional and separately owned
+- **WHEN** no main Atlas seed asset is present because the producer has not joined the release handoff
+- **THEN** the release adapter continues without fabricating a seed or weakening the ordinary archive gates
+
+#### Scenario: Partial or wrong-version seed inventory fails closed
+- **WHEN** a local seed pair is partial, or a hosted seed asset has a different tag, malformed digest, symlink, second snapshot digest, byte mismatch, or no complete exact staged pair for interrupted-upload recovery
+- **THEN** release staging fails before creating or repairing the GitHub release
+
+#### Scenario: Hosted seed repair is immutable
+- **WHEN** an existing release already contains the exact validated seed pair
+- **THEN** staging requires byte equality and repairs only replaceable assets without clobbering either seed object
+
+#### Scenario: Interrupted seed-pair upload is recoverable
+- **WHEN** an existing release contains exactly one expected immutable seed member and a retry supplies the complete validated byte-identical pair
+- **THEN** the retained member is not clobbered and the retry uploads only its missing companion
+
+### Requirement: Dependency automation follows the active release branch
+Repository dependency automation SHALL target `main`. Obsolete automated PRs targeting `dev` MUST be explicitly dispositioned without merging their dependency changes into v0.4.5.
+
+#### Scenario: Future dependency update routing
+- **WHEN** Dependabot creates a Cargo or GitHub Actions update after this change lands
+- **THEN** its base branch is `main`
+
+#### Scenario: Existing obsolete PR cleanup
+- **WHEN** a `dev`-targeted automated PR has no unresolved review feedback and is outside v0.4.5 scope
+- **THEN** it is closed with a reason and its head may be pruned without changing dependency versions
+
+### Requirement: IssueOps hard-gates architecture evidence and final reconciliation
+For every open mapped issue, IssueOps MUST require the `Architecture Diagrams` section either to contain local `dev/docs/*.md#heading` links whose exact linked sections contain closed fenced Mermaid blocks accepted by the repository-locked Mermaid syntax parser, or to contain exactly `N/A: <reason>` with a non-empty reason. A heading, prose, an empty, declaration-only, malformed, syntactically invalid Mermaid, or another code-fence type SHALL NOT satisfy the diagram path. The final OpenSpec task MUST require comparison of the finished implementation with the diagrams, correction of either until they agree, or reconfirmation of the reasoned `N/A`.
+
+#### Scenario: Linked section contains a real Mermaid diagram
+- **WHEN** an architecture link resolves to a local Markdown heading whose owned section contains a closed `mermaid` fence beginning with a diagram declaration and followed by actual diagram content
+- **THEN** IssueOps accepts the architecture evidence
+
+#### Scenario: Prose-only architecture section fails
+- **WHEN** the linked heading exists but its section has only prose, an empty or declaration-only Mermaid fence, an ordinary code fence, or syntactically invalid Mermaid content
+- **THEN** IssueOps fails the mapped issue
+
+#### Scenario: No architecture change is a conscious decision
+- **WHEN** the issue records `N/A: <reason>` and no architecture diagram is needed
+- **THEN** IssueOps accepts the reasoned decision while rejecting bare or unexplained `N/A`
+
+#### Scenario: Final architecture reconciliation is mandatory
+- **WHEN** the local OpenSpec checklist does not end with the standard implementation-to-architecture reconciliation task
+- **THEN** IssueOps fails the mapped issue before closure or release
+
+### Requirement: Release milestone planning admits only implementation-ready issues
+When an open issue is assigned to a canonical release milestone, IssueOps MUST require exactly `status:ready`, a local OpenSpec mapping, readable proposal/design/delta-spec/tasks artifacts, complete required proposal and design sections, explicit cross-issue impact or a reasoned `N/A`, resolved open questions, at least one delta-spec requirement and scenario, and checked `1.x` contract/specification tasks. The existing mapped-issue contract MUST additionally pass for synchronized tasks, issue shape, architecture evidence, and final reconciliation.
+
+#### Scenario: Ready mapped issue can be planned
+- **WHEN** an open issue satisfies every readiness artifact and issue-contract requirement before milestone assignment
+- **THEN** the issue-event IssueOps gate accepts the planned release scope
+
+#### Scenario: Unmapped or backlog issue cannot be planned
+- **WHEN** an open issue has no local OpenSpec mapping or retains a non-ready status label
+- **THEN** IssueOps fails its release-milestone planning event
+
+#### Scenario: Incomplete specification cannot be hidden behind a ready label
+- **WHEN** a ready-labeled issue is missing a required OpenSpec artifact or section, has unresolved open questions, omits cross-issue impact, lacks requirement scenarios, or has unchecked contract tasks
+- **THEN** IssueOps fails the planning event

--- a/openspec/changes/release-candidates-and-pr-cleanup/specs/release-candidate-promotion/spec.md
+++ b/openspec/changes/release-candidates-and-pr-cleanup/specs/release-candidate-promotion/spec.md
@@ -61,6 +61,10 @@ The release workflow SHALL serialize runs by exact requested version, SHALL publ
 - **WHEN** an RC is created or repaired and the workflow captured the current Latest tag before publication
 - **THEN** GitHub's Latest endpoint remains exactly that captured tag after publication
 
+#### Scenario: Published RC completes the installed agent workflow
+- **WHEN** an RC is published and the Linux installer smoke accepts its exact hosted artifact
+- **THEN** the RC remains a non-Latest prerelease, indexes a real project, serves fresh brief and source evidence through its generated stdio MCP configuration, and the release workflow succeeds only after the remaining platform smokes also pass
+
 #### Scenario: New stable publication becomes Latest
 - **WHEN** final `v0.4.5` is newly created after its milestone is complete
 - **THEN** the release record is not prerelease and GitHub's Latest endpoint identifies `v0.4.5`

--- a/openspec/changes/release-candidates-and-pr-cleanup/tasks.md
+++ b/openspec/changes/release-candidates-and-pr-cleanup/tasks.md
@@ -1,0 +1,23 @@
+## 1. Contract
+
+- [ ] 1.1 Map `release-candidates-and-pr-cleanup` to GitHub issue #448 in `openspec/issue-map.json` and keep the issue checklist synchronized with this file.
+- [x] 1.2 Specify version-agnostic stable/RC syntax, stable milestone derivation, prerelease/Latest behavior, recovery refusal, cumulative release-note history, parser asset identity, installer pin compatibility, automatic dispatch, dependency cleanup, and IssueOps architecture/readiness boundaries.
+
+## 2. Implementation
+
+- [x] 2.1 Add the smallest shared standard-library, version-agnostic stable/RC classifier used by workflows and Python release tooling without a new dependency or generic versioning framework.
+- [x] 2.2 Publish and repair GitHub releases with exact stable/prerelease classification, exact-head validation, and post-publication Latest verification.
+- [x] 2.3 Preserve automatic stable and RC dispatch, development-version exclusion, existing-tag exclusion, exact optional-parser handoff, and cumulative notes from the preceding stable tag through every RC and the final release.
+- [x] 2.4 Preserve complete RC identity in optional-parser assets and POSIX/PowerShell installer downstream-pin checks.
+- [x] 2.5 Retarget Dependabot to `main` and close obsolete or superseded dependency PRs against `dev` with explicit dispositions and no dependency-version changes.
+- [x] 2.6 Hard-gate IssueOps architecture evidence to a real Mermaid diagram in every linked section or a reasoned `N/A`, and require the standard final architecture-reconciliation task.
+- [x] 2.7 Add an issue-event IssueOps gate that admits an open issue to a release milestone only after its mapped OpenSpec, contract tasks, dependencies, open questions, issue contract, and `status:ready` state are implementation-ready.
+
+## 3. Verification and Documentation
+
+- [x] 3.1 Add and run focused positive, negative, failure, and stable-compatibility checks for generic stable, RC, malformed, and development versions, milestone derivation/readiness, cumulative release-note history, and workflow routing.
+- [ ] 3.2 Strengthen and run the existing installer E2E coverage for exact stable and RC downstream pins, stale pins, and unrelated repositories.
+- [ ] 3.3 Update release guidance and the stable-versus-RC architecture diagram, render and visually inspect the Mermaid output, and synchronize issue #448.
+- [ ] 3.4 Verify the generic post-publication contract covers exact tag head, stable/prerelease metadata, new-release and repair Latest behavior, and immutable optional-asset repair without making any gated implementation issue depend on the release it blocks.
+- [ ] 3.5 Run OpenSpec, IssueOps, release, Rust, and repository gates and reconcile every live review thread before closure.
+- [ ] 3.6 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/changes/release-candidates-and-pr-cleanup/tasks.md
+++ b/openspec/changes/release-candidates-and-pr-cleanup/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Contract
 
-- [ ] 1.1 Map `release-candidates-and-pr-cleanup` to GitHub issue #448 in `openspec/issue-map.json` and keep the issue checklist synchronized with this file.
+- [x] 1.1 Map `release-candidates-and-pr-cleanup` to GitHub issue #448 in `openspec/issue-map.json` and keep the issue checklist synchronized with this file.
 - [x] 1.2 Specify version-agnostic stable/RC syntax, stable milestone derivation, prerelease/Latest behavior, recovery refusal, cumulative release-note history, parser asset identity, installer pin compatibility, automatic dispatch, dependency cleanup, and IssueOps architecture/readiness boundaries.
 
 ## 2. Implementation
@@ -17,7 +17,7 @@
 
 - [x] 3.1 Add and run focused positive, negative, failure, and stable-compatibility checks for generic stable, RC, malformed, and development versions, milestone derivation/readiness, cumulative release-note history, and workflow routing.
 - [ ] 3.2 Strengthen and run the existing installer E2E coverage for exact stable and RC downstream pins, stale pins, and unrelated repositories.
-- [ ] 3.3 Update release guidance and the stable-versus-RC architecture diagram, render and visually inspect the Mermaid output, and synchronize issue #448.
+- [x] 3.3 Update release guidance and the stable-versus-RC architecture diagram, render and visually inspect the Mermaid output, and synchronize issue #448.
 - [x] 3.4 Verify the generic post-publication contract covers exact tag head, stable/prerelease metadata, new-release and repair Latest behavior, and immutable optional-asset repair without making any gated implementation issue depend on the release it blocks.
 - [ ] 3.5 Run OpenSpec, IssueOps, release, Rust, and repository gates and reconcile every live review thread before closure.
 - [ ] 3.6 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/changes/release-candidates-and-pr-cleanup/tasks.md
+++ b/openspec/changes/release-candidates-and-pr-cleanup/tasks.md
@@ -18,6 +18,6 @@
 - [x] 3.1 Add and run focused positive, negative, failure, and stable-compatibility checks for generic stable, RC, malformed, and development versions, milestone derivation/readiness, cumulative release-note history, and workflow routing.
 - [ ] 3.2 Strengthen and run the existing installer E2E coverage for exact stable and RC downstream pins, stale pins, and unrelated repositories.
 - [ ] 3.3 Update release guidance and the stable-versus-RC architecture diagram, render and visually inspect the Mermaid output, and synchronize issue #448.
-- [ ] 3.4 Verify the generic post-publication contract covers exact tag head, stable/prerelease metadata, new-release and repair Latest behavior, and immutable optional-asset repair without making any gated implementation issue depend on the release it blocks.
+- [x] 3.4 Verify the generic post-publication contract covers exact tag head, stable/prerelease metadata, new-release and repair Latest behavior, and immutable optional-asset repair without making any gated implementation issue depend on the release it blocks.
 - [ ] 3.5 Run OpenSpec, IssueOps, release, Rust, and repository gates and reconcile every live review thread before closure.
 - [ ] 3.6 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/changes/release-candidates-and-pr-cleanup/tasks.md
+++ b/openspec/changes/release-candidates-and-pr-cleanup/tasks.md
@@ -16,8 +16,8 @@
 ## 3. Verification and Documentation
 
 - [x] 3.1 Add and run focused positive, negative, failure, and stable-compatibility checks for generic stable, RC, malformed, and development versions, milestone derivation/readiness, cumulative release-note history, and workflow routing.
-- [ ] 3.2 Strengthen and run the existing installer E2E coverage for exact stable and RC downstream pins, stale pins, and unrelated repositories.
+- [ ] 3.2 Strengthen and run the installer E2E coverage for exact stable and RC downstream pins, stale pins, and unrelated repositories; add the post-publication holistic RC agent workflow from prerelease metadata through install, indexing, and stdio MCP evidence.
 - [x] 3.3 Update release guidance and the stable-versus-RC architecture diagram, render and visually inspect the Mermaid output, and synchronize issue #448.
 - [x] 3.4 Verify the generic post-publication contract covers exact tag head, stable/prerelease metadata, new-release and repair Latest behavior, and immutable optional-asset repair without making any gated implementation issue depend on the release it blocks.
 - [ ] 3.5 Run OpenSpec, IssueOps, release, Rust, and repository gates and reconcile every live review thread before closure.
-- [ ] 3.6 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
+- [x] 3.6 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/changes/release-candidates-and-pr-cleanup/tasks.md
+++ b/openspec/changes/release-candidates-and-pr-cleanup/tasks.md
@@ -16,8 +16,8 @@
 ## 3. Verification and Documentation
 
 - [x] 3.1 Add and run focused positive, negative, failure, and stable-compatibility checks for generic stable, RC, malformed, and development versions, milestone derivation/readiness, cumulative release-note history, and workflow routing.
-- [ ] 3.2 Strengthen and run the installer E2E coverage for exact stable and RC downstream pins, stale pins, and unrelated repositories; add the post-publication holistic RC agent workflow from prerelease metadata through install, indexing, and stdio MCP evidence.
+- [x] 3.2 Strengthen and run the installer E2E coverage for exact stable and RC downstream pins, stale pins, and unrelated repositories; add the post-publication holistic RC agent workflow from prerelease metadata through install, indexing, and stdio MCP evidence.
 - [x] 3.3 Update release guidance and the stable-versus-RC architecture diagram, render and visually inspect the Mermaid output, and synchronize issue #448.
 - [x] 3.4 Verify the generic post-publication contract covers exact tag head, stable/prerelease metadata, new-release and repair Latest behavior, and immutable optional-asset repair without making any gated implementation issue depend on the release it blocks.
-- [ ] 3.5 Run OpenSpec, IssueOps, release, Rust, and repository gates and reconcile every live review thread before closure.
+- [x] 3.5 Run OpenSpec, IssueOps, release, Rust, and repository gates and reconcile every live review thread before closure.
 - [x] 3.6 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -63,13 +63,14 @@
         {
           "issue": 314,
           "first_task": "1.1",
-          "last_task": "7.4"
+          "last_task": "7.5"
         }
       ]
     },
     "prefer-worktree-guidance-before-database-preflight": 412,
     "publish-rustdoc-readme-links": 300,
     "reject-incompatible-schema-before-write": 410,
+    "release-candidates-and-pr-cleanup": 448,
     "report-installer-host-restart": 383,
     "resolve-configured-module-aliases": 385,
     "reuse-release-proof-by-inputs": 366,

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -3656,7 +3656,7 @@ function Write-ProjectAtlasWorkflowPinReport {
             if ($line -notmatch 'github\.com/styler-ai/ProjectAtlas/releases/download/') {
                 continue
             }
-            $pinMatches = [System.Text.RegularExpressions.Regex]::Matches($line, 'v[0-9]+\.[0-9]+\.[0-9]+')
+            $pinMatches = [System.Text.RegularExpressions.Regex]::Matches($line, 'v[0-9]+\.[0-9]+\.[0-9]+(?:-rc[1-9][0-9]*)?')
             foreach ($match in $pinMatches) {
                 $foundTag = $match.Value
                 if ($foundTag -and $foundTag -ne $releaseTag) {

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -3653,12 +3653,9 @@ function Write-ProjectAtlasWorkflowPinReport {
         $lineNumber = 0
         foreach ($line in Get-Content -LiteralPath $file.FullName) {
             $lineNumber += 1
-            if ($line -notmatch 'github\.com/styler-ai/ProjectAtlas/releases/download/') {
-                continue
-            }
-            $pinMatches = [System.Text.RegularExpressions.Regex]::Matches($line, 'v[0-9]+\.[0-9]+\.[0-9]+(?:-rc[1-9][0-9]*)?')
+            $pinMatches = [System.Text.RegularExpressions.Regex]::Matches($line, 'https://github\.com/styler-ai/ProjectAtlas/releases/download/([^/\s]+)/')
             foreach ($match in $pinMatches) {
-                $foundTag = $match.Value
+                $foundTag = $match.Groups[1].Value
                 if ($foundTag -and $foundTag -ne $releaseTag) {
                     $relativePath = $file.FullName
                     if ($relativePath.StartsWith($rootPath, [System.StringComparison]::OrdinalIgnoreCase)) {

--- a/plugins/projectatlas/scripts/install-runtime.ps1
+++ b/plugins/projectatlas/scripts/install-runtime.ps1
@@ -3656,7 +3656,10 @@ function Write-ProjectAtlasWorkflowPinReport {
             $pinMatches = [System.Text.RegularExpressions.Regex]::Matches($line, 'https://github\.com/styler-ai/ProjectAtlas/releases/download/([^/\s]+)/')
             foreach ($match in $pinMatches) {
                 $foundTag = $match.Groups[1].Value
-                if ($foundTag -and $foundTag -ne $releaseTag) {
+                if ($foundTag -notmatch '^v[0-9][A-Za-z0-9.+-]*$') {
+                    continue
+                }
+                if ($foundTag -ne $releaseTag) {
                     $relativePath = $file.FullName
                     if ($relativePath.StartsWith($rootPath, [System.StringComparison]::OrdinalIgnoreCase)) {
                         $relativePath = $relativePath.Substring($rootPath.Length).TrimStart('\', '/')

--- a/plugins/projectatlas/scripts/install-runtime.sh
+++ b/plugins/projectatlas/scripts/install-runtime.sh
@@ -1393,6 +1393,7 @@ report_projectatlas_workflow_pins() {
           printf '%s\n' "$line" |
             grep -Eo 'https://github\.com/styler-ai/ProjectAtlas/releases/download/[^/[:space:]]+/' |
             sed -E 's#^.*/download/([^/]+)/$#\1#' |
+            grep -E '^v[0-9][A-Za-z0-9.+-]*$' |
             sort -u |
             while IFS= read -r found_tag; do
               if [ "$found_tag" != "$release_tag" ]; then

--- a/plugins/projectatlas/scripts/install-runtime.sh
+++ b/plugins/projectatlas/scripts/install-runtime.sh
@@ -1389,9 +1389,10 @@ report_projectatlas_workflow_pins() {
     while IFS= read -r line || [ -n "$line" ]; do
       line_number=$((line_number + 1))
       case "$line" in
-        *github.com/styler-ai/ProjectAtlas/releases/download/v*)
+        *github.com/styler-ai/ProjectAtlas/releases/download/*/*)
           printf '%s\n' "$line" |
-            grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+(-rc[1-9][0-9]*)?' |
+            grep -Eo 'https://github\.com/styler-ai/ProjectAtlas/releases/download/[^/[:space:]]+/' |
+            sed -E 's#^.*/download/([^/]+)/$#\1#' |
             sort -u |
             while IFS= read -r found_tag; do
               if [ "$found_tag" != "$release_tag" ]; then

--- a/plugins/projectatlas/scripts/install-runtime.sh
+++ b/plugins/projectatlas/scripts/install-runtime.sh
@@ -1391,7 +1391,7 @@ report_projectatlas_workflow_pins() {
       case "$line" in
         *github.com/styler-ai/ProjectAtlas/releases/download/v*)
           printf '%s\n' "$line" |
-            grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' |
+            grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+(-rc[1-9][0-9]*)?' |
             sort -u |
             while IFS= read -r found_tag; do
               if [ "$found_tag" != "$release_tag" ]; then


### PR DESCRIPTION
## Summary

- add generic stable/RC classification, RC-first promotion, cumulative notes, repair, Latest, and immutable optional-seed policy
- harden IssueOps planning/architecture validation and retire obsolete dev-targeted dependency automation
- preserve exact RC identity through parser assets and both installers
- add a post-publication holistic RC E2E from hosted prerelease metadata through install, indexing, and generated stdio MCP evidence

## Issue

Closes #448

## Checklist

- [x] `projectatlas scan` run when indexed context changed.
- [x] `projectatlas lint --report-untracked --purpose-level low` passes, and `projectatlas purpose queue` has been reviewed for touched high-value paths.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo check --workspace --all-targets --all-features --locked` clean.
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` clean.
- [x] `cargo test --workspace --all-features --locked` and stable workspace doctests clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --locked` clean.
- [x] Tests updated or added where behavior changed.
- [x] All active OpenSpec changes are mapped, issue #448 mirrors the local checklist, and the repository-wide IssueOps gate passes.
- [x] README, Markdown docs, and GitHub Pages/rustdoc-facing content are updated or confirmed current.
- [x] PR text contains no private or internal-only details.