### PR TITLE
fix(release): close v0.4.5-rc3 root-cause gaps

### DIFF
--- a/.github/workflows/04-docs.yml
+++ b/.github/workflows/04-docs.yml
@@ -105,6 +105,7 @@ jobs:
                 <div class="grid">
                   <a class="card" href="https://github.com/styler-ai/ProjectAtlas/blob/main/docs/agent-integration.md">Agent Integration<span class="label">MCP-first startup, exact navigation, purpose curation, and runtime repair</span></a>
                   <a class="card" href="https://github.com/styler-ai/ProjectAtlas/blob/main/docs/worktree-lifecycle.md#worktree-atlas-continuity">Worktree Atlas Continuity<span class="label">short aliases, safe hydration, isolated graphs, federation, and aggregate tokens</span></a>
+                  <a class="card" href="https://github.com/styler-ai/ProjectAtlas/blob/main/docs/v0.4.5-rc3-release-notes.md">v0.4.5-rc3<span class="label">shared graph-limit, qualified-symbol, and typed lint root-cause fixes</span></a>
                   <a class="card" href="https://github.com/styler-ai/ProjectAtlas/blob/main/docs/v0.4.5-rc2-release-notes.md">v0.4.5-rc2<span class="label">candidate stabilization, compatibility, deliberate boundaries, and proof policy</span></a>
                   <a class="card" href="https://github.com/styler-ai/ProjectAtlas/blob/main/docs/projectatlas-3-architecture.md#architecture-views">Architecture Views<span class="label">system ownership, SQLite authority, indexing, communication, and failure flows</span></a>
                   <a class="card" href="language-support/">Language &amp; Ecosystem Support<span class="label">honest capability tiers, candidates, and classified ecosystem coverage</span></a>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
         shell: bash
         run: |
           cargo test --locked -p projectatlas-cli --test e2e csharp_symbol_identity_boundary_preserves_full_and_incremental_publication -- --exact --include-ignored --nocapture
+          cargo test --locked -p projectatlas-cli --test e2e deep_qualified_symbol_parents_preserve_full_and_incremental_publication -- --exact --include-ignored --nocapture
+          cargo test --locked -p projectatlas-cli --test e2e partial_markdown_limit_persists_without_losing_complete_publication -- --exact --include-ignored --nocapture
+          cargo test --locked -p projectatlas-cli --test e2e lint_formats_share_typed_cli_and_mcp_report -- --exact --include-ignored --nocapture
           cargo test --locked -p projectatlas-cli --test e2e classified_document_navigation_agrees_across_cli_and_mcp -- --exact --include-ignored --nocapture
           cargo test --locked -p projectatlas-cli --test e2e conditional_purpose_review_cli_reconciles_source_before_apply -- --exact --include-ignored --nocapture
           cargo test --locked -p projectatlas-cli --test e2e persistent_mcp_purpose_review_reconciles_source_before_apply -- --exact --include-ignored --nocapture

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,9 @@ jobs:
         timeout-minutes: 10
         run: |
           cargo test --locked -p projectatlas-cli --test e2e csharp_symbol_identity_boundary_preserves_full_and_incremental_publication -- --exact --include-ignored --nocapture
+          cargo test --locked -p projectatlas-cli --test e2e deep_qualified_symbol_parents_preserve_full_and_incremental_publication -- --exact --include-ignored --nocapture
+          cargo test --locked -p projectatlas-cli --test e2e partial_markdown_limit_persists_without_losing_complete_publication -- --exact --include-ignored --nocapture
+          cargo test --locked -p projectatlas-cli --test e2e lint_formats_share_typed_cli_and_mcp_report -- --exact --include-ignored --nocapture
           cargo test --locked -p projectatlas-cli --test e2e classified_document_navigation_agrees_across_cli_and_mcp -- --exact --include-ignored --nocapture
           cargo test --locked -p projectatlas-cli --test e2e conditional_purpose_review_cli_reconciles_source_before_apply -- --exact --include-ignored --nocapture
           cargo test --locked -p projectatlas-cli --test e2e persistent_mcp_purpose_review_reconciles_source_before_apply -- --exact --include-ignored --nocapture
@@ -467,6 +470,9 @@ jobs:
           for test in \
             installed_candidate_version_is_consistent_across_cli_runtime_and_token_tui \
             csharp_symbol_identity_boundary_preserves_full_and_incremental_publication \
+            deep_qualified_symbol_parents_preserve_full_and_incremental_publication \
+            partial_markdown_limit_persists_without_losing_complete_publication \
+            lint_formats_share_typed_cli_and_mcp_report \
             token_tui_cli_respects_selected_terminal_viewport \
             classified_document_navigation_agrees_across_cli_and_mcp \
             conditional_purpose_review_cli_reconciles_source_before_apply \
@@ -657,6 +663,9 @@ jobs:
           foreach ($test in @(
             "installed_candidate_version_is_consistent_across_cli_runtime_and_token_tui",
             "csharp_symbol_identity_boundary_preserves_full_and_incremental_publication",
+            "deep_qualified_symbol_parents_preserve_full_and_incremental_publication",
+            "partial_markdown_limit_persists_without_losing_complete_publication",
+            "lint_formats_share_typed_cli_and_mcp_report",
             "token_tui_cli_respects_selected_terminal_viewport",
             "classified_document_navigation_agrees_across_cli_and_mcp",
             "conditional_purpose_review_cli_reconciles_source_before_apply",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-cli"
-version = "0.4.5-rc2"
+version = "0.4.5-rc3"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-core"
-version = "0.4.5-rc2"
+version = "0.4.5-rc3"
 dependencies = [
  "blake3",
  "object",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-db"
-version = "0.4.5-rc2"
+version = "0.4.5-rc3"
 dependencies = [
  "blake3",
  "getrandom 0.4.3",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-fs"
-version = "0.4.5-rc2"
+version = "0.4.5-rc3"
 dependencies = [
  "blake3",
  "ignore",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-lints"
-version = "0.4.5-rc2"
+version = "0.4.5-rc3"
 dependencies = [
  "proc-macro2",
  "regex",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-service"
-version = "0.4.5-rc2"
+version = "0.4.5-rc3"
 dependencies = [
  "blake3",
  "globset",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-symbols"
-version = "0.4.5-rc2"
+version = "0.4.5-rc3"
 dependencies = [
  "blake3",
  "projectatlas-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.5-rc2"
+version = "0.4.5-rc3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/styler-ai/ProjectAtlas"
@@ -69,11 +69,11 @@ must_use_candidate = "allow"
 missing_inline_in_public_items = "allow"
 
 [workspace.dependencies]
-projectatlas-core = { path = "crates/projectatlas-core", version = "0.4.5-rc2" }
-projectatlas-db = { path = "crates/projectatlas-db", version = "0.4.5-rc2" }
-projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.4.5-rc2" }
-projectatlas-service = { path = "crates/projectatlas-service", version = "0.4.5-rc2" }
-projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.4.5-rc2" }
+projectatlas-core = { path = "crates/projectatlas-core", version = "0.4.5-rc3" }
+projectatlas-db = { path = "crates/projectatlas-db", version = "0.4.5-rc3" }
+projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.4.5-rc3" }
+projectatlas-service = { path = "crates/projectatlas-service", version = "0.4.5-rc3" }
+projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.4.5-rc3" }
 assert_cmd = "2.0"
 blake3 = "1.5"
 clap = { version = "4.5", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Warm indexed CLI reads in the same audit stayed around 160–166 ms. Repository 
 
 Full benchmark campaigns are manual-only and run only when explicitly requested.
 
-The [v0.4.5-rc2 candidate](https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.4.5-rc2) and [release notes](docs/v0.4.5-rc2-release-notes.md) cover RC1 workflow stabilization across documentation navigation, purpose mutation, terminal rendering, symbol publication, Btrfs database placement, and recreated worktrees. RC2 is published as a prerelease and does not replace the preceding stable GitHub Latest release.
+The [v0.4.5-rc3 candidate](https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.4.5-rc3) and [release notes](docs/v0.4.5-rc3-release-notes.md) fix graph-limit persistence, deep cross-language symbol identities, and typed CLI/MCP lint output. RC3 is published as a prerelease and does not replace the preceding stable GitHub Latest release. The [RC2 notes](docs/v0.4.5-rc2-release-notes.md) cover preceding stabilization work.
 
 ## Documentation
 

--- a/crates/projectatlas-cli/src/atlas_map.rs
+++ b/crates/projectatlas-cli/src/atlas_map.rs
@@ -455,6 +455,139 @@ pub(crate) struct LintOptions {
     pub(crate) strict_untracked: bool,
 }
 
+/// Typed map-owned portion of one lint result.
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct MapLintReport {
+    /// Whether every map-owned check passed.
+    pub(crate) ok: bool,
+    /// Compatibility notices that do not fail lint.
+    pub(crate) notes: Vec<String>,
+    /// Validation state for the non-source purpose registry.
+    pub(crate) non_source: NonSourceLintReport,
+    /// Untracked-file inventory when requested.
+    pub(crate) untracked: Option<UntrackedLintReport>,
+}
+
+/// Typed non-source purpose-registry lint facts.
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct NonSourceLintReport {
+    /// File-level parse or validation errors.
+    pub(crate) errors: Vec<String>,
+    /// Registry entries whose paths do not exist.
+    pub(crate) missing: Vec<String>,
+    /// Registry entries with invalid summaries, keyed by path.
+    pub(crate) invalid: BTreeMap<String, Vec<String>>,
+}
+
+/// Typed untracked-file lint inventory.
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct UntrackedLintReport {
+    /// Total untracked non-source files found.
+    pub(crate) total: usize,
+    /// Files admitted by configured purpose or allow-list policy.
+    pub(crate) allowed: usize,
+    /// Files not admitted by configured purpose or allow-list policy.
+    pub(crate) disallowed: Vec<String>,
+    /// Disallowed file counts grouped by normalized extension.
+    pub(crate) disallowed_extension_counts: BTreeMap<String, usize>,
+    /// Allowed file counts grouped by normalized extension.
+    pub(crate) allowed_extension_counts: BTreeMap<String, usize>,
+    /// Configured asset roots that currently exist.
+    pub(crate) asset_roots_present: usize,
+    /// Asset files found outside configured asset roots.
+    pub(crate) assets_outside_roots: Vec<String>,
+    /// Existing paths excluded from source scanning.
+    pub(crate) excluded_paths_present: usize,
+    /// Whether disallowed untracked files fail lint.
+    pub(crate) strict: bool,
+}
+
+impl MapLintReport {
+    /// Return the CLI-compatible exit code for map-owned findings.
+    pub(crate) const fn exit_code(&self) -> i32 {
+        if self.ok { 0 } else { 1 }
+    }
+
+    /// Render the compatibility text from the same typed facts.
+    pub(crate) fn render_text(&self) -> String {
+        let mut report = self.notes.clone();
+        if let Some(untracked) = &self.untracked {
+            untracked.append_text(&mut report);
+        }
+        self.non_source.append_errors(&mut report);
+        if self
+            .untracked
+            .as_ref()
+            .is_some_and(|untracked| untracked.strict && !untracked.disallowed.is_empty())
+        {
+            report.push("Untracked files detected.".to_string());
+        }
+        join_report(&report)
+    }
+}
+
+impl NonSourceLintReport {
+    /// Return whether the non-source registry contains blocking findings.
+    fn is_empty(&self) -> bool {
+        self.errors.is_empty() && self.missing.is_empty() && self.invalid.is_empty()
+    }
+
+    /// Append compatibility text for blocking non-source findings.
+    fn append_errors(&self, report: &mut Vec<String>) {
+        if !self.errors.is_empty() {
+            report.push("Non-source file list errors:".to_string());
+            report.push(format_list(&self.errors));
+        }
+        if !self.missing.is_empty() {
+            report.push("Missing non-source file entries:".to_string());
+            report.push(format_list(&self.missing));
+        }
+        if !self.invalid.is_empty() {
+            report.push("Invalid non-source file summaries:".to_string());
+            report.extend(
+                self.invalid
+                    .iter()
+                    .map(|(path, issues)| format!(" - {path}: {}", issues.join(", "))),
+            );
+        }
+    }
+}
+
+impl UntrackedLintReport {
+    /// Append compatibility text for the typed untracked-file inventory.
+    fn append_text(&self, report: &mut Vec<String>) {
+        report.push(format!(
+            "Untracked files (non-source extensions): {} (allowed {}, disallowed {})",
+            self.total,
+            self.allowed,
+            self.disallowed.len()
+        ));
+        if self.disallowed.is_empty() {
+            report.push("Disallowed untracked files: 0".to_string());
+        } else {
+            report.push("Disallowed untracked files:".to_string());
+            report.push(format_list(&self.disallowed));
+            report.push("Disallowed extension counts:".to_string());
+            report.push(format_extension_counts(&self.disallowed_extension_counts));
+        }
+        report.push("Allowed untracked extension counts:".to_string());
+        report.push(if self.allowed_extension_counts.is_empty() {
+            " (none)".to_string()
+        } else {
+            format_extension_counts(&self.allowed_extension_counts)
+        });
+        report.push(format!("Asset roots present: {}", self.asset_roots_present));
+        if !self.assets_outside_roots.is_empty() {
+            report.push("Asset files outside allowed roots:".to_string());
+            report.push(format_list(&self.assets_outside_roots));
+        }
+        report.push(format!(
+            "Excluded paths present: {}",
+            self.excluded_paths_present
+        ));
+    }
+}
+
 /// Purpose record imported from legacy `ProjectAtlas` metadata.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ImportedPurposeRecord {
@@ -918,31 +1051,40 @@ fn load_db_purpose_records(config: &AtlasMapConfig) -> AtlasMapResult<BTreeMap<S
         .collect())
 }
 
-/// Lint the atlas map and return a report plus exit code.
+/// Lint map-owned repository inputs and return typed facts.
 pub(crate) fn lint_map(
     config: &AtlasMapConfig,
     options: LintOptions,
-) -> AtlasMapResult<(String, i32)> {
+) -> AtlasMapResult<MapLintReport> {
     let paths = collect_repo_paths(config)?;
     let nonsource = read_nonsource_file_entries(config)?;
-    let mut report = Vec::new();
-    let mut errors = Vec::new();
-    if options.strict_folders {
-        report.push(
+    let notes = if options.strict_folders {
+        vec![
             "Note: --strict-folders is deprecated; database folder purpose linting uses --purpose-level."
                 .to_string(),
-        );
-    }
-
-    append_nonsource_errors(&mut errors, &nonsource);
-    if options.report_untracked {
-        append_untracked_report(&mut report, &mut errors, config, &paths, options)?;
-    }
-    if !errors.is_empty() {
-        report.extend(errors);
-        return Ok((join_report(&report), 1));
-    }
-    Ok((join_report(&report), 0))
+        ]
+    } else {
+        Vec::new()
+    };
+    let non_source = NonSourceLintReport {
+        errors: nonsource.errors,
+        missing: nonsource.missing,
+        invalid: nonsource.invalid,
+    };
+    let untracked = options
+        .report_untracked
+        .then(|| build_untracked_report(config, &paths, options))
+        .transpose()?;
+    let ok = non_source.is_empty()
+        && !untracked
+            .as_ref()
+            .is_some_and(|report| report.strict && !report.disallowed.is_empty());
+    Ok(MapLintReport {
+        ok,
+        notes,
+        non_source,
+        untracked,
+    })
 }
 
 /// Find a default config path under the current root.
@@ -2500,39 +2642,12 @@ fn record_json(record: &MapRecord) -> serde_json::Value {
     })
 }
 
-/// Append non-source validation errors.
-fn append_nonsource_errors(errors: &mut Vec<String>, nonsource: &NonsourceEntries) {
-    if !nonsource.errors.is_empty() {
-        errors.push("Non-source file list errors:".to_string());
-        errors.push(format_list(&nonsource.errors));
-    }
-    if !nonsource.missing.is_empty() {
-        errors.push("Missing non-source file entries:".to_string());
-        errors.push(format_list(&nonsource.missing));
-    }
-    if !nonsource.invalid.is_empty() {
-        errors.push("Invalid non-source file summaries:".to_string());
-        append_invalid_map(errors, &nonsource.invalid);
-    }
-}
-
-/// Append invalid path issue map.
-fn append_invalid_map(errors: &mut Vec<String>, invalid: &BTreeMap<String, Vec<String>>) {
-    errors.extend(
-        invalid
-            .iter()
-            .map(|(path, issues)| format!(" - {path}: {}", issues.join(", "))),
-    );
-}
-
-/// Append untracked-file report and optional errors.
-fn append_untracked_report(
-    report: &mut Vec<String>,
-    errors: &mut Vec<String>,
+/// Build the typed untracked-file inventory.
+fn build_untracked_report(
     config: &AtlasMapConfig,
     paths: &RepoPaths,
     options: LintOptions,
-) -> AtlasMapResult<()> {
+) -> AtlasMapResult<UntrackedLintReport> {
     let nonsource = read_nonsource_file_entries(config)?;
     let nonsource_paths = nonsource
         .records
@@ -2558,43 +2673,17 @@ fn append_untracked_report(
             disallowed.push(path.clone());
         }
     }
-    report.push(format!(
-        "Untracked files (non-source extensions): {} (allowed {}, disallowed {})",
-        paths.untracked_files.len(),
-        allowed.len(),
-        disallowed.len()
-    ));
-    if disallowed.is_empty() {
-        report.push("Disallowed untracked files: 0".to_string());
-    } else {
-        report.push("Disallowed untracked files:".to_string());
-        report.push(format_list(&disallowed));
-        report.push("Disallowed extension counts:".to_string());
-        report.push(format_list(&summarize_extensions(&disallowed)));
-    }
-    report.push("Allowed untracked extension counts:".to_string());
-    let allowed_summary = summarize_extensions(&allowed);
-    report.push(if allowed_summary.is_empty() {
-        " (none)".to_string()
-    } else {
-        format_list(&allowed_summary)
-    });
-    report.push(format!(
-        "Asset roots present: {}",
-        existing_asset_roots(config).len()
-    ));
-    if !asset_outside_roots.is_empty() {
-        report.push("Asset files outside allowed roots:".to_string());
-        report.push(format_list(&asset_outside_roots));
-    }
-    report.push(format!(
-        "Excluded paths present: {}",
-        paths.excluded_paths.len()
-    ));
-    if options.strict_untracked && !disallowed.is_empty() {
-        errors.push("Untracked files detected.".to_string());
-    }
-    Ok(())
+    Ok(UntrackedLintReport {
+        total: paths.untracked_files.len(),
+        allowed: allowed.len(),
+        disallowed_extension_counts: summarize_extensions(&disallowed),
+        allowed_extension_counts: summarize_extensions(&allowed),
+        asset_roots_present: existing_asset_roots(config).len(),
+        assets_outside_roots: asset_outside_roots,
+        excluded_paths_present: paths.excluded_paths.len(),
+        strict: options.strict_untracked,
+        disallowed,
+    })
 }
 
 /// Parse file and folder hashes from TOON.
@@ -2646,7 +2735,7 @@ fn existing_asset_roots(config: &AtlasMapConfig) -> Vec<String> {
 }
 
 /// Summarize extensions for reporting.
-fn summarize_extensions(paths: &[String]) -> Vec<String> {
+fn summarize_extensions(paths: &[String]) -> BTreeMap<String, usize> {
     let mut counts: BTreeMap<String, usize> = BTreeMap::new();
     for path in paths {
         let extension = normalized_extension(path);
@@ -2658,9 +2747,16 @@ fn summarize_extensions(paths: &[String]) -> Vec<String> {
         *counts.entry(key).or_default() += 1;
     }
     counts
-        .into_iter()
-        .map(|(extension, count)| format!("{extension}={count}"))
-        .collect()
+}
+
+/// Format deterministic extension counts as compatibility list items.
+fn format_extension_counts(counts: &BTreeMap<String, usize>) -> String {
+    format_list(
+        &counts
+            .iter()
+            .map(|(extension, count)| format!("{extension}={count}"))
+            .collect::<Vec<_>>(),
+    )
 }
 
 /// Format report list items.

--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -10,7 +10,7 @@ mod token_tui;
 
 use atlas_map::{
     AtlasMapConfig, IgnoreEntryKind, LintOptions, add_ignore_entry, effective_config_report,
-    init_gitignore, init_project_with_config, lint_map, list_ignore_entries, load_atlas_config,
+    init_gitignore, init_project_with_config, list_ignore_entries, load_atlas_config,
     remove_ignore_entry, write_map,
 };
 use clap::parser::ValueSource;
@@ -70,7 +70,7 @@ use runtime::{
     config_root_mismatch_error, default_cli_project_root, default_mcp_project_root,
     defaultable_cli_project_root, estimated_source_tokens_for_indexed_files,
     estimated_source_tokens_for_paths, index_work_control, init_config_path, init_path_status,
-    lint_database_if_present, load_synchronized_repository_token_report, next_step_report_payload,
+    lint_project, load_synchronized_repository_token_report, next_step_report_payload,
     next_step_report_with_selection, normalized_folder_filter, open_atlas_store_for_project,
     open_atlas_store_read_only_for_project, open_federated_atlas_stores_for_project,
     open_fresh_atlas_store_for_project, purpose_curation_page, ranked_folder_nodes_with_reasons,
@@ -2752,30 +2752,28 @@ fn run(cli: &mut Cli) -> Result<(), CliError> {
         } => {
             cli.preflight_implicit_project_root()?;
             let config = load_cli_atlas_config(cli)?;
-            let (mut report, mut exit_code) = lint_map(
+            let report = lint_project(
                 &config,
+                &cli.db,
+                cli.config.as_deref(),
                 LintOptions {
                     strict_folders: *strict_folders,
                     report_untracked: *report_untracked,
                     strict_untracked: *strict_untracked,
                 },
-            )?;
-            let (db_report, db_exit_code) = lint_database_if_present(
-                &cli.db,
-                &config.root,
-                cli.config.as_deref(),
                 (*purpose_level).into(),
             )?;
-            if !db_report.is_empty() {
-                if !report.ends_with('\n') {
-                    report.push('\n');
-                }
-                report.push_str(&db_report);
-            }
-            exit_code = exit_code.max(db_exit_code);
-            write_stderr(&report)?;
-            if exit_code != 0 {
-                std::process::exit(exit_code);
+            let payload = NamedPayload {
+                key: "lint",
+                payload: &report,
+            };
+            let output = match cli.format {
+                OutputFormat::Toon => encode_agent_payload(&payload),
+                OutputFormat::Json => format!("{}\n", serde_json::to_string_pretty(&payload)?),
+            };
+            write_stdout(&output)?;
+            if report.exit_code != 0 {
+                std::process::exit(report.exit_code);
             }
         }
         Command::Token {

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -3,7 +3,7 @@
 
 use crate::atlas_map::{
     AtlasMapConfig, IgnoreEntryKind, LintOptions, add_ignore_entry, effective_config_report,
-    init_gitignore, init_project_with_config, lint_map, list_ignore_entries, load_atlas_config,
+    init_gitignore, init_project_with_config, list_ignore_entries, load_atlas_config,
     load_atlas_config_for_root, remove_ignore_entry, write_map,
 };
 use crate::runtime::{
@@ -19,7 +19,7 @@ use crate::runtime::{
     config_root_mismatch_error, default_mcp_project_root,
     estimated_source_tokens_for_indexed_files, estimated_source_tokens_for_paths,
     federated_worktree_error, index_init_required, index_work_control, init_config_path,
-    init_next_steps, lint_database_if_present, load_synchronized_repository_token_report,
+    init_next_steps, lint_project, load_synchronized_repository_token_report,
     next_step_report_payload, next_step_report_with_selection, normalized_folder_filter,
     open_atlas_store_for_project, open_atlas_store_read_only_for_project,
     open_federated_atlas_stores_for_project, purpose_curation_page, purpose_curator_handoff,
@@ -1822,17 +1822,6 @@ struct McpMapReport {
     json: bool,
     /// Human-readable reason when no file was written.
     skipped_reason: Option<String>,
-}
-
-/// MCP response for lint reports.
-#[derive(Debug, Serialize)]
-struct McpLintReport {
-    /// Whether lint passed.
-    ok: bool,
-    /// CLI-compatible exit code that callers can gate on.
-    exit_code: i32,
-    /// Combined lint report text.
-    report: String,
 }
 
 /// Bounded control-atlas view of Git and `ProjectAtlas` worktree state.
@@ -5818,35 +5807,20 @@ impl ProjectAtlasMcpServer {
     fn lint_report_for_state(
         state: &McpProjectState,
         params: &AtlasLintParams,
-    ) -> Result<McpLintReport, CliError> {
+    ) -> Result<crate::runtime::LintReport, CliError> {
         let config = Self::load_config_for_state(state)?;
-        let (mut report, mut exit_code) = lint_map(
+        let purpose_level = Self::parse_purpose_lint_level(params.purpose_level.as_deref())?;
+        lint_project(
             &config,
+            &state.db_path,
+            state.config_path.as_deref(),
             LintOptions {
                 strict_folders: params.strict_folders.unwrap_or(false),
                 report_untracked: params.report_untracked.unwrap_or(false),
                 strict_untracked: params.strict_untracked.unwrap_or(false),
             },
-        )?;
-        let purpose_level = Self::parse_purpose_lint_level(params.purpose_level.as_deref())?;
-        let (db_report, db_exit_code) = lint_database_if_present(
-            &state.db_path,
-            &state.root,
-            state.config_path.as_deref(),
             purpose_level,
-        )?;
-        if !db_report.is_empty() {
-            if !report.ends_with('\n') {
-                report.push('\n');
-            }
-            report.push_str(&db_report);
-        }
-        exit_code = exit_code.max(db_exit_code);
-        Ok(McpLintReport {
-            ok: exit_code == 0,
-            exit_code,
-            report,
-        })
+        )
     }
 
     /// Build startup state from CLI-supplied DB/config paths.
@@ -12905,6 +12879,32 @@ mod tests {
             .ok_or_else(|| io::Error::other("migratable target identity is missing"))?;
         drop(migratable_store);
         let predecessor = rusqlite::Connection::open(&target_b_db)?;
+        let current_limits = GraphLimitKind::ALL
+            .iter()
+            .map(|limit| format!("'{}'", limit.as_str()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let current_coverage_schema: String = predecessor.query_row(
+            "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'graph_coverage'",
+            [],
+            |row| row.get(0),
+        )?;
+        let predecessor_coverage_schema = current_coverage_schema.replace(
+            &current_limits,
+            "'rows', 'occurrences', 'depth', 'output_bytes'",
+        );
+        require(
+            predecessor_coverage_schema != current_coverage_schema,
+            "predecessor fixture did not replace the current graph limit domain",
+        )?;
+        // This isolated fixture needs the exact released schema-17 declaration; rebuilding the
+        // table here would duplicate the complete production graph DDL in the CLI crate.
+        predecessor.execute_batch("PRAGMA writable_schema = ON;")?;
+        predecessor.execute(
+            "UPDATE sqlite_schema SET sql = ?1 WHERE type = 'table' AND name = 'graph_coverage'",
+            [predecessor_coverage_schema],
+        )?;
+        predecessor.execute_batch("PRAGMA writable_schema = OFF;")?;
         predecessor.execute_batch(
             "DROP TABLE usage_instance_worktree_origins;
              DROP TABLE worktree_usage_aggregates;

--- a/crates/projectatlas-cli/src/runtime.rs
+++ b/crates/projectatlas-cli/src/runtime.rs
@@ -33,7 +33,7 @@ use projectatlas_core::graph::{ExtendedRelationKind, GraphRelationKind, ProjectI
 use projectatlas_core::health::{
     CATEGORY_DUPLICATE_PURPOSE, CATEGORY_MISSING_PURPOSE, CATEGORY_PURPOSE_AGENT_REVIEW_REQUIRED,
     CATEGORY_REPEATED_TEMPORARY_FOLDER, CATEGORY_STALE_PURPOSE, CATEGORY_SUGGESTED_PURPOSE_REVIEW,
-    Severity,
+    HealthFinding, Severity,
 };
 use projectatlas_core::language::{
     ACCEPTED_LANGUAGE_CAPABILITY_SET_VERSION, ContentClassification, ContentSelection,
@@ -5603,15 +5603,99 @@ pub(crate) fn watcher_status_report(active: bool) -> WatchStatusReport {
     }
 }
 
-/// Build lint output for an existing `SQLite` index.
+/// Typed SQLite-owned portion of one lint result.
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct DatabaseLintReport {
+    /// Purpose strictness used to select blocking health categories.
+    pub(crate) purpose_level: String,
+    /// Blocking findings returned within the bounded page.
+    pub(crate) shown: usize,
+    /// Total matching health findings before category blocking policy.
+    pub(crate) total: usize,
+    /// Typed blocking health findings.
+    pub(crate) findings: Vec<HealthFinding>,
+}
+
+impl DatabaseLintReport {
+    /// Render the compatibility text from typed health findings.
+    fn render_text(&self) -> Result<String, CliError> {
+        if self.findings.is_empty() {
+            return Ok(String::new());
+        }
+        let mut report = format!(
+            "ProjectAtlas SQLite index health findings (purpose-level {}, showing {} of {}):\n",
+            self.purpose_level, self.shown, self.total
+        );
+        for finding in &self.findings {
+            writeln!(
+                &mut report,
+                "- [{}] {}: {}",
+                finding.category, finding.path, finding.recommendation
+            )
+            .map_err(|source| CliError::Output(io::Error::other(source.to_string())))?;
+        }
+        Ok(report)
+    }
+}
+
+/// Shared typed lint result consumed by CLI and MCP adapters.
+#[derive(Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct LintReport {
+    /// Whether every selected lint check passed.
+    pub(crate) ok: bool,
+    /// CLI-compatible process exit code.
+    pub(crate) exit_code: i32,
+    /// Map and filesystem-owned lint facts.
+    pub(crate) map: atlas_map::MapLintReport,
+    /// SQLite-owned lint facts when an index exists.
+    pub(crate) index: Option<DatabaseLintReport>,
+    /// Human-readable compatibility rendering of the same facts.
+    pub(crate) report: String,
+}
+
+/// Build one shared typed lint result for CLI and MCP callers.
+pub(crate) fn lint_project(
+    config: &atlas_map::AtlasMapConfig,
+    db: &Path,
+    config_path: Option<&Path>,
+    options: atlas_map::LintOptions,
+    purpose_level: PurposeLintLevel,
+) -> Result<LintReport, CliError> {
+    let map = atlas_map::lint_map(config, options)?;
+    let index = lint_database_if_present(db, &config.root, config_path, purpose_level)?;
+    let exit_code = map.exit_code().max(i32::from(
+        index
+            .as_ref()
+            .is_some_and(|report| !report.findings.is_empty()),
+    ));
+    let mut report = map.render_text();
+    if let Some(index) = &index {
+        let index_text = index.render_text()?;
+        if !index_text.is_empty() {
+            if !report.is_empty() && !report.ends_with('\n') {
+                report.push('\n');
+            }
+            report.push_str(&index_text);
+        }
+    }
+    Ok(LintReport {
+        ok: exit_code == 0,
+        exit_code,
+        map,
+        index,
+        report,
+    })
+}
+
+/// Build typed lint facts for an existing `SQLite` index.
 pub(crate) fn lint_database_if_present(
     db: &Path,
     root: &Path,
     config_path: Option<&Path>,
     purpose_level: PurposeLintLevel,
-) -> Result<(String, i32), CliError> {
+) -> Result<Option<DatabaseLintReport>, CliError> {
     match db.try_exists() {
-        Ok(false) => return Ok((String::new(), 0)),
+        Ok(false) => return Ok(None),
         Ok(true) => {}
         Err(source) => {
             return Err(CliError::Io {
@@ -5620,32 +5704,24 @@ pub(crate) fn lint_database_if_present(
             });
         }
     }
-    let store = open_fresh_atlas_store_for_project(db, root, config_path)?;
+    let control = standalone_index_work_control();
+    let exact = open_exact_saved_source_matches_index_controlled(db, root, config_path, &control)?;
+    let store = &exact.store;
     let query = purpose_level.health_query();
     let page = store.unresolved_health_findings_page_current(&query)?;
     let blocking = page
         .findings
-        .iter()
+        .into_iter()
         .filter(|finding| purpose_level.blocks_category(finding.category.as_str()))
         .collect::<Vec<_>>();
-    if blocking.is_empty() {
-        return Ok((String::new(), 0));
-    }
-    let mut report = format!(
-        "ProjectAtlas SQLite index health findings (purpose-level {}, showing {} of {}):\n",
-        purpose_level.as_str(),
-        blocking.len(),
-        page.total
-    );
-    for finding in blocking {
-        writeln!(
-            &mut report,
-            "- [{}] {}: {}",
-            finding.category, finding.path, finding.recommendation
-        )
-        .map_err(|source| CliError::Output(io::Error::other(source.to_string())))?;
-    }
-    Ok((report, 1))
+    let report = DatabaseLintReport {
+        purpose_level: purpose_level.as_str().to_string(),
+        shown: blocking.len(),
+        total: page.total,
+        findings: blocking,
+    };
+    store.finish_index_read_snapshot()?;
+    Ok(Some(report))
 }
 
 /// Purpose curation strictness used by `projectatlas lint`.

--- a/crates/projectatlas-cli/src/runtime/graph_projection.rs
+++ b/crates/projectatlas-cli/src/runtime/graph_projection.rs
@@ -13,9 +13,9 @@ use projectatlas_core::graph::{
     CoverageState, DocumentTargetUnresolvedReason, EntityResolutionKey, EntitySelector,
     ExtendedRelationKind, ExternalSelector, GraphContractError, GraphEntity, GraphIdentityText,
     GraphLimitKind, GraphLimits, GraphRelationKind, LogicalRelation, LogicalRelationKey,
-    PackageSelector, ProjectInstanceId, RelationDependencyKey, RelationOccurrence,
-    RelationResolution, RepositoryFilePath, RepositoryNodePath, ResolutionKeyDomain, SourceSpan,
-    SymbolSelector,
+    MAX_GRAPH_IDENTITY_BYTES, PackageSelector, ProjectInstanceId, QUALIFIED_SYMBOL_SCOPE_PREFIX,
+    RelationDependencyKey, RelationOccurrence, RelationResolution, RepositoryFilePath,
+    RepositoryNodePath, ResolutionKeyDomain, SourceSpan, SymbolSelector,
 };
 use projectatlas_core::language::{SemanticProviderOwner, SymbolParserOwner, language_capability};
 use projectatlas_core::symbols::{
@@ -697,40 +697,103 @@ fn is_cargo_manifest_path(path: &str) -> bool {
 
 /// Qualify graph-only parent identity from the parser's existing containment rows.
 ///
-/// Sorting is `O(n log n)`; each same-name candidate is pushed and popped at most once.
-fn qualified_symbol_parents(graph: &SymbolGraph) -> Vec<Option<String>> {
+/// Sorting and active-scope lookup are `O(n log n)`. Identity work is
+/// `O(n * MAX_GRAPH_IDENTITY_BYTES)`: every retained parent is bounded, and an
+/// overflowing candidate is hashed without materializing more than one bounded
+/// parent plus one admitted component.
+fn qualified_symbol_parents(
+    graph: &SymbolGraph,
+) -> Result<Vec<Option<GraphIdentityText>>, CliError> {
     let mut order = (0..graph.symbols.len()).collect::<Vec<_>>();
     order.sort_by_key(|&index| (graph.symbols[index].line_start, index));
     let mut active_by_name = BTreeMap::<&str, Vec<usize>>::new();
-    let mut qualified_names = vec![None::<String>; graph.symbols.len()];
+    let mut qualified_names = vec![None::<GraphIdentityText>; graph.symbols.len()];
     let mut parents = vec![None; graph.symbols.len()];
     for index in order {
         let symbol = &graph.symbols[index];
-        let parent = symbol.parent.as_deref().map(|parent| {
-            let Some(candidates) = active_by_name.get_mut(parent) else {
-                return parent.to_string();
-            };
+        let name = source_symbol_identity(symbol.name.clone())?;
+        let mut parent = symbol
+            .parent
+            .clone()
+            .map(source_symbol_identity)
+            .transpose()?;
+        if let Some(immediate_parent) = parent.as_ref()
+            && let Some(candidates) = active_by_name.get_mut(immediate_parent.as_str())
+        {
             while candidates.last().is_some_and(|&candidate_index| {
                 graph.symbols[candidate_index].line_end < symbol.line_end
             }) {
                 candidates.pop();
             }
-            candidates
+            if let Some(qualified_parent) = candidates
                 .last()
                 .and_then(|&candidate_index| qualified_names[candidate_index].clone())
-                .unwrap_or_else(|| parent.to_string())
+            {
+                parent = Some(qualified_parent);
+            }
+        }
+        qualified_names[index] = Some(match parent.as_ref() {
+            Some(parent) => qualified_symbol_identity(parent, &name)?,
+            None => name,
         });
-        qualified_names[index] = Some(parent.as_ref().map_or_else(
-            || symbol.name.clone(),
-            |parent| format!("{parent}::{}", symbol.name),
-        ));
         parents[index] = parent;
         active_by_name
             .entry(symbol.name.as_str())
             .or_default()
             .push(index);
     }
-    parents
+    Ok(parents)
+}
+
+/// Admit one parser-owned symbol identity outside the derived-scope namespace.
+fn source_symbol_identity(value: String) -> Result<GraphIdentityText, CliError> {
+    let identity = GraphIdentityText::new(value).map_err(invalid_graph_contract)?;
+    if identity.as_str().starts_with(QUALIFIED_SYMBOL_SCOPE_PREFIX) {
+        return Err(invalid_graph_contract(
+            GraphContractError::InvalidIdentityText {
+                reason: "source symbol identity uses the reserved derived-scope namespace",
+            },
+        ));
+    }
+    Ok(identity)
+}
+
+/// Derive one exact or compact qualified scope from validated components.
+fn qualified_symbol_identity(
+    parent: &GraphIdentityText,
+    name: &GraphIdentityText,
+) -> Result<GraphIdentityText, CliError> {
+    const SEPARATOR: &str = "::";
+    const DIGEST_DOMAIN: &str = "projectatlas.graph.qualified-symbol-scope.v1";
+    let qualified_len = parent.as_str().len() + SEPARATOR.len() + name.as_str().len();
+    if qualified_len <= MAX_GRAPH_IDENTITY_BYTES {
+        let mut qualified = String::with_capacity(qualified_len);
+        qualified.push_str(parent.as_str());
+        qualified.push_str(SEPARATOR);
+        qualified.push_str(name.as_str());
+        return GraphIdentityText::new(qualified).map_err(invalid_graph_contract);
+    }
+
+    let compact_len =
+        QUALIFIED_SYMBOL_SCOPE_PREFIX.len() + 64 + SEPARATOR.len() + name.as_str().len();
+    if compact_len > MAX_GRAPH_IDENTITY_BYTES {
+        return Err(invalid_graph_contract(
+            GraphContractError::InvalidIdentityText {
+                reason: "derived scope cannot retain its nearest admitted symbol name",
+            },
+        ));
+    }
+    let mut hasher = blake3::Hasher::new_derive_key(DIGEST_DOMAIN);
+    hasher.update(parent.as_str().as_bytes());
+    hasher.update(SEPARATOR.as_bytes());
+    hasher.update(name.as_str().as_bytes());
+    let digest = hasher.finalize().to_hex();
+    let mut compact = String::with_capacity(compact_len);
+    compact.push_str(QUALIFIED_SYMBOL_SCOPE_PREFIX);
+    compact.push_str(digest.as_str());
+    compact.push_str(SEPARATOR);
+    compact.push_str(name.as_str());
+    GraphIdentityText::new(compact).map_err(invalid_graph_contract)
 }
 
 /// Project file, symbol, package, and canonical export facts from parser graphs.
@@ -823,7 +886,7 @@ fn build_entity_projection_with_config(
         let file_digest = file.key().digest().to_string();
         insert_entity(&mut entity_by_digest, file)?;
         let mut symbol_digests = Vec::with_capacity(graph.symbols.len());
-        let qualified_parents = qualified_symbol_parents(graph);
+        let qualified_parents = qualified_symbol_parents(graph)?;
         for (symbol, qualified_parent) in graph.symbols.iter().zip(qualified_parents) {
             control.check(IndexWorkStage::SymbolParsing)?;
             let entity = match symbol.kind {
@@ -855,10 +918,7 @@ fn build_entity_projection_with_config(
                                 name: GraphIdentityText::new(symbol.name.clone())
                                     .map_err(invalid_graph_contract)?,
                                 kind: symbol.kind,
-                                parent: qualified_parent
-                                    .map(GraphIdentityText::new)
-                                    .transpose()
-                                    .map_err(invalid_graph_contract)?,
+                                parent: qualified_parent,
                                 signature: GraphIdentityText::new(
                                     if symbol.signature.trim().is_empty() {
                                         symbol.name.clone()
@@ -3940,14 +4000,16 @@ mod tests {
         CliError, DocumentResolutionIndex, DocumentTargetIdentity, GRAPH_STAGE_DATABASE_FILE_NAME,
         GRAPH_STAGE_DIRECTORY_PREFIX, GraphOwners, GraphSymbolIndex, MAX_INCREMENTAL_GRAPH_BYTES,
         MAX_INCREMENTAL_GRAPH_ROWS, PackageIndex, ProjectResolutionRegistry,
-        RepositoryGraphMutation, StagedRepositoryGraph, build_entity_projection,
-        build_entity_projection_with_config, cleanup_abandoned_graph_staging,
-        document_casefold_resolution_key, document_coverage, document_fact_map_retained_bytes,
-        enforce_incremental_projection_budget, enforce_incremental_projection_limits,
-        explicit_external_selector, finish_projection, finish_projection_in_database,
-        insert_relation, is_cargo_manifest_path, normalize_document_target, project_document_rows,
-        registry_resolution_matches, relation_resolution, remove_owned_graph_stage_payload,
-        repository_path_belongs_to, resolution_registry_from_exports, rust_toolchain_identity,
+        QUALIFIED_SYMBOL_SCOPE_PREFIX, RepositoryGraphMutation, StagedRepositoryGraph,
+        build_entity_projection, build_entity_projection_with_config,
+        cleanup_abandoned_graph_staging, document_casefold_resolution_key, document_coverage,
+        document_fact_map_retained_bytes, enforce_incremental_projection_budget,
+        enforce_incremental_projection_limits, explicit_external_selector, finish_projection,
+        finish_projection_in_database, insert_relation, is_cargo_manifest_path,
+        normalize_document_target, project_document_rows, qualified_symbol_identity,
+        qualified_symbol_parents, registry_resolution_matches, relation_resolution,
+        remove_owned_graph_stage_payload, repository_path_belongs_to,
+        resolution_registry_from_exports, rust_toolchain_identity, source_symbol_identity,
         stage_incremental_repository_graph, try_graph_stage_lease,
     };
     use crate::runtime::{
@@ -3956,9 +4018,10 @@ mod tests {
     use projectatlas_core::graph::{
         CanonicalResolutionKey, Completeness, ConfidenceClass, CoverageScope, CoverageState,
         DocumentTargetUnresolvedReason, EntityResolutionKey, EntitySelector, ExtendedRelationKind,
-        GraphEntity, GraphIdentityText, GraphRelationKind, LogicalRelation, PackageSelector,
-        ProjectInstanceId, RelationDependencyKey, RelationResolution, RepositoryFilePath,
-        RepositoryNodePath, ResolutionKeyDomain, ReusableTargetSelector, SymbolSelector,
+        GraphEntity, GraphIdentityText, GraphLimitKind, GraphRelationKind, LogicalRelation,
+        MAX_GRAPH_IDENTITY_BYTES, PackageSelector, ProjectInstanceId, RelationDependencyKey,
+        RelationResolution, RepositoryFilePath, RepositoryNodePath, ResolutionKeyDomain,
+        ReusableTargetSelector, SymbolSelector,
     };
     use projectatlas_core::relation_capabilities::{
         RELATION_FAMILY_CAPABILITIES, RelationFamilyState,
@@ -3978,7 +4041,8 @@ mod tests {
     use projectatlas_symbols::extract_symbol_graph;
     use projectatlas_symbols::{
         ConfiguredModuleResolution, EcmaScriptConfigKind, EcmaScriptModuleConfig,
-        EcmaScriptPathMapping,
+        EcmaScriptPathMapping, MAX_DOCUMENT_SELECTOR_BYTES, MAX_MARKDOWN_EVIDENCE_BYTES,
+        MAX_MARKDOWN_LABEL_BYTES, MarkdownFactLimit,
     };
     use std::borrow::Cow;
     use std::collections::{BTreeMap, BTreeSet};
@@ -4780,6 +4844,193 @@ mod tests {
                 .iter()
                 .all(|entity| !entity.key().canonical_identity().contains("super-secret")),
             "negative fixture leaked a secret into graph identity",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn qualified_symbol_identity_preserves_boundaries_and_compacts_stably()
+    -> Result<(), Box<dyn Error>> {
+        let name = GraphIdentityText::new("leaf")?;
+        require_eq(
+            &qualified_symbol_identity(&GraphIdentityText::new("outer")?, &name)?,
+            &GraphIdentityText::new("outer::leaf")?,
+            "shallow qualified identity",
+        )?;
+
+        let exact_parent = GraphIdentityText::new(
+            "x".repeat(MAX_GRAPH_IDENTITY_BYTES - "::".len() - name.as_str().len()),
+        )?;
+        let exact = qualified_symbol_identity(&exact_parent, &name)?;
+        require_eq(
+            &exact.as_str().len(),
+            &MAX_GRAPH_IDENTITY_BYTES,
+            "exact-boundary qualified identity bytes",
+        )?;
+        require(
+            exact.as_str().ends_with("::leaf"),
+            "exact-boundary qualified identity changed its readable suffix",
+        )?;
+
+        let first_overbound_parent = GraphIdentityText::new(
+            "x".repeat(MAX_GRAPH_IDENTITY_BYTES - "::".len() - name.as_str().len() + 1),
+        )?;
+        let compact = qualified_symbol_identity(&first_overbound_parent, &name)?;
+        require(
+            compact.as_str().len() <= MAX_GRAPH_IDENTITY_BYTES,
+            "first overbound qualified identity remained oversized",
+        )?;
+        require(
+            compact.as_str().ends_with("::leaf"),
+            "compacted qualified identity lost its nearest symbol name",
+        )?;
+        require_eq(
+            &qualified_symbol_identity(&first_overbound_parent, &name)?,
+            &compact,
+            "repeated compact qualified identity",
+        )?;
+
+        let multibyte_parent = GraphIdentityText::new(format!(
+            "{}x",
+            "é".repeat((MAX_GRAPH_IDENTITY_BYTES - "::".len() - "界".len() - 1) / "é".len())
+        ))?;
+        let multibyte =
+            qualified_symbol_identity(&multibyte_parent, &GraphIdentityText::new("界")?)?;
+        require_eq(
+            &multibyte.as_str().len(),
+            &MAX_GRAPH_IDENTITY_BYTES,
+            "multibyte exact-boundary qualified identity bytes",
+        )?;
+        require(
+            multibyte.as_str().ends_with("::界"),
+            "multibyte qualified identity changed its readable suffix",
+        )?;
+
+        let parent_a = GraphIdentityText::new("a".repeat(MAX_GRAPH_IDENTITY_BYTES))?;
+        let parent_b = GraphIdentityText::new("b".repeat(MAX_GRAPH_IDENTITY_BYTES))?;
+        let scoped_a = qualified_symbol_identity(&parent_a, &name)?;
+        let scoped_b = qualified_symbol_identity(&parent_b, &name)?;
+        require(
+            scoped_a != scoped_b,
+            "distinct deep ancestors with an equal suffix shared one identity",
+        )?;
+        require(
+            scoped_a != qualified_symbol_identity(&parent_a, &GraphIdentityText::new("other")?)?,
+            "distinct overbound candidates shared one compact identity",
+        )?;
+        let (literal_parent, _) = scoped_a
+            .as_str()
+            .rsplit_once("::")
+            .ok_or_else(|| io::Error::other("compact scope omitted its readable suffix"))?;
+        require(
+            source_symbol_identity(literal_parent.to_string()).is_err(),
+            "compact scope namespace remained admissible as an exact source parent",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn qualified_symbol_parents_reject_invalid_raw_components() -> Result<(), Box<dyn Error>> {
+        for (name, parent) in [
+            ("bad\nname".to_string(), None),
+            ("valid".to_string(), Some("bad\nparent".to_string())),
+            (
+                format!("{QUALIFIED_SYMBOL_SCOPE_PREFIX}literal"),
+                Some("parent".to_string()),
+            ),
+            (
+                "valid".to_string(),
+                Some(format!("{QUALIFIED_SYMBOL_SCOPE_PREFIX}literal")),
+            ),
+            (
+                "x".repeat(MAX_GRAPH_IDENTITY_BYTES + 1),
+                Some("parent".to_string()),
+            ),
+        ] {
+            let graph = SymbolGraph {
+                path: "src/invalid.rs".to_string(),
+                language: Some("rust".to_string()),
+                parser: ParserKind::TreeSitter,
+                symbols: vec![CodeSymbol {
+                    path: "src/invalid.rs".to_string(),
+                    language: Some("rust".to_string()),
+                    name,
+                    kind: SymbolKind::Function,
+                    signature: "fn valid()".to_string(),
+                    exported: false,
+                    documentation: None,
+                    line_start: 1,
+                    line_end: 1,
+                    source_selector: None,
+                    parent,
+                    parser: ParserKind::TreeSitter,
+                    detail: Some("function_item".to_string()),
+                }],
+                relations: Vec::new(),
+            };
+            require(
+                qualified_symbol_parents(&graph).is_err(),
+                "invalid raw symbol identity reached qualified derivation",
+            )?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn qualified_symbol_parents_bound_four_thousand_deep_scopes() -> Result<(), Box<dyn Error>> {
+        const DEPTH: usize = 4_000;
+        let names = (0..DEPTH)
+            .map(|index| format!("scope_{index:04}_{}", "x".repeat(229)))
+            .collect::<Vec<_>>();
+        let graph = SymbolGraph {
+            path: "src/deep.rs".to_string(),
+            language: Some("rust".to_string()),
+            parser: ParserKind::TreeSitter,
+            symbols: names
+                .iter()
+                .enumerate()
+                .map(|(index, name)| CodeSymbol {
+                    path: "src/deep.rs".to_string(),
+                    language: Some("rust".to_string()),
+                    name: name.clone(),
+                    kind: SymbolKind::Module,
+                    signature: name.clone(),
+                    exported: false,
+                    documentation: None,
+                    line_start: index + 1,
+                    line_end: DEPTH * 2 - index,
+                    source_selector: None,
+                    parent: index.checked_sub(1).map(|parent| names[parent].clone()),
+                    parser: ParserKind::TreeSitter,
+                    detail: Some("mod_item".to_string()),
+                })
+                .collect(),
+            relations: Vec::new(),
+        };
+        let first = qualified_symbol_parents(&graph)?;
+        require_eq(&first.len(), &DEPTH, "deep qualified parent count")?;
+        require(
+            first.first().is_some_and(Option::is_none),
+            "deep root unexpectedly gained a parent",
+        )?;
+        require(
+            first
+                .iter()
+                .flatten()
+                .all(|parent| parent.as_str().len() <= MAX_GRAPH_IDENTITY_BYTES),
+            "deep qualification retained an oversized parent",
+        )?;
+        require(
+            first
+                .iter()
+                .flatten()
+                .any(|parent| parent.as_str().starts_with("@projectatlas.scope.v1:")),
+            "deep qualification never exercised compact scope identity",
+        )?;
+        require_eq(
+            &qualified_symbol_parents(&graph)?,
+            &first,
+            "repeated deep qualified parents",
         )?;
         Ok(())
     }
@@ -6157,6 +6408,44 @@ mod tests {
             "empty document relation coverage",
         )?;
         require_eq(&coverage.total(), &0, "empty document relation total")?;
+        Ok(())
+    }
+
+    #[test]
+    fn partial_markdown_evidence_limit_maps_to_intermediate_bytes_coverage()
+    -> Result<(), Box<dyn Error>> {
+        let label = "l".repeat(MAX_MARKDOWN_LABEL_BYTES);
+        let selector = format!(
+            "src/{}.rs",
+            "s".repeat(MAX_DOCUMENT_SELECTOR_BYTES - "src/".len() - ".rs".len())
+        );
+        let evidence_bytes = label.len() + selector.len();
+        let source = format!("[{label}]({selector})\n")
+            .repeat(MAX_MARKDOWN_EVIDENCE_BYTES / evidence_bytes + 1);
+        let facts = projectatlas_symbols::extract_markdown_facts(&source);
+        require(
+            facts
+                .coverage
+                .limits
+                .contains(&MarkdownFactLimit::EvidenceBytes),
+            "real Markdown extraction did not reach its evidence-byte limit",
+        )?;
+        require(
+            !facts.link_candidates.is_empty(),
+            "evidence-limited Markdown extraction lost every valid candidate",
+        )?;
+
+        let coverage = document_coverage("docs/limited.md", &facts, IndexGeneration::new(7))?;
+        require_eq(
+            &coverage.state(),
+            &CoverageState::Partial,
+            "evidence-limited document coverage state",
+        )?;
+        require_eq(
+            &coverage.reached_limit(),
+            &Some(GraphLimitKind::IntermediateBytes),
+            "evidence-limited document graph limit",
+        )?;
         Ok(())
     }
 

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -264,6 +264,7 @@ const AGENT_EFFICIENCY_BENCHMARK_PATH: &str =
 const AGENT_EFFICIENCY_PARTIAL_FILE: &str = "partial.json";
 const SUBDIR_CONFIG_DIR: &str = "config";
 const SESSION_TEST_FILE_NAME: &str = "session.rs";
+const WRONG_PROJECT_OWNER_DIR_NAME: &str = "wrong-owner";
 #[cfg(any(
     windows,
     all(target_os = "macos", feature = "optional-parser-supervisor")
@@ -8644,13 +8645,33 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
             .into());
         }
     }
-    let symbol_identity_contract = "cargo test --locked -p projectatlas-cli --test e2e csharp_symbol_identity_boundary_preserves_full_and_incremental_publication -- --exact --include-ignored --nocapture";
-    for (name, workflow) in [("ordinary CI", ci.as_str()), ("release", release.as_str())] {
-        if !workflow.contains(symbol_identity_contract) {
-            return Err(io::Error::other(format!(
-                "{name} omitted the C# symbol-identity publication contract"
-            ))
-            .into());
+    for (test, label) in [
+        (
+            "csharp_symbol_identity_boundary_preserves_full_and_incremental_publication",
+            "C# symbol-identity publication",
+        ),
+        (
+            "deep_qualified_symbol_parents_preserve_full_and_incremental_publication",
+            "deep qualified-symbol publication",
+        ),
+        (
+            "partial_markdown_limit_persists_without_losing_complete_publication",
+            "partial Markdown publication",
+        ),
+        (
+            "lint_formats_share_typed_cli_and_mcp_report",
+            "typed lint serialization",
+        ),
+    ] {
+        let contract = format!(
+            "cargo test --locked -p projectatlas-cli --test e2e {test} -- --exact --include-ignored --nocapture"
+        );
+        for (name, workflow) in [("ordinary CI", ci.as_str()), ("release", release.as_str())] {
+            if !workflow.contains(&contract) {
+                return Err(
+                    io::Error::other(format!("{name} omitted the {label} contract")).into(),
+                );
+            }
         }
     }
     let checklist_step = ci
@@ -8975,6 +8996,9 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
         for contract in [
             "installed_candidate_version_is_consistent_across_cli_runtime_and_token_tui",
             "csharp_symbol_identity_boundary_preserves_full_and_incremental_publication",
+            "deep_qualified_symbol_parents_preserve_full_and_incremental_publication",
+            "partial_markdown_limit_persists_without_losing_complete_publication",
+            "lint_formats_share_typed_cli_and_mcp_report",
             "token_tui_cli_respects_selected_terminal_viewport",
             "classified_document_navigation_agrees_across_cli_and_mcp",
             "conditional_purpose_review_cli_reconciles_source_before_apply",
@@ -20508,7 +20532,7 @@ fn packaged_cli_commands_own_their_real_sqlite_effects() -> Result<(), Box<dyn E
                 "--purpose-level".to_string(),
                 "low".to_string(),
             ],
-            output: CliContractOutput::Empty,
+            output: CliContractOutput::JsonObject,
             effect: McpSqliteEffect::None,
             expected_exit_code: 0,
         },
@@ -20706,7 +20730,7 @@ fn packaged_cli_commands_own_their_real_sqlite_effects() -> Result<(), Box<dyn E
     Connection::open(&database)?.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")?;
     let missing_root = temp.path().join(MISSING_INDEX_DIR_NAME);
     fs::create_dir(&missing_root)?;
-    let wrong_root = temp.path().join("wrong-owner");
+    let wrong_root = temp.path().join(WRONG_PROJECT_OWNER_DIR_NAME);
     let wrong_atlas_dir = wrong_root.join(ATLAS_DIR_NAME);
     fs::create_dir_all(&wrong_atlas_dir)?;
     let wrong_database = wrong_atlas_dir.join("projectatlas.db");
@@ -25719,6 +25743,210 @@ fn csharp_symbol_identity_boundary_preserves_full_and_incremental_publication()
 }
 
 #[test]
+fn deep_qualified_symbol_parents_preserve_full_and_incremental_publication()
+-> Result<(), Box<dyn Error>> {
+    const DEEP_PATH: &str = "src/deep.rs";
+    const UNRELATED_PATH: &str = "src/unrelated.rs";
+
+    let nested_source = |depth: usize| -> Result<String, std::fmt::Error> {
+        let mut source = String::new();
+        for index in 0..depth {
+            let name = format!("scope{index:02}{}", "x".repeat(233));
+            writeln!(source, "mod {name} {{")?;
+        }
+        source.push_str("pub fn deep_marker() {}\n");
+        for _ in 0..depth {
+            source.push_str("}\n");
+        }
+        Ok(source)
+    };
+    let assert_deep_publication = |snapshot: &DerivedResultSnapshot| -> Result<(), Box<dyn Error>> {
+        if !snapshot
+            .symbols
+            .iter()
+            .any(|symbol| symbol.path == DEEP_PATH && symbol.name == "deep_marker")
+        {
+            return Err(io::Error::other("deep Rust marker was not published").into());
+        }
+        if !snapshot.graph_entities.iter().any(|entity| {
+            entity.contains("deep_marker") && entity.contains("@projectatlas.scope.v1:")
+        }) {
+            return Err(io::Error::other(
+                "deep Rust marker did not receive a bounded qualified graph parent",
+            )
+            .into());
+        }
+        Ok(())
+    };
+
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join(TEST_REPO_DIR);
+    let database = temp.path().join("deep-qualified-symbol-parents.db");
+    fs::create_dir_all(repo.join(SRC_DIR_NAME))?;
+    fs::write(repo.join(".gitignore"), ".projectatlas/\n")?;
+    let deep = repo.join(DEEP_PATH);
+    fs::write(&deep, nested_source(18)?)?;
+    fs::write(
+        repo.join(UNRELATED_PATH),
+        "pub fn retained_entry() -> u32 { retained_helper() }\nfn retained_helper() -> u32 { 7 }\n",
+    )?;
+
+    run_scan(&repo, &database)?;
+    let initial_publication = AtlasStore::open_read_only(&database)?
+        .index_publication()?
+        .ok_or_else(|| io::Error::other("initial deep publication missing"))?;
+    let initial = derived_result_snapshot(&database)?;
+    assert_deep_publication(&initial)?;
+    let unrelated_symbols = initial
+        .symbols
+        .iter()
+        .filter(|symbol| symbol.path == UNRELATED_PATH)
+        .cloned()
+        .collect::<Vec<_>>();
+    let unrelated_relations = initial
+        .symbol_relations
+        .iter()
+        .filter(|relation| relation.path == UNRELATED_PATH)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    fs::write(&deep, nested_source(19)?)?;
+    run_watch_once(&repo, &database)?;
+    let refreshed_publication = AtlasStore::open_read_only(&database)?
+        .index_publication()?
+        .ok_or_else(|| io::Error::other("incremental deep publication missing"))?;
+    if refreshed_publication.generation <= initial_publication.generation {
+        return Err(io::Error::other("deep-scope edit did not publish a new generation").into());
+    }
+    let refreshed = derived_result_snapshot(&database)?;
+    assert_deep_publication(&refreshed)?;
+    if refreshed
+        .symbols
+        .iter()
+        .filter(|symbol| symbol.path == UNRELATED_PATH)
+        .cloned()
+        .collect::<Vec<_>>()
+        != unrelated_symbols
+        || refreshed
+            .symbol_relations
+            .iter()
+            .filter(|relation| relation.path == UNRELATED_PATH)
+            .cloned()
+            .collect::<Vec<_>>()
+            != unrelated_relations
+    {
+        return Err(io::Error::other(
+            "deep-scope incremental publication changed unrelated graph facts",
+        )
+        .into());
+    }
+    let listed = run_packaged_cli_json(
+        &mcp_contract_executable(),
+        &repo,
+        &database,
+        &["symbols", "list", "--file", DEEP_PATH, "--limit", "50"],
+    )?;
+    if !listed
+        .as_array()
+        .is_some_and(|symbols| symbols.iter().any(|symbol| symbol["name"] == "deep_marker"))
+    {
+        return Err(io::Error::other("CLI navigation omitted the deep Rust marker").into());
+    }
+    assert_clean_scan_convergence(
+        &repo,
+        &database,
+        temp.path(),
+        "deep-qualified-symbol-parents",
+    )
+}
+
+#[test]
+fn partial_markdown_limit_persists_without_losing_complete_publication()
+-> Result<(), Box<dyn Error>> {
+    const DOCUMENT_PATH: &str = "docs/limited.md";
+
+    let label = "l".repeat(projectatlas_symbols::MAX_MARKDOWN_LABEL_BYTES);
+    let selector = format!(
+        "src/{}.rs",
+        "s".repeat(projectatlas_symbols::MAX_DOCUMENT_SELECTOR_BYTES - "src/".len() - ".rs".len())
+    );
+    let evidence_bytes = label.len() + selector.len();
+    let limited_source = format!("[{label}]({selector})\n")
+        .repeat(projectatlas_symbols::MAX_MARKDOWN_EVIDENCE_BYTES / evidence_bytes + 1);
+
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join(TEST_REPO_DIR);
+    let database = temp.path().join("partial-markdown-limit.db");
+    fs::create_dir_all(repo.join("docs"))?;
+    fs::write(repo.join(".gitignore"), ".projectatlas/\n")?;
+    let document = repo.join(DOCUMENT_PATH);
+    fs::write(&document, &limited_source)?;
+
+    let assert_partial_coverage = || -> Result<(), Box<dyn Error>> {
+        let store = AtlasStore::open_read_only(&database)?;
+        let publication = store
+            .index_publication()?
+            .ok_or_else(|| io::Error::other("Markdown publication missing"))?;
+        let project = store
+            .project_instance_id()?
+            .ok_or_else(|| io::Error::other("Markdown project identity missing"))?;
+        let coverage = store.repository_graph_coverage(
+            project,
+            &CoverageScope::Path {
+                path: RepositoryNodePath::new(Path::new(DOCUMENT_PATH))?,
+            },
+            100,
+        )?;
+        if publication.state != projectatlas_db::IndexPublicationState::Complete
+            || !coverage.rows.iter().any(|row| {
+                row.state() == CoverageState::Partial
+                    && row.reached_limit() == Some(GraphLimitKind::IntermediateBytes)
+            })
+        {
+            return Err(io::Error::other(format!(
+                "Markdown intermediate-byte coverage was not durably published: {coverage:?}"
+            ))
+            .into());
+        }
+        Ok(())
+    };
+
+    run_scan(&repo, &database)?;
+    assert_partial_coverage()?;
+    let before_failed_publication = AtlasStore::open_read_only(&database)?
+        .index_publication()?
+        .ok_or_else(|| io::Error::other("publication missing before failed Markdown refresh"))?;
+    let before_failed_snapshot = derived_result_snapshot(&database)?;
+    fs::write(
+        &document,
+        format!("{limited_source}\n[extra](missing.md)\n"),
+    )?;
+    Command::new(mcp_contract_executable())
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&database)
+        .args(["watch", ".", "--once", "--timeout-seconds", "0"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("index work deadline was reached"));
+    let after_failed_publication = AtlasStore::open_read_only(&database)?
+        .index_publication()?
+        .ok_or_else(|| io::Error::other("publication missing after failed Markdown refresh"))?;
+    if after_failed_publication != before_failed_publication
+        || derived_result_snapshot(&database)? != before_failed_snapshot
+    {
+        return Err(io::Error::other(
+            "failed Markdown refresh changed the last complete publication",
+        )
+        .into());
+    }
+
+    run_watch_once(&repo, &database)?;
+    assert_partial_coverage()?;
+    assert_clean_scan_convergence(&repo, &database, temp.path(), "partial-markdown-limit")
+}
+
+#[test]
 fn incremental_refreshes_converge_with_clean_scan_results() -> Result<(), Box<dyn Error>> {
     const CONFIG: &str = "[project]\nroot = \".\"\n\n[scan]\nexclude_dir_names = [\".git\", \".projectatlas\", \"target\"]\n";
     const CHANGED_CONFIG: &str = "[project]\nroot = \".\"\n\n[scan]\nexclude_dir_names = [\".git\", \".projectatlas\", \"target\"]\ntext_index_max_bytes = 8192\n";
@@ -29545,6 +29773,325 @@ fn generated_purpose_queue_avoids_generic_and_asset_noise() -> Result<(), Box<dy
 }
 
 #[test]
+fn lint_formats_share_typed_cli_and_mcp_report() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join(TEST_REPO_DIR);
+    let atlas = repo.join(ATLAS_DIR_NAME);
+    let source = repo.join(SRC_DIR_NAME);
+    let database = atlas.join("projectatlas.db");
+    let executable = mcp_contract_executable();
+    fs::create_dir_all(&atlas)?;
+    fs::create_dir(&source)?;
+    fs::write(
+        atlas.join("config.toml"),
+        "[project]\nroot = \".\"\n\n[scan]\nexclude_dir_names = [\".git\", \".projectatlas\", \"target\"]\n",
+    )?;
+    fs::write(
+        atlas.join("projectatlas-nonsource-files.toon"),
+        "nonsource_files[]:\n",
+    )?;
+    fs::write(repo.join(".gitignore"), ".projectatlas/\ntarget/\n")?;
+    fs::write(source.join("lib.rs"), "pub fn lint_contract() {}\n")?;
+    fs::write(repo.join("stray.bin"), b"untracked")?;
+
+    Command::new(&executable)
+        .current_dir(&repo)
+        .arg("--db")
+        .arg(&database)
+        .args(["scan", "."])
+        .assert()
+        .success();
+    let store = AtlasStore::open(&database)?;
+    for node in store.load_nodes()? {
+        if node.node.path == "stray.bin" {
+            continue;
+        }
+        store.set_purpose(
+            &node.node.path,
+            &format!(
+                "Agent-reviewed lint contract purpose for {}",
+                node.node.path
+            ),
+            PurposeSource::Agent,
+        )?;
+    }
+    let before = mcp_database_snapshot(&database)?;
+
+    let clean_json = Command::new(&executable)
+        .current_dir(&repo)
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&database)
+        .args(["lint", "--purpose-level", "low"])
+        .output()?;
+    if !clean_json.status.success() || !clean_json.stderr.is_empty() {
+        return Err(io::Error::other(format!(
+            "clean JSON lint violated status or stream ownership: {}",
+            String::from_utf8_lossy(&clean_json.stderr)
+        ))
+        .into());
+    }
+    let clean_json_value: Value = serde_json::from_slice(&clean_json.stdout)?;
+    require_json_bool(&clean_json_value, &["lint", "ok"], true)?;
+    require_json_usize(&clean_json_value, &["lint", "exit_code"], 0)?;
+
+    let clean_toon = Command::new(&executable)
+        .current_dir(&repo)
+        .arg("--format")
+        .arg("toon")
+        .arg("--db")
+        .arg(&database)
+        .args(["lint", "--purpose-level", "low"])
+        .output()?;
+    if !clean_toon.status.success()
+        || !clean_toon.stderr.is_empty()
+        || clean_toon.stdout == clean_json.stdout
+    {
+        return Err(io::Error::other("clean TOON lint violated format or stream ownership").into());
+    }
+    let clean_toon_value: Value =
+        toon_format::decode_default(&String::from_utf8(clean_toon.stdout)?)?;
+    if clean_toon_value != clean_json_value {
+        return Err(io::Error::other("clean JSON and TOON lint facts diverged").into());
+    }
+
+    let (rejected_reader, rejected_writer) = io::pipe()?;
+    drop(rejected_reader);
+    let rejected = StdCommand::new(&executable)
+        .current_dir(&repo)
+        .env("PROJECTATLAS_NO_TELEMETRY", "1")
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&database)
+        .args(["lint", "--purpose-level", "low"])
+        .stdout(Stdio::from(rejected_writer))
+        .stderr(Stdio::piped())
+        .output()?;
+    if rejected.status.success() || rejected.stderr.is_empty() {
+        return Err(io::Error::other("lint did not propagate a rejected stdout write").into());
+    }
+
+    let lint_arguments = [
+        "lint",
+        "--report-untracked",
+        "--strict-untracked",
+        "--purpose-level",
+        "low",
+    ];
+    let failing_json = Command::new(&executable)
+        .current_dir(&repo)
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&database)
+        .args(lint_arguments)
+        .output()?;
+    if failing_json.status.code() != Some(1) || !failing_json.stderr.is_empty() {
+        return Err(io::Error::other(format!(
+            "failing JSON lint violated status or stream ownership: {}",
+            String::from_utf8_lossy(&failing_json.stderr)
+        ))
+        .into());
+    }
+    let failing_json_value: Value = serde_json::from_slice(&failing_json.stdout)?;
+    require_json_bool(&failing_json_value, &["lint", "ok"], false)?;
+    require_json_usize(&failing_json_value, &["lint", "exit_code"], 1)?;
+    let disallowed = json_at(
+        &failing_json_value,
+        &["lint", "map", "untracked", "disallowed"],
+    )?
+    .as_array()
+    .ok_or_else(|| io::Error::other("typed disallowed lint paths were not an array"))?;
+    if !disallowed.iter().any(|path| path == "stray.bin") {
+        return Err(io::Error::other("typed lint report omitted stray.bin").into());
+    }
+
+    let failing_toon = Command::new(&executable)
+        .current_dir(&repo)
+        .arg("--format")
+        .arg("toon")
+        .arg("--db")
+        .arg(&database)
+        .args(lint_arguments)
+        .output()?;
+    if failing_toon.status.code() != Some(1)
+        || !failing_toon.stderr.is_empty()
+        || failing_toon.stdout == failing_json.stdout
+    {
+        return Err(
+            io::Error::other("failing TOON lint violated format or stream ownership").into(),
+        );
+    }
+    let failing_toon_value: Value =
+        toon_format::decode_default(&String::from_utf8(failing_toon.stdout)?)?;
+    if failing_toon_value != failing_json_value {
+        return Err(io::Error::other("failing JSON and TOON lint facts diverged").into());
+    }
+    let cli_after = mcp_database_snapshot(&database)?;
+    if cli_after != before {
+        return Err(io::Error::other(format!(
+            "CLI lint mutated SQLite state: authoritative={:?} usage={:?} generation={}=>{} purpose_revision={}=>{} publication={}=>{}",
+            changed_snapshot_keys(&before.authoritative, &cli_after.authoritative),
+            changed_snapshot_keys(&before.usage, &cli_after.usage),
+            before.generation,
+            cli_after.generation,
+            before.purpose_revision,
+            cli_after.purpose_revision,
+            before.publication_state,
+            cli_after.publication_state
+        ))
+        .into());
+    }
+
+    let mut mcp = McpContractSession::spawn(&executable, &repo, &database)?;
+    let mcp_before = mcp_database_snapshot(&database)?;
+    let result = (|| -> Result<(), Box<dyn Error>> {
+        let mcp_lint: Value = toon_format::decode_default(&mcp.call_tool(
+            "atlas_lint",
+            &serde_json::json!({
+                "project_path": repo.to_string_lossy(),
+                "report_untracked": true,
+                "strict_untracked": true,
+                "purpose_level": "low"
+            }),
+        )?)?;
+        if json_at(&mcp_lint, &["lint"])? != json_at(&failing_json_value, &["lint"])? {
+            return Err(io::Error::other("CLI and MCP typed lint reports diverged").into());
+        }
+        if mcp_database_snapshot(&database)? != mcp_before {
+            return Err(io::Error::other("MCP lint mutated SQLite state").into());
+        }
+        Ok(())
+    })();
+    complete_mcp_test_after_shutdown(result, || mcp.shutdown())?;
+
+    let missing_root = temp.path().join(MISSING_INDEX_DIR_NAME);
+    let missing_atlas = missing_root.join(ATLAS_DIR_NAME);
+    let missing_database = missing_atlas.join("projectatlas.db");
+    fs::create_dir_all(&missing_atlas)?;
+    fs::write(
+        missing_atlas.join("config.toml"),
+        "[project]\nroot = \".\"\n\n[scan]\nexclude_dir_names = [\".git\", \".projectatlas\", \"target\"]\n",
+    )?;
+    fs::write(
+        missing_atlas.join("projectatlas-nonsource-files.toon"),
+        "nonsource_files[]:\n",
+    )?;
+    fs::write(missing_root.join(".gitignore"), ".projectatlas/\n")?;
+    let missing_cli = Command::new(&executable)
+        .current_dir(&missing_root)
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&missing_database)
+        .args(["lint", "--purpose-level", "low"])
+        .output()?;
+    if !missing_cli.status.success() || !missing_cli.stderr.is_empty() {
+        return Err(
+            io::Error::other("missing-index CLI lint did not return a clean report").into(),
+        );
+    }
+    let missing_cli: Value = serde_json::from_slice(&missing_cli.stdout)?;
+    if !json_at(&missing_cli, &["lint", "index"])?.is_null() || missing_database.exists() {
+        return Err(io::Error::other("missing-index CLI lint created or reported an index").into());
+    }
+
+    Connection::open(&database)?.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    let wrong_root = temp.path().join(WRONG_PROJECT_OWNER_DIR_NAME);
+    let wrong_atlas = wrong_root.join(ATLAS_DIR_NAME);
+    let wrong_database = wrong_atlas.join("projectatlas.db");
+    fs::create_dir_all(&wrong_atlas)?;
+    fs::write(
+        wrong_atlas.join("config.toml"),
+        "[project]\nroot = \".\"\n\n[scan]\nexclude_dir_names = [\".git\", \".projectatlas\", \"target\"]\n",
+    )?;
+    fs::write(
+        wrong_atlas.join("projectatlas-nonsource-files.toon"),
+        "nonsource_files[]:\n",
+    )?;
+    fs::write(wrong_root.join(".gitignore"), ".projectatlas/\n")?;
+    fs::copy(&database, &wrong_database)?;
+    let wrong_before = mcp_database_snapshot(&wrong_database)?;
+    let wrong_cli = Command::new(&executable)
+        .current_dir(&wrong_root)
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&wrong_database)
+        .args(["lint", "--purpose-level", "low"])
+        .output()?;
+    if wrong_cli.status.success()
+        || !String::from_utf8_lossy(&wrong_cli.stderr).contains("project_mismatch")
+        || mcp_database_snapshot(&wrong_database)? != wrong_before
+    {
+        return Err(
+            io::Error::other("wrong-root CLI lint lost identity or no-mutation behavior").into(),
+        );
+    }
+
+    let mut routing = McpContractSession::spawn(&executable, &repo, &database)?;
+    let routing_result = (|| -> Result<(), Box<dyn Error>> {
+        let missing_mcp: Value = toon_format::decode_default(&routing.call_tool(
+            "atlas_lint",
+            &serde_json::json!({
+                "project_path": missing_root,
+                "purpose_level": "low"
+            }),
+        )?)?;
+        if json_at(&missing_mcp, &["lint"])? != json_at(&missing_cli, &["lint"])?
+            || missing_database.exists()
+        {
+            return Err(io::Error::other(
+                "missing-index CLI/MCP lint facts diverged or created an index",
+            )
+            .into());
+        }
+        let wrong_mcp = routing.call_tool(
+            "atlas_lint",
+            &serde_json::json!({
+                "project_path": wrong_root,
+                "purpose_level": "low"
+            }),
+        )?;
+        if !wrong_mcp.contains("project_mismatch")
+            || mcp_database_snapshot(&wrong_database)? != wrong_before
+        {
+            return Err(io::Error::other(
+                "wrong-root MCP lint lost identity or no-mutation behavior",
+            )
+            .into());
+        }
+        Ok(())
+    })();
+    complete_mcp_test_after_shutdown(routing_result, || routing.shutdown())?;
+
+    let stale_before = mcp_database_snapshot(&database)?;
+    fs::write(source.join("lib.rs"), "pub fn lint_contract_changed() {}\n")?;
+    let stale = Command::new(&executable)
+        .current_dir(&repo)
+        .arg("--format")
+        .arg("json")
+        .arg("--db")
+        .arg(&database)
+        .args(["lint", "--purpose-level", "low"])
+        .output()?;
+    if stale.status.success()
+        || !stale.stdout.is_empty()
+        || !String::from_utf8_lossy(&stale.stderr).contains("refresh_required")
+    {
+        return Err(
+            io::Error::other("stale lint did not fail closed with typed refresh guidance").into(),
+        );
+    }
+    if mcp_database_snapshot(&database)? != stale_before {
+        return Err(io::Error::other("stale lint repaired or mutated SQLite state").into());
+    }
+    Ok(())
+}
+
+#[test]
 fn lint_purpose_levels_require_agent_review_at_configured_scope() -> Result<(), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let repo = temp.path().join(TEST_REPO_DIR);
@@ -29608,12 +30155,12 @@ fn lint_purpose_levels_require_agent_review_at_configured_scope() -> Result<(), 
     if fresh_strict.status.success() {
         return Err(io::Error::other("fresh strict purpose lint unexpectedly passed").into());
     }
-    let fresh_strict_stderr = String::from_utf8(fresh_strict.stderr)?;
-    if !fresh_strict_stderr.contains("[missing-purpose]")
-        && !fresh_strict_stderr.contains("[suggested-purpose-review]")
+    let fresh_strict_stdout = String::from_utf8(fresh_strict.stdout)?;
+    if !fresh_strict_stdout.contains("[missing-purpose]")
+        && !fresh_strict_stdout.contains("[suggested-purpose-review]")
     {
         return Err(io::Error::other(format!(
-            "fresh strict purpose lint did not report missing or suggested purposes:\n{fresh_strict_stderr}"
+            "fresh strict purpose lint did not report missing or suggested purposes:\n{fresh_strict_stdout}"
         ))
         .into());
     }
@@ -29655,15 +30202,15 @@ fn lint_purpose_levels_require_agent_review_at_configured_scope() -> Result<(), 
         ))
         .into());
     }
-    let low_stderr = String::from_utf8(low.stderr)?;
+    let low_stdout = String::from_utf8(low.stdout)?;
     for unexpected in [
         "purpose-agent-review-required",
         "src/detail.rs",
         "assets/logo.svg",
     ] {
-        if low_stderr.contains(unexpected) {
+        if low_stdout.contains(unexpected) {
             return Err(io::Error::other(format!(
-                "low purpose lint should not block on advisory curation work `{unexpected}`:\n{low_stderr}"
+                "low purpose lint should not block on advisory curation work `{unexpected}`:\n{low_stdout}"
             ))
             .into());
         }
@@ -29680,16 +30227,16 @@ fn lint_purpose_levels_require_agent_review_at_configured_scope() -> Result<(), 
     if medium.status.success() {
         return Err(io::Error::other("medium purpose lint unexpectedly passed").into());
     }
-    let medium_stderr = String::from_utf8(medium.stderr)?;
-    if !medium_stderr.contains("[purpose-agent-review-required] src/detail.rs:") {
+    let medium_stdout = String::from_utf8(medium.stdout)?;
+    if !medium_stdout.contains("[purpose-agent-review-required] src/detail.rs:") {
         return Err(io::Error::other(format!(
-            "medium purpose lint missed source file:\n{medium_stderr}"
+            "medium purpose lint missed source file:\n{medium_stdout}"
         ))
         .into());
     }
-    if medium_stderr.contains("assets/logo.svg") {
+    if medium_stdout.contains("assets/logo.svg") {
         return Err(io::Error::other(format!(
-            "medium purpose lint included asset file:\n{medium_stderr}"
+            "medium purpose lint included asset file:\n{medium_stdout}"
         ))
         .into());
     }
@@ -29705,10 +30252,10 @@ fn lint_purpose_levels_require_agent_review_at_configured_scope() -> Result<(), 
     if strict.status.success() {
         return Err(io::Error::other("strict purpose lint unexpectedly passed").into());
     }
-    let strict_stderr = String::from_utf8(strict.stderr)?;
-    if !strict_stderr.contains("[purpose-agent-review-required] assets/logo.svg:") {
+    let strict_stdout = String::from_utf8(strict.stdout)?;
+    if !strict_stdout.contains("[purpose-agent-review-required] assets/logo.svg:") {
         return Err(io::Error::other(format!(
-            "strict purpose lint missed asset file:\n{strict_stderr}"
+            "strict purpose lint missed asset file:\n{strict_stdout}"
         ))
         .into());
     }
@@ -29745,6 +30292,15 @@ fn lint_purpose_levels_require_agent_review_at_configured_scope() -> Result<(), 
         repo.join(SRC_DIR_NAME).join("detail.rs"),
         "// Purpose: Rust implementation detail for purpose lint strictness tests.\npub fn detail_changed() {}\n",
     )?;
+    Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .arg("--config")
+        .arg(&config)
+        .arg("--db")
+        .arg(&db)
+        .args(["watch", "--once"])
+        .assert()
+        .success();
     let changed_low = Command::cargo_bin("projectatlas")?
         .current_dir(&repo)
         .arg("--config")
@@ -29760,10 +30316,10 @@ fn lint_purpose_levels_require_agent_review_at_configured_scope() -> Result<(), 
         ))
         .into());
     }
-    let changed_low_stderr = String::from_utf8(changed_low.stderr)?;
-    if changed_low_stderr.contains("[stale-purpose]") {
+    let changed_low_stdout = String::from_utf8(changed_low.stdout)?;
+    if changed_low_stdout.contains("[stale-purpose]") {
         return Err(io::Error::other(format!(
-            "ordinary source changes produced stale-purpose findings:\n{changed_low_stderr}"
+            "ordinary source changes produced stale-purpose findings:\n{changed_low_stdout}"
         ))
         .into());
     }

--- a/crates/projectatlas-cli/tests/fixtures/cli-surfaces.json
+++ b/crates/projectatlas-cli/tests/fixtures/cli-surfaces.json
@@ -424,5 +424,78 @@
       "token": ["--view=agent", "--theme=dark"],
       "watch": ["[PATH]=.", "--poll-seconds=2", "--max-cycles=0"]
     }
+  },
+  "v0.4.5-rc3": {
+    "commands": [
+      "init",
+      "map",
+      "scan",
+      "overview",
+      "folders",
+      "files",
+      "next",
+      "outline",
+      "summary",
+      "search",
+      "slice",
+      "symbols",
+      "settings",
+      "snapshot",
+      "parser-pack",
+      "root",
+      "config",
+      "ignore",
+      "watch-status",
+      "watch",
+      "health-check",
+      "health",
+      "lint",
+      "token",
+      "parity",
+      "strip-legacy-purpose",
+      "reset-index",
+      "mcp",
+      "mcp-config",
+      "runtime-info",
+      "purpose"
+    ],
+    "subcommands": {
+      "health": ["resolve"],
+      "ignore": ["list", "init-gitignore", "add", "remove"],
+      "parity": ["report"],
+      "parser-pack": ["verify", "install", "enable", "update", "disable", "remove", "status"],
+      "purpose": ["set", "review", "queue"],
+      "root": ["set", "show", "status", "verify"],
+      "symbols": ["build", "list", "relations", "slice"]
+    },
+    "actions": {
+      "snapshot": ["export", "import"]
+    },
+    "defaults": {
+      "": ["--db=.projectatlas/projectatlas.db", "--format=toon", "--session=default"],
+      "files": ["--limit=10"],
+      "folders": ["--limit=10"],
+      "health-check": ["--start-index=0", "--limit=50"],
+      "lint": ["--purpose-level=low"],
+      "mcp-config": ["--server-name=projectatlas", "--harness=mcp-json"],
+      "next": ["--limit=3"],
+      "outline": ["--lines=12"],
+      "parity": ["--profile=repository-intelligence"],
+      "parity report": ["--profile=repository-intelligence"],
+      "purpose queue": ["--start-index=0", "--limit=50"],
+      "root set": ["--transition=bind"],
+      "root status": ["[PATH]=."],
+      "scan": ["[PATH]=."],
+      "search": ["--retrieval-mode=lexical", "--context-lines=0", "--start-index=0", "--limit=20"],
+      "slice": ["--output-bytes=262144"],
+      "strip-legacy-purpose": ["[PATH]=."],
+      "summary": ["--limit=25"],
+      "symbols build": ["[PATH]=.", "--max-bytes=2000000"],
+      "symbols list": ["--limit=50"],
+      "symbols relations": ["--view=legacy", "--direction=outbound", "--minimum-confidence=low", "--resolution=any", "--depth=1", "--occurrence-limit=25", "--output-bytes=262144", "--limit=50"],
+      "symbols slice": ["--output-bytes=262144"],
+      "token": ["--view=agent", "--theme=dark"],
+      "watch": ["[PATH]=.", "--poll-seconds=2", "--max-cycles=0"]
+    }
   }
 }

--- a/crates/projectatlas-core/src/graph.rs
+++ b/crates/projectatlas-core/src/graph.rs
@@ -14,8 +14,10 @@ const ENTITY_KEY_DOMAIN: &str = "projectatlas.graph.entity.v1";
 const RELATION_KEY_DOMAIN: &str = "projectatlas.graph.relation.v1";
 /// Canonical identity namespace for repository resolution keys.
 const RESOLUTION_KEY_DOMAIN: &str = "projectatlas.graph.resolution.v1";
-/// Largest accepted identity component in bytes.
-const MAX_IDENTITY_BYTES: usize = 4_096;
+/// Largest accepted repository graph identity component in bytes.
+pub const MAX_GRAPH_IDENTITY_BYTES: usize = 4_096;
+/// Reserved namespace for compact graph-derived qualified symbol scopes.
+pub const QUALIFIED_SYMBOL_SCOPE_PREFIX: &str = "@projectatlas.scope.v1:";
 /// Maximum portable canonical resolver material retained in a derived snapshot.
 const MAX_PORTABLE_RESOLUTION_IDENTITY_BYTES: usize = 32 * 1_024;
 
@@ -225,7 +227,7 @@ impl GraphIdentityText {
                 reason: "identity text must not contain surrounding whitespace",
             });
         }
-        if value.len() > MAX_IDENTITY_BYTES {
+        if value.len() > MAX_GRAPH_IDENTITY_BYTES {
             return Err(GraphContractError::InvalidIdentityText {
                 reason: "identity text exceeds the byte limit",
             });
@@ -1810,28 +1812,65 @@ pub enum CoverageScope {
     },
 }
 
-/// Absolute product limit that a coverage or query row reached.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum GraphLimitKind {
+/// Define the closed graph-limit domain from one variant-to-spelling inventory.
+macro_rules! define_graph_limit_kinds {
+    ($( $(#[$variant_meta:meta])* $variant:ident => $stable_name:literal),+ $(,)?) => {
+        /// Absolute product limit that a coverage or query row reached.
+        #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+        pub enum GraphLimitKind {
+            $(
+                $(#[$variant_meta])*
+                #[serde(rename = $stable_name)]
+                $variant,
+            )+
+        }
+
+        impl GraphLimitKind {
+            /// Closed ordered inventory of every supported graph limit kind.
+            pub const ALL: [Self; define_graph_limit_kinds!(@count $($variant),+)] = [
+                $(Self::$variant,)+
+            ];
+
+            /// Return the stable persistence and serialization spelling.
+            #[must_use]
+            pub const fn as_str(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $stable_name,)+
+                }
+            }
+
+            /// Parse one stable persistence and serialization spelling.
+            #[must_use]
+            pub fn from_stable_name(value: &str) -> Option<Self> {
+                Self::ALL.into_iter().find(|kind| kind.as_str() == value)
+            }
+        }
+    };
+    (@count $($variant:ident),+) => {
+        <[()]>::len(&[$(define_graph_limit_kinds!(@unit $variant)),+])
+    };
+    (@unit $variant:ident) => { () };
+}
+
+define_graph_limit_kinds! {
     /// Result-row limit.
-    Rows,
+    Rows => "rows",
     /// Unique or active node limit.
-    Nodes,
+    Nodes => "nodes",
     /// Inspected logical-edge limit.
-    Edges,
+    Edges => "edges",
     /// Per-relation source-occurrence limit.
-    Occurrences,
+    Occurrences => "occurrences",
     /// Node-simple visited-state limit.
-    Visited,
+    Visited => "visited",
     /// Decoded or retained intermediate-memory byte limit.
-    IntermediateBytes,
+    IntermediateBytes => "intermediate_bytes",
     /// Elapsed request deadline.
-    Deadline,
+    Deadline => "deadline",
     /// Traversal-depth limit.
-    Depth,
+    Depth => "depth",
     /// Encoded-output byte limit.
-    OutputBytes,
+    OutputBytes => "output_bytes",
 }
 
 /// Coverage report with counts consistent with its lifecycle state.
@@ -2250,7 +2289,7 @@ fn decode_canonical_fields(mut canonical: &str) -> Option<Vec<&str>> {
         }
         canonical = canonical.get(separator + 1..)?;
         if length == 0
-            || length > MAX_IDENTITY_BYTES
+            || length > MAX_GRAPH_IDENTITY_BYTES
             || length > canonical.len()
             || !canonical.is_char_boundary(length)
         {
@@ -2265,7 +2304,9 @@ fn decode_canonical_fields(mut canonical: &str) -> Option<Vec<&str>> {
 
 /// Apply the original identity-field constraints to portable canonical data.
 fn valid_canonical_identity_field(value: &str) -> bool {
-    !value.is_empty() && value.len() <= MAX_IDENTITY_BYTES && !value.chars().any(char::is_control)
+    !value.is_empty()
+        && value.len() <= MAX_GRAPH_IDENTITY_BYTES
+        && !value.chars().any(char::is_control)
 }
 
 /// Append an optional identity field without conflating absent and empty values.
@@ -2821,7 +2862,7 @@ mod tests {
             "control-bearing identity text was accepted",
         )?;
         require(
-            GraphIdentityText::new("x".repeat(super::MAX_IDENTITY_BYTES + 1)).is_err(),
+            GraphIdentityText::new("x".repeat(super::MAX_GRAPH_IDENTITY_BYTES + 1)).is_err(),
             "oversized identity text was accepted",
         )?;
         require(
@@ -2854,6 +2895,43 @@ mod tests {
         require(
             package == serde_json::from_str(&serde_json::to_string(&package)?)?,
             "package selector did not round-trip",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn graph_limit_kind_inventory_and_stable_names_stay_exhaustive()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let serialized = serde_json::to_string(&GraphLimitKind::ALL)?;
+        require(
+            serialized
+                == r#"["rows","nodes","edges","occurrences","visited","intermediate_bytes","deadline","depth","output_bytes"]"#,
+            "graph limit stable protocol drifted without an explicit migration",
+        )?;
+        let mut names = std::collections::BTreeSet::new();
+        for kind in GraphLimitKind::ALL {
+            let stable_name = kind.as_str();
+            require(
+                names.insert(stable_name),
+                "graph limit inventory contains a duplicate stable name",
+            )?;
+            let encoded = serde_json::to_string(&kind)?;
+            require(
+                encoded == format!("\"{stable_name}\""),
+                "graph limit serde spelling drifted from its stable name",
+            )?;
+            require(
+                serde_json::from_str::<GraphLimitKind>(&encoded)? == kind,
+                "graph limit serde value did not round-trip",
+            )?;
+            require(
+                GraphLimitKind::from_stable_name(stable_name) == Some(kind),
+                "graph limit stable-name parsing did not round-trip",
+            )?;
+        }
+        require(
+            GraphLimitKind::from_stable_name("unknown").is_none(),
+            "unknown graph limit stable name was accepted",
         )?;
         Ok(())
     }

--- a/crates/projectatlas-core/src/language.rs
+++ b/crates/projectatlas-core/src/language.rs
@@ -17,7 +17,7 @@ pub const LANGUAGE_CAPABILITY_REGISTRY_VERSION: u32 = 4;
 pub const SEMANTIC_PROVIDER_CONTRACT_VERSION: u32 = 1;
 
 /// Version of the accepted language capability floor.
-pub const ACCEPTED_LANGUAGE_CAPABILITY_SET_VERSION: u32 = 10;
+pub const ACCEPTED_LANGUAGE_CAPABILITY_SET_VERSION: u32 = 11;
 
 /// Version of exact detector precedence and content-matching semantics.
 pub const LANGUAGE_DETECTION_POLICY_VERSION: u32 = 1;
@@ -91,6 +91,13 @@ pub const ACCEPTED_LANGUAGE_CAPABILITY_SET_V9_DIGEST: &str =
 /// binding ProjectAtlas-owned parser provenance to the 0.4.5-rc2 runtime.
 pub const ACCEPTED_LANGUAGE_CAPABILITY_SET_V10_DIGEST: &str =
     "cbede576a7b2ab4309798075210b59dbece0cf99cc7874a9659fd17f3c2d961f";
+
+/// Historical acceptance seal for capability-set version 11.
+///
+/// Version 11 preserves version 10 membership and capability strength while
+/// binding ProjectAtlas-owned parser provenance to the 0.4.5-rc3 runtime.
+pub const ACCEPTED_LANGUAGE_CAPABILITY_SET_V11_DIGEST: &str =
+    "3776f19c62b3debfcae13715e3bdc3ec3029978a4f7ba1428b7a06d433524915";
 
 /// Maximum content prefix inspected by the bounded content/dialect detector.
 pub const LANGUAGE_CONTENT_DETECTION_MAX_BYTES: usize = 512;
@@ -2317,6 +2324,7 @@ pub fn validate_language_registry() -> Result<(), LanguageRegistryError> {
         8 => ACCEPTED_LANGUAGE_CAPABILITY_SET_V8_DIGEST,
         9 => ACCEPTED_LANGUAGE_CAPABILITY_SET_V9_DIGEST,
         10 => ACCEPTED_LANGUAGE_CAPABILITY_SET_V10_DIGEST,
+        11 => ACCEPTED_LANGUAGE_CAPABILITY_SET_V11_DIGEST,
         version => {
             return Err(LanguageRegistryError::new(format!(
                 "accepted language capability-set version {version} lacks a historical digest seal"

--- a/crates/projectatlas-core/src/optional_parser_pack.rs
+++ b/crates/projectatlas-core/src/optional_parser_pack.rs
@@ -36,7 +36,7 @@ pub const OPTIONAL_GRAMMAR_CATALOG_RELEASE_TAG: &str = "v1.13.2";
 pub const OPTIONAL_GRAMMAR_CATALOG_SOURCE_BUNDLE_SHA256: &str =
     "d684799dc664553c9c746d5fe676a5b599f9efcec4cad5450bec7ec5a29574a9";
 /// Exact `ProjectAtlas` release line selected to consume the first pack.
-pub const OPTIONAL_PARSER_PACK_PROJECTATLAS_VERSION: &str = "0.4.5-rc2";
+pub const OPTIONAL_PARSER_PACK_PROJECTATLAS_VERSION: &str = "0.4.5-rc3";
 /// Exact Tree-sitter runtime selected by the consuming parser worker.
 pub const OPTIONAL_PARSER_PACK_TREE_SITTER_VERSION: &str = "0.26.9";
 /// Oldest grammar ABI accepted by the selected Tree-sitter runtime.

--- a/crates/projectatlas-db/src/diagnostics.rs
+++ b/crates/projectatlas-db/src/diagnostics.rs
@@ -757,7 +757,7 @@ mod tests {
         )?;
         require_eq(
             &predecessor.schema.migration_steps_remaining,
-            &Some(10),
+            &Some(11),
             "predecessor migration steps",
         )?;
         require_eq(
@@ -810,7 +810,7 @@ mod tests {
         )?;
         require_eq(
             &resolution.schema.migration_steps_remaining,
-            &Some(6),
+            &Some(7),
             "schema-12 migration steps",
         )?;
         require_eq(

--- a/crates/projectatlas-db/src/repository_graph.rs
+++ b/crates/projectatlas-db/src/repository_graph.rs
@@ -5169,7 +5169,7 @@ fn insert_coverage(
             sqlite_count("graph_coverage.covered", record.covered())?,
             sqlite_count("graph_coverage.omitted", record.omitted())?,
             record.reason().map(GraphIdentityText::as_str),
-            record.reached_limit().map(limit_kind_name),
+            record.reached_limit().map(GraphLimitKind::as_str),
         ])?;
     }
     Ok(())
@@ -6885,38 +6885,12 @@ fn parse_parser_kind(field: &'static str, value: &str) -> DbResult<ParserKind> {
     }
 }
 
-/// Return the normalized reached-limit spelling.
-const fn limit_kind_name(limit: GraphLimitKind) -> &'static str {
-    match limit {
-        GraphLimitKind::Rows => "rows",
-        GraphLimitKind::Nodes => "nodes",
-        GraphLimitKind::Edges => "edges",
-        GraphLimitKind::Occurrences => "occurrences",
-        GraphLimitKind::Visited => "visited",
-        GraphLimitKind::IntermediateBytes => "intermediate_bytes",
-        GraphLimitKind::Deadline => "deadline",
-        GraphLimitKind::Depth => "depth",
-        GraphLimitKind::OutputBytes => "output_bytes",
-    }
-}
-
 /// Parse one normalized reached-limit spelling.
 pub(crate) fn parse_limit_kind(value: &str) -> DbResult<GraphLimitKind> {
-    match value {
-        "rows" => Ok(GraphLimitKind::Rows),
-        "nodes" => Ok(GraphLimitKind::Nodes),
-        "edges" => Ok(GraphLimitKind::Edges),
-        "occurrences" => Ok(GraphLimitKind::Occurrences),
-        "visited" => Ok(GraphLimitKind::Visited),
-        "intermediate_bytes" => Ok(GraphLimitKind::IntermediateBytes),
-        "deadline" => Ok(GraphLimitKind::Deadline),
-        "depth" => Ok(GraphLimitKind::Depth),
-        "output_bytes" => Ok(GraphLimitKind::OutputBytes),
-        _ => Err(DbError::InvalidEnum {
-            field: "graph_coverage.reached_limit",
-            value: value.to_string(),
-        }),
-    }
+    GraphLimitKind::from_stable_name(value).ok_or_else(|| DbError::InvalidEnum {
+        field: "graph_coverage.reached_limit",
+        value: value.to_string(),
+    })
 }
 
 #[cfg(test)]
@@ -10895,6 +10869,88 @@ mod tests {
             |row| row.get::<_, usize>(0),
         )?;
         require_eq(&relation_count, &FANOUT, "retained document relation count")?;
+        Ok(())
+    }
+
+    #[test]
+    fn every_graph_limit_kind_round_trips_and_unknown_spelling_rolls_back()
+    -> Result<(), Box<dyn Error>> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("graph-limit-kinds");
+        fs::create_dir_all(&root)?;
+        let database = root.join("projectatlas.db");
+        let mut store = AtlasStore::open_for_project(&database, &root)?;
+        let project = store
+            .project_instance_id()?
+            .ok_or_else(|| io::Error::other("graph-limit fixture identity is missing"))?;
+        let generation = IndexGeneration::new(1);
+        let mut coverage = Vec::with_capacity(GraphLimitKind::ALL.len());
+        for kind in GraphLimitKind::ALL {
+            coverage.push(CoverageRecord::new(
+                CoverageScope::Path {
+                    path: RepositoryNodePath::new(Path::new(&format!(
+                        "limits/{}.rs",
+                        kind.as_str()
+                    )))?,
+                },
+                None,
+                CoverageState::Partial,
+                1,
+                1,
+                generation,
+                Some(GraphIdentityText::new("graph limit reached")?),
+                Some(kind),
+            )?);
+        }
+        let mut publication = store.begin_index_publication("graph-limit-kinds")?;
+        publication.replace_repository_graph(project, &[], &[], &[], &coverage)?;
+        publication.complete()?;
+
+        let verify = |store: &AtlasStore| -> Result<(), Box<dyn Error>> {
+            for kind in GraphLimitKind::ALL {
+                let page = store.repository_graph_coverage(
+                    project,
+                    &CoverageScope::Path {
+                        path: RepositoryNodePath::new(Path::new(&format!(
+                            "limits/{}.rs",
+                            kind.as_str()
+                        )))?,
+                    },
+                    1,
+                )?;
+                require_eq(&page.rows.len(), &1, "graph-limit coverage row count")?;
+                require_eq(
+                    &page.rows[0].reached_limit(),
+                    &Some(kind),
+                    "graph-limit coverage spelling",
+                )?;
+            }
+            Ok(())
+        };
+        verify(&store)?;
+
+        store.connection.execute_batch("BEGIN IMMEDIATE")?;
+        let invalid = (|| -> DbResult<()> {
+            store.connection.execute("DELETE FROM graph_coverage", [])?;
+            store.connection.execute(
+                "INSERT INTO graph_coverage(
+                    project_instance_id, scope_kind, state, total, covered, omitted,
+                    reason, reached_limit
+                 ) VALUES(?1, 'project', 'partial', 2, 1, 1, 'invalid limit', 'rowz')",
+                [&project.as_bytes()[..]],
+            )?;
+            Ok(())
+        })();
+        require(
+            matches!(invalid, Err(DbError::Sqlite(_))),
+            "unknown graph-limit spelling bypassed the SQLite constraint",
+        )?;
+        store.connection.execute_batch("ROLLBACK")?;
+        verify(&store)?;
+        drop(store);
+
+        let reopened = AtlasStore::open_read_only_for_project(&database, &root)?;
+        verify(&reopened)?;
         Ok(())
     }
 

--- a/crates/projectatlas-db/src/schema.rs
+++ b/crates/projectatlas-db/src/schema.rs
@@ -5,7 +5,7 @@ use crate::sqlite_profile::{
     open_read_only_connection, verify_current_read_profile,
 };
 use crate::{DbError, DbResult};
-use projectatlas_core::graph::ProjectInstanceId;
+use projectatlas_core::graph::{GraphLimitKind, ProjectInstanceId};
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -15,7 +15,7 @@ use std::sync::OnceLock;
 use projectatlas_core::normalize_native_path_display;
 
 /// Current `SQLite` schema version supported by this crate.
-pub(crate) const SCHEMA_VERSION: i64 = 18;
+pub(crate) const SCHEMA_VERSION: i64 = 19;
 /// Released 0.3.26 schema accepted by the migration inventory.
 pub(crate) const PREVIOUS_SCHEMA_VERSION: i64 = 8;
 /// First internal schema with explicit publication invalidation.
@@ -36,6 +36,8 @@ const LEXICAL_SCHEMA_VERSION: i64 = 15;
 const COMPACT_GRAPH_SCHEMA_VERSION: i64 = 16;
 /// First schema with classified documentation graph storage.
 const CLASSIFIED_GRAPH_SCHEMA_VERSION: i64 = 17;
+/// First schema with local worktree registration and aggregate telemetry control state.
+const WORKTREE_CONTROL_SCHEMA_VERSION: i64 = 18;
 /// Metadata key for the durable schema version.
 pub(crate) const SCHEMA_VERSION_KEY: &str = "schema_version";
 /// Metadata key for the owning project root.
@@ -138,8 +140,13 @@ const MIGRATIONS: &[Migration] = &[
     },
     Migration {
         from: CLASSIFIED_GRAPH_SCHEMA_VERSION,
-        to: SCHEMA_VERSION,
+        to: WORKTREE_CONTROL_SCHEMA_VERSION,
         apply: migrate_17_to_18,
+    },
+    Migration {
+        from: WORKTREE_CONTROL_SCHEMA_VERSION,
+        to: SCHEMA_VERSION,
+        apply: migrate_18_to_19,
     },
 ];
 
@@ -275,6 +282,8 @@ static COVERAGE_DISCOVERY_PREDECESSOR_SCHEMA_CONTRACT: OnceLock<SchemaContract> 
 static COMPACT_GRAPH_PREDECESSOR_SCHEMA_CONTRACT: OnceLock<SchemaContract> = OnceLock::new();
 /// Immutable expected schema-17 contract before worktree control storage.
 static CLASSIFIED_GRAPH_PREDECESSOR_SCHEMA_CONTRACT: OnceLock<SchemaContract> = OnceLock::new();
+/// Immutable expected schema-18 contract before complete graph-limit admission.
+static WORKTREE_CONTROL_PREDECESSOR_SCHEMA_CONTRACT: OnceLock<SchemaContract> = OnceLock::new();
 
 /// Immutable physical schema emitted by the released 0.3.26 runtime.
 #[cfg(test)]
@@ -283,6 +292,10 @@ const RELEASED_SCHEMA_EIGHT_SQL: &str = include_str!("../tests/fixtures/released
 #[cfg(test)]
 const EVOLVED_RELEASED_SCHEMA_EIGHT_SQL: &str =
     include_str!("../tests/fixtures/released-schema-8-evolved.sql");
+/// BLAKE3 of the complete schema-18 contract captured before schema 19 existed.
+#[cfg(test)]
+const RELEASED_SCHEMA_EIGHTEEN_CONTRACT_BLAKE3: &str =
+    "5fbdebf57bae7e3320d000e6c419390380f266d6a426cf0ea236a2728e057673";
 
 /// Create the historical released schema without consulting current DDL.
 #[cfg(test)]
@@ -736,7 +749,7 @@ const GRAPH_SCHEMA_SQL: &str = "
         omitted INTEGER NOT NULL CHECK(typeof(omitted) = 'integer' AND omitted >= 0),
         reason TEXT CHECK(reason IS NULL OR (typeof(reason) = 'text' AND length(reason) > 0)),
         reached_limit TEXT
-            CHECK(reached_limit IS NULL OR reached_limit IN ('rows', 'occurrences', 'depth', 'output_bytes')),
+            CHECK(reached_limit IS NULL OR reached_limit IN (__GRAPH_LIMIT_KINDS__)),
         FOREIGN KEY(project_instance_id)
             REFERENCES project_identity(project_instance_id) ON DELETE RESTRICT,
         CHECK(
@@ -796,6 +809,27 @@ const GRAPH_SCHEMA_SQL: &str = "
     CREATE INDEX idx_graph_coverage_relation_state
         ON graph_coverage(relation_scope, relation_kind, state, id);
 ";
+
+/// Exact reached-limit domain emitted by schemas 10 through 18.
+const HISTORICAL_GRAPH_LIMIT_KINDS_SQL: &str = "'rows', 'occurrences', 'depth', 'output_bytes'";
+
+/// Closed graph DDL shapes retained for supported historical contracts.
+#[derive(Clone, Copy)]
+enum GraphSchemaShape {
+    /// Compact graph storage without classified-document additions.
+    Compact,
+    /// Classified-document storage with the historical reached-limit domain.
+    ClassifiedDocuments,
+    /// Current classified-document storage with every closed reached-limit kind.
+    Current,
+}
+
+impl GraphSchemaShape {
+    /// Return whether this shape includes classified-document graph contracts.
+    const fn includes_classified_documents(self) -> bool {
+        matches!(self, Self::ClassifiedDocuments | Self::Current)
+    }
+}
 
 /// Persist one closed content role for every currently admitted file node.
 const FILE_CONTENT_CLASSIFICATION_SCHEMA_SQL: &str = "
@@ -914,27 +948,37 @@ const WORKTREE_CONTROL_SCHEMA_SQL: &str = "
         ON usage_instance_worktree_origins(registration_id, instance_row_id);
 ";
 
-/// Produce the historical or current graph constraints from one DDL authority.
-fn graph_schema_sql(include_classified_documents: bool) -> String {
-    let heading = if include_classified_documents {
+/// Produce one exact historical or current graph contract from one DDL authority.
+fn graph_schema_sql(shape: GraphSchemaShape) -> String {
+    let heading = if shape.includes_classified_documents() {
         ", 'heading'"
     } else {
         ""
     };
-    let documents = if include_classified_documents {
+    let documents = if shape.includes_classified_documents() {
         ", 'documents'"
     } else {
         ""
     };
-    let reason_column = if include_classified_documents {
+    let reason_column = if shape.includes_classified_documents() {
         "document_unresolved_reason TEXT CHECK(document_unresolved_reason IS NULL OR document_unresolved_reason IN ('missing', 'ignored', 'outside_root', 'case_conflict', 'unsupported', 'no_static_target')),"
     } else {
         ""
     };
-    let reason_constraint = if include_classified_documents {
+    let reason_constraint = if shape.includes_classified_documents() {
         ", CHECK(document_unresolved_reason IS NULL OR (relation_scope = 'extended' AND relation_kind = 'documents' AND resolution_status = 'unresolved'))"
     } else {
         ""
+    };
+    let reached_limit_kinds = match shape {
+        GraphSchemaShape::Compact | GraphSchemaShape::ClassifiedDocuments => {
+            HISTORICAL_GRAPH_LIMIT_KINDS_SQL.to_string()
+        }
+        GraphSchemaShape::Current => GraphLimitKind::ALL
+            .iter()
+            .map(|kind| format!("'{}'", kind.as_str()))
+            .collect::<Vec<_>>()
+            .join(", "),
     };
     GRAPH_SCHEMA_SQL
         .replace("__DOCUMENT_HEADING_SYMBOL_KIND__", heading)
@@ -944,14 +988,12 @@ fn graph_schema_sql(include_classified_documents: bool) -> String {
             "__DOCUMENT_UNRESOLVED_REASON_CONSTRAINT__",
             reason_constraint,
         )
+        .replace("__GRAPH_LIMIT_KINDS__", &reached_limit_kinds)
 }
 
 /// Create one historical or current normalized graph schema.
-fn create_graph_schema(
-    connection: &Connection,
-    include_classified_documents: bool,
-) -> DbResult<()> {
-    let sql = graph_schema_sql(include_classified_documents);
+fn create_graph_schema(connection: &Connection, shape: GraphSchemaShape) -> DbResult<()> {
+    let sql = graph_schema_sql(shape);
     connection.execute_batch(&sql)?;
     Ok(())
 }
@@ -1680,7 +1722,7 @@ fn create_fresh(connection: &Connection, expected_root: Option<&str>) -> DbResul
     connection.execute_batch(BASE_SCHEMA_SQL)?;
     add_symbol_source_selector_storage(connection)?;
     connection.execute_batch(SOURCE_PARSE_PROVENANCE_SCHEMA_SQL)?;
-    create_graph_schema(connection, true)?;
+    create_graph_schema(connection, GraphSchemaShape::Current)?;
     create_coverage_discovery_schema(connection)?;
     connection.execute_batch(RESOLUTION_KEY_SCHEMA_SQL)?;
     connection.execute_batch(TELEMETRY_STORAGE_SCHEMA_SQL)?;
@@ -1726,7 +1768,7 @@ fn migrate_8_to_9(connection: &Connection) -> DbResult<()> {
 
 /// Add normalized graph storage and invalidate predecessor publication trust.
 fn migrate_9_to_10(connection: &Connection) -> DbResult<()> {
-    create_graph_schema(connection, false)?;
+    create_graph_schema(connection, GraphSchemaShape::Compact)?;
     if read_metadata(connection, PROJECT_ROOT_KEY)?.is_some() {
         crate::project_identity::ensure_project_identity(connection)?;
     }
@@ -1809,6 +1851,11 @@ fn migrate_17_to_18(connection: &Connection) -> DbResult<()> {
     Ok(())
 }
 
+/// Admit every closed graph limit while rebuilding only disposable graph state.
+fn migrate_18_to_19(connection: &Connection) -> DbResult<()> {
+    recreate_disposable_graph_projection_with_shape(connection, GraphSchemaShape::Current)
+}
+
 /// Add selector columns by rebuilding the derived symbol table in the caller transaction.
 fn add_symbol_source_selector_storage(connection: &Connection) -> DbResult<()> {
     connection.execute_batch(SYMBOL_SOURCE_SELECTOR_SCHEMA_SQL)?;
@@ -1819,6 +1866,19 @@ fn add_symbol_source_selector_storage(connection: &Connection) -> DbResult<()> {
 pub(crate) fn recreate_disposable_graph_projection(
     connection: &Connection,
     include_classified_documents: bool,
+) -> DbResult<()> {
+    let shape = if include_classified_documents {
+        GraphSchemaShape::ClassifiedDocuments
+    } else {
+        GraphSchemaShape::Compact
+    };
+    recreate_disposable_graph_projection_with_shape(connection, shape)
+}
+
+/// Rebuild disposable normalized graph state under one exact schema contract.
+fn recreate_disposable_graph_projection_with_shape(
+    connection: &Connection,
+    shape: GraphSchemaShape,
 ) -> DbResult<()> {
     let project_identity = connection
         .query_row(
@@ -1839,7 +1899,7 @@ pub(crate) fn recreate_disposable_graph_projection(
         DROP TABLE project_identity;
         ",
     )?;
-    create_graph_schema(connection, include_classified_documents)?;
+    create_graph_schema(connection, shape)?;
     if let Some(project_identity) = project_identity {
         connection.execute(
             "INSERT INTO project_identity(singleton, project_instance_id, active_generation)
@@ -1912,6 +1972,7 @@ fn validate_schema_shape(connection: &Connection, state: SchemaState) -> DbResul
                 }
                 COMPACT_GRAPH_SCHEMA_VERSION => compact_graph_predecessor_schema_contract()?,
                 CLASSIFIED_GRAPH_SCHEMA_VERSION => classified_graph_predecessor_schema_contract()?,
+                WORKTREE_CONTROL_SCHEMA_VERSION => worktree_control_predecessor_schema_contract()?,
                 found => {
                     return Err(DbError::SchemaVersion {
                         found,
@@ -2217,7 +2278,7 @@ fn schema_contract() -> DbResult<&'static SchemaContract> {
     connection.execute_batch(BASE_SCHEMA_SQL)?;
     add_symbol_source_selector_storage(&connection)?;
     connection.execute_batch(SOURCE_PARSE_PROVENANCE_SCHEMA_SQL)?;
-    create_graph_schema(&connection, true)?;
+    create_graph_schema(&connection, GraphSchemaShape::Current)?;
     create_coverage_discovery_schema(&connection)?;
     connection.execute_batch(RESOLUTION_KEY_SCHEMA_SQL)?;
     connection.execute_batch(TELEMETRY_STORAGE_SCHEMA_SQL)?;
@@ -2238,7 +2299,7 @@ fn graph_predecessor_schema_contract() -> DbResult<&'static SchemaContract> {
     let connection = Connection::open_in_memory()?;
     connection.execute_batch(BASE_SCHEMA_SQL)?;
     connection.execute_batch(LEGACY_USAGE_SCHEMA_SQL)?;
-    create_graph_schema(&connection, false)?;
+    create_graph_schema(&connection, GraphSchemaShape::Compact)?;
     let contract = read_schema_contract(&connection)?;
     Ok(GRAPH_PREDECESSOR_SCHEMA_CONTRACT.get_or_init(|| contract))
 }
@@ -2250,7 +2311,7 @@ fn telemetry_predecessor_schema_contract() -> DbResult<&'static SchemaContract> 
     }
     let connection = Connection::open_in_memory()?;
     connection.execute_batch(BASE_SCHEMA_SQL)?;
-    create_graph_schema(&connection, false)?;
+    create_graph_schema(&connection, GraphSchemaShape::Compact)?;
     connection.execute_batch(TELEMETRY_STORAGE_SCHEMA_SQL)?;
     connection.execute_batch(CURRENT_USAGE_SCHEMA_SQL)?;
     let contract = read_schema_contract(&connection)?;
@@ -2264,7 +2325,7 @@ fn resolution_predecessor_schema_contract() -> DbResult<&'static SchemaContract>
     }
     let connection = Connection::open_in_memory()?;
     connection.execute_batch(BASE_SCHEMA_SQL)?;
-    create_graph_schema(&connection, false)?;
+    create_graph_schema(&connection, GraphSchemaShape::Compact)?;
     connection.execute_batch(RESOLUTION_KEY_SCHEMA_SQL)?;
     connection.execute_batch(TELEMETRY_STORAGE_SCHEMA_SQL)?;
     connection.execute_batch(CURRENT_USAGE_SCHEMA_SQL)?;
@@ -2280,7 +2341,7 @@ fn parser_provenance_predecessor_schema_contract() -> DbResult<&'static SchemaCo
     let connection = Connection::open_in_memory()?;
     connection.execute_batch(BASE_SCHEMA_SQL)?;
     connection.execute_batch(SOURCE_PARSE_PROVENANCE_SCHEMA_SQL)?;
-    create_graph_schema(&connection, false)?;
+    create_graph_schema(&connection, GraphSchemaShape::Compact)?;
     connection.execute_batch(RESOLUTION_KEY_SCHEMA_SQL)?;
     connection.execute_batch(TELEMETRY_STORAGE_SCHEMA_SQL)?;
     connection.execute_batch(CURRENT_USAGE_SCHEMA_SQL)?;
@@ -2296,7 +2357,7 @@ fn coverage_discovery_predecessor_schema_contract() -> DbResult<&'static SchemaC
     let connection = Connection::open_in_memory()?;
     connection.execute_batch(BASE_SCHEMA_SQL)?;
     connection.execute_batch(SOURCE_PARSE_PROVENANCE_SCHEMA_SQL)?;
-    create_graph_schema(&connection, false)?;
+    create_graph_schema(&connection, GraphSchemaShape::Compact)?;
     create_coverage_discovery_schema(&connection)?;
     connection.execute_batch(RESOLUTION_KEY_SCHEMA_SQL)?;
     connection.execute_batch(TELEMETRY_STORAGE_SCHEMA_SQL)?;
@@ -2313,7 +2374,7 @@ fn compact_graph_predecessor_schema_contract() -> DbResult<&'static SchemaContra
     let connection = Connection::open_in_memory()?;
     connection.execute_batch(BASE_SCHEMA_SQL)?;
     connection.execute_batch(SOURCE_PARSE_PROVENANCE_SCHEMA_SQL)?;
-    create_graph_schema(&connection, false)?;
+    create_graph_schema(&connection, GraphSchemaShape::Compact)?;
     create_coverage_discovery_schema(&connection)?;
     connection.execute_batch(RESOLUTION_KEY_SCHEMA_SQL)?;
     connection.execute_batch(TELEMETRY_STORAGE_SCHEMA_SQL)?;
@@ -2333,7 +2394,7 @@ fn classified_graph_predecessor_schema_contract() -> DbResult<&'static SchemaCon
     connection.execute_batch(BASE_SCHEMA_SQL)?;
     add_symbol_source_selector_storage(&connection)?;
     connection.execute_batch(SOURCE_PARSE_PROVENANCE_SCHEMA_SQL)?;
-    create_graph_schema(&connection, true)?;
+    create_graph_schema(&connection, GraphSchemaShape::ClassifiedDocuments)?;
     create_coverage_discovery_schema(&connection)?;
     connection.execute_batch(RESOLUTION_KEY_SCHEMA_SQL)?;
     connection.execute_batch(TELEMETRY_STORAGE_SCHEMA_SQL)?;
@@ -2343,6 +2404,28 @@ fn classified_graph_predecessor_schema_contract() -> DbResult<&'static SchemaCon
     connection.execute_batch(FILE_CONTENT_CLASSIFICATION_SCHEMA_SQL)?;
     let contract = read_schema_contract(&connection)?;
     Ok(CLASSIFIED_GRAPH_PREDECESSOR_SCHEMA_CONTRACT.get_or_init(|| contract))
+}
+
+/// Build the immutable schema-18 contract before complete graph-limit admission.
+fn worktree_control_predecessor_schema_contract() -> DbResult<&'static SchemaContract> {
+    if let Some(contract) = WORKTREE_CONTROL_PREDECESSOR_SCHEMA_CONTRACT.get() {
+        return Ok(contract);
+    }
+    let connection = Connection::open_in_memory()?;
+    connection.execute_batch(BASE_SCHEMA_SQL)?;
+    add_symbol_source_selector_storage(&connection)?;
+    connection.execute_batch(SOURCE_PARSE_PROVENANCE_SCHEMA_SQL)?;
+    create_graph_schema(&connection, GraphSchemaShape::ClassifiedDocuments)?;
+    create_coverage_discovery_schema(&connection)?;
+    connection.execute_batch(RESOLUTION_KEY_SCHEMA_SQL)?;
+    connection.execute_batch(TELEMETRY_STORAGE_SCHEMA_SQL)?;
+    connection.execute_batch(CURRENT_USAGE_SCHEMA_SQL)?;
+    connection.execute_batch(FILE_TEXT_FTS_SCHEMA_SQL)?;
+    connection.execute_batch(SYMBOL_RELATION_LOOKUP_SCHEMA_SQL)?;
+    connection.execute_batch(FILE_CONTENT_CLASSIFICATION_SCHEMA_SQL)?;
+    connection.execute_batch(WORKTREE_CONTROL_SCHEMA_SQL)?;
+    let contract = read_schema_contract(&connection)?;
+    Ok(WORKTREE_CONTROL_PREDECESSOR_SCHEMA_CONTRACT.get_or_init(|| contract))
 }
 
 /// Build the immutable schema-8/9 contract from the unchanged base DDL.
@@ -2740,6 +2823,7 @@ pub(crate) fn recreate_pre_selector_symbol_storage_for_test(
 mod tests {
     use super::*;
     use crate::{AtlasStore, DbError};
+    use projectatlas_core::graph::{CoverageScope, RepositoryNodePath};
     use projectatlas_core::telemetry::{
         TokenOverview, TokenTrendPeriod, TokenTrendWindow, UsageEvent, usage_from_estimates,
     };
@@ -4386,6 +4470,7 @@ mod tests {
              ) VALUES(?1, ?2, 7, 700, 70)",
             params![project_identity.as_slice(), dimension_id],
         )?;
+        recreate_disposable_graph_projection(&store.connection, true)?;
         store.connection.execute_batch(
             "DROP TABLE usage_instance_worktree_origins;
              DROP TABLE worktree_usage_aggregates;
@@ -4449,6 +4534,263 @@ mod tests {
     }
 
     #[test]
+    fn schema_eighteen_upgrade_is_atomic_and_preserves_only_authored_graph_state()
+    -> Result<(), Box<dyn Error>> {
+        let predecessor_contract = worktree_control_predecessor_schema_contract()?;
+        let predecessor_digest =
+            blake3::hash(format!("{predecessor_contract:?}").as_bytes()).to_hex();
+        if predecessor_digest.as_str() != RELEASED_SCHEMA_EIGHTEEN_CONTRACT_BLAKE3 {
+            return Err(io::Error::other(format!(
+                "captured schema-18 contract drifted: {predecessor_digest}"
+            ))
+            .into());
+        }
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("repository");
+        fs::create_dir(&root)?;
+        let database = temp.path().join("projectatlas.db");
+        let store = AtlasStore::open_for_project(&database, &root)?;
+        let project = store
+            .project_instance_id()?
+            .ok_or_else(|| io::Error::other("schema-18 fixture identity is missing"))?;
+        store.connection.execute(
+            "INSERT INTO nodes(path, kind) VALUES('src/lib.rs', 'file')",
+            [],
+        )?;
+        store.connection.execute(
+            "INSERT INTO purposes(node_id, purpose, source, status, updated_by)
+             SELECT id, 'Own the library.', 'agent', 'approved', 'schema-test'
+               FROM nodes WHERE path = 'src/lib.rs'",
+            [],
+        )?;
+        recreate_disposable_graph_projection(&store.connection, true)?;
+        store.connection.execute(
+            "UPDATE project_identity SET active_generation = 7 WHERE singleton = 1",
+            [],
+        )?;
+        for limit in ["rows", "occurrences", "depth", "output_bytes"] {
+            store.connection.execute(
+                "INSERT INTO graph_coverage(
+                    project_instance_id, scope_kind, scope_path, state,
+                    total, covered, omitted, reason, reached_limit
+                 ) VALUES(?1, 'path', ?2, 'partial', 2, 1, 1, 'graph limit', ?3)",
+                params![
+                    &project.as_bytes()[..],
+                    format!("historical/{limit}.rs"),
+                    limit,
+                ],
+            )?;
+        }
+        if store
+            .connection
+            .execute(
+                "INSERT INTO graph_coverage(
+                    project_instance_id, scope_kind, scope_path, state,
+                    total, covered, omitted, reason, reached_limit
+                 ) VALUES(?1, 'path', 'historical/nodes.rs', 'partial',
+                          2, 1, 1, 'graph limit', 'nodes')",
+                [&project.as_bytes()[..]],
+            )
+            .is_ok()
+        {
+            return Err(io::Error::other("schema-18 admitted a schema-19 graph limit").into());
+        }
+        for (key, value) in [
+            (INDEX_PUBLICATION_STATE_KEY, "complete"),
+            (INDEX_PUBLICATION_FINGERPRINT_KEY, "schema-18-fixture"),
+            (INDEX_PUBLICATION_GENERATION_KEY, "7"),
+            (SCHEMA_VERSION_KEY, "18"),
+        ] {
+            set_metadata(&store.connection, key, value)?;
+        }
+        if read_schema_contract(&store.connection)?
+            != *worktree_control_predecessor_schema_contract()?
+        {
+            return Err(io::Error::other("schema-18 fixture shape drifted").into());
+        }
+        drop(store);
+
+        let expected_root = normalize_native_path_display(&root);
+        let (before, _) = preflight(&database, Some(&expected_root))?;
+        if before.state != SchemaState::UpgradeRequired
+            || before.schema_version != Some(WORKTREE_CONTROL_SCHEMA_VERSION)
+        {
+            return Err(io::Error::other("exact schema-18 fixture was not admitted").into());
+        }
+
+        let connection = Connection::open(&database)?;
+        configure_writable(&connection)?;
+        connection.execute_batch(&format!(
+            "CREATE TEMP TRIGGER abort_schema_nineteen
+             BEFORE UPDATE OF value ON metadata
+             WHEN OLD.key = 'schema_version' AND NEW.value = '{SCHEMA_VERSION}'
+             BEGIN SELECT RAISE(ABORT, 'injected schema-19 failure'); END;"
+        ))?;
+        let failed = initialize(&connection, Some(&expected_root));
+        if !matches!(failed, Err(DbError::Sqlite(_))) {
+            return Err(io::Error::other(format!(
+                "schema-19 injected failure returned the wrong result: {failed:?}"
+            ))
+            .into());
+        }
+        let rolled_back = connection.query_row(
+            "SELECT
+                (SELECT value FROM metadata WHERE key = 'schema_version'),
+                (SELECT project_instance_id FROM project_identity WHERE singleton = 1),
+                (SELECT active_generation FROM project_identity WHERE singleton = 1),
+                (SELECT COUNT(*) FROM purposes
+                  WHERE purpose = 'Own the library.' AND source = 'agent'
+                    AND status = 'approved' AND updated_by = 'schema-test'),
+                (SELECT COUNT(*) FROM graph_coverage
+                  WHERE reached_limit IN ('rows', 'occurrences', 'depth', 'output_bytes')
+                    AND state = 'partial'),
+                (SELECT COUNT(*) FROM metadata WHERE key IN (
+                    'index_publication_state',
+                    'index_publication_fingerprint',
+                    'index_publication_generation'
+                ))",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, i64>(5)?,
+                ))
+            },
+        )?;
+        if rolled_back
+            != (
+                WORKTREE_CONTROL_SCHEMA_VERSION.to_string(),
+                project.as_bytes().to_vec(),
+                7,
+                1,
+                4,
+                3,
+            )
+            || read_schema_contract(&connection)?
+                != *worktree_control_predecessor_schema_contract()?
+        {
+            return Err(io::Error::other(format!(
+                "schema-19 failure exposed partial migration state: {rolled_back:?}"
+            ))
+            .into());
+        }
+        drop(connection);
+
+        let mut migrated = AtlasStore::open_for_project(&database, &root)?;
+        let migrated_state = migrated.connection.query_row(
+            "SELECT
+                (SELECT value FROM metadata WHERE key = 'schema_version'),
+                (SELECT project_instance_id FROM project_identity WHERE singleton = 1),
+                (SELECT active_generation FROM project_identity WHERE singleton = 1),
+                (SELECT COUNT(*) FROM purposes
+                  WHERE purpose = 'Own the library.' AND source = 'agent'
+                    AND status = 'approved' AND updated_by = 'schema-test'),
+                (SELECT COUNT(*) FROM graph_coverage),
+                (SELECT COUNT(*) FROM metadata WHERE key IN (
+                    'index_publication_state',
+                    'index_publication_fingerprint',
+                    'index_publication_generation'
+                ))",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, i64>(5)?,
+                ))
+            },
+        )?;
+        if migrated_state
+            != (
+                SCHEMA_VERSION.to_string(),
+                project.as_bytes().to_vec(),
+                0,
+                1,
+                0,
+                0,
+            )
+            || read_schema_contract(&migrated.connection)? != *schema_contract()?
+        {
+            return Err(io::Error::other(format!(
+                "schema-19 migration changed its authority boundary: {migrated_state:?}"
+            ))
+            .into());
+        }
+
+        let transaction = migrated.connection.transaction()?;
+        transaction.execute(
+            "UPDATE project_identity SET active_generation = 1 WHERE singleton = 1",
+            [],
+        )?;
+        for kind in GraphLimitKind::ALL {
+            transaction.execute(
+                "INSERT INTO graph_coverage(
+                    project_instance_id, scope_kind, scope_path, state,
+                    total, covered, omitted, reason, reached_limit
+                 ) VALUES(?1, 'path', ?2, 'partial', 2, 1, 1, 'graph limit', ?3)",
+                params![
+                    &project.as_bytes()[..],
+                    format!("limits/{}.rs", kind.as_str()),
+                    kind.as_str(),
+                ],
+            )?;
+        }
+        set_metadata(&transaction, INDEX_PUBLICATION_STATE_KEY, "complete")?;
+        set_metadata(
+            &transaction,
+            INDEX_PUBLICATION_FINGERPRINT_KEY,
+            "schema-19-limit-round-trip",
+        )?;
+        set_metadata(&transaction, INDEX_PUBLICATION_GENERATION_KEY, "1")?;
+        transaction.commit()?;
+
+        for kind in GraphLimitKind::ALL {
+            let coverage = migrated.repository_graph_coverage(
+                project,
+                &CoverageScope::Path {
+                    path: RepositoryNodePath::new(Path::new(&format!(
+                        "limits/{}.rs",
+                        kind.as_str()
+                    )))?,
+                },
+                1,
+            )?;
+            if coverage.rows.len() != 1 || coverage.rows[0].reached_limit() != Some(kind) {
+                return Err(io::Error::other(format!(
+                    "migrated schema did not round-trip graph limit {}",
+                    kind.as_str()
+                ))
+                .into());
+            }
+        }
+        drop(migrated);
+
+        let reopened = AtlasStore::open_read_only_for_project(&database, &root)?;
+        if read_schema_contract(&reopened.connection)? != *schema_contract()? {
+            return Err(io::Error::other("reopened schema-19 contract drifted").into());
+        }
+        let last = GraphLimitKind::OutputBytes;
+        let coverage = reopened.repository_graph_coverage(
+            project,
+            &CoverageScope::Path {
+                path: RepositoryNodePath::new(Path::new("limits/output_bytes.rs"))?,
+            },
+            1,
+        )?;
+        if coverage.rows.len() != 1 || coverage.rows[0].reached_limit() != Some(last) {
+            return Err(io::Error::other("reopen changed migrated graph-limit rows").into());
+        }
+        Ok(())
+    }
+
+    #[test]
     fn resolution_schema_migrates_parser_provenance_without_weakening_existing_facts()
     -> Result<(), Box<dyn Error>> {
         let temp = tempfile::tempdir()?;
@@ -4456,7 +4798,7 @@ mod tests {
         let connection = Connection::open(&database)?;
         configure_writable(&connection)?;
         connection.execute_batch(BASE_SCHEMA_SQL)?;
-        create_graph_schema(&connection, false)?;
+        create_graph_schema(&connection, GraphSchemaShape::Compact)?;
         connection.execute_batch(RESOLUTION_KEY_SCHEMA_SQL)?;
         connection.execute_batch(TELEMETRY_STORAGE_SCHEMA_SQL)?;
         connection.execute_batch(CURRENT_USAGE_SCHEMA_SQL)?;
@@ -4562,7 +4904,7 @@ mod tests {
         let connection = Connection::open(&db_path)?;
         configure_writable(&connection)?;
         connection.execute_batch(BASE_SCHEMA_SQL)?;
-        create_graph_schema(&connection, false)?;
+        create_graph_schema(&connection, GraphSchemaShape::Compact)?;
         connection.execute_batch(TELEMETRY_STORAGE_SCHEMA_SQL)?;
         connection.execute_batch(CURRENT_USAGE_SCHEMA_SQL)?;
         crate::telemetry::initialize_empty_storage(&connection)?;

--- a/crates/projectatlas-symbols/src/lib.rs
+++ b/crates/projectatlas-symbols/src/lib.rs
@@ -28,6 +28,7 @@ pub use resolution_keys::{
     resolve_relative_import_path, semantic_resolution_contract_digest, source_stems_for_path,
 };
 
+use projectatlas_core::graph::QUALIFIED_SYMBOL_SCOPE_PREFIX;
 use projectatlas_core::language::{
     EmbeddedHostKind, EmbeddedLanguageCapability, SymbolParserOwner, TreeSitterGrammar,
     builtin_tree_sitter_language_ids, language_capability, tree_sitter_grammar,
@@ -2178,7 +2179,10 @@ fn push_symbol_with_metadata(
 /// Return one compact identity that can be represented by every graph consumer.
 fn compact_symbol_identity(value: &str) -> Option<String> {
     let value = compact_text(value);
-    (!value.is_empty() && value.chars().count() <= MAX_SNIPPET_CHARS).then_some(value)
+    (!value.is_empty()
+        && value.chars().count() <= MAX_SNIPPET_CHARS
+        && !value.starts_with(QUALIFIED_SYMBOL_SCOPE_PREFIX))
+    .then_some(value)
 }
 
 /// Push a relation while enforcing per-file graph bounds.
@@ -2272,8 +2276,9 @@ fn is_snippet_boundary(character: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        MAX_SNIPPET_CHARS, MAX_SYMBOLS_PER_FILE, content_without_leading_purpose_header,
-        empty_graph, extract_cargo_manifest_graph_checked, extract_fallback_graph,
+        MAX_SNIPPET_CHARS, MAX_SYMBOLS_PER_FILE, QUALIFIED_SYMBOL_SCOPE_PREFIX,
+        compact_symbol_identity, content_without_leading_purpose_header, empty_graph,
+        extract_cargo_manifest_graph_checked, extract_fallback_graph,
         extract_fallback_graph_checked, extract_powershell_graph_checked, extract_symbol_graph,
         extract_symbol_graph_checked, extract_symbol_graph_controlled,
         extract_vue_sfc_graph_checked, languages, specialized_languages,
@@ -3606,6 +3611,16 @@ public class Registry
         assert!(!graph.relations.iter().any(|relation| {
             relation.kind == RelationKind::Contains && relation.target_name == "Retained"
         }));
+    }
+
+    #[test]
+    fn derived_qualified_scope_namespace_is_reserved_from_source_symbols() {
+        let reserved = format!("{QUALIFIED_SYMBOL_SCOPE_PREFIX}literal");
+        assert!(compact_symbol_identity(&reserved).is_none());
+        assert_eq!(
+            compact_symbol_identity("ordinary"),
+            Some("ordinary".to_string())
+        );
     }
 
     #[test]

--- a/crates/projectatlas-symbols/src/markdown.rs
+++ b/crates/projectatlas-symbols/src/markdown.rs
@@ -154,10 +154,11 @@ impl MarkdownFacts {
         let symbols = self
             .headings
             .iter()
-            .map(|heading| CodeSymbol {
+            .filter_map(|heading| Some((heading, crate::compact_symbol_identity(&heading.text)?)))
+            .map(|(heading, name)| CodeSymbol {
                 path: path.to_owned(),
                 language: language.map(str::to_owned),
-                name: heading.text.clone(),
+                name,
                 kind: SymbolKind::Heading,
                 signature: heading_signature(&heading.slug, heading.occurrence),
                 exported: false,
@@ -895,6 +896,26 @@ mod tests {
                 .detail
                 .as_deref()
                 .is_some_and(|detail| detail.contains("slug=über-atlas;occurrence=1;bytes="))
+        );
+    }
+
+    #[test]
+    fn symbol_graph_reserves_the_derived_scope_namespace() {
+        let content = format!(
+            "# {}literal\n\n# Visible\n",
+            projectatlas_core::graph::QUALIFIED_SYMBOL_SCOPE_PREFIX
+        );
+        let facts = extract_markdown_facts(&content);
+        let graph = facts.symbol_graph("README.md", Some("markdown"));
+
+        assert_eq!(facts.headings.len(), 2);
+        assert_eq!(
+            graph
+                .symbols
+                .iter()
+                .map(|symbol| symbol.name.as_str())
+                .collect::<Vec<_>>(),
+            ["Visible"]
         );
     }
 

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -2,7 +2,7 @@
 
 This document is generated from the versioned Rust language capability registry. Do not edit the capability table or totals by hand. Canonical rows count once; aliases and extensions never increase a capability total.
 
-Registry version: `4`. Accepted capability-set version: `10`. Detection policy version: `1`. Registry digest: `cbede576a7b2ab4309798075210b59dbece0cf99cc7874a9659fd17f3c2d961f`. Accepted-set digest: `cbede576a7b2ab4309798075210b59dbece0cf99cc7874a9659fd17f3c2d961f`. Semantic-provider digest: `b26c4aa768ebe3bb185d5929350d2f41c6b1b2f93630080248dec7eb6ec00e82`.
+Registry version: `4`. Accepted capability-set version: `11`. Detection policy version: `1`. Registry digest: `3776f19c62b3debfcae13715e3bdc3ec3029978a4f7ba1428b7a06d433524915`. Accepted-set digest: `3776f19c62b3debfcae13715e3bdc3ec3029978a4f7ba1428b7a06d433524915`. Semantic-provider digest: `b26c4aa768ebe3bb185d5929350d2f41c6b1b2f93630080248dec7eb6ec00e82`.
 
 Optional catalog input: `tree-sitter-language-pack@1.13.2` revision `6258abac30304283763a0d2dc8a48cb87fbcf438` under `MIT` metadata license. This catalog identity is not a grammar-license or runtime-support claim.
 
@@ -30,53 +30,53 @@ Broad candidate rows are admitted only when the pinned catalog supplies a stable
 | `cpp` | `source` | `c++` | `.cpp`, `.cxx`, `.cc` | tree-sitter-cpp@0.23.4 | supported | supported | unavailable | — | unavailable | — | `tree-sitter-cpp@0.23.4` | `MIT` |
 | `h` | `source` | — | `.h` | tree-sitter-c@0.24.2 | supported | supported | unavailable | — | unavailable | — | `tree-sitter-c@0.24.2` | `MIT` |
 | `hpp` | `source` | — | `.hpp`, `.hxx`, `.hh` | tree-sitter-cpp@0.23.4 | supported | supported | unavailable | — | unavailable | — | `tree-sitter-cpp@0.23.4` | `MIT` |
-| `cargo-manifest` | `configuration_data` | — | exact `Cargo.toml` | projectatlas:cargo-manifest | supported | supported | supported (cargo) | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `cargo-lock` | `configuration_data` | — | exact `Cargo.lock` | projectatlas:cargo-manifest | supported | supported | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `vue` | `source` | — | `.vue` | projectatlas:vue | supported | supported | unavailable | component → ecma-script | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `markdown` | `documentation` | `md` | `.md`, `.mdx` | projectatlas:markdown | supported | supported | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `json` | `configuration_data` | — | `.json`, `.jsonc` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `yaml` | `configuration_data` | `yml` | `.yml`, `.yaml` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `css` | `source` | — | `.css`, `.scss`, `.sass`, `.less`, `.stylus`, `.styl` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `html` | `source` | — | `.html`, `.htm` | unavailable | supported | unavailable | unavailable | html-like → ecma-script | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `toon` | `configuration_data` | — | `.toon` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `dockerfile` | `source` | — | exact `Dockerfile` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `makefile` | `source` | — | exact `Makefile` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `text` | `other_text` | `txt` | `.txt` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `toml` | `configuration_data` | — | `.toml` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `xml` | `configuration_data` | — | `.xml` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `svelte` | `source` | — | `.svelte` | projectatlas:fallback | fallback | fallback | unavailable | template → ecma-script | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `astro` | `source` | — | `.astro` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `jsp` | `source` | — | `.jsp`, `.jspx`, `.jspf` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `jsp-tag` | `source` | — | `.tag`, `.tagx` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `gsp` | `source` | — | `.gsp` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `groovy` | `source` | — | `.gradle`, `.groovy` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `protobuf` | `source` | `proto` | `.proto` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `handlebars` | `source` | `hbs` | `.hbs`, `.handlebars` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `ejs` | `source` | — | `.ejs` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `pug` | `source` | — | `.pug` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `freemarker` | `source` | `ftl` | `.ftl` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `mustache` | `source` | — | `.mustache` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `liquid` | `source` | — | `.liquid` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `erb` | `source` | — | `.erb` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `sql` | `source` | — | `.sql`, `.ddl`, `.dml`, `.mysql`, `.postgresql`, `.psql`, `.sqlite`, `.mssql`, `.oracle`, `.ora`, `.db2`, `.proc`, `.procedure`, `.func`, `.function`, `.view`, `.trigger`, `.index`, `.migration`, `.seed`, `.fixture`, `.schema`, `.cql`, `.cypher`, `.sparql`, `.liquibase`, `.flyway` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `graphql` | `source` | `gql` | `.gql` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `config` | `configuration_data` | — | `.ini`, `.cfg`, `.conf`, `.properties`, `.env`, `.gitignore`, `.dockerignore`, `.editorconfig` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `ruby` | `source` | `rb` | `.rb`, shebang `ruby` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `php` | `source` | — | `.php` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `swift` | `source` | — | `.swift` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `scala` | `source` | — | `.scala` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `shell` | `source` | `sh` | `.sh`, `.bash`, `.zsh`, shebang `sh`, shebang `bash`, shebang `dash`, shebang `ash`, shebang `zsh`, shebang `ksh`, shebang `mksh`, shebang `fish` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `powershell` | `source` | `pwsh` | `.ps1`, `.psm1`, `.psd1`, shebang `powershell`, shebang `pwsh` | projectatlas:powershell | supported | supported | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `batch` | `source` | — | `.bat`, `.cmd` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `r` | `source` | `rscript` | `.r`, `.R`, shebang `rscript` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `perl` | `source` | — | `.pl`, `.pm`, shebang `perl` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `lua` | `source` | — | `.lua`, shebang `lua` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `dart` | `source` | — | `.dart` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `haskell` | `source` | `hs` | `.hs` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `ocaml` | `source` | — | `.ml`, `.mli` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `fsharp` | `source` | `f#` | `.fs`, `.fsx` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `clojure` | `source` | `clj` | `.clj`, `.cljs` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
-| `vim` | `source` | `vimscript` | `.vim` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc2` | `MIT` |
+| `cargo-manifest` | `configuration_data` | — | exact `Cargo.toml` | projectatlas:cargo-manifest | supported | supported | supported (cargo) | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `cargo-lock` | `configuration_data` | — | exact `Cargo.lock` | projectatlas:cargo-manifest | supported | supported | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `vue` | `source` | — | `.vue` | projectatlas:vue | supported | supported | unavailable | component → ecma-script | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `markdown` | `documentation` | `md` | `.md`, `.mdx` | projectatlas:markdown | supported | supported | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `json` | `configuration_data` | — | `.json`, `.jsonc` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `yaml` | `configuration_data` | `yml` | `.yml`, `.yaml` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `css` | `source` | — | `.css`, `.scss`, `.sass`, `.less`, `.stylus`, `.styl` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `html` | `source` | — | `.html`, `.htm` | unavailable | supported | unavailable | unavailable | html-like → ecma-script | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `toon` | `configuration_data` | — | `.toon` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `dockerfile` | `source` | — | exact `Dockerfile` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `makefile` | `source` | — | exact `Makefile` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `text` | `other_text` | `txt` | `.txt` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `toml` | `configuration_data` | — | `.toml` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `xml` | `configuration_data` | — | `.xml` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `svelte` | `source` | — | `.svelte` | projectatlas:fallback | fallback | fallback | unavailable | template → ecma-script | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `astro` | `source` | — | `.astro` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `jsp` | `source` | — | `.jsp`, `.jspx`, `.jspf` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `jsp-tag` | `source` | — | `.tag`, `.tagx` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `gsp` | `source` | — | `.gsp` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `groovy` | `source` | — | `.gradle`, `.groovy` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `protobuf` | `source` | `proto` | `.proto` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `handlebars` | `source` | `hbs` | `.hbs`, `.handlebars` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `ejs` | `source` | — | `.ejs` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `pug` | `source` | — | `.pug` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `freemarker` | `source` | `ftl` | `.ftl` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `mustache` | `source` | — | `.mustache` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `liquid` | `source` | — | `.liquid` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `erb` | `source` | — | `.erb` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `sql` | `source` | — | `.sql`, `.ddl`, `.dml`, `.mysql`, `.postgresql`, `.psql`, `.sqlite`, `.mssql`, `.oracle`, `.ora`, `.db2`, `.proc`, `.procedure`, `.func`, `.function`, `.view`, `.trigger`, `.index`, `.migration`, `.seed`, `.fixture`, `.schema`, `.cql`, `.cypher`, `.sparql`, `.liquibase`, `.flyway` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `graphql` | `source` | `gql` | `.gql` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `config` | `configuration_data` | — | `.ini`, `.cfg`, `.conf`, `.properties`, `.env`, `.gitignore`, `.dockerignore`, `.editorconfig` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `ruby` | `source` | `rb` | `.rb`, shebang `ruby` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `php` | `source` | — | `.php` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `swift` | `source` | — | `.swift` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `scala` | `source` | — | `.scala` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `shell` | `source` | `sh` | `.sh`, `.bash`, `.zsh`, shebang `sh`, shebang `bash`, shebang `dash`, shebang `ash`, shebang `zsh`, shebang `ksh`, shebang `mksh`, shebang `fish` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `powershell` | `source` | `pwsh` | `.ps1`, `.psm1`, `.psd1`, shebang `powershell`, shebang `pwsh` | projectatlas:powershell | supported | supported | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `batch` | `source` | — | `.bat`, `.cmd` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `r` | `source` | `rscript` | `.r`, `.R`, shebang `rscript` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `perl` | `source` | — | `.pl`, `.pm`, shebang `perl` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `lua` | `source` | — | `.lua`, shebang `lua` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `dart` | `source` | — | `.dart` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `haskell` | `source` | `hs` | `.hs` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `ocaml` | `source` | — | `.ml`, `.mli` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `fsharp` | `source` | `f#` | `.fs`, `.fsx` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `clojure` | `source` | `clj` | `.clj`, `.cljs` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `vim` | `source` | `vimscript` | `.vim` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
 | `abl` | `source` | — | `.p` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | broad-parser | `tree-sitter-language-pack@1.13.2` | `MIT` |
 | `actionscript` | `source` | — | `.as` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | broad-parser | `tree-sitter-language-pack@1.13.2` | `MIT` |
 | `ada` | `source` | — | `.ada` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | broad-parser | `tree-sitter-language-pack@1.13.2` | `MIT` |
@@ -288,7 +288,7 @@ Broad candidate rows are admitted only when the pinned catalog supplies a stable
 
 ## Language & Ecosystem Support
 
-Complete-support schema version: `1`. Ecosystem catalog version: `1`. Catalog digest: `751e505d1b77d9fadb8836f4648b23d20b40b0e3de530c79755ef0e846a33ed7`.
+Complete-support schema version: `1`. Ecosystem catalog version: `1`. Catalog digest: `b142590eeb65e4af79d51d76e73342fce6515c3834a2637d8a7aee349c35fa70`.
 
 `Complete` means conformance to the fixed ProjectAtlas navigation contract, not compiler, build-system, runtime, or whole-language completeness. Final v0.4 MCP navigation revalidation retained every runtime candidate at its achieved detected/parsed/symbol/semantic/benchmarked tier: none has the complete schema-bound capability and agent-navigation evidence required for promotion.
 

--- a/docs/projectatlas-3-architecture.md
+++ b/docs/projectatlas-3-architecture.md
@@ -573,8 +573,8 @@ erDiagram
     RESOLUTION_KEY ||--o{ RELATION_DEPENDENCY : identifies
 ```
 
-The diagram shows the current schema-16 normalized hot relationship model, not
-every compatibility or telemetry table. Schema 16 retains one
+The diagram shows the current schema-19 normalized hot relationship model, not
+every compatibility or telemetry table. Schema 19 retains the
 `graph_resolution_keys` authority plus `graph_entity_exports` and
 `graph_relation_dependencies` owner bindings. The registry permits only one
 canonical collision witness for a project/domain/digest identity, even when the
@@ -868,7 +868,7 @@ are added.
 
 | CLI route | MCP route | Physical database and source access | Freshness and generation contract | Transaction, bounds, telemetry, and target owner |
 | --- | --- | --- | --- | --- |
-| `init` | `atlas_init` | Create/validate project-local config and the one project database; unless `no_scan`, scan current local source, import controlled purpose inputs, and derive text, summaries, symbols, and graph projections. | The selected source tree and effective ignore/config policy are authoritative. Initialization binds project identity and publishes one active complete generation when scanning runs. | Discovery/extraction is admitted under existing entry, byte, parser-output, worker, deadline, and cancellation limits; prepared mutations publish in one short parent-owned transaction. It writes no separate authoritative product database. Introduced in schema 11 and preserved by schema 16, bounded telemetry, passive checkpoint state, reusable-page state, and ownership-validated private graph staging remain part of the current contract. |
+| `init` | `atlas_init` | Create/validate project-local config and the one project database; unless `no_scan`, scan current local source, import controlled purpose inputs, and derive text, summaries, symbols, and graph projections. | The selected source tree and effective ignore/config policy are authoritative. Initialization binds project identity and publishes one active complete generation when scanning runs. | Discovery/extraction is admitted under existing entry, byte, parser-output, worker, deadline, and cancellation limits; prepared mutations publish in one short parent-owned transaction. It writes no separate authoritative product database. Introduced in schema 11 and preserved by schema 19, bounded telemetry, passive checkpoint state, reusable-page state, and ownership-validated private graph staging remain part of the current contract. |
 | `scan` | `atlas_scan` | Read/hash/parse current included source off-writer, stage bounded typed batches, and replace the complete derived projection in the same database. | Revalidate source, configuration, purpose inputs, and base generation before publication. Readers keep the last complete generation until commit. | One short `BEGIN IMMEDIATE` publication owns all prepared mutations and one generation advance; failure/cancellation rolls back. Background MCP execution changes task delivery, not database ownership. No navigation telemetry is appended. |
 | `symbols build` | `atlas_symbols_build` | Read selected indexed source off-writer and rebuild compatible symbol plus normalized graph projections in the same database. | Revalidate the source and publication contract; preserve the last complete generation on failure. | Bounded parser workers, source bytes, retained parser output, deadline, and cancellation feed one publication transaction. No navigation telemetry is appended. |
 | `watch` and `watch --once` | `atlas_watch_once` | Observe or poll current local source, derive one changed-path batch off-writer, and publish affected text/symbol/graph rows in the same database; a correctness-required event may request a full scan. | Each successful batch revalidates source/policy/base generation and advances exactly once. Failed batches remain eligible for retry and expose no partial generation. | Each batch has bounded path/source/parser/worker/deadline/cancellation controls and one short publication transaction. The long-lived verified observation epoch is current. Database maintenance is bounded, content-free, and never introduces an abandoned spill authority. |
@@ -1222,7 +1222,7 @@ distributed filesystems remain typed `unsupported`; ProjectAtlas never falls
 back to a weaker journal or synchronous mode.
 
 SQLite auto-checkpoint remains the engine baseline for structural publication.
-Introduced in schema 11 and preserved by schema 16, the telemetry lifecycle
+Introduced in schema 11 and preserved by schema 19, the telemetry lifecycle
 additionally counts committed telemetry writes and, after 1,024
 writes by default, attempts one `PASSIVE` checkpoint only after the event
 transaction has committed. Busy or failed checkpoint state is recorded for
@@ -1433,7 +1433,7 @@ flowchart TB
     Lookalike[Foreign, linked, or lookalike state] --> Retain
 ```
 
-The current schema 16 implements this bounded lifecycle in the one authoritative database.
+The current schema 19 implements this bounded lifecycle in the one authoritative database.
 The normal read path never performs an unbounded purge, blocking truncate
 checkpoint, blind `VACUUM`, or destructive rebuild. Telemetry compaction
 preserves supported all-time totals and declared trend windows; retained,
@@ -1609,14 +1609,14 @@ The durable responsibilities and access paths are:
 
 | Responsibility | Principal physical state | Authority and primary access | Current/target state |
 | --- | --- | --- | --- |
-| Compatibility and publication | `metadata`, `project_identity` | Durable schema/root/contract identity; read-only preflight, migration, root transition, and active-generation lookup. | Schema 18 is current and retains one append-only migration owner. |
-| Local structure | `nodes`, `summaries`, `file_texts`, `file_text_fts`, `source_parse_metadata`, `file_content_classifications` | Rebuildable exact path/parent/kind, authoritative persisted text, a trigger-free rebuildable FTS5 trigram candidate projection keyed by `file_texts.rowid`, summary, hash, source-parse provenance, independently persisted fact-graph parser provenance, and one closed classification per current file. | Parser-provenance separation introduced in schema 13 remains authoritative in schema 18; parser/provider discovery uses `(source_parser, path)` and `(fact_parser, path)` indexes without duplicating provenance into coverage rows. Schema 17 added indexed classification/path ownership. FTS mutation, revision publication, and backfill share the authoritative text transaction; revision drift disables acceleration and never replaces exact fallback semantics. |
-| Purpose | `purposes` joined to `nodes` plus an authored-purpose revision | Generated/suggested versus agent/approved lifecycle; accepted path-owned responsibility remains authored across derived changes and is projected by exact owning path or nearest applicable folder. | Schema 18 preserves the schema-17 accepted-purpose contract without hash-driven invalidation; bounded projection and cursor revision binding are current. |
-| Compatible code facts | `symbols`, `symbol_relations` | Rebuildable file-level symbols, exact current-source selectors, and relation calls. | Schema 17 introduced optional heading byte/column selectors; schema 18 preserves those rows and their co-publication with normalized graph facts. |
-| Normalized graph | `graph_entities`, `graph_relations`, `graph_relation_occurrences`, `graph_coverage`, `graph_resolution_keys`, `graph_entity_exports`, `graph_relation_dependencies`, `document_unresolved_reason` | Rebuildable stable identity, source/target adjacency, occurrences, coverage, dependency-key closure, and one typed reason only for unresolved canonical document relations. | Schema 18 preserves the schema-17 compact graph, constrained unresolved-document evidence, project identity, and authored state. Bounded hydration, traversal, cursors, and aggregate budgets are current. |
+| Compatibility and publication | `metadata`, `project_identity` | Durable schema/root/contract identity; read-only preflight, migration, root transition, and active-generation lookup. | Schema 19 is current and retains one append-only migration owner. |
+| Local structure | `nodes`, `summaries`, `file_texts`, `file_text_fts`, `source_parse_metadata`, `file_content_classifications` | Rebuildable exact path/parent/kind, authoritative persisted text, a trigger-free rebuildable FTS5 trigram candidate projection keyed by `file_texts.rowid`, summary, hash, source-parse provenance, independently persisted fact-graph parser provenance, and one closed classification per current file. | Parser-provenance separation introduced in schema 13 remains authoritative in schema 19; parser/provider discovery uses `(source_parser, path)` and `(fact_parser, path)` indexes without duplicating provenance into coverage rows. Schema 17 added indexed classification/path ownership. FTS mutation, revision publication, and backfill share the authoritative text transaction; revision drift disables acceleration and never replaces exact fallback semantics. |
+| Purpose | `purposes` joined to `nodes` plus an authored-purpose revision | Generated/suggested versus agent/approved lifecycle; accepted path-owned responsibility remains authored across derived changes and is projected by exact owning path or nearest applicable folder. | Schema 19 preserves the schema-17 accepted-purpose contract without hash-driven invalidation; bounded projection and cursor revision binding are current. |
+| Compatible code facts | `symbols`, `symbol_relations` | Rebuildable file-level symbols, exact current-source selectors, and relation calls. | Schema 17 introduced optional heading byte/column selectors; schema 19 preserves those rows and their co-publication with normalized graph facts. |
+| Normalized graph | `graph_entities`, `graph_relations`, `graph_relation_occurrences`, `graph_coverage`, `graph_resolution_keys`, `graph_entity_exports`, `graph_relation_dependencies`, `document_unresolved_reason` | Rebuildable stable identity, source/target adjacency, occurrences, coverage, dependency-key closure, and one typed reason only for unresolved canonical document relations. | Schema 19 preserves the schema-18 graph model while admitting the complete closed graph-limit domain; migration preserves project identity and authored state while invalidating only derived publication. Bounded hydration, traversal, cursors, and aggregate budgets are current. |
 | Health resolution | `health_resolutions` | Authored exact finding disposition. | Current and preserved across derived publication. |
-| Usage measurement | `usage_instances`, `usage_bucket_dimensions`, `usage_instance_baselines`, `usage_labels`, exact global/instance/day aggregate tables, bounded `usage_events`, retention state, and label/instance tombstones | Internal runtime lifecycle, active modeled-baseline witnesses, exact durable totals/trends, recent optional detail, and content-free maintenance truth. Source rows are project-scoped; indexes own label/state/age and raw instance/time access. | Introduced by schema 11 and preserved by schema 18; every detail dimension is bounded independently, supported totals remain exact after pruning, and retained/partial/expired/unavailable detail is reported without a second database. |
-| Worktree coordination | `usage_aggregate_revisions`, `worktree_registrations`, `worktree_usage_aggregates`, `usage_instance_worktree_origins` | Bounded active/retired alias identity, exact routed origins, monotonic synchronized lifetime/daily aggregates, and repository-total attribution in the explicitly selected control atlas. | Schema 18 adds the indexed local-control model; each worktree graph remains private and independently writable. |
+| Usage measurement | `usage_instances`, `usage_bucket_dimensions`, `usage_instance_baselines`, `usage_labels`, exact global/instance/day aggregate tables, bounded `usage_events`, retention state, and label/instance tombstones | Internal runtime lifecycle, active modeled-baseline witnesses, exact durable totals/trends, recent optional detail, and content-free maintenance truth. Source rows are project-scoped; indexes own label/state/age and raw instance/time access. | Introduced by schema 11 and preserved by schema 19; every detail dimension is bounded independently, supported totals remain exact after pruning, and retained/partial/expired/unavailable detail is reported without a second database. |
+| Worktree coordination | `usage_aggregate_revisions`, `worktree_registrations`, `worktree_usage_aggregates`, `usage_instance_worktree_origins` | Bounded active/retired alias identity, exact routed origins, monotonic synchronized lifetime/daily aggregates, and repository-total attribution in the explicitly selected control atlas. | Schema 18 adds the indexed local-control model and schema 19 preserves it; each worktree graph remains private and independently writable. |
 | Future Memory Atlas | #314-owned tables | Separately capped authored context and independent context revision. | Conceptual boundary only; #308 does not prebuild its schema. |
 
 Legacy symbol rows and normalized graph rows are compatible co-published
@@ -1627,7 +1627,7 @@ The validated SQLite operating profile is explicit:
 
 | Concern | Current live state | Accepted target and owner |
 | --- | --- | --- |
-| Schema | Version 18 with append-only 8 through 18 migration ownership; 10 to 11 streams telemetry into normalized instances, dimensions, aggregates, raw detail, and retention state, 11 to 12 adds dependency-resolution keys and normalizes the accepted-purpose lifecycle, 12 to 13 records parser provenance and parser-failure state, 13 to 14 adds bounded coverage-discovery indexes, 14 to 15 adds the trigger-free FTS5 candidate projection, 15 to 16 compacts stable graph-key storage, 16 to 17 adds constrained file classifications, exact symbol selectors, and typed unresolved-document evidence, and 17 to 18 adds local worktree registrations, aggregate revisions, routed origins, and normalized synchronized aggregates without replacing existing graph, purpose, or telemetry authority. | Keep one append-only owner; migration rollback preserves the complete predecessor for deterministic retry, and incompatible future state is refused without mutation. |
+| Schema | Version 19 with append-only 8 through 19 migration ownership; 10 to 11 streams telemetry into normalized instances, dimensions, aggregates, raw detail, and retention state, 11 to 12 adds dependency-resolution keys and normalizes the accepted-purpose lifecycle, 12 to 13 records parser provenance and parser-failure state, 13 to 14 adds bounded coverage-discovery indexes, 14 to 15 adds the trigger-free FTS5 candidate projection, 15 to 16 compacts stable graph-key storage, 16 to 17 adds constrained file classifications, exact symbol selectors, and typed unresolved-document evidence, 17 to 18 adds local worktree registrations and normalized synchronized aggregates, and 18 to 19 widens only the graph coverage limit domain through the existing disposable graph rebuild. | Keep one append-only owner; migration rollback preserves the complete predecessor for deterministic retry, and incompatible future state is refused without mutation. |
 | Rust/SQLite build | Workspace `rusqlite` 0.32.1, `libsqlite3-sys` 0.30.1, bundled SQLite 3.46.0. | Settings reports the actual linked runtime version and a bounded compile-option identity; source package versions alone are not runtime proof. |
 | Filesystem | One project-local database on a filesystem with supported SQLite locking/shared-memory behavior; writable preflight returns typed supported, unsupported, or uncertain state before mutation. | Keep rejecting unsupported or uncertain live network filesystems without a silent durability downgrade. |
 | Writable connections | `foreign_keys=ON`, WAL, `synchronous=FULL`, five-second ordinary busy timeout with bounded WAL-establishment retry for concurrent validated openers; publication acquisition remains fail-fast and ancillary telemetry remains 25 ms. | The accepted mixed authored/derived durability profile is enforced and verified on production writable paths, including concurrent MCP requests with short authored and telemetry writes. |
@@ -1863,7 +1863,7 @@ flowchart TB
     Resolution -->|one exact target| Resolved[Resolved source file or symbol]
     Resolution -->|several exact candidates| Ambiguous[Typed ambiguous evidence]
     Resolution -->|missing, ignored, outside root, case conflict, unsupported| Unresolved[Typed unresolved reason]
-    Empty --> Normalize[Schema-18 documents complete-zero row]
+    Empty --> Normalize[Documents complete-zero row]
     Normalize --> Generation[(Complete graph generation)]
     Headings --> Generation
     Resolved --> Generation
@@ -1883,7 +1883,7 @@ references become relations. Ordinary prose, similarity, topic overlap, and
 unproven implementation claims create no edges. Complete extraction with no
 supported candidates remains graph-visible as trusted `no_candidates` coverage;
 an admitted candidate that cannot resolve remains a typed relation with its
-exact unresolved reason. Schema 18 stores the trusted zero state through its
+exact unresolved reason. Schema 19 stores the trusted zero state through its
 existing constrained complete-zero row. RC1's older projection fingerprint
 forces one typed full refresh before stale heading-owned rows can be served;
 authored purpose and project identity remain intact.
@@ -1897,8 +1897,8 @@ flowchart TB
     Revalidate --> Registry[Worktree list and lifecycle-bound registration]
     Resolver -->|active-row CAS for a moved root| Registry
     Registry --> Control
-    Resolver -->|read registry or select main| Control[(Control schema-18 atlas and registry)]
-    Resolver -->|issue alias| DbB[(Private ignored schema-18 target atlas)]
+    Resolver -->|read registry or select main| Control[(Control schema-19 atlas and registry)]
+    Resolver -->|issue alias| DbB[(Private ignored schema-19 target atlas)]
     Control -->|safe reusable baseline| Candidate[Private hydration candidate]
     Candidate --> Reconcile[Reconcile exact branch and dirty bytes]
     Reconcile --> DbB
@@ -1913,7 +1913,7 @@ flowchart TB
     Control -. never one shared writable graph .- DbB
 ```
 
-The selected worktree's active schema-18 generation owns classifications,
+The selected worktree's active schema-19 generation owns classifications,
 headings, exact selectors, canonical document relations, completeness,
 provenance, purposes, and typed unresolved evidence. A valid released database
 migrates in place. An absent registered target may hydrate reusable graph,

--- a/docs/v0.4.5-rc3-release-notes.md
+++ b/docs/v0.4.5-rc3-release-notes.md
@@ -1,0 +1,78 @@
+# ProjectAtlas v0.4.5-rc3 release notes
+
+ProjectAtlas v0.4.5-rc3 closes three shared root-cause gaps found while reviewing
+the RC2 fixes across every language and adapter, rather than extending only the
+original C# and Markdown reproducers.
+
+## Highlights
+
+- Persist every closed `GraphLimitKind`. Schema 19 derives the current SQLite
+  `graph_coverage.reached_limit` constraint from the nine-value core inventory,
+  while schema 18 retains its exact historical four-value contract. The
+  transactional upgrade preserves project identity and authored purposes,
+  invalidates only rebuildable graph publication, and rolls back completely on
+  failure.
+- Bound qualified symbol parents after parser admission. Exact readable
+  `parent::child` identities remain unchanged through the 4,096-byte boundary;
+  deeper valid chains use a deterministic domain-separated BLAKE3 scope. This
+  scope has a reserved namespace that exact parser identities cannot occupy.
+  The shared rule applies to every tree-sitter language and Markdown, and
+  prevents publication aborts, compact-versus-literal key collisions, and the
+  prior quadratic retained-string growth at the 4,000-symbol/file boundary.
+- Return one typed lint report from the shared runtime. CLI JSON and TOON now
+  use stdout and the standard flushed output adapter, MCP returns the same map
+  and SQLite facts, blocking exit codes remain unchanged, and stderr is
+  reserved for execution failures. Lint now verifies stale source without
+  implicitly repairing or publishing the database.
+
+## Root-cause breadth
+
+RC2's C# field reproducer exposed two different boundaries. Raw declaration
+identity is correctly owned by the shared symbols crate, but later graph
+qualification could still rebuild an overbound ancestor chain for Rust, Java,
+C#, TypeScript, or any other nested tree-sitter language. RC3 fixes that second
+shared owner and proves it with deeply nested Rust modules plus full,
+incremental, and clean publication.
+
+RC2's Markdown file-anchoring work was also correct at its projection owner,
+but valid partial Markdown coverage could emit `intermediate_bytes`, which the
+schema-18 constraint did not admit. RC3 aligns the closed Rust domain, SQLite
+DDL, writer, reader, migration, and real Markdown publication without mapping
+distinct limits onto a generic value or raising any graph budget.
+
+The RC2 terminal viewport, purpose-mutation admission, Btrfs placement, and
+worktree lifecycle fixes were rechecked at their shared owners. They do not
+contain a comparable language-specific residual: the terminal and purpose
+paths are language-neutral, Btrfs is intentionally Linux-filesystem-specific
+but shared by every SQLite caller, and the worktree contract is repository
+lifecycle behavior rather than parser behavior.
+
+## Compatibility and upgrade
+
+Opening a valid schema-18 database upgrades it transactionally to schema 19 and
+requests the normal graph refresh because graph rows are derived. Authored
+purpose state and project identity remain intact. Exact shallow graph keys,
+existing lint rules, CLI exit codes, MCP compatibility text, JSON/TOON command
+selection, and graph work limits remain compatible.
+
+## Deliberate boundaries
+
+RC3 adds no crate, dependency, index, worker, lock, transport, parser branch,
+or generic schema framework. It does not raise the graph identity limit, hash
+invalid raw parser input into validity, preserve disposable graph rows during
+the one-time schema correction, or let lint mutate stale source state.
+
+## Verification policy
+
+RC3 is published only after the locked workspace gates, all-nine SQLite
+round-trip and schema-18 fault/reopen coverage, 4,000-deep bounded-resource
+projection, real full/incremental/clean Rust publication, real partial Markdown
+publication with last-complete rollback, CLI/MCP JSON/TOON lint parity,
+installed-candidate checks on Windows, Linux, and macOS, strict OpenSpec and
+IssueOps synchronization, and exact-head review resolution. It is a GitHub
+prerelease and does not replace the preceding stable GitHub Latest release.
+
+For the complete workflow and storage boundaries, see
+[Agent navigation](agent-navigation.md),
+[Worktree atlas continuity](worktree-lifecycle.md), and
+[ProjectAtlas 3 Architecture](projectatlas-3-architecture.md#architecture-views).

--- a/docs/worktree-lifecycle.md
+++ b/docs/worktree-lifecycle.md
@@ -49,7 +49,7 @@ flowchart LR
 Ownership remains inside the existing crates:
 
 - `projectatlas-fs` reads bounded structural Git evidence without starting Git.
-- `projectatlas-db` owns schema 18 registration, hydration, exact database identity, and normalized telemetry synchronization.
+- `projectatlas-db` owns schema 19 registration, hydration, exact database identity, and normalized telemetry synchronization.
 - `projectatlas-cli` owns MCP schemas, alias resolution, targeted init orchestration, and aggregate token presentation.
 - `projectatlas-service` owns bounded read-only graph federation.
 

--- a/openspec/changes/bound-qualified-symbol-parents/.openspec.yaml
+++ b/openspec/changes/bound-qualified-symbol-parents/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/bound-qualified-symbol-parents/design.md
+++ b/openspec/changes/bound-qualified-symbol-parents/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The symbols crate now admits only compact non-empty raw names and immediate parents up to 240 Unicode scalars. The language-neutral graph projection subsequently reconstructs fully qualified containment strings so equal local names under different nested scopes remain distinct. That derived string is currently unbounded and is converted to `GraphIdentityText`, whose 4,096-byte ceiling correctly protects canonical keys and SQLite rows. A valid deep symbol tree can therefore fail after parser admission and abort the publication transaction.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep every derived parent admitted by `GraphIdentityText` without losing valid nested symbols.
+- Retain exact readable qualification while it fits and deterministic scope distinction after it does not.
+- Apply one language-neutral rule to full and incremental graph publication.
+- Keep allocation and hashing bounded by the existing graph identity ceiling.
+
+**Non-Goals:**
+
+- Raise or remove the graph identity limit.
+- Relax raw symbol-name admission or hash malformed parser identities into validity.
+- Change containment discovery, parser grammars, source positions, or SQLite schema.
+
+## Decisions
+
+### Make the graph byte ceiling an observable domain contract
+
+`projectatlas-core` will expose the existing maximum graph identity bytes as a documented constant. The constructor remains the final validator. Projection can therefore distinguish the one expected composition overflow from other invalid text instead of treating every constructor error as an invitation to synthesize a value.
+
+Repeating the literal `4_096` in the CLI is rejected because it would create the same cross-owner drift class as #471. Adding a new validated identity type is rejected because `GraphIdentityText` already owns the invariant.
+
+### Compact only the derived qualification chain
+
+`qualified_symbol_parents` will carry validated `GraphIdentityText` values. A readable `parent::name` remains byte-for-byte unchanged when it fits. When composition alone exceeds the ceiling, projection will replace that derived scope name with a bounded domain-separated BLAKE3 form that retains the nearest symbol name plus the digest of the complete candidate. Descendants continue from that bounded scope value and may compact again only when required.
+
+The compact form uses one core-owned reserved prefix. Built-in source-symbol admission omits raw names or parents in that namespace, and the shared projection boundary rejects a directly constructed graph that bypasses parser admission. Exact raw qualification therefore cannot reproduce a compact derived identity.
+
+This does not hash an invalid raw symbol into admission: every component has already passed parser-side admission and graph validation. The digest exists only to preserve stable scope distinction when the exact composed display cannot fit the established key boundary.
+
+Dropping the parent, reverting to the immediate name, or omitting the child is rejected because repeated deep branches could collapse or lose valid symbols. Truncating the prefix is rejected because distinct scopes can share the retained suffix. Raising the ceiling is rejected because it transfers unbounded input into canonical keys and storage.
+
+### Validate before entity construction
+
+The qualifier will return `Result<Vec<Option<GraphIdentityText>>, CliError>`. Entity projection consumes the validated parent directly, so no later `GraphIdentityText::new` call can turn a valid symbol tree into a repository-wide failure. Any non-size contract violation still propagates fail-closed.
+
+The existing ordering and active-containment algorithm remains `O(n log n)`. Every retained identity is bounded to the graph ceiling and each temporary candidate is bounded to one retained parent plus one parser-admitted component, so total qualification work is `O(n log n + n * limit)` rather than the current quadratic cumulative-string retention. A 4,000-deep regression at the existing per-file symbol ceiling protects the intended resource model. No new collection, worker, lock, I/O, or SQLite cost is added.
+
+## Risks / Trade-offs
+
+- [A compacted parent is less human-readable] -> Preserve the nearest name and compact only after the exact chain cannot be represented; exact shallow identities remain unchanged.
+- [Two deep scopes collapse] -> Reserve the compact namespace from raw source identities, hash the complete bounded predecessor plus current name with a domain separator, and prove equal suffixes under different ancestors remain distinct and stable.
+- [Hashing masks invalid raw input] -> Run raw admission first and use fallback only when validated components compose beyond the public byte ceiling; all other validation errors still fail.
+- [Full and incremental keys diverge] -> Keep one deterministic projection function and compare both publication modes plus clean-scan convergence.
+- [Deep valid input exhausts memory before validation] -> Collapse each step immediately and exercise the existing 4,000-symbol/file ceiling without retaining cumulative ancestor strings.
+
+## Migration Plan
+
+No schema or durable migration is required. The graph projection contract fingerprint changes so existing derived graph keys are rebuilt under the normal publication path. Authored state and source bytes remain unchanged.
+
+## Dependencies / Cross-Issue Impact
+
+This closes the remaining derived-qualification gap after the raw symbol-admission fix in #467. It is implementation-independent from #471 and #472; the shared RC3 workflow matrix proves all three changes on the same supported source and installed-candidate platforms.
+
+## Open Questions
+
+None.

--- a/openspec/changes/bound-qualified-symbol-parents/proposal.md
+++ b/openspec/changes/bound-qualified-symbol-parents/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+RC2 bounds every parser-provided symbol name and immediate parent, but graph projection later rebuilds an unbounded `A::B::...` containment identity and submits it to the 4,096-byte graph boundary. Deep valid nesting can therefore still abort whole-repository publication in any tree-sitter language.
+
+## What Changes
+
+- Bound graph-only qualified parent identities at the shared projection owner.
+- Preserve valid nested symbols with deterministic collision-resistant qualification when the readable chain exceeds the graph identity ceiling.
+- Reserve the core-owned compact-scope prefix from raw source names and immediate parents so exact source identities cannot collide with derived compact identities.
+- Prove shallow compatibility, exact boundary behavior, deep language-neutral nesting, and full/incremental publication.
+- Keep every other raw symbol admission rule, graph identity limit, and relation semantic unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `bounded-symbol-parent-qualification`: Project arbitrarily deep valid containment without producing an invalid graph identity or aborting publication.
+
+### Modified Capabilities
+
+None. The reserved prefix belongs to the new `bounded-symbol-parent-qualification` capability because it separates that capability's compact derived namespace from exact source identities; every other `bounded-symbol-identity-extraction` admission and omission rule remains unchanged.
+
+## Impact
+
+The change affects the graph identity byte-bound contract in `projectatlas-core`, shared source-symbol admission in `projectatlas-symbols` including Markdown symbol projection, derived qualified-parent construction in the CLI graph projection, and their unit/E2E publication tests. It adds one language-neutral reserved-prefix admission rule and no language-specific branch, dependency, schema, query, or platform behavior.
+
+## Non-Goals
+
+- Raising the graph identity byte ceiling.
+- Truncating, hashing, or admitting invalid raw parser symbol names.
+- Changing raw source-symbol admission outside the one reserved compact-scope namespace.
+- Changing parser grammars, source spans, containment discovery, or public commands.
+- Adding a generic identity framework.
+
+This change is ready for implementation in `v0.4.5-rc3`.

--- a/openspec/changes/bound-qualified-symbol-parents/specs/bounded-symbol-parent-qualification/spec.md
+++ b/openspec/changes/bound-qualified-symbol-parents/specs/bounded-symbol-parent-qualification/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Qualified symbol parents always satisfy the graph identity contract
+The system SHALL convert every valid parser-admitted containment chain into a deterministic `GraphIdentityText` parent no larger than the shared graph identity byte ceiling.
+
+#### Scenario: Readable chain fits
+- **WHEN** a qualified `parent::child` containment identity fits the byte ceiling
+- **THEN** projection retains the exact readable qualification
+
+#### Scenario: Exact byte boundary
+- **WHEN** a qualified parent is exactly at the byte ceiling
+- **THEN** projection admits it without compaction or rejection
+
+#### Scenario: Qualification exceeds the byte ceiling
+- **WHEN** valid nested components compose beyond the byte ceiling
+- **THEN** projection uses a bounded deterministic derived scope identity and preserves the symbol
+
+### Requirement: Deep scope identity remains stable and distinct
+The system SHALL keep deeply nested symbols under different ancestor chains distinct without using mutable source positions.
+
+#### Scenario: Equal suffixes under different deep ancestors
+- **WHEN** two overbound containment chains end in the same local parent and symbol names but have different ancestors
+- **THEN** their derived parent identities and canonical symbol keys remain distinct
+
+#### Scenario: Literal source identity resembles a compact scope
+- **WHEN** a parser or directly constructed symbol graph supplies a raw name or parent in the reserved compact-scope namespace
+- **THEN** source admission omits it or the shared projection boundary rejects it before it can collide with a derived identity
+
+#### Scenario: Repeated projection
+- **WHEN** the same deep symbol graph is projected in full, incremental, and clean rebuild modes
+- **THEN** it produces the same bounded parent identities and canonical graph keys
+
+### Requirement: Raw symbol admission remains strict
+The system MUST NOT use derived qualification compaction to admit an empty, malformed, control-bearing, or overbound raw symbol name or immediate parent.
+
+#### Scenario: Invalid raw sibling
+- **WHEN** one invalid raw declaration appears beside valid shallow and deep declarations
+- **THEN** the invalid declaration is omitted according to symbol admission policy while valid siblings remain publishable
+
+### Requirement: Deep nesting cannot abort repository publication
+The system SHALL apply bounded parent qualification before entity construction for every source language and publication mode.
+
+#### Scenario: Language-neutral nested graph
+- **WHEN** any tree-sitter parser emits enough valid nested declarations to exceed the composed parent ceiling
+- **THEN** the scan publishes a complete generation and the nested symbols remain queryable
+
+#### Scenario: Incremental deep nesting change
+- **WHEN** a current repository adds or removes an overbound nested scope and runs one incremental refresh
+- **THEN** publication remains atomic, unrelated graph facts are retained, and a subsequent clean scan converges to the same graph

--- a/openspec/changes/bound-qualified-symbol-parents/tasks.md
+++ b/openspec/changes/bound-qualified-symbol-parents/tasks.md
@@ -1,0 +1,19 @@
+## 1. Bounded Qualification
+
+- [x] 1.1 Expose the existing graph identity byte ceiling from `projectatlas-core` without changing its value or validation semantics.
+- [x] 1.2 Make shared graph projection retain exact fitting qualified parents and use a bounded domain-separated digest only when valid composed containment exceeds the ceiling.
+- [x] 1.3 Reserve the compact-scope namespace at shared source-symbol admission and consume validated parent identities directly while preserving every other raw-admission and non-size failure rule.
+
+## 2. Identity Proof
+
+- [x] 2.1 Add focused shallow, exact-boundary, overbound, multibyte, repeated-branch, invalid-raw-sibling, stability, collision-resistance, and 4,000-deep bounded-resource tests.
+- [x] 2.2 Add language-neutral full/incremental/clean-scan publication coverage proving deep nested symbols remain queryable and unrelated facts converge unchanged.
+
+## 3. Release Compatibility
+
+- [x] 3.1 Wire the exact deep-qualified-parent publication contract into mandatory source and installed-candidate release workflows across supported platforms.
+
+## 4. Release Gates
+
+- [x] 4.1 Run focused core/CLI unit and E2E tests plus `cargo fmt --check`, warnings-denied Clippy, diff checks, and the complete workspace/OpenSpec/IssueOps/release-candidate gates.
+- [x] 4.2 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/changes/persist-graph-coverage-limits/.openspec.yaml
+++ b/openspec/changes/persist-graph-coverage-limits/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/persist-graph-coverage-limits/design.md
+++ b/openspec/changes/persist-graph-coverage-limits/design.md
@@ -1,0 +1,66 @@
+## Context
+
+`GraphLimitKind` is a closed Rust enum with nine serialized spellings, while the schema-18 `graph_coverage.reached_limit` constraint repeats only four spellings. Repository graph producers are language-neutral and may persist any variant; Markdown projection already emits `intermediate_bytes`. The graph tables are derived, transactionally published state, while project identity and purposes are durable authored state.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep the Rust domain, SQLite admission constraint, writer, and reader on one complete stable spelling set.
+- Upgrade released schema-18 databases atomically and preserve authored state.
+- Retain distinct partial-coverage reasons and the last-complete publication contract.
+- Cover every variant, migration, invalid input, and full publication behavior.
+
+**Non-Goals:**
+
+- Change graph budgets, traversal algorithms, relation selection, or parser behavior.
+- Add a generic schema-definition framework or dependency.
+- Preserve rebuildable graph rows through a one-time corrective migration.
+
+## Decisions
+
+### Keep stable limit spellings at the closed domain owner
+
+`GraphLimitKind` will expose its closed ordered variant inventory and stable snake-case spelling. Repository graph binding and parsing will reuse that inventory, and current graph DDL will derive its admitted values from it. A focused test will require the inventory, serde spelling, storage spelling, and round trip to agree.
+
+Keeping another hand-maintained list only in `schema.rs` is rejected because it recreates the root cause. A procedural macro or external enum helper is rejected because nine closed variants do not justify new generation infrastructure or a dependency.
+
+### Append one schema transition and reuse disposable projection rebuild
+
+Schema 18 remains an exact supported predecessor. Schema 19 widens only the `reached_limit` domain. Migration 18 to 19 will run inside the existing caller-owned migration transaction and reuse `recreate_disposable_graph_projection`, preserving the project instance identity, all authored state, and existing non-graph tables while resetting derived graph generations and publication metadata.
+
+A bespoke `graph_coverage` rename/copy/swap migration is rejected: coverage is derived and its foreign keys/indexes are coupled to the graph projection, while the existing rebuild path already owns safe invalidation and recovery. Reusing it is smaller and avoids a second table-rebuild protocol. The accepted trade-off is one bounded rebuild of derived graph rows followed by the normal required scan.
+
+Historical schema contracts will continue to render their exact old limit constraint. The current contract alone will use the complete domain, so schema-shape preflight cannot misclassify an old database as current.
+
+The owning migration test also pins a BLAKE3 digest of the complete introspected schema-18 predecessor contract. That independent released-contract seal fails if future edits make the historical renderer and a generated fixture co-drift.
+
+### Prove the storage boundary, not a C# fixture
+
+The owning database test will stage and read one coverage row for every `GraphLimitKind`, reject an unknown spelling, and verify schema-18 migration preserves authored state while invalidating derived publication. An adapter-level scan regression will exercise a non-language-specific producer that reaches a formerly rejected limit and prove publication completes.
+
+This protects C#, Rust, Java, TypeScript, Markdown, and future parser producers equally because they all converge on the same repository graph writer and SQLite constraint.
+
+## Risks / Trade-offs
+
+- [A schema-18 database has a large derived graph] -> The migration is one transaction using the existing derived-projection rebuild; it adds no per-row application round trips or new index and leaves a typed refresh requirement.
+- [A future enum variant is added without storage admission] -> The current DDL is generated from the closed inventory and the exhaustive round-trip test fails on drift.
+- [Migration fails midway] -> The existing caller-owned SQLite transaction rolls back the DDL, graph deletion, identity restoration, and version stamp together.
+- [Historical shape validation drifts] -> Schema-18 receives its own predecessor contract built from the historical four-value constraint.
+
+## Migration Plan
+
+1. Preflight schema 18 against its exact historical contract.
+2. Recreate the disposable classified-document graph with the complete limit domain inside the migration transaction.
+3. Preserve project identity, invalidate derived publication metadata, and stamp schema 19 only after success.
+4. Require the normal full refresh before graph-backed reads resume.
+
+Rollback is SQLite transaction rollback before the version stamp. Published RC artifacts are immutable; reverting the runtime requires restoring a compatible database backup or reinitializing derived state under the older runtime.
+
+## Dependencies / Cross-Issue Impact
+
+This closes the shared persistence gap exposed by the Markdown publication added for #461. It is implementation-independent from #472 and #473, although all three changes share the RC3 source and installed-candidate release gates. Schema 19 remains an ordinary forward compatibility boundary: older runtimes continue to reject it without mutation.
+
+## Open Questions
+
+None.

--- a/openspec/changes/persist-graph-coverage-limits/proposal.md
+++ b/openspec/changes/persist-graph-coverage-limits/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Repository graph publication can emit any of the nine closed `GraphLimitKind` values, but the current SQLite constraint admits only four. A valid partial-coverage row can therefore abort the entire scan instead of preserving the last complete generation and publishing the new complete index.
+
+## What Changes
+
+- Make the durable `graph_coverage.reached_limit` contract admit every `GraphLimitKind` spelling without collapsing distinct limit reasons.
+- Migrate released schema-18 databases transactionally while preserving authored state and invalidating only rebuildable derived graph publication.
+- Prove fresh and migrated databases persist and read every closed limit variant and reject values outside that domain.
+- Keep scan limits, indexed scopes, and partial-coverage semantics unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `graph-coverage-limit-persistence`: Persist every closed graph coverage limit kind without aborting transactional publication.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The change affects the closed graph-limit domain in `projectatlas-core`, SQLite graph schema and migration ownership in `projectatlas-db`, repository graph persistence tests, schema compatibility fixtures, and release migration proof. It adds no dependency, public command, query shape, index, or platform-specific behavior.
+
+## Non-Goals
+
+- Raising or changing any graph work budget.
+- Changing which files, languages, parsers, relations, or documentation scopes are indexed.
+- Mapping distinct limits onto a generic row-limit value.
+- Preserving disposable derived graph rows during this corrective migration.
+
+This change is ready for implementation in `v0.4.5-rc3`.

--- a/openspec/changes/persist-graph-coverage-limits/specs/graph-coverage-limit-persistence/spec.md
+++ b/openspec/changes/persist-graph-coverage-limits/specs/graph-coverage-limit-persistence/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Every graph limit kind is durably admissible
+The system SHALL persist and read `rows`, `nodes`, `edges`, `occurrences`, `visited`, `intermediate_bytes`, `deadline`, `depth`, and `output_bytes` as distinct `graph_coverage.reached_limit` values.
+
+#### Scenario: Complete closed-domain round trip
+- **WHEN** one valid partial coverage record for each `GraphLimitKind` is published
+- **THEN** every record is committed and read back with the same distinct limit kind
+
+#### Scenario: Unknown limit spelling
+- **WHEN** a coverage row contains a reached-limit spelling outside the closed domain
+- **THEN** SQLite rejects the row and the publication transaction does not expose partial state
+
+### Requirement: Reached limits preserve repository publication
+The system SHALL treat a valid reached graph limit as partial coverage rather than as a repository-wide publication failure, independent of source language or fact provider.
+
+#### Scenario: Formerly rejected producer limit
+- **WHEN** graph projection reaches `nodes`, `edges`, `visited`, `intermediate_bytes`, or `deadline`
+- **THEN** the scan publishes one complete generation with the affected coverage row marked partial and the exact reached limit retained
+
+#### Scenario: Language-independent persistence
+- **WHEN** any parser, Markdown extractor, traversal, or future graph producer emits a valid limit kind
+- **THEN** the shared repository graph writer applies the same persistence contract without language-specific mapping
+
+### Requirement: Released databases migrate without authored-state loss
+The system SHALL upgrade a valid schema-18 database transactionally to the complete graph-limit domain while preserving authored state and project identity and invalidating only rebuildable derived graph publication.
+
+#### Scenario: Successful schema-18 upgrade
+- **WHEN** the current runtime opens a valid schema-18 database
+- **THEN** it reaches schema 19, preserves purposes and project identity, clears stale derived graph publication, and requests the normal full refresh
+
+#### Scenario: Failed schema-18 upgrade
+- **WHEN** any migration step fails before commit
+- **THEN** SQLite rolls back the schema version and all migration-owned changes together
+
+### Requirement: Existing graph budgets remain unchanged
+The system MUST NOT raise graph limits or broaden indexed scopes as part of admitting all reached-limit values.
+
+#### Scenario: Coverage admission after upgrade
+- **WHEN** a workload reaches its existing configured graph budget
+- **THEN** work stops at the same boundary and only the durable partial-coverage reason differs from the failed schema-18 behavior

--- a/openspec/changes/persist-graph-coverage-limits/tasks.md
+++ b/openspec/changes/persist-graph-coverage-limits/tasks.md
@@ -1,0 +1,20 @@
+## 1. Closed Limit Domain
+
+- [x] 1.1 Define one closed stable-spelling inventory for every `GraphLimitKind` and make serde/storage round-trip drift fail focused tests.
+- [x] 1.2 Generate the current SQLite admission constraint from that inventory while retaining exact historical graph-schema shapes.
+
+## 2. Schema and Persistence
+
+- [x] 2.1 Append the schema-18 to schema-19 migration through the existing disposable graph rebuild, preserving project identity and authored state while invalidating derived publication.
+- [x] 2.2 Prove fresh and migrated databases persist/read all nine limit kinds, reject an unknown kind, roll back failures, and reopen under the exact current contract.
+
+## 3. Publication Compatibility
+
+- [x] 3.1 Add a real non-language-specific partial Markdown graph-publication regression for a formerly rejected limit and prove last-complete/atomic scan behavior.
+- [x] 3.2 Keep source and installed-candidate CI/release contracts exercising schema migration and graph publication on the affected supported platform matrix.
+
+## 4. Release Gates
+
+- [x] 4.1 Run focused core, database, CLI publication, migration, negative, rollback, and compatibility tests plus `cargo fmt --check`, warnings-denied Clippy, and diff checks.
+- [x] 4.2 Run the complete workspace all-target/all-feature compile, test, doc, lint, OpenSpec, IssueOps, architecture-link, and release-candidate gates without relaxing existing limits.
+- [x] 4.3 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/changes/serialize-lint-reports/.openspec.yaml
+++ b/openspec/changes/serialize-lint-reports/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/serialize-lint-reports/design.md
+++ b/openspec/changes/serialize-lint-reports/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The CLI and MCP adapters both call the same map and SQLite lint routines, but each independently concatenates pre-rendered strings. The CLI then bypasses the normal serializer, ignores `cli.format`, writes the payload to stderr, and exits. MCP wraps the same opaque text with `ok` and `exit_code`. The path is platform-neutral and does not depend on source language.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Build one typed lint result for both adapters.
+- Preserve current lint rules, blocking decisions, deterministic order, and exit codes.
+- Serialize CLI output through the existing JSON/TOON path on stdout.
+- Preserve the MCP compatibility summary while exposing structured details.
+
+**Non-Goals:**
+
+- Add a lint-specific serializer, transport, dependency, or command framework.
+- Change Clap global-option placement, lint policy, or database mutation behavior.
+- Add platform-specific output branches.
+
+## Decisions
+
+### Return existing domain facts instead of formatting during collection
+
+Map lint will retain its existing deterministic collections but return a serializable report containing notes, non-source validation facts, and optional untracked-file counts/lists. SQLite lint will return the purpose level, bounded finding counts, and the existing typed health findings. One combined `LintReport` will own `ok`, `exit_code`, the structured map/index sections, and the existing human-readable `report` compatibility summary.
+
+Keeping only `{ ok, exit_code, report: String }` is rejected because JSON would still require text parsing. Removing the text field is rejected because existing MCP consumers may display it. Generic key/value findings or a new trait hierarchy are rejected because the two closed lint sections already have concrete domain shapes.
+
+### Compose once in the shared runtime
+
+The shared runtime will own `lint_project`, which calls map lint and optional database lint exactly once and computes the maximum exit code. CLI and MCP will both call this function. This removes the duplicated concatenation and makes adapter drift impossible without adding a new crate or public service.
+
+### Reuse the standard output adapter
+
+CLI lint will encode the combined report under the stable `lint` payload key and call the existing flushed stdout writer. TOON remains the default; `--format json` emits pretty JSON. The payload is flushed to stdout before the process exits with the report's unchanged code. Stderr remains reserved for top-level execution failures or diagnostics.
+
+The adapter selects the requested serializer before encoding the borrowed named payload. JSON therefore does not build or discard a TOON representation, and neither format first clones the complete report into an intermediate `serde_json::Value`.
+
+MCP will encode the same report under its existing `lint` key and never terminates the transport. Missing indexes remain a valid `index: null` result, wrong-root failures remain typed preflight errors, and lint performs no implicit scan or mutation.
+
+## Risks / Trade-offs
+
+- [Existing MCP clients depend on the text report] -> Retain `report` while adding typed sections.
+- [A lint failure exits before stdout is observable] -> Use the existing fallible stdout writer/flush before applying the exit code.
+- [Structured and text views drift] -> Derive both from the same collected report value and cover clean and failing adapter outputs.
+- [Large untracked repositories produce large output] -> Preserve the existing collected scope and deterministic ordering; this change does not widen filesystem traversal or add a second copy beyond the serialized response already required.
+
+## Migration Plan
+
+No durable migration is required. Release the additive MCP payload and new CLI stream/format behavior together. Existing consumers that display `lint.report` continue to work; machine consumers can adopt the typed sections.
+
+## Dependencies / Cross-Issue Impact
+
+This change is independent from the graph persistence and qualification fixes in #471 and #473. It reuses their RC3 source and installed-candidate workflow matrix, but adds no schema, parser, graph identity, or release-classification dependency.
+
+## Open Questions
+
+None.

--- a/openspec/changes/serialize-lint-reports/proposal.md
+++ b/openspec/changes/serialize-lint-reports/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+`projectatlas lint` bypasses the shared output serializer, ignores the documented global format, and writes its entire response to stderr. The same lint work is also composed independently for CLI and MCP as pre-rendered strings, leaving no shared machine-readable contract.
+
+## What Changes
+
+- Return one typed lint report from the shared lint owner for both CLI and MCP callers.
+- Route CLI lint reports through the existing TOON/JSON serializer on stdout while preserving the lint exit code.
+- Keep stderr for execution errors and diagnostics rather than successful or failing lint payloads.
+- Prove JSON, TOON, clean, failing, CLI, and MCP behavior through the real adapters.
+
+## Capabilities
+
+### New Capabilities
+
+- `lint-report-serialization`: Expose one deterministic typed lint result through CLI TOON/JSON output and MCP.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The change affects lint report construction in `projectatlas-cli`, the CLI output adapter, the MCP lint tool, and their contract tests. It adds no dependency, database schema, filesystem policy, global-argument parsing change, or platform-specific branch.
+
+## Non-Goals
+
+- Making `--format` valid after subcommands; that remains uniform Clap behavior.
+- Changing lint rules, purpose strictness, untracked-file classification, or exit-code semantics.
+- Adding a second serializer or a lint-specific transport framework.
+
+This change is ready for implementation in `v0.4.5-rc3`.

--- a/openspec/changes/serialize-lint-reports/specs/lint-report-serialization/spec.md
+++ b/openspec/changes/serialize-lint-reports/specs/lint-report-serialization/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Lint exposes one typed result
+The system SHALL expose one deterministic lint result containing `ok`, the CLI-compatible `exit_code`, structured map lint facts, optional structured SQLite health facts, and a human-readable compatibility report.
+
+#### Scenario: Clean repository
+- **WHEN** all selected lint checks pass
+- **THEN** the result has `ok: true`, `exit_code: 0`, typed empty or zero-valued sections, and deterministic output
+
+#### Scenario: Blocking findings
+- **WHEN** any selected map or SQLite lint check blocks
+- **THEN** the result has `ok: false`, preserves the highest applicable exit code, and identifies each blocking fact in its owning structured section
+
+#### Scenario: Missing index
+- **WHEN** lint runs for a project with no SQLite index and map lint can run
+- **THEN** the result contains no index section, performs no initialization or scan, and reports the map lint outcome
+
+### Requirement: CLI lint honors the global output format and stream contract
+The CLI SHALL serialize the typed lint result through the standard output adapter on stdout and SHALL reserve stderr for execution errors and diagnostics.
+
+#### Scenario: JSON output
+- **WHEN** `projectatlas --format json lint` completes its checks
+- **THEN** stdout contains a parseable JSON `lint` payload, stderr contains no lint report, and the process exits with the payload's `exit_code`
+
+#### Scenario: TOON output
+- **WHEN** `projectatlas --format toon lint` completes its checks
+- **THEN** stdout contains a TOON `lint` payload distinct from JSON, stderr contains no lint report, and the process exits with the payload's `exit_code`
+
+#### Scenario: Output write failure
+- **WHEN** stdout cannot accept or flush the serialized lint payload
+- **THEN** the CLI returns an output error instead of silently reporting the lint exit code
+
+### Requirement: MCP lint shares the CLI report owner
+`atlas_lint` SHALL return the same typed lint report and blocking semantics as CLI lint without terminating the MCP transport.
+
+#### Scenario: CLI and MCP parity
+- **WHEN** CLI lint and `atlas_lint` run with equivalent options against the same current project
+- **THEN** their typed lint facts, `ok`, and `exit_code` agree
+
+#### Scenario: Explicit project root
+- **WHEN** `atlas_lint` receives a valid explicit `project_path`
+- **THEN** it lints only that addressed project and returns its typed result without changing the process default root
+
+#### Scenario: Wrong root
+- **WHEN** `atlas_lint` receives a root or index identity mismatch
+- **THEN** it returns the existing typed routing or preflight error and does not substitute another project's result
+
+#### Scenario: No implicit mutation
+- **WHEN** CLI or MCP lint reads a current project
+- **THEN** it performs no scan, purpose write, configuration edit, or database mutation
+
+### Requirement: Lint behavior is platform and language neutral
+The system SHALL apply the same serialization and stream contract on supported Windows, Linux, and macOS runtimes and SHALL not branch on indexed source language.
+
+#### Scenario: Packaged runtimes
+- **WHEN** the installed candidate runs the lint format contract on each supported platform
+- **THEN** JSON and TOON payload shapes, stdout/stderr ownership, and exit-code semantics match

--- a/openspec/changes/serialize-lint-reports/tasks.md
+++ b/openspec/changes/serialize-lint-reports/tasks.md
@@ -1,0 +1,21 @@
+## 1. Shared Typed Report
+
+- [x] 1.1 Return deterministic typed non-source and untracked-file facts from map lint while preserving current classifications and compatibility text.
+- [x] 1.2 Return typed bounded SQLite purpose-health facts and compose one shared `LintReport` with `ok`, `exit_code`, map/index sections, and compatibility text.
+
+## 2. Adapter Integration
+
+- [x] 2.1 Route CLI lint through the existing JSON/TOON stdout serializer and flush before preserving clean/failing exit codes; keep stderr for execution diagnostics.
+- [x] 2.2 Make `atlas_lint` use the same report owner and preserve explicit-root, wrong-root, missing-index, transport, and no-implicit-mutation behavior.
+
+## 3. Contract Proof
+
+- [x] 3.1 Add focused clean/failing CLI subprocess tests for parseable JSON, TOON, distinct formats, stdout/stderr ownership, exit-code preservation, and rejected stdout writes.
+- [x] 3.2 Add CLI/MCP parity tests covering typed map/index facts, explicit project routing, missing index, wrong root, and no mutation.
+- [x] 3.3 Wire one exact installed-candidate lint-format contract into mandatory Windows, Linux, and macOS release verification and its static workflow gate.
+
+## 4. Release Gates
+
+- [x] 4.1 Run focused CLI/MCP unit and E2E tests plus `cargo fmt --check`, warnings-denied Clippy, and diff checks.
+- [x] 4.2 Run the complete workspace all-target/all-feature compile, test, doc, lint, OpenSpec, IssueOps, architecture-link, and release-candidate gates.
+- [x] 4.3 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -9,6 +9,7 @@
     "advance-rust-repository-intelligence": 308,
     "await-observable-watch-readiness": 422,
     "bound-impact-analysis-deadlines": 380,
+    "bound-qualified-symbol-parents": 473,
     "centralize-cargo-dependency-management": 316,
     "close-mcp-cli-parity": 281,
     "close-v043-release-regressions": {
@@ -70,6 +71,7 @@
         }
       ]
     },
+    "persist-graph-coverage-limits": 471,
     "prefer-worktree-guidance-before-database-preflight": 412,
     "preserve-indexing-across-invalid-symbol-identities": 467,
     "publish-rustdoc-readme-links": 300,
@@ -83,6 +85,7 @@
     "reuse-release-proof-by-inputs": 366,
     "reuse-unchanged-ci-build-layers": 341,
     "show-agent-efficiency-dashboard": 340,
+    "serialize-lint-reports": 472,
     "simplify-token-tui-dashboard": 296,
     "stabilize-hostile-parser-fixture-admission": 397,
     "stabilize-parser-recovery-harness": 391

--- a/packaging/parser-pack/accepted-capabilities.json
+++ b/packaging/parser-pack/accepted-capabilities.json
@@ -18,16 +18,16 @@
   },
   "runtime": {
     "consumer": "projectatlas-parser-worker",
-    "projectatlas_version": "0.4.5-rc2",
+    "projectatlas_version": "0.4.5-rc3",
     "tree_sitter_version": "0.26.9",
     "minimum_abi": 13,
     "maximum_abi": 15
   },
   "registry": {
     "registry_version": 4,
-    "registry_digest": "cbede576a7b2ab4309798075210b59dbece0cf99cc7874a9659fd17f3c2d961f",
-    "accepted_set_version": 10,
-    "accepted_set_digest": "cbede576a7b2ab4309798075210b59dbece0cf99cc7874a9659fd17f3c2d961f"
+    "registry_digest": "3776f19c62b3debfcae13715e3bdc3ec3029978a4f7ba1428b7a06d433524915",
+    "accepted_set_version": 11,
+    "accepted_set_digest": "3776f19c62b3debfcae13715e3bdc3ec3029978a4f7ba1428b7a06d433524915"
   },
   "required_platforms": [
     "x86_64-unknown-linux-gnu",
@@ -7597,5 +7597,5 @@
       "capability_digest": "d11ac33f63f87c732d6bcac6b300eace2a4eba4775097f03c0f835f5fa2db4e9"
     }
   ],
-  "capability_set_digest": "9ce2cc658c311ee110c1164716cc2b24796f97c8104de25ee43bf6d0b3a433ab"
+  "capability_set_digest": "009a932c0499c9726f0c56e4ad0744ebe72d3940640a7921f702e05a25d5193c"
 }

--- a/packaging/parser-pack/accepted-capabilities.json.sha256
+++ b/packaging/parser-pack/accepted-capabilities.json.sha256
@@ -1,1 +1,1 @@
-62822417fc34d01f9329c016f6cf25dbc34d3cbf2ca0c13873b730414cd2b3f5  accepted-capabilities.json
+18dd758afcb3ac565b013cc290403ebfbbd4a072d473089ef288bcee9bd4496e  accepted-capabilities.json

--- a/plugins/projectatlas/.claude-plugin/plugin.json
+++ b/plugins/projectatlas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.4.5-rc2",
+  "version": "0.4.5-rc3",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for Claude Code.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/.codex-plugin/plugin.json
+++ b/plugins/projectatlas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.4.5-rc2",
+  "version": "0.4.5-rc3",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for coding agents.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/opencode/opencode.json
+++ b/plugins/projectatlas/opencode/opencode.json
@@ -6,7 +6,7 @@
       "command": [
         "/absolute/path/to/projectatlas",
         "--require-version",
-        "0.4.5-rc2",
+        "0.4.5-rc3",
         "--db",
         "/absolute/path/to/project/.projectatlas/projectatlas.db",
         "mcp"


### PR DESCRIPTION
## Summary

Closes the three confirmed shared root-cause gaps for v0.4.5-rc3:

- makes every closed `GraphLimitKind` spelling admissible in SQLite schema 19, with transactional schema-18 migration and real language-neutral Markdown publication proof
- makes CLI and MCP lint share one typed report owner, with JSON/TOON stdout serialization, flush/error handling, routing, no-mutation, and installed-candidate contracts
- bounds qualified symbol-parent identities at the shared graph projection boundary, reserves the compact namespace from raw source identities, and keeps 4,000-deep language-neutral publication bounded and collision-separated

The RC2 breadth review found these at shared storage, adapter, and graph-identity owners rather than adding C#-only patches. It also reconfirmed the remaining RC2 fixes at their intended language/platform/caller boundaries.

## Issue

Refs #471
Refs #472
Refs #473

## Checklist

- [x] The exact v0.4.5-rc3 candidate migrated and refreshed the project-local schema-19 atlas, then returned a clean typed JSON lint result.
- [x] Workspace formatting, all-target/all-feature check, warnings-denied Clippy, full tests, doctests, and warnings-denied rustdoc pass.
- [x] Cargo deny advisories, bans, licenses, and sources pass.
- [x] Focused core, SQLite migration/rollback/reopen, CLI/MCP, full/incremental, negative, output-failure, intended-scale, and compatibility tests cover the changed owners.
- [x] The ignored holistic worktree init/scan/watch/CLI/MCP lifecycle E2E passes.
- [x] All three OpenSpec changes validate strictly, mirror their fully checked live issue task sections, and the complete IssueOps map passes.
- [x] Changed Mermaid views render, pass the locked parser, and were visually inspected against the final architecture.
- [x] Version, plugin, parser capability digest, release-note, JSON/YAML, and prerelease/Latest contracts are coherent.

The final hosted exact-head, installed-package, release-asset, issue/milestone closure, and preserved-Latest checks remain pending until CI and the v0.4.5-rc3 artifact prove them.