### PR TITLE
test(release): make packaged scan ownership deterministic

### DIFF
--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -20721,7 +20721,7 @@ fn mcp_advertised_tools_own_their_real_sqlite_effects() -> Result<(), Box<dyn Er
             )?,
             "atlas_scan" => fs::write(
                 repo.join(SRC_DIR_NAME).join(SCANNED_RS_FILE_NAME),
-                "pub fn rescanned_contract() {}\n",
+                "pub fn rescanned_contract() { rescanned_contract(); }\n",
             )?,
             "atlas_file_summary" => fs::write(
                 repo.join(SRC_DIR_NAME).join(LIB_RS_FILE_NAME),


### PR DESCRIPTION
Fixes #448

Why:
- Release run 31973886432 installed the Linux package successfully, then exposed a timing-dependent packaged MCP ownership fixture.
- The fixture renamed one function without changing parse counts, so `source_parse_metadata` appeared changed only if SQLite's second-resolution timestamp advanced.

Change:
- Keep the single-symbol fixture but add one self-call relation, forcing a deterministic parse-metadata delta without changing the frozen symbol-count contract.

Verification:
- Exact all-features packaged MCP contract: 3 consecutive focused passes.
- Full pre-push workspace/unit/E2E/doc/policy/IssueOps/scan gate passed, including 132/132 non-ignored CLI E2Es.
- Strict Clippy and formatting passed.