### PR TITLE
chore(release): promote v0.4.5

### DIFF
--- a/.github/scripts/release-notes.py
+++ b/.github/scripts/release-notes.py
@@ -143,6 +143,19 @@ def summary_from_html(body_html, fallback):
     return parser.items[:3] or [fallback]
 
 
+def note_sources(body_html, fallback, closed_issues, seen_issue_numbers):
+    emitted_issue = False
+    for item in closed_issues:
+        if item["number"] in seen_issue_numbers:
+            continue
+        seen_issue_numbers.add(item["number"])
+        emitted_issue = True
+        yield item, item["title"]
+    if not emitted_issue:
+        for line in summary_from_html(body_html, fallback):
+            yield None, line
+
+
 def section_for(title="", labels=(), fallback_title=""):
     names = {label.get("name", "") for label in labels}
     for candidate in (title, fallback_title):
@@ -258,21 +271,23 @@ def write_notes(repo, version):
     prs = merged_prs(repo, start_tag)
     sections = {name: [] for name in SECTIONS}
     changelog = []
+    seen_issue_numbers = set()
 
     for pr in prs:
         author = pr.get("user", {}).get("login", "unknown")
         changelog.append(f"- #{pr['number']} {clean(pr['title'])} @{author}")
         body_html, closed_issues = pr_metadata(repo, pr["number"])
-        if closed_issues:
-            for item in closed_issues:
+        for item, line in note_sources(
+            body_html, pr["title"], closed_issues, seen_issue_numbers
+        ):
+            if item is not None:
                 section = section_for(item.get("title", ""), item.get("labels", []))
                 sections[section].append(
                     f"- {note_title(item['title'])}. "
                     f"([#{item['number']}]({item['html_url']}), "
                     f"[#{pr['number']}]({pr['html_url']}))"
                 )
-        else:
-            for line in summary_from_html(body_html, pr["title"]):
+            else:
                 section = section_for(line, pr.get("labels", []), pr["title"])
                 sections[section].append(
                     f"- {note_title(line)}. "
@@ -338,6 +353,27 @@ def self_test():
         f"<h2>Summary</h2><ul><li>{SUMMARY_PLACEHOLDER}</li></ul>",
         "fallback",
     ) == ["fallback"]
+    shared_issue = {"number": 448, "title": "Gate release candidates"}
+    seen_issue_numbers = set()
+    sources = []
+    for body, title in (
+        ("", "chore: initial release gate"),
+        (
+            "<h2>Summary</h2><ul><li>"
+            "test: Make packaged scan deterministic.</li></ul>",
+            "fallback",
+        ),
+        (
+            "<h2>Summary</h2><ul><li>fix: Repair holistic MCP request.</li></ul>",
+            "fallback",
+        ),
+    ):
+        sources.extend(note_sources(body, title, [shared_issue], seen_issue_numbers))
+    assert sources == [
+        (shared_issue, "Gate release candidates"),
+        (None, "test: Make packaged scan deterministic."),
+        (None, "fix: Repair holistic MCP request."),
+    ]
     assert note_title("bug: stale runtime remains") == "Stale runtime remains"
     assert note_title("docs(memory): specify the Memory Atlas") == "Specify the Memory Atlas"
     assert note_title("test(parser): keep cancellation bounded") == "Keep cancellation bounded"

--- a/.github/workflows/04-docs.yml
+++ b/.github/workflows/04-docs.yml
@@ -105,6 +105,7 @@ jobs:
                 <div class="grid">
                   <a class="card" href="https://github.com/styler-ai/ProjectAtlas/blob/main/docs/agent-integration.md">Agent Integration<span class="label">MCP-first startup, exact navigation, purpose curation, and runtime repair</span></a>
                   <a class="card" href="https://github.com/styler-ai/ProjectAtlas/blob/main/docs/worktree-lifecycle.md#worktree-atlas-continuity">Worktree Atlas Continuity<span class="label">short aliases, safe hydration, isolated graphs, federation, and aggregate tokens</span></a>
+                  <a class="card" href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.4.5">v0.4.5 stable<span class="label">worktree navigation, candidate stabilization, and shared root-cause fixes</span></a>
                   <a class="card" href="https://github.com/styler-ai/ProjectAtlas/blob/main/docs/v0.4.5-rc3-release-notes.md">v0.4.5-rc3<span class="label">shared graph-limit, qualified-symbol, and typed lint root-cause fixes</span></a>
                   <a class="card" href="https://github.com/styler-ai/ProjectAtlas/blob/main/docs/v0.4.5-rc2-release-notes.md">v0.4.5-rc2<span class="label">candidate stabilization, compatibility, deliberate boundaries, and proof policy</span></a>
                   <a class="card" href="https://github.com/styler-ai/ProjectAtlas/blob/main/docs/projectatlas-3-architecture.md#architecture-views">Architecture Views<span class="label">system ownership, SQLite authority, indexing, communication, and failure flows</span></a>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-cli"
-version = "0.4.5-rc3"
+version = "0.4.5"
 dependencies = [
  "assert_cmd",
  "blake3",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-core"
-version = "0.4.5-rc3"
+version = "0.4.5"
 dependencies = [
  "blake3",
  "object",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-db"
-version = "0.4.5-rc3"
+version = "0.4.5"
 dependencies = [
  "blake3",
  "getrandom 0.4.3",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-fs"
-version = "0.4.5-rc3"
+version = "0.4.5"
 dependencies = [
  "blake3",
  "ignore",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-lints"
-version = "0.4.5-rc3"
+version = "0.4.5"
 dependencies = [
  "proc-macro2",
  "regex",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-service"
-version = "0.4.5-rc3"
+version = "0.4.5"
 dependencies = [
  "blake3",
  "globset",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "projectatlas-symbols"
-version = "0.4.5-rc3"
+version = "0.4.5"
 dependencies = [
  "blake3",
  "projectatlas-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.5-rc3"
+version = "0.4.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/styler-ai/ProjectAtlas"
@@ -69,11 +69,11 @@ must_use_candidate = "allow"
 missing_inline_in_public_items = "allow"
 
 [workspace.dependencies]
-projectatlas-core = { path = "crates/projectatlas-core", version = "0.4.5-rc3" }
-projectatlas-db = { path = "crates/projectatlas-db", version = "0.4.5-rc3" }
-projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.4.5-rc3" }
-projectatlas-service = { path = "crates/projectatlas-service", version = "0.4.5-rc3" }
-projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.4.5-rc3" }
+projectatlas-core = { path = "crates/projectatlas-core", version = "0.4.5" }
+projectatlas-db = { path = "crates/projectatlas-db", version = "0.4.5" }
+projectatlas-fs = { path = "crates/projectatlas-fs", version = "0.4.5" }
+projectatlas-service = { path = "crates/projectatlas-service", version = "0.4.5" }
+projectatlas-symbols = { path = "crates/projectatlas-symbols", version = "0.4.5" }
 assert_cmd = "2.0"
 blake3 = "1.5"
 clap = { version = "4.5", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/styler-ai/ProjectAtlas/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.4.4"><img alt="release" src="https://img.shields.io/badge/release-v0.4.4-blue"></a>
+  <a href="https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.4.5"><img alt="release" src="https://img.shields.io/badge/release-v0.4.5-blue"></a>
   <img alt="rust" src="https://img.shields.io/badge/Rust-2024-orange">
   <img alt="license" src="https://img.shields.io/badge/license-MIT-green">
 </p>
@@ -37,7 +37,7 @@ Point your agent to the ProjectAtlas GitHub repository and ask it to install the
 The Codex plugin is the recommended path:
 
 ```bash
-codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.4.4
+codex plugin marketplace add styler-ai/ProjectAtlas --ref v0.4.5
 codex plugin add projectatlas --marketplace projectatlas
 ```
 
@@ -46,8 +46,8 @@ Then tell Codex: **“Use ProjectAtlas for this repo.”**
 | Route | When to use it |
 | --- | --- |
 | Codex plugin | Recommended agent setup; supplies the version-matched skill, native runtime installer, and MCP templates. |
-| [Native release](https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.4.4) | Install a verified prebuilt binary without Rust/Cargo. |
-| Cargo | `cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.4.4 projectatlas-cli --locked` |
+| [Native release](https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.4.5) | Install a verified prebuilt binary without Rust/Cargo. |
+| Cargo | `cargo install --git https://github.com/styler-ai/ProjectAtlas --tag v0.4.5 projectatlas-cli --locked` |
 | Claude Code / OpenCode | Run the native installer, then `projectatlas init`; it writes their version-matched project-local MCP configs. |
 
 Initialize each repository once:
@@ -86,7 +86,7 @@ The complete [agent and MCP workflow](docs/agent-integration.md) owns tool routi
 
 ## Work Across Existing Git Worktrees
 
-ProjectAtlas v0.4.5-rc1 lets an agent stay in one selected control checkout and address existing Git worktrees anywhere on the filesystem by short MCP alias:
+ProjectAtlas v0.4.5 lets an agent stay in one selected control checkout and address existing Git worktrees anywhere on the filesystem by short MCP alias:
 
 ```text
 atlas_worktree_list(include_retired: false)
@@ -137,7 +137,7 @@ Warm indexed CLI reads in the same audit stayed around 160–166 ms. Repository 
 
 ## Release Quality
 
-`v0.4.4` ships through the full release matrix:
+`v0.4.5` ships through the full release matrix:
 
 - Rust format, check, clippy, dependency policy, tests, doctests, and rustdoc.
 - Linux x64, Windows x64, macOS x64, and macOS arm64 native packages.
@@ -146,7 +146,7 @@ Warm indexed CLI reads in the same audit stayed around 160–166 ms. Repository 
 
 Full benchmark campaigns are manual-only and run only when explicitly requested.
 
-The [v0.4.5-rc3 candidate](https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.4.5-rc3) and [release notes](docs/v0.4.5-rc3-release-notes.md) fix graph-limit persistence, deep cross-language symbol identities, and typed CLI/MCP lint output. RC3 is published as a prerelease and does not replace the preceding stable GitHub Latest release. The [RC2 notes](docs/v0.4.5-rc2-release-notes.md) cover preceding stabilization work.
+ProjectAtlas [v0.4.5](https://github.com/styler-ai/ProjectAtlas/releases/tag/v0.4.5) promotes the tested RC3 line to stable. The [RC1](docs/v0.4.5-rc1-release-notes.md), [RC2](docs/v0.4.5-rc2-release-notes.md), and [RC3](docs/v0.4.5-rc3-release-notes.md) notes cover worktree navigation, stabilization, and the shared root-cause fixes included in this release.
 
 ## Documentation
 

--- a/crates/projectatlas-cli/tests/fixtures/cli-surfaces.json
+++ b/crates/projectatlas-cli/tests/fixtures/cli-surfaces.json
@@ -497,5 +497,78 @@
       "token": ["--view=agent", "--theme=dark"],
       "watch": ["[PATH]=.", "--poll-seconds=2", "--max-cycles=0"]
     }
+  },
+  "v0.4.5": {
+    "commands": [
+      "init",
+      "map",
+      "scan",
+      "overview",
+      "folders",
+      "files",
+      "next",
+      "outline",
+      "summary",
+      "search",
+      "slice",
+      "symbols",
+      "settings",
+      "snapshot",
+      "parser-pack",
+      "root",
+      "config",
+      "ignore",
+      "watch-status",
+      "watch",
+      "health-check",
+      "health",
+      "lint",
+      "token",
+      "parity",
+      "strip-legacy-purpose",
+      "reset-index",
+      "mcp",
+      "mcp-config",
+      "runtime-info",
+      "purpose"
+    ],
+    "subcommands": {
+      "health": ["resolve"],
+      "ignore": ["list", "init-gitignore", "add", "remove"],
+      "parity": ["report"],
+      "parser-pack": ["verify", "install", "enable", "update", "disable", "remove", "status"],
+      "purpose": ["set", "review", "queue"],
+      "root": ["set", "show", "status", "verify"],
+      "symbols": ["build", "list", "relations", "slice"]
+    },
+    "actions": {
+      "snapshot": ["export", "import"]
+    },
+    "defaults": {
+      "": ["--db=.projectatlas/projectatlas.db", "--format=toon", "--session=default"],
+      "files": ["--limit=10"],
+      "folders": ["--limit=10"],
+      "health-check": ["--start-index=0", "--limit=50"],
+      "lint": ["--purpose-level=low"],
+      "mcp-config": ["--server-name=projectatlas", "--harness=mcp-json"],
+      "next": ["--limit=3"],
+      "outline": ["--lines=12"],
+      "parity": ["--profile=repository-intelligence"],
+      "parity report": ["--profile=repository-intelligence"],
+      "purpose queue": ["--start-index=0", "--limit=50"],
+      "root set": ["--transition=bind"],
+      "root status": ["[PATH]=."],
+      "scan": ["[PATH]=."],
+      "search": ["--retrieval-mode=lexical", "--context-lines=0", "--start-index=0", "--limit=20"],
+      "slice": ["--output-bytes=262144"],
+      "strip-legacy-purpose": ["[PATH]=."],
+      "summary": ["--limit=25"],
+      "symbols build": ["[PATH]=.", "--max-bytes=2000000"],
+      "symbols list": ["--limit=50"],
+      "symbols relations": ["--view=legacy", "--direction=outbound", "--minimum-confidence=low", "--resolution=any", "--depth=1", "--occurrence-limit=25", "--output-bytes=262144", "--limit=50"],
+      "symbols slice": ["--output-bytes=262144"],
+      "token": ["--view=agent", "--theme=dark"],
+      "watch": ["[PATH]=.", "--poll-seconds=2", "--max-cycles=0"]
+    }
   }
 }

--- a/crates/projectatlas-core/src/language.rs
+++ b/crates/projectatlas-core/src/language.rs
@@ -17,7 +17,7 @@ pub const LANGUAGE_CAPABILITY_REGISTRY_VERSION: u32 = 4;
 pub const SEMANTIC_PROVIDER_CONTRACT_VERSION: u32 = 1;
 
 /// Version of the accepted language capability floor.
-pub const ACCEPTED_LANGUAGE_CAPABILITY_SET_VERSION: u32 = 11;
+pub const ACCEPTED_LANGUAGE_CAPABILITY_SET_VERSION: u32 = 12;
 
 /// Version of exact detector precedence and content-matching semantics.
 pub const LANGUAGE_DETECTION_POLICY_VERSION: u32 = 1;
@@ -98,6 +98,13 @@ pub const ACCEPTED_LANGUAGE_CAPABILITY_SET_V10_DIGEST: &str =
 /// binding ProjectAtlas-owned parser provenance to the 0.4.5-rc3 runtime.
 pub const ACCEPTED_LANGUAGE_CAPABILITY_SET_V11_DIGEST: &str =
     "3776f19c62b3debfcae13715e3bdc3ec3029978a4f7ba1428b7a06d433524915";
+
+/// Historical acceptance seal for capability-set version 12.
+///
+/// Version 12 preserves version 11 membership and capability strength while
+/// binding ProjectAtlas-owned parser provenance to the 0.4.5 runtime.
+pub const ACCEPTED_LANGUAGE_CAPABILITY_SET_V12_DIGEST: &str =
+    "bae01db588d8e6c8666bb1afd66ffcbffb3022c23c68df52f9822c291f9d895c";
 
 /// Maximum content prefix inspected by the bounded content/dialect detector.
 pub const LANGUAGE_CONTENT_DETECTION_MAX_BYTES: usize = 512;
@@ -2325,6 +2332,7 @@ pub fn validate_language_registry() -> Result<(), LanguageRegistryError> {
         9 => ACCEPTED_LANGUAGE_CAPABILITY_SET_V9_DIGEST,
         10 => ACCEPTED_LANGUAGE_CAPABILITY_SET_V10_DIGEST,
         11 => ACCEPTED_LANGUAGE_CAPABILITY_SET_V11_DIGEST,
+        12 => ACCEPTED_LANGUAGE_CAPABILITY_SET_V12_DIGEST,
         version => {
             return Err(LanguageRegistryError::new(format!(
                 "accepted language capability-set version {version} lacks a historical digest seal"

--- a/crates/projectatlas-core/src/optional_parser_pack.rs
+++ b/crates/projectatlas-core/src/optional_parser_pack.rs
@@ -36,7 +36,7 @@ pub const OPTIONAL_GRAMMAR_CATALOG_RELEASE_TAG: &str = "v1.13.2";
 pub const OPTIONAL_GRAMMAR_CATALOG_SOURCE_BUNDLE_SHA256: &str =
     "d684799dc664553c9c746d5fe676a5b599f9efcec4cad5450bec7ec5a29574a9";
 /// Exact `ProjectAtlas` release line selected to consume the first pack.
-pub const OPTIONAL_PARSER_PACK_PROJECTATLAS_VERSION: &str = "0.4.5-rc3";
+pub const OPTIONAL_PARSER_PACK_PROJECTATLAS_VERSION: &str = "0.4.5";
 /// Exact Tree-sitter runtime selected by the consuming parser worker.
 pub const OPTIONAL_PARSER_PACK_TREE_SITTER_VERSION: &str = "0.26.9";
 /// Oldest grammar ABI accepted by the selected Tree-sitter runtime.

--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -2,7 +2,7 @@
 
 This document is generated from the versioned Rust language capability registry. Do not edit the capability table or totals by hand. Canonical rows count once; aliases and extensions never increase a capability total.
 
-Registry version: `4`. Accepted capability-set version: `11`. Detection policy version: `1`. Registry digest: `3776f19c62b3debfcae13715e3bdc3ec3029978a4f7ba1428b7a06d433524915`. Accepted-set digest: `3776f19c62b3debfcae13715e3bdc3ec3029978a4f7ba1428b7a06d433524915`. Semantic-provider digest: `b26c4aa768ebe3bb185d5929350d2f41c6b1b2f93630080248dec7eb6ec00e82`.
+Registry version: `4`. Accepted capability-set version: `12`. Detection policy version: `1`. Registry digest: `bae01db588d8e6c8666bb1afd66ffcbffb3022c23c68df52f9822c291f9d895c`. Accepted-set digest: `bae01db588d8e6c8666bb1afd66ffcbffb3022c23c68df52f9822c291f9d895c`. Semantic-provider digest: `b26c4aa768ebe3bb185d5929350d2f41c6b1b2f93630080248dec7eb6ec00e82`.
 
 Optional catalog input: `tree-sitter-language-pack@1.13.2` revision `6258abac30304283763a0d2dc8a48cb87fbcf438` under `MIT` metadata license. This catalog identity is not a grammar-license or runtime-support claim.
 
@@ -30,53 +30,53 @@ Broad candidate rows are admitted only when the pinned catalog supplies a stable
 | `cpp` | `source` | `c++` | `.cpp`, `.cxx`, `.cc` | tree-sitter-cpp@0.23.4 | supported | supported | unavailable | — | unavailable | — | `tree-sitter-cpp@0.23.4` | `MIT` |
 | `h` | `source` | — | `.h` | tree-sitter-c@0.24.2 | supported | supported | unavailable | — | unavailable | — | `tree-sitter-c@0.24.2` | `MIT` |
 | `hpp` | `source` | — | `.hpp`, `.hxx`, `.hh` | tree-sitter-cpp@0.23.4 | supported | supported | unavailable | — | unavailable | — | `tree-sitter-cpp@0.23.4` | `MIT` |
-| `cargo-manifest` | `configuration_data` | — | exact `Cargo.toml` | projectatlas:cargo-manifest | supported | supported | supported (cargo) | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `cargo-lock` | `configuration_data` | — | exact `Cargo.lock` | projectatlas:cargo-manifest | supported | supported | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `vue` | `source` | — | `.vue` | projectatlas:vue | supported | supported | unavailable | component → ecma-script | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `markdown` | `documentation` | `md` | `.md`, `.mdx` | projectatlas:markdown | supported | supported | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `json` | `configuration_data` | — | `.json`, `.jsonc` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `yaml` | `configuration_data` | `yml` | `.yml`, `.yaml` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `css` | `source` | — | `.css`, `.scss`, `.sass`, `.less`, `.stylus`, `.styl` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `html` | `source` | — | `.html`, `.htm` | unavailable | supported | unavailable | unavailable | html-like → ecma-script | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `toon` | `configuration_data` | — | `.toon` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `dockerfile` | `source` | — | exact `Dockerfile` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `makefile` | `source` | — | exact `Makefile` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `text` | `other_text` | `txt` | `.txt` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `toml` | `configuration_data` | — | `.toml` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `xml` | `configuration_data` | — | `.xml` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `svelte` | `source` | — | `.svelte` | projectatlas:fallback | fallback | fallback | unavailable | template → ecma-script | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `astro` | `source` | — | `.astro` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `jsp` | `source` | — | `.jsp`, `.jspx`, `.jspf` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `jsp-tag` | `source` | — | `.tag`, `.tagx` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `gsp` | `source` | — | `.gsp` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `groovy` | `source` | — | `.gradle`, `.groovy` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `protobuf` | `source` | `proto` | `.proto` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `handlebars` | `source` | `hbs` | `.hbs`, `.handlebars` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `ejs` | `source` | — | `.ejs` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `pug` | `source` | — | `.pug` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `freemarker` | `source` | `ftl` | `.ftl` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `mustache` | `source` | — | `.mustache` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `liquid` | `source` | — | `.liquid` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `erb` | `source` | — | `.erb` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `sql` | `source` | — | `.sql`, `.ddl`, `.dml`, `.mysql`, `.postgresql`, `.psql`, `.sqlite`, `.mssql`, `.oracle`, `.ora`, `.db2`, `.proc`, `.procedure`, `.func`, `.function`, `.view`, `.trigger`, `.index`, `.migration`, `.seed`, `.fixture`, `.schema`, `.cql`, `.cypher`, `.sparql`, `.liquibase`, `.flyway` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `graphql` | `source` | `gql` | `.gql` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `config` | `configuration_data` | — | `.ini`, `.cfg`, `.conf`, `.properties`, `.env`, `.gitignore`, `.dockerignore`, `.editorconfig` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `ruby` | `source` | `rb` | `.rb`, shebang `ruby` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `php` | `source` | — | `.php` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `swift` | `source` | — | `.swift` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `scala` | `source` | — | `.scala` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `shell` | `source` | `sh` | `.sh`, `.bash`, `.zsh`, shebang `sh`, shebang `bash`, shebang `dash`, shebang `ash`, shebang `zsh`, shebang `ksh`, shebang `mksh`, shebang `fish` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `powershell` | `source` | `pwsh` | `.ps1`, `.psm1`, `.psd1`, shebang `powershell`, shebang `pwsh` | projectatlas:powershell | supported | supported | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `batch` | `source` | — | `.bat`, `.cmd` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `r` | `source` | `rscript` | `.r`, `.R`, shebang `rscript` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `perl` | `source` | — | `.pl`, `.pm`, shebang `perl` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `lua` | `source` | — | `.lua`, shebang `lua` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `dart` | `source` | — | `.dart` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `haskell` | `source` | `hs` | `.hs` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `ocaml` | `source` | — | `.ml`, `.mli` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `fsharp` | `source` | `f#` | `.fs`, `.fsx` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `clojure` | `source` | `clj` | `.clj`, `.cljs` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
-| `vim` | `source` | `vimscript` | `.vim` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5-rc3` | `MIT` |
+| `cargo-manifest` | `configuration_data` | — | exact `Cargo.toml` | projectatlas:cargo-manifest | supported | supported | supported (cargo) | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `cargo-lock` | `configuration_data` | — | exact `Cargo.lock` | projectatlas:cargo-manifest | supported | supported | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `vue` | `source` | — | `.vue` | projectatlas:vue | supported | supported | unavailable | component → ecma-script | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `markdown` | `documentation` | `md` | `.md`, `.mdx` | projectatlas:markdown | supported | supported | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `json` | `configuration_data` | — | `.json`, `.jsonc` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `yaml` | `configuration_data` | `yml` | `.yml`, `.yaml` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `css` | `source` | — | `.css`, `.scss`, `.sass`, `.less`, `.stylus`, `.styl` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `html` | `source` | — | `.html`, `.htm` | unavailable | supported | unavailable | unavailable | html-like → ecma-script | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `toon` | `configuration_data` | — | `.toon` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `dockerfile` | `source` | — | exact `Dockerfile` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `makefile` | `source` | — | exact `Makefile` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `text` | `other_text` | `txt` | `.txt` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `toml` | `configuration_data` | — | `.toml` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `xml` | `configuration_data` | — | `.xml` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `svelte` | `source` | — | `.svelte` | projectatlas:fallback | fallback | fallback | unavailable | template → ecma-script | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `astro` | `source` | — | `.astro` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `jsp` | `source` | — | `.jsp`, `.jspx`, `.jspf` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `jsp-tag` | `source` | — | `.tag`, `.tagx` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `gsp` | `source` | — | `.gsp` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `groovy` | `source` | — | `.gradle`, `.groovy` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `protobuf` | `source` | `proto` | `.proto` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `handlebars` | `source` | `hbs` | `.hbs`, `.handlebars` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `ejs` | `source` | — | `.ejs` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `pug` | `source` | — | `.pug` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `freemarker` | `source` | `ftl` | `.ftl` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `mustache` | `source` | — | `.mustache` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `liquid` | `source` | — | `.liquid` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `erb` | `source` | — | `.erb` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `sql` | `source` | — | `.sql`, `.ddl`, `.dml`, `.mysql`, `.postgresql`, `.psql`, `.sqlite`, `.mssql`, `.oracle`, `.ora`, `.db2`, `.proc`, `.procedure`, `.func`, `.function`, `.view`, `.trigger`, `.index`, `.migration`, `.seed`, `.fixture`, `.schema`, `.cql`, `.cypher`, `.sparql`, `.liquibase`, `.flyway` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `graphql` | `source` | `gql` | `.gql` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `config` | `configuration_data` | — | `.ini`, `.cfg`, `.conf`, `.properties`, `.env`, `.gitignore`, `.dockerignore`, `.editorconfig` | unavailable | supported | unavailable | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `ruby` | `source` | `rb` | `.rb`, shebang `ruby` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `php` | `source` | — | `.php` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `swift` | `source` | — | `.swift` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `scala` | `source` | — | `.scala` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `shell` | `source` | `sh` | `.sh`, `.bash`, `.zsh`, shebang `sh`, shebang `bash`, shebang `dash`, shebang `ash`, shebang `zsh`, shebang `ksh`, shebang `mksh`, shebang `fish` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `powershell` | `source` | `pwsh` | `.ps1`, `.psm1`, `.psd1`, shebang `powershell`, shebang `pwsh` | projectatlas:powershell | supported | supported | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `batch` | `source` | — | `.bat`, `.cmd` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `r` | `source` | `rscript` | `.r`, `.R`, shebang `rscript` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `perl` | `source` | — | `.pl`, `.pm`, shebang `perl` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `lua` | `source` | — | `.lua`, shebang `lua` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `dart` | `source` | — | `.dart` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `haskell` | `source` | `hs` | `.hs` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `ocaml` | `source` | — | `.ml`, `.mli` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `fsharp` | `source` | `f#` | `.fs`, `.fsx` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `clojure` | `source` | `clj` | `.clj`, `.cljs` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
+| `vim` | `source` | `vimscript` | `.vim` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | — | `projectatlas@0.4.5` | `MIT` |
 | `abl` | `source` | — | `.p` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | broad-parser | `tree-sitter-language-pack@1.13.2` | `MIT` |
 | `actionscript` | `source` | — | `.as` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | broad-parser | `tree-sitter-language-pack@1.13.2` | `MIT` |
 | `ada` | `source` | — | `.ada` | projectatlas:fallback | fallback | fallback | unavailable | — | unavailable | broad-parser | `tree-sitter-language-pack@1.13.2` | `MIT` |
@@ -288,7 +288,7 @@ Broad candidate rows are admitted only when the pinned catalog supplies a stable
 
 ## Language & Ecosystem Support
 
-Complete-support schema version: `1`. Ecosystem catalog version: `1`. Catalog digest: `b142590eeb65e4af79d51d76e73342fce6515c3834a2637d8a7aee349c35fa70`.
+Complete-support schema version: `1`. Ecosystem catalog version: `1`. Catalog digest: `beeec910b11bfecfda27fed007a68c2198d70ffcdc2c4e01b8ff9a50e1af0fe3`.
 
 `Complete` means conformance to the fixed ProjectAtlas navigation contract, not compiler, build-system, runtime, or whole-language completeness. Final v0.4 MCP navigation revalidation retained every runtime candidate at its achieved detected/parsed/symbol/semantic/benchmarked tier: none has the complete schema-bound capability and agent-navigation evidence required for promotion.
 

--- a/docs/worktree-lifecycle.md
+++ b/docs/worktree-lifecycle.md
@@ -1,6 +1,6 @@
 # Worktree atlas continuity
 
-ProjectAtlas v0.4.5-rc1 lets an agent remain in one explicitly selected control checkout while it registers, initializes, refreshes, and queries existing Git worktrees through short MCP aliases. The control checkout and every linked checkout may live anywhere on the filesystem, including under `.worktrees`; no branch or directory name defines control authority.
+ProjectAtlas v0.4.5 lets an agent remain in one explicitly selected control checkout while it registers, initializes, refreshes, and queries existing Git worktrees through short MCP aliases. The control checkout and every linked checkout may live anywhere on the filesystem, including under `.worktrees`; no branch or directory name defines control authority.
 
 Every checkout still owns an ignored, independently writable `.projectatlas/projectatlas.db`. ProjectAtlas may hydrate a new target from reusable control-atlas state, but it never shares one writable graph or purpose database across divergent checkouts. It also never creates, switches, moves, prunes, or deletes Git worktrees or branches.
 
@@ -273,4 +273,4 @@ Recovery remains explicit:
 - a registered reset that observes a changed Git lifecycle restores staged files without clobbering replacement state; an incomplete restore reports the retained target-local recovery directory.
 - a missing target retains its last accepted telemetry aggregate but ProjectAtlas cannot fabricate unsynchronized bytes that were externally deleted.
 
-The future distributed/versioned released-main atlas tracked by issue #456 is intentionally separate. v0.4.5-rc1 coordinates only local registrations and local databases visible to one explicitly selected control process.
+The future distributed/versioned released-main atlas tracked by issue #456 is intentionally separate. v0.4.5 coordinates only local registrations and local databases visible to one explicitly selected control process.

--- a/packaging/parser-pack/accepted-capabilities.json
+++ b/packaging/parser-pack/accepted-capabilities.json
@@ -18,16 +18,16 @@
   },
   "runtime": {
     "consumer": "projectatlas-parser-worker",
-    "projectatlas_version": "0.4.5-rc3",
+    "projectatlas_version": "0.4.5",
     "tree_sitter_version": "0.26.9",
     "minimum_abi": 13,
     "maximum_abi": 15
   },
   "registry": {
     "registry_version": 4,
-    "registry_digest": "3776f19c62b3debfcae13715e3bdc3ec3029978a4f7ba1428b7a06d433524915",
-    "accepted_set_version": 11,
-    "accepted_set_digest": "3776f19c62b3debfcae13715e3bdc3ec3029978a4f7ba1428b7a06d433524915"
+    "registry_digest": "bae01db588d8e6c8666bb1afd66ffcbffb3022c23c68df52f9822c291f9d895c",
+    "accepted_set_version": 12,
+    "accepted_set_digest": "bae01db588d8e6c8666bb1afd66ffcbffb3022c23c68df52f9822c291f9d895c"
   },
   "required_platforms": [
     "x86_64-unknown-linux-gnu",
@@ -7597,5 +7597,5 @@
       "capability_digest": "d11ac33f63f87c732d6bcac6b300eace2a4eba4775097f03c0f835f5fa2db4e9"
     }
   ],
-  "capability_set_digest": "009a932c0499c9726f0c56e4ad0744ebe72d3940640a7921f702e05a25d5193c"
+  "capability_set_digest": "2b79ce19130ade117c8a8ccaadcf341708c54647f55be552b8ce8ac6e32eddf6"
 }

--- a/packaging/parser-pack/accepted-capabilities.json.sha256
+++ b/packaging/parser-pack/accepted-capabilities.json.sha256
@@ -1,1 +1,1 @@
-18dd758afcb3ac565b013cc290403ebfbbd4a072d473089ef288bcee9bd4496e  accepted-capabilities.json
+7ea752d16ac0f93a20b2ff7dac0da969fb83f9a40fc303c021711377f89cd842  accepted-capabilities.json

--- a/plugins/projectatlas/.claude-plugin/plugin.json
+++ b/plugins/projectatlas/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.4.5-rc3",
+  "version": "0.4.5",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for Claude Code.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/.codex-plugin/plugin.json
+++ b/plugins/projectatlas/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "projectatlas",
-  "version": "0.4.5-rc3",
+  "version": "0.4.5",
   "description": "Agent-first Rust repository atlas, TOON output, and MCP workflows for coding agents.",
   "author": {
     "name": "ProjectAtlas Contributors",

--- a/plugins/projectatlas/opencode/opencode.json
+++ b/plugins/projectatlas/opencode/opencode.json
@@ -6,7 +6,7 @@
       "command": [
         "/absolute/path/to/projectatlas",
         "--require-version",
-        "0.4.5-rc3",
+        "0.4.5",
         "--db",
         "/absolute/path/to/project/.projectatlas/projectatlas.db",
         "mcp"


### PR DESCRIPTION
## Summary

- promote the verified v0.4.5-rc3 capability set to stable v0.4.5 across Rust packages, plugin manifests, installer pins, documentation, and frozen CLI surfaces
- preserve the cumulative v0.4.4 stable release-note baseline and de-duplicate shared closing issues so distinct follow-up fixes remain visible
- keep the existing RC ancestry, optional-parser proof, prerelease/Latest, and hosted release contracts from #448

## Verification

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace --all-targets --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --workspace --no-deps --all-features`
- `cargo deny --locked --all-features check -D warnings`
- `python -B .github/scripts/release-notes.py --self-test`
- production v0.4.5 release-note dry run against authenticated live PR/issue metadata
- `openspec validate --all --strict --no-interactive`
- milestone IssueOps and release-version self-tests