### PR TITLE
fix(release): align parser ownership check (#448)

### DIFF
--- a/.github/scripts/test-parser-pack-construction-diagnostics.ps1
+++ b/.github/scripts/test-parser-pack-construction-diagnostics.ps1
@@ -471,7 +471,6 @@ try {
         "cssparser",
         "jsonc-parser",
         "notify",
-        "pulldown-cmark",
         "projectatlas-db",
         "projectatlas-fs",
         "projectatlas-service",

--- a/.github/scripts/test-parser-pack-construction-diagnostics.ps1
+++ b/.github/scripts/test-parser-pack-construction-diagnostics.ps1
@@ -465,6 +465,9 @@ try {
             ) -and
             $runtimeBoundaryMeasurementText.Contains('[AllowEmptyString()]')) `
         "Absent-pack control must build the runnable CLI core without the optional supervisor."
+    Require `
+        (-not $cliManifestText.Contains("pulldown-cmark")) `
+        "The Markdown parser dependency must remain outside the main CLI ownership boundary."
     foreach ($dependency in @(
         "blake3",
         "clap",


### PR DESCRIPTION
## Summary

- remove the stale requirement that `pulldown-cmark` remain an optional dependency of `projectatlas-cli`
- preserve the #440 ownership boundary where Markdown parsing lives in `projectatlas-symbols`
- unblock clean optional-parser-pack construction without restoring unnecessary CLI build coupling

Refs #448

## Verification

- failing before: `pwsh -NoProfile -File .github/scripts/test-parser-pack-construction-diagnostics.ps1` reported `Main CLI dependency is not feature-owned: pulldown-cmark`
- passing after: the same diagnostic and runtime-containment artifact self-test
- full repository pre-push gate passed, including Rust tests, doc tests, rustdoc, source/dependency policy, IssueOps, scan, and lint
