### PR TITLE
test(cli): pin token trend palette viewport (#495)

### DIFF
--- a/crates/projectatlas-cli/src/token_tui.rs
+++ b/crates/projectatlas-cli/src/token_tui.rs
@@ -3382,9 +3382,10 @@ mod tests {
     #[test]
     fn trend_dashboard_light_theme_remaps_semantic_palette() {
         let report = sample_trend_report();
-        let dashboard = rendered_dashboard(render_token_trend_dashboard_with_theme(
+        let dashboard = rendered_dashboard(render_token_trend_dashboard_with_theme_in_viewport(
             &report,
             TokenDashboardTheme::Light,
+            test_viewport(140, 30),
         ));
 
         assert!(dashboard.contains("\x1b["));

--- a/docs/projectatlas-3-architecture.md
+++ b/docs/projectatlas-3-architecture.md
@@ -2777,6 +2777,32 @@ fit, while wide-but-short terminals skip the optional graph read. The serializer
 emits CJK, combining, emoji, and ASCII graphemes once and bounds rows by terminal
 display cells rather than Unicode scalar count.
 
+### Token trend palette test viewport ownership
+
+```mermaid
+sequenceDiagram
+    actor Runtime as Production request
+    actor Test as Palette regression
+    participant Adapter as Token TUI viewport adapter
+    participant Renderer as Trend renderer
+
+    Runtime->>Adapter: Render token trend
+    Adapter->>Adapter: Capture live terminal viewport
+    alt viewport is at least 80 x 30
+        Adapter->>Renderer: Render full layout
+    else viewport is smaller
+        Adapter->>Renderer: Render compact layout
+    end
+    Renderer-->>Adapter: ANSI snapshot
+    Adapter-->>Runtime: Bounded terminal output
+
+    Test->>Adapter: Render light theme with test_viewport(140, 30)
+    Adapter->>Renderer: Render full layout
+    Renderer-->>Adapter: Full-layout ANSI snapshot
+    Adapter-->>Test: Deterministic snapshot
+    Test->>Test: Assert light semantic palette
+```
+
 For registered worktrees, the explicitly selected control atlas is the durable
 repository-total authority while each worktree remains the authority for its
 own raw local events and exact per-session detail. Alias-routed MCP events

--- a/openspec/changes/pin-token-trend-palette-test-viewport/.openspec.yaml
+++ b/openspec/changes/pin-token-trend-palette-test-viewport/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/pin-token-trend-palette-test-viewport/design.md
+++ b/openspec/changes/pin-token-trend-palette-test-viewport/design.md
@@ -1,0 +1,51 @@
+## Context
+
+The production trend renderer captures one terminal viewport and deliberately selects the full layout only at 80 by 30 or larger. The palette regression asserts cells emitted only by that full layout but currently calls the production entry point, so a real short PTY changes the branch under test. The existing `render_token_trend_dashboard_with_theme_in_viewport` and `test_viewport` helpers already provide the required deterministic test seam.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the full-layout palette regression independent of the host terminal.
+- Preserve every existing light-theme semantic palette assertion.
+- Preserve production live-viewport capture and compact/full selection unchanged.
+- Prove the correction in both non-TTY and approximately 80-by-24 PTY execution.
+
+**Non-Goals:**
+
+- Change a production renderer, threshold, palette, or terminal contract.
+- Add an abstraction, dependency, environment override, or committed PTY harness.
+- Expand this one-test correction into a token TUI redesign.
+
+## Decisions
+
+### Inject the viewport at the existing test seam
+
+Change only `trend_dashboard_light_theme_remaps_semantic_palette` to call `render_token_trend_dashboard_with_theme_in_viewport` with `test_viewport(140, 30)`. This viewport is explicitly large enough for the established full trend layout and keeps the test focused on palette semantics rather than terminal discovery.
+
+Alternative rejected: set `COLUMNS` and `LINES`. Environment mutation is process-global, can race parallel tests, and still exercises viewport discovery rather than the layout-specific rendering contract.
+
+Alternative rejected: change the production wrapper or full-layout threshold. The approximately 80-by-24 PTY is supposed to select compact output; changing production to satisfy the test would regress issue #462's accepted behavior.
+
+### Keep the assertions and renderer ownership unchanged
+
+The test retains its ANSI, light panel background, saved-green, identity-color, hard-coded-cyan absence, and dark-background absence assertions. The existing renderer remains the sole palette owner; the test supplies only its input viewport.
+
+### Record production and test viewport ownership once
+
+The focused Mermaid view in `docs/projectatlas-3-architecture.md` shows production live viewport capture and its full/compact branch separately from deterministic test injection. It documents the existing control flow and does not introduce another renderer or architecture layer.
+
+## Risks / Trade-offs
+
+- **[A fixed viewport hides production small-terminal defects]** -> Existing compact/full boundary tests and production entry points remain unchanged; this regression owns only full-layout palette semantics.
+- **[The test passes after assertions are weakened]** -> Retain the complete existing assertion set verbatim.
+- **[Only non-TTY execution is verified]** -> Repeat the exact regression in both non-TTY and approximately 80-by-24 PTY contexts.
+- **[Documentation implies a second renderer]** -> Show both paths converging on the existing trend rendering boundary and inspect the rendered Mermaid for semantic truth.
+
+## Migration Plan
+
+No migration or rollback path is required. The change modifies only a test call site and specification documentation. Reverting that call restores the prior test behavior without affecting production or stored data.
+
+## Open Questions
+
+None. The existing viewport-injected helper and 140-by-30 test viewport settle the implementation boundary.

--- a/openspec/changes/pin-token-trend-palette-test-viewport/proposal.md
+++ b/openspec/changes/pin-token-trend-palette-test-viewport/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`token_tui::tests::trend_dashboard_light_theme_remaps_semantic_palette` renders through the production entry point, so the test inherits the host terminal viewport. A normal non-TTY run selects the full trend layout and passes, while an approximately 80-by-24 PTY correctly selects the compact layout and then fails assertions that belong to the full layout. Production viewport behavior is correct; the layout-specific regression does not own its test viewport.
+
+## What Changes
+
+- Render only the full-layout light-theme trend regression through the existing viewport-injected helper with `test_viewport(140, 30)`.
+- Retain the complete semantic palette assertion set and all production viewport behavior.
+- Verify the regression repeatedly in non-TTY and approximately 80-by-24 PTY execution, then run the focused token TUI and repository-required gates.
+- Document the existing separation between production live-viewport selection and deterministic test viewport injection in one focused Mermaid view.
+
+## Capabilities
+
+### New Capabilities
+
+- `token-dashboard-test-determinism`: Layout-specific token-dashboard regressions select an explicit qualifying viewport while real TUI invocations continue to use the captured terminal viewport.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The implementation is limited to one test in `crates/projectatlas-cli/src/token_tui.rs`, its verification, this OpenSpec change, the issue mapping, and the focused architecture view in `docs/projectatlas-3-architecture.md`. It changes no production code, public interface, dependency, telemetry calculation, persistence, CLI/MCP payload, or terminal-layout boundary.
+
+## Non-Goals
+
+- Change production viewport capture or the 80-by-30 full-trend boundary.
+- Force the production renderer into the full layout in a small terminal.
+- Weaken or remove semantic palette assertions.
+- Add a renderer abstraction, dependency, committed PTY harness, or architecture documentation beyond the single focused ownership view.
+- Change telemetry calculations, persistence, CLI/MCP payloads, or public interfaces.
+
+This test-only correction is ready for implementation after its specification is accepted.

--- a/openspec/changes/pin-token-trend-palette-test-viewport/specs/token-dashboard-test-determinism/spec.md
+++ b/openspec/changes/pin-token-trend-palette-test-viewport/specs/token-dashboard-test-determinism/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Layout-specific token-dashboard regressions own their viewport
+
+A token-dashboard regression that asserts behavior unique to the full or compact layout SHALL render through an explicit deterministic viewport that selects the intended layout. It SHALL NOT depend on terminal discovery, process-global dimension mutation, test order, or the host PTY dimensions.
+
+#### Scenario: Full-layout palette regression runs inside a short PTY
+
+- **WHEN** `trend_dashboard_light_theme_remaps_semantic_palette` runs in an approximately 80-by-24 PTY
+- **THEN** the test SHALL render through `test_viewport(140, 30)` and the existing viewport-injected trend helper
+- **AND** it SHALL assert the full-layout light semantic palette rather than inheriting the PTY's compact-layout choice.
+
+### Requirement: Production viewport behavior remains authoritative
+
+Real token TUI invocations SHALL continue to capture one live terminal viewport and select the full trend layout only at 80 by 30 or larger. The deterministic test viewport SHALL NOT alter production capture, layout thresholds, compact behavior, public output contracts, or telemetry data.
+
+#### Scenario: Production trend runs inside a short terminal
+
+- **WHEN** a real token trend request runs below 80 columns or 30 rows
+- **THEN** ProjectAtlas SHALL continue to render the existing bounded compact trend layout
+- **AND** no test-only viewport SHALL affect that production decision.
+
+### Requirement: The regression is verified across terminal contexts
+
+The exact palette regression SHALL pass repeatedly in non-TTY and approximately 80-by-24 PTY execution while retaining its semantic assertions. The focused token TUI tests and repository-required format, hosted CI, strict OpenSpec, and IssueOps gates SHALL remain green.
+
+#### Scenario: Verification executes in both contexts
+
+- **WHEN** the test-only correction is evaluated for merge
+- **THEN** repeated non-TTY and PTY runs SHALL select the same explicit full-layout test viewport and pass
+- **AND** existing compact/full production-boundary regressions SHALL continue to pass unchanged.

--- a/openspec/changes/pin-token-trend-palette-test-viewport/tasks.md
+++ b/openspec/changes/pin-token-trend-palette-test-viewport/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Deterministic Token Trend Palette Regression
 
-- [ ] 1.1 Freeze the regression contract: this test owns an explicit 140-by-30 full-trend viewport, while real token TUI invocations retain live terminal capture and compact selection below 80 by 30.
-- [ ] 1.2 Change only `trend_dashboard_light_theme_remaps_semantic_palette` to render through `render_token_trend_dashboard_with_theme_in_viewport(&report, TokenDashboardTheme::Light, test_viewport(140, 30))`, retaining every existing semantic palette assertion.
+- [x] 1.1 Freeze the regression contract: this test owns an explicit 140-by-30 full-trend viewport, while real token TUI invocations retain live terminal capture and compact selection below 80 by 30.
+- [x] 1.2 Change only `trend_dashboard_light_theme_remaps_semantic_palette` to render through `render_token_trend_dashboard_with_theme_in_viewport(&report, TokenDashboardTheme::Light, test_viewport(140, 30))`, retaining every existing semantic palette assertion.
 - [ ] 1.3 Pass the exact regression repeatedly in non-TTY and approximately 80-by-24 PTY execution; pass `cargo test -p projectatlas-cli --bin projectatlas --all-features --locked token_tui::tests`, `cargo fmt --check`, required hosted CI, strict OpenSpec validation, and the IssueOps checklist gate without changing production viewport behavior.
-- [ ] 1.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
+- [x] 1.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/changes/pin-token-trend-palette-test-viewport/tasks.md
+++ b/openspec/changes/pin-token-trend-palette-test-viewport/tasks.md
@@ -2,5 +2,5 @@
 
 - [x] 1.1 Freeze the regression contract: this test owns an explicit 140-by-30 full-trend viewport, while real token TUI invocations retain live terminal capture and compact selection below 80 by 30.
 - [x] 1.2 Change only `trend_dashboard_light_theme_remaps_semantic_palette` to render through `render_token_trend_dashboard_with_theme_in_viewport(&report, TokenDashboardTheme::Light, test_viewport(140, 30))`, retaining every existing semantic palette assertion.
-- [ ] 1.3 Pass the exact regression repeatedly in non-TTY and approximately 80-by-24 PTY execution; pass `cargo test -p projectatlas-cli --bin projectatlas --all-features --locked token_tui::tests`, `cargo fmt --check`, required hosted CI, strict OpenSpec validation, and the IssueOps checklist gate without changing production viewport behavior.
+- [x] 1.3 Pass the exact regression repeatedly in non-TTY and approximately 80-by-24 PTY execution; pass `cargo test -p projectatlas-cli --bin projectatlas --all-features --locked token_tui::tests`, `cargo fmt --check`, required hosted CI, strict OpenSpec validation, and the IssueOps checklist gate without changing production viewport behavior.
 - [x] 1.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/changes/pin-token-trend-palette-test-viewport/tasks.md
+++ b/openspec/changes/pin-token-trend-palette-test-viewport/tasks.md
@@ -1,0 +1,6 @@
+## 1. Deterministic Token Trend Palette Regression
+
+- [ ] 1.1 Freeze the regression contract: this test owns an explicit 140-by-30 full-trend viewport, while real token TUI invocations retain live terminal capture and compact selection below 80 by 30.
+- [ ] 1.2 Change only `trend_dashboard_light_theme_remaps_semantic_palette` to render through `render_token_trend_dashboard_with_theme_in_viewport(&report, TokenDashboardTheme::Light, test_viewport(140, 30))`, retaining every existing semantic palette assertion.
+- [ ] 1.3 Pass the exact regression repeatedly in non-TTY and approximately 80-by-24 PTY execution; pass `cargo test -p projectatlas-cli --bin projectatlas --all-features --locked token_tui::tests`, `cargo fmt --check`, required hosted CI, strict OpenSpec validation, and the IssueOps checklist gate without changing production viewport behavior.
+- [ ] 1.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -60,6 +60,7 @@
     "match-token-impact-reference-tui": 302,
     "migrate-released-database-layouts": 379,
     "pin-sql-fixture-line-endings": 401,
+    "pin-token-trend-palette-test-viewport": 495,
     "persist-agent-project-context": {
       "contract": "checklist-v1",
       "primary_issue": 314,


### PR DESCRIPTION
Fixes #495

## Summary

- pin the full-layout light-theme trend regression to the existing explicit 140-by-30 test viewport
- preserve production terminal capture, compact/full thresholds, and every semantic palette assertion
- add the focused OpenSpec contract and rendered architecture view

## Verification

- exact regression: 5/5 non-TTY passes
- exact regression: 3/3 passes in a real 80-by-24 PTY
- `cargo test -p projectatlas-cli --bin projectatlas --all-features --locked token_tui::tests -- --test-threads=1`: 32 passed
- complete pre-push repository gate: passed
- strict OpenSpec validation and IssueOps checklist validation: passed

Task 1.3 remains open until this PR's hosted CI passes.