### PR TITLE
chore(benchmarks): bound tracked raw artifacts

### DIFF
--- a/.github/scripts/verify-manual-benchmark-policy.py
+++ b/.github/scripts/verify-manual-benchmark-policy.py
@@ -4,10 +4,56 @@
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
-from pathlib import Path
+import tempfile
+from pathlib import Path, PurePosixPath
 
 CAMPAIGN_ENTRYPOINTS = ("agent_navigation.py", "system_scale.py")
+MAX_TRACKED_RAW_BENCHMARK_BYTES = 4 * 1024 * 1024
+
+
+def is_oversized_tracked_raw_result(
+    relative: str, size: int, *, tracked: bool = True
+) -> bool:
+    """Identify only oversized root-level JSONL benchmark traces."""
+
+    path = PurePosixPath(relative)
+    return (
+        tracked
+        and path.parts[:2] == ("docs", "benchmarks")
+        and len(path.parts) == 3
+        and path.suffix.lower() == ".jsonl"
+        and size > MAX_TRACKED_RAW_BENCHMARK_BYTES
+    )
+
+
+def oversized_tracked_raw_results(root: Path) -> list[tuple[str, int]]:
+    """Return oversized tracked raw benchmark blobs selected by ``HEAD``."""
+
+    process = subprocess.run(
+        ["git", "ls-tree", "-r", "-l", "-z", "HEAD", "--", "docs/benchmarks"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        timeout=120,
+    )
+    if process.returncode != 0:
+        raise RuntimeError("could not inspect committed benchmark blobs")
+
+    findings: list[tuple[str, int]] = []
+    for encoded in process.stdout.split(b"\0"):
+        if not encoded:
+            continue
+        header, separator, encoded_path = encoded.partition(b"\t")
+        fields = header.split()
+        if not separator or len(fields) != 4 or fields[1] != b"blob":
+            continue
+        relative = encoded_path.decode("utf-8")
+        size = int(fields[3])
+        if is_oversized_tracked_raw_result(relative, size):
+            findings.append((relative, size))
+    return findings
 
 
 def campaign_entrypoint(line: str) -> bool:
@@ -22,7 +68,90 @@ def campaign_entrypoint(line: str) -> bool:
     )
 
 
+def self_test() -> None:
+    """Protect the narrow raw-trace boundary and its allowed false positives."""
+
+    assert not is_oversized_tracked_raw_result(
+        "docs/benchmarks/v0.4-agent-navigation-results.json",
+        MAX_TRACKED_RAW_BENCHMARK_BYTES + 1,
+    )
+    assert not is_oversized_tracked_raw_result(
+        "docs/benchmarks/fixtures/generated.jsonl",
+        MAX_TRACKED_RAW_BENCHMARK_BYTES + 1,
+    )
+    assert not is_oversized_tracked_raw_result(
+        "docs/benchmarks/local-output.jsonl",
+        MAX_TRACKED_RAW_BENCHMARK_BYTES + 1,
+        tracked=False,
+    )
+    assert not is_oversized_tracked_raw_result(
+        "release/benchmark.jsonl.gz", MAX_TRACKED_RAW_BENCHMARK_BYTES + 1
+    )
+    assert is_oversized_tracked_raw_result(
+        "docs/benchmarks/v0.4-agent-navigation-failed-binary-init-29a4863.jsonl",
+        MAX_TRACKED_RAW_BENCHMARK_BYTES + 1,
+    )
+    assert is_oversized_tracked_raw_result(
+        r"docs/benchmarks/trace\part.jsonl",
+        MAX_TRACKED_RAW_BENCHMARK_BYTES + 1,
+    )
+    assert not is_oversized_tracked_raw_result(
+        "docs/benchmarks/v0.4-agent-navigation-failed-binary-init-29a4863.jsonl",
+        MAX_TRACKED_RAW_BENCHMARK_BYTES,
+    )
+
+    temporary_root = Path(__file__).resolve().parents[2] / ".tmp"
+    temporary_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        prefix="benchmark-policy-", dir=temporary_root
+    ) as temporary:
+        root = Path(temporary)
+        benchmark_root = root / "docs" / "benchmarks"
+        benchmark_root.mkdir(parents=True)
+        oversized = benchmark_root / "oversized.jsonl"
+        compact = benchmark_root / "compact.jsonl"
+        oversized.write_bytes(b"x" * (MAX_TRACKED_RAW_BENCHMARK_BYTES + 1))
+        compact.write_bytes(b"x" * (MAX_TRACKED_RAW_BENCHMARK_BYTES - 1))
+        for command in (
+            ["git", "init", "--quiet"],
+            [
+                "git",
+                "add",
+                "--",
+                "docs/benchmarks/oversized.jsonl",
+                "docs/benchmarks/compact.jsonl",
+            ],
+            [
+                "git",
+                "-c",
+                "user.name=benchmark-policy-self-test",
+                "-c",
+                "user.email=benchmark-policy-self-test@example.invalid",
+                "commit",
+                "--quiet",
+                "-m",
+                "fixture",
+            ],
+        ):
+            subprocess.run(
+                command,
+                cwd=root,
+                check=True,
+                capture_output=True,
+                timeout=30,
+            )
+
+        expected = [
+            ("docs/benchmarks/oversized.jsonl", MAX_TRACKED_RAW_BENCHMARK_BYTES + 1)
+        ]
+        assert oversized_tracked_raw_results(root) == expected
+        oversized.unlink()
+        compact.write_bytes(b"x" * (MAX_TRACKED_RAW_BENCHMARK_BYTES + 1))
+        assert oversized_tracked_raw_results(root) == expected
+
+
 def main() -> int:
+    self_test()
     if campaign_entrypoint("python docs/benchmarks/harness/test_agent_navigation.py"):
         raise RuntimeError("benchmark unit tests must remain allowed")
     if not campaign_entrypoint(
@@ -56,6 +185,18 @@ def main() -> int:
         print(
             "full system-scale and agent-navigation campaigns are manual-only; "
             "remove automated invocations from " + ", ".join(violations),
+            file=sys.stderr,
+        )
+        return 1
+    oversized = oversized_tracked_raw_results(root)
+    if oversized:
+        shown = oversized[:8]
+        details = ", ".join(f"{path} ({size} bytes)" for path, size in shown)
+        if len(oversized) > len(shown):
+            details += f", ... and {len(oversized) - len(shown)} more"
+        print(
+            "tracked raw benchmark traces exceed the 4 MiB source bound; "
+            "retain compact sanitized evidence or use ignored local output: " + details,
             file=sys.stderr,
         )
         return 1

--- a/crates/projectatlas-lints/src/main.rs
+++ b/crates/projectatlas-lints/src/main.rs
@@ -3,7 +3,7 @@
 
 use proc_macro2::{TokenStream, TokenTree};
 use regex::Regex;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::ffi::OsString;
 use std::fmt::{self, Display};
@@ -348,6 +348,7 @@ fn lint_repository_private_paths(root: &Path) -> Result<Vec<StringLiteralViolati
     }
     let rules = private_path_rules()?;
     let mut violations = Vec::new();
+    let mut missing_worktree_paths = BTreeSet::new();
     for raw_path in output
         .stdout
         .split(|byte| *byte == 0)
@@ -355,10 +356,20 @@ fn lint_repository_private_paths(root: &Path) -> Result<Vec<StringLiteralViolati
     {
         let relative_path = std::str::from_utf8(raw_path).map_err(LintError::NonUtf8GitPath)?;
         let path = root.join(relative_path);
-        let metadata = fs::symlink_metadata(&path).map_err(|source| LintError::ReadFile {
-            path: relative_path.to_string(),
-            source,
-        })?;
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                lint_committed_private_path(root, relative_path, &rules, &mut violations)?;
+                missing_worktree_paths.insert(relative_path.to_string());
+                continue;
+            }
+            Err(source) => {
+                return Err(LintError::ReadFile {
+                    path: relative_path.to_string(),
+                    source,
+                });
+            }
+        };
         let source = if metadata.file_type().is_symlink() {
             let target = fs::read_link(&path).map_err(|source| LintError::ReadFile {
                 path: relative_path.to_string(),
@@ -395,20 +406,33 @@ fn lint_repository_private_paths(root: &Path) -> Result<Vec<StringLiteralViolati
         .filter(|path| !path.is_empty())
     {
         let relative_path = std::str::from_utf8(raw_path).map_err(LintError::NonUtf8GitPath)?;
-        let committed = Command::new("git")
-            .args(["cat-file", "blob"])
-            .arg(format!("HEAD:{relative_path}"))
-            .current_dir(root)
-            .output()
-            .map_err(LintError::ListGitFiles)?;
-        let Ok(source) = String::from_utf8(committed.stdout) else {
-            continue;
-        };
-        if committed.status.success() {
-            violations.extend(lint_private_path_source(relative_path, &source, &rules));
+        if !missing_worktree_paths.contains(relative_path) {
+            lint_committed_private_path(root, relative_path, &rules, &mut violations)?;
         }
     }
     Ok(violations)
+}
+
+/// Lint the committed `HEAD` source for a path unavailable in the worktree.
+fn lint_committed_private_path(
+    root: &Path,
+    relative_path: &str,
+    rules: &[Regex],
+    violations: &mut Vec<StringLiteralViolation>,
+) -> Result<(), LintError> {
+    let committed = Command::new("git")
+        .args(["cat-file", "blob"])
+        .arg(format!("HEAD:{relative_path}"))
+        .current_dir(root)
+        .output()
+        .map_err(LintError::ListGitFiles)?;
+    let Ok(source) = String::from_utf8(committed.stdout) else {
+        return Ok(());
+    };
+    if committed.status.success() {
+        violations.extend(lint_private_path_source(relative_path, &source, rules));
+    }
+    Ok(())
 }
 
 /// Compile the fixed repository-private path rules.
@@ -1035,7 +1059,15 @@ mod tests {
                     .success(),
                 "temporary Git repository commit failed",
             )?;
-            fs::write(repo.join("private.txt"), "checkout = <project-root>\n")?;
+            require(
+                Command::new("git")
+                    .args(["update-index", "--skip-worktree", "private.txt"])
+                    .current_dir(&repo)
+                    .status()?
+                    .success(),
+                "temporary skip-worktree setup failed",
+            )?;
+            fs::remove_file(repo.join("private.txt"))?;
             require(
                 Command::new("git")
                     .args(["rm", "--cached", "--quiet", "private-link"])

--- a/docs/benchmarks/v0.4-agent-navigation-evaluation.md
+++ b/docs/benchmarks/v0.4-agent-navigation-evaluation.md
@@ -202,7 +202,7 @@ in the locked preregistration:
 | [Path-expansion failure](v0.4-agent-navigation-failed-path-expansion-b33164f.json) | All 45 scheduled rows remain failed; the final harness resolves environment paths before launch. |
 | [Skill-path failure](v0.4-agent-navigation-failed-skill-path-e81d929.jsonl) | Three failed rows remain; the final harness resolves the packaged-skill path before charging its bytes. |
 | [Storage-sampler failure](v0.4-agent-navigation-failed-storage-sampler-aa7ee10.jsonl) | Six failed rows remain; disappearing owned SQLite sidecars are sampled as zero. |
-| [Binary-init and cleanup failure](v0.4-agent-navigation-failed-binary-init-29a4863.jsonl) | Fifteen failed rows and cleanup failures remain disclosed; v0.4 handles definite non-UTF-8 ordinary source headers and uses bounded ownership-validated cleanup. |
+| [Binary-init and cleanup failure (compact summary)](v0.4-agent-navigation-failed-binary-init-29a4863-summary.json) | Fifteen failed rows and cleanup failures remain disclosed; v0.4 handles definite non-UTF-8 ordinary source headers and uses bounded ownership-validated cleanup. |
 | Superseded prior publications | Retained in Git history or locally as declared by the preregistration; none is used as final release evidence. |
 | Committed-lock preflight | No measurement ran; validation rejected a preregistration that differed from its committed input lock. |
 

--- a/docs/benchmarks/v0.4-agent-navigation-failed-binary-init-29a4863-summary.json
+++ b/docs/benchmarks/v0.4-agent-navigation-failed-binary-init-29a4863-summary.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "source_artifact": {
+    "path": "docs/benchmarks/v0.4-agent-navigation-failed-binary-init-29a4863.jsonl",
+    "classification": "binary-init-and-cleanup failure",
+    "retained_disposition": "Fifteen failed rows and cleanup failures remain disclosed; v0.4 handles definite non-UTF-8 ordinary source headers and uses bounded ownership-validated cleanup.",
+    "bytes": 42809126,
+    "sha256": "f1ce8550ed30c9acccbdc1db40a0f3f0f7b0bcb1fd82df759b01802376254baf"
+  },
+  "source_identity": {
+    "candidate_revision": "f274acc1b973da16626e7cbeb7bb9acbaf10f86d",
+    "artifact_introduction_commit": "7985f0d7937438ecd569e5957e17062bfa804b1c",
+    "repository_baseline_revision": "60ca219d66fe68e0ccb12cf865e160656abee38d",
+    "preregistration": "docs/benchmarks/v0.4-agent-navigation-preregistration.json",
+    "preregistration_sha256": "b428bd48b73ad8c1e1b65cfccdc092c0762c4740c022e403e31ef8326189d86a"
+  },
+  "harness": {
+    "path": "docs/benchmarks/harness/agent_navigation.py",
+    "sha256": "d04ded52a0a109da96df5ce1cf5b3370258731b8ccaf54e9d04022a93085fa58",
+    "runtime": "projectatlas 0.4.0",
+    "runtime_sha256": "6c819a272e7d4c258f2f97357b691706b5c2aafca1e5ea5cbbc598d4b7e4e3d3",
+    "codex_model": "gpt-5.6-sol",
+    "codex_cli_sha256": "83751f15cb6a0a7b97df67752c001e3fe1c20e18ffbfec3ff63567296205eb6c"
+  },
+  "observed_record": {
+    "run_id": "r01-small-clean-v0.4",
+    "repeat": 1,
+    "case": "small-clean",
+    "arm": "v0.4",
+    "execution_status": "completed",
+    "trace_events": 22,
+    "successful_mcp_calls": 7,
+    "correctness_passed": true
+  },
+  "reproduction": {
+    "mode": "manual-only",
+    "command": "python docs/benchmarks/harness/agent_navigation.py --preregistration docs/benchmarks/v0.4-agent-navigation-preregistration.json --output <ignored local output> --work-root <ignored local work root> --corpus-cache <ignored local corpus cache> --repeats 3",
+    "sanitization": "Remove runs[].raw_jsonl and replace opaque cursor values with a fixed marker plus byte length before publication."
+  }
+}

--- a/openspec/changes/complete-v050-release-readiness/tasks.md
+++ b/openspec/changes/complete-v050-release-readiness/tasks.md
@@ -154,10 +154,10 @@
 
 ## 23. Oversized benchmark artifact retention (#489)
 
-- [ ] 23.1 Confirm the 42,809,126-byte `docs/benchmarks/v0.4-agent-navigation-failed-binary-init-29a4863.jsonl` is reproducible from the retained preregistration/harness and define the smallest tracked benchmark-result size/allowlist rule after checking all current benchmark artifacts, compressed/release artifacts, Git LFS absence, `.gitignore`, and publication alternatives.
-- [ ] 23.2 Remove only that raw JSONL from the current tree without rewriting history; retain a compact sanitized failure summary with candidate/repository revision, harness/runtime identity, failure classification, digest/size, and reproduction command if those facts remain useful.
-- [ ] 23.3 Extend the narrow existing benchmark/repository policy check to reject an accidentally tracked oversized raw benchmark output while allowing normal fixtures, explicitly approved compact results, ignored local outputs, compressed/release assets, and tested false positives; wire it through the existing CI/release policy owner.
-- [ ] 23.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
+- [x] 23.1 Confirm the 42,809,126-byte `docs/benchmarks/v0.4-agent-navigation-failed-binary-init-29a4863.jsonl` is reproducible from the retained preregistration/harness and define the smallest tracked benchmark-result size/allowlist rule after checking all current benchmark artifacts, compressed/release artifacts, Git LFS absence, `.gitignore`, and publication alternatives.
+- [x] 23.2 Remove only that raw JSONL from the current tree without rewriting history; retain a compact sanitized failure summary with candidate/repository revision, harness/runtime identity, failure classification, digest/size, and reproduction command if those facts remain useful.
+- [x] 23.3 Extend the narrow existing benchmark/repository policy check to reject an accidentally tracked oversized raw benchmark output while allowing normal fixtures, explicitly approved compact results, ignored local outputs, compressed/release assets, and tested false positives; wire it through the existing CI/release policy owner.
+- [x] 23.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
 
 ## 24. Repeatable real-task agent evaluation (#490)
 


### PR DESCRIPTION
Removes the oversized failed benchmark JSONL from the current tree, retains a sanitized digest and reproduction summary, and adds a narrow tracked raw JSONL policy with fixture, compact-result, release-asset, and false-positive coverage.

Closes #489