### PR TITLE
chore(toolchain): pin Rust 1.98.0 across CI and release

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -8,6 +8,7 @@ for git_variable in $(git rev-parse --local-env-vars); do
   unset "$git_variable"
 done
 
+python3 .github/scripts/verify-rust-toolchain.py
 cargo run --locked -p projectatlas-lints --bin cargo-projectatlas-lints -- strict-strings
 python3 docs/benchmarks/harness/mcp_composition.py --self-test
 python3 .github/scripts/verify-manual-benchmark-policy.py

--- a/.github/scripts/run-parser-pack-contained-construction.ps1
+++ b/.github/scripts/run-parser-pack-contained-construction.ps1
@@ -64,6 +64,23 @@ $constructionDiagnosticMaxBytes = 64 * 1024
 $reusableCargoTargetMaxEntries = 200000
 $reusableCargoTargetMaxBytes = [uint64](8GB)
 
+function Get-CargoCacheTag {
+    return "Signature: 8a477f597d28d172789f06886806bc55`n# This file is a cache directory tag created by cargo.`n# For information about cache directory tags see https://bford.info/cachedir/`n"
+}
+
+function Write-CargoCacheTag {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BuildDirectory
+    )
+
+    [System.IO.File]::WriteAllText(
+        [System.IO.Path]::Combine($BuildDirectory, "CACHEDIR.TAG"),
+        (Get-CargoCacheTag),
+        [System.Text.UTF8Encoding]::new($false)
+    )
+}
+
 function Get-CanonicalDirectory {
     param(
         [Parameter(Mandatory = $true)]
@@ -136,6 +153,16 @@ function Assert-ReusableCargoTarget {
         (($root.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
         throw "Reusable Cargo target root is not one direct non-reparse directory."
     }
+    $cacheTag = Get-Item `
+        -LiteralPath ([System.IO.Path]::Combine($root.FullName, "CACHEDIR.TAG")) `
+        -Force `
+        -ErrorAction SilentlyContinue
+    if ($null -eq $cacheTag -or
+        $cacheTag.PSIsContainer -or
+        (($cacheTag.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) -or
+        [System.IO.File]::ReadAllText($cacheTag.FullName) -cne (Get-CargoCacheTag)) {
+        throw "Reusable Cargo target is missing a valid Cargo cache tag."
+    }
     $prefix = "$($root.FullName.TrimEnd(
         [System.IO.Path]::DirectorySeparatorChar,
         [System.IO.Path]::AltDirectorySeparatorChar
@@ -190,6 +217,7 @@ function Initialize-ReusableCargoTarget {
     $existing = Get-Item -LiteralPath $BuildDirectory -Force -ErrorAction SilentlyContinue
     if ($null -eq $existing) {
         [System.IO.Directory]::CreateDirectory($BuildDirectory) | Out-Null
+        Write-CargoCacheTag -BuildDirectory $BuildDirectory
         return [pscustomobject]@{
             disposition = "miss"
             entries = 0
@@ -229,6 +257,7 @@ function Initialize-ReusableCargoTarget {
         }
         Write-Warning "Reusable Cargo target rejected: $rejection"
         [System.IO.Directory]::CreateDirectory($BuildDirectory) | Out-Null
+        Write-CargoCacheTag -BuildDirectory $BuildDirectory
         return [pscustomobject]@{
             disposition = "rejected"
             entries = 0

--- a/.github/scripts/test-parser-pack-construction-diagnostics.ps1
+++ b/.github/scripts/test-parser-pack-construction-diagnostics.ps1
@@ -150,6 +150,8 @@ foreach ($name in @(
     "Invoke-Checked",
     "Write-ConstructionStatus",
     "Assert-CargoConstructionEnvironment",
+    "Get-CargoCacheTag",
+    "Write-CargoCacheTag",
     "Assert-ReusableCargoTarget",
     "Initialize-ReusableCargoTarget"
 )) {
@@ -282,7 +284,10 @@ try {
         -MaximumBytes 1024
     Require `
         ($miss.disposition -eq "miss" -and
-            [System.IO.Directory]::Exists($cacheBuild)) `
+            [System.IO.Directory]::Exists($cacheBuild) -and
+            [System.IO.File]::ReadAllText(
+                [System.IO.Path]::Combine($cacheBuild, "CACHEDIR.TAG")
+            ) -ceq (Get-CargoCacheTag)) `
         "Absent reusable Cargo target did not produce a clean miss."
     $cacheDependency = [System.IO.Directory]::CreateDirectory(
         [System.IO.Path]::Combine($cacheBuild, "release", "deps")
@@ -298,9 +303,44 @@ try {
         -MaximumBytes 1024
     Require `
         ($hit.disposition -eq "hit" -and
-            $hit.entries -eq 3 -and
-            $hit.bytes -eq 10) `
+            $hit.entries -eq 4 -and
+            $hit.bytes -eq (
+                10 + [System.Text.Encoding]::UTF8.GetByteCount((Get-CargoCacheTag))
+            )) `
         "Valid reusable Cargo target was not admitted with exact metrics."
+
+    Remove-Item `
+        -LiteralPath ([System.IO.Path]::Combine($cacheBuild, "CACHEDIR.TAG")) `
+        -Force
+    $missingTagRejected = Initialize-ReusableCargoTarget `
+        -OutputDirectory $cacheOutput `
+        -BuildDirectory $cacheBuild `
+        -MaximumEntries 8 `
+        -MaximumBytes 1024
+    Require `
+        ($missingTagRejected.disposition -eq "rejected" -and
+            [System.IO.File]::ReadAllText(
+                [System.IO.Path]::Combine($cacheBuild, "CACHEDIR.TAG")
+            ) -ceq (Get-CargoCacheTag) -and
+            @(Get-ChildItem -LiteralPath $cacheBuild -Force).Count -eq 1) `
+        "Missing reusable Cargo cache tag was not quarantined and recreated."
+
+    [System.IO.File]::WriteAllText(
+        [System.IO.Path]::Combine($cacheBuild, "CACHEDIR.TAG"),
+        "invalid cache tag"
+    )
+    $invalidTagRejected = Initialize-ReusableCargoTarget `
+        -OutputDirectory $cacheOutput `
+        -BuildDirectory $cacheBuild `
+        -MaximumEntries 8 `
+        -MaximumBytes 1024
+    Require `
+        ($invalidTagRejected.disposition -eq "rejected" -and
+            [System.IO.File]::ReadAllText(
+                [System.IO.Path]::Combine($cacheBuild, "CACHEDIR.TAG")
+            ) -ceq (Get-CargoCacheTag) -and
+            @(Get-ChildItem -LiteralPath $cacheBuild -Force).Count -eq 1) `
+        "Invalid reusable Cargo cache tag was not quarantined and recreated."
 
     $fileRootOutput = [System.IO.Directory]::CreateDirectory(
         [System.IO.Path]::Combine($testRoot, "cargo-cache-file-root")
@@ -323,6 +363,7 @@ try {
     $entryLimitBuild = [System.IO.Directory]::CreateDirectory(
         [System.IO.Path]::Combine($entryLimitOutput, "build")
     ).FullName
+    Write-CargoCacheTag -BuildDirectory $entryLimitBuild
     [System.IO.File]::WriteAllText(
         [System.IO.Path]::Combine($entryLimitBuild, "first"),
         "1"
@@ -351,6 +392,7 @@ try {
     $byteLimitBuild = [System.IO.Directory]::CreateDirectory(
         [System.IO.Path]::Combine($byteLimitOutput, "build")
     ).FullName
+    Write-CargoCacheTag -BuildDirectory $byteLimitBuild
     [System.IO.File]::WriteAllText(
         [System.IO.Path]::Combine($byteLimitBuild, "oversized"),
         "12"
@@ -375,6 +417,7 @@ try {
     $linkBuild = [System.IO.Directory]::CreateDirectory(
         [System.IO.Path]::Combine($linkOutput, "build")
     ).FullName
+    Write-CargoCacheTag -BuildDirectory $linkBuild
     $linkTarget = [System.IO.Directory]::CreateDirectory(
         [System.IO.Path]::Combine($testRoot, "cargo-cache-link-target")
     ).FullName
@@ -399,8 +442,11 @@ try {
         ($link.disposition -eq "rejected" -and
             $quarantines.Count -eq 1 -and
             [System.IO.Directory]::Exists($linkBuild) -and
-            @(Get-ChildItem -LiteralPath $linkBuild -Force).Count -eq 0) `
-        "Path-indirected reusable Cargo target did not fall back to an empty build."
+            @(Get-ChildItem -LiteralPath $linkBuild -Force).Count -eq 1 -and
+            [System.IO.File]::Exists(
+                [System.IO.Path]::Combine($linkBuild, "CACHEDIR.TAG")
+            )) `
+        "Path-indirected reusable Cargo target did not fall back to a tagged build."
 
     Require `
         ($workflowText.Contains("clean_construction:") -and

--- a/.github/scripts/verify-rust-toolchain.py
+++ b/.github/scripts/verify-rust-toolchain.py
@@ -1,0 +1,995 @@
+#!/usr/bin/env python3
+"""Verify the repository-owned Rust toolchain before build or release work."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+
+CHANNEL_RE = re.compile(r'^\s*channel\s*=\s*"([^"]+)"\s*$', re.MULTILINE)
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+TARGET_TRIPLE_RE = re.compile(
+    r"^(?:aarch64|x86_64)-(?:unknown-linux-(?:gnu|musl)|"
+    r"pc-windows-(?:gnu|msvc)|apple-darwin)$"
+)
+RELEASE_RE = re.compile(r"(?:^|\n)release:\s*(\d+\.\d+\.\d+)")
+COMMIT_RE = re.compile(r"\(([0-9a-f]{10,40})\s")
+PROXY_DIGEST_CHUNK_SIZE = 1024 * 1024
+
+
+class PreflightError(RuntimeError):
+    """Raised for an invalid repository or toolchain identity."""
+
+
+@dataclass(frozen=True)
+class ToolEvidence:
+    """Observed identity for one Rust tool."""
+
+    name: str
+    path: str | None
+    output: str | None
+    release: str | None = None
+    commit: str | None = None
+
+
+def read_declared_channel(toolchain_file: Path) -> str:
+    """Read the one exact numeric channel from ``rust-toolchain.toml``."""
+
+    try:
+        text = toolchain_file.read_text(encoding="utf-8")
+    except OSError as error:
+        raise PreflightError(f"cannot read {toolchain_file}: {error}") from error
+    channels = CHANNEL_RE.findall(text)
+    if len(channels) != 1:
+        raise PreflightError(
+            f"{toolchain_file} must contain exactly one channel assignment"
+        )
+    channel = channels[0]
+    if not VERSION_RE.fullmatch(channel):
+        raise PreflightError(
+            f"{toolchain_file} must pin an exact numeric version, got {channel!r}"
+        )
+    return channel
+
+
+def version_matches(expected: str, actual: str | None) -> bool:
+    """Return whether a rustup name is the exact release or its target triple."""
+
+    if actual == expected:
+        return True
+    if not actual or not actual.startswith(f"{expected}-"):
+        return False
+    return bool(TARGET_TRIPLE_RE.fullmatch(actual[len(expected) + 1 :]))
+
+
+def same_directory(left: str | Path, right: str | Path) -> bool:
+    """Compare identity, falling back only for missing/non-directory paths."""
+
+    left_path = Path(left)
+    right_path = Path(right)
+    try:
+        return left_path.samefile(right_path)
+    except (FileNotFoundError, NotADirectoryError):
+        # Missing/non-directory paths are retained for deterministic unit-test
+        # and diagnostic comparisons; existing paths must use filesystem identity.
+        pass
+    except (PermissionError, OSError, ValueError, RuntimeError):
+        return False
+
+    try:
+        left_path = os.path.normcase(str(left_path.resolve(strict=False)))
+        right_path = os.path.normcase(str(right_path.resolve(strict=False)))
+    except (OSError, ValueError, RuntimeError):
+        return False
+    return left_path == right_path
+
+
+def executable_digest(path: Path) -> tuple[int, bytes] | None:
+    """Return a bounded size/digest identity for one regular executable file."""
+
+    try:
+        metadata = path.stat()
+        if not stat.S_ISREG(metadata.st_mode):
+            return None
+        digest = hashlib.sha256()
+        remaining = metadata.st_size
+        with path.open("rb") as executable:
+            while remaining:
+                chunk = executable.read(min(PROXY_DIGEST_CHUNK_SIZE, remaining))
+                if not chunk:
+                    return None
+                digest.update(chunk)
+                remaining -= len(chunk)
+        if path.stat().st_size != metadata.st_size:
+            return None
+        return metadata.st_size, digest.digest()
+    except (OSError, ValueError, RuntimeError):
+        return None
+
+
+def inventory_contains(expected: str, output: str | None) -> bool:
+    """Return whether a non-installing Rustup inventory lists the expected toolchain."""
+
+    if output is None:
+        return False
+    return any(
+        version_matches(expected, line.split(maxsplit=1)[0])
+        for line in output.splitlines()
+        if line.split(maxsplit=1)
+    )
+
+
+def commits_match(first: str | None, second: str | None) -> bool:
+    """Return whether two full or abbreviated commit identities agree."""
+
+    return bool(first and second) and (
+        first.startswith(second) or second.startswith(first)
+    )
+
+
+def executable_error(name: str, path: str | None, proxy_directory: Path) -> str | None:
+    """Return a missing or out-of-proxy diagnostic for one executable path."""
+
+    if path is None:
+        return f"{name} is missing from PATH"
+    if name == "rustup":
+        return None
+    if not same_directory(Path(path).parent, proxy_directory):
+        return (
+            f"{name} is selected at {path!r} outside rustup proxy directory "
+            f"{str(proxy_directory)!r}"
+        )
+    return None
+
+
+def evaluate(
+    expected: str,
+    *,
+    rustup_available: bool,
+    rustup_error: str | None = None,
+    active_toolchain: str | None,
+    override: str | None,
+    proxy_directory: Path,
+    evidence: tuple[ToolEvidence, ...],
+) -> list[str]:
+    """Return every mismatch so the report includes expected and actual facts."""
+
+    errors: list[str] = []
+    if not rustup_available:
+        errors.append("rustup is missing from PATH")
+    elif rustup_error:
+        errors.append(rustup_error)
+    if override and not version_matches(expected, override):
+        errors.append(
+            f"RUSTUP_TOOLCHAIN override is {override!r}; expected {expected!r}"
+        )
+    if not version_matches(expected, active_toolchain):
+        errors.append(
+            f"active rustup toolchain is {active_toolchain or '<unavailable>'!r}; "
+            f"expected {expected!r}"
+        )
+
+    for tool in evidence:
+        path_error = executable_error(tool.name, tool.path, proxy_directory)
+        if path_error:
+            errors.append(path_error)
+        if tool.output is None:
+            errors.append(f"{tool.name} did not report an identity")
+    rustc = next((tool for tool in evidence if tool.name == "rustc"), None)
+    cargo = next((tool for tool in evidence if tool.name == "cargo"), None)
+    clippy = next((tool for tool in evidence if tool.name == "clippy"), None)
+    rustfmt = next((tool for tool in evidence if tool.name == "rustfmt"), None)
+    if rustc and rustc.release != expected:
+        errors.append(
+            f"rustc release is {rustc.release or '<unavailable>'!r}; expected {expected!r}"
+        )
+    if cargo and cargo.release != expected:
+        errors.append(
+            f"cargo release is {cargo.release or '<unavailable>'!r}; expected {expected!r}"
+        )
+    expected_clippy = f"0.1.{expected.split('.')[1]}"
+    if clippy and clippy.release != expected_clippy:
+        errors.append(
+            f"clippy release is {clippy.release or '<unavailable>'!r}; "
+            f"expected {expected_clippy!r} for Rust {expected}"
+        )
+    if rustc and rustfmt and rustc.commit and rustfmt.commit:
+        if not commits_match(rustc.commit, rustfmt.commit):
+            errors.append(
+                f"rustfmt commit {rustfmt.commit!r} does not match rustc commit "
+                f"{rustc.commit!r}"
+            )
+    elif rustfmt:
+        errors.append("rustfmt did not report a commit identity")
+    if clippy and not clippy.commit:
+        errors.append("clippy did not report a commit identity")
+    elif rustc and clippy and rustc.commit and clippy.commit:
+        if not commits_match(rustc.commit, clippy.commit):
+            errors.append(
+                f"clippy commit {clippy.commit!r} does not match rustc commit "
+                f"{rustc.commit!r}"
+            )
+    return errors
+
+
+def run(
+    command: list[str], root: Path, *, timeout: int = 20
+) -> subprocess.CompletedProcess[str] | None:
+    """Run one bounded identity probe without mutating repository state."""
+
+    try:
+        return subprocess.run(
+            command,
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def output_of(result: subprocess.CompletedProcess[str] | None) -> str | None:
+    """Return combined command output when the probe completed successfully."""
+
+    if result is None or result.returncode != 0:
+        return None
+    return f"{result.stdout}{result.stderr}".strip()
+
+
+def evidence_for(
+    name: str, path: str | None, arguments: list[str], root: Path
+) -> ToolEvidence:
+    """Capture one validated executable's bounded version output."""
+
+    output = output_of(run([path, *arguments], root)) if path else None
+    release = None
+    commit = None
+    if output:
+        if name in {"rustc", "cargo"}:
+            match = RELEASE_RE.search(output)
+            release = match.group(1) if match else None
+            if name == "cargo" and release is None:
+                match = re.search(r"^cargo\s+(\d+\.\d+\.\d+)", output)
+                release = match.group(1) if match else None
+            match = re.search(r"commit-hash:\s*([0-9a-f]{10,40})", output)
+            commit = match.group(1) if match else None
+        elif name == "clippy":
+            match = re.search(r"^clippy\s+(\d+\.\d+\.\d+)", output)
+            release = match.group(1) if match else None
+            match = COMMIT_RE.search(output)
+            commit = match.group(1) if match else None
+        else:
+            match = COMMIT_RE.search(output)
+            commit = match.group(1) if match else None
+    return ToolEvidence(name, path, output, release, commit)
+
+
+def preflight(root: Path, *, install: bool) -> int:
+    """Run the repository preflight and print all expected/actual identities."""
+
+    expected = read_declared_channel(root / "rust-toolchain.toml")
+    cargo_home = Path(os.environ.get("CARGO_HOME", Path.home() / ".cargo"))
+    proxy_directory = cargo_home / "bin"
+    paths = {
+        "rustup": shutil.which("rustup"),
+        "rustc": shutil.which("rustc"),
+        "cargo": shutil.which("cargo"),
+        "cargo-clippy": shutil.which("cargo-clippy"),
+        "rustfmt": shutil.which("rustfmt"),
+    }
+    rustup_path = paths["rustup"]
+    path_errors = {
+        name: error
+        for name, path in paths.items()
+        if name != "rustup"
+        if (error := executable_error(name, path, proxy_directory))
+    }
+    rustup_error = "rustup is missing from PATH" if rustup_path is None else None
+    if rustup_path and not path_errors:
+        rustup_executable = Path(rustup_path)
+        rustup_digest: tuple[int, bytes] | None = None
+        try:
+            same_backing_executable = True
+            for name in ("rustc", "cargo", "cargo-clippy", "rustfmt"):
+                candidate = Path(paths[name])
+                if rustup_executable.samefile(candidate):
+                    continue
+                if rustup_digest is None:
+                    rustup_digest = executable_digest(rustup_executable)
+                if rustup_digest is None or executable_digest(candidate) != rustup_digest:
+                    same_backing_executable = False
+                    break
+        except (OSError, ValueError, RuntimeError):
+            same_backing_executable = False
+        if not same_backing_executable:
+            rustup_error = (
+                "rustup is not the executable backing the validated Rust proxies"
+            )
+    override = os.environ.get("RUSTUP_TOOLCHAIN")
+    override_error = None
+    if override and not version_matches(expected, override):
+        override_error = (
+            f"RUSTUP_TOOLCHAIN override is {override!r}; expected {expected!r}"
+        )
+    active = None
+    install_error = None
+    evidence = (
+        ToolEvidence("rustc", paths["rustc"], None),
+        ToolEvidence("cargo", paths["cargo"], None),
+        ToolEvidence("clippy", paths["cargo-clippy"], None),
+        ToolEvidence("rustfmt", paths["rustfmt"], None),
+    )
+    manager_blockers = list(path_errors.values())
+    if rustup_error:
+        manager_blockers.insert(0, rustup_error)
+    if override_error:
+        manager_blockers.append(override_error)
+    expected_installed = False
+    if rustup_path and not manager_blockers:
+        inventory_result = run([rustup_path, "toolchain", "list"], root)
+        inventory_output = output_of(inventory_result)
+        if inventory_result is None or inventory_result.returncode != 0:
+            rustup_error = "rustup did not report installed toolchains"
+        elif not install and not inventory_contains(expected, inventory_output):
+            rustup_error = f"expected Rust toolchain {expected!r} is not installed"
+        elif install:
+            result = run(
+                [
+                    rustup_path,
+                    "toolchain",
+                    "install",
+                    expected,
+                    "--profile",
+                    "minimal",
+                    "--component",
+                    "clippy,rustfmt",
+                ],
+                root,
+                timeout=120,
+            )
+            if result is None or result.returncode != 0:
+                install_error = "rustup toolchain install failed"
+            else:
+                inventory_result = run([rustup_path, "toolchain", "list"], root)
+                inventory_output = output_of(inventory_result)
+                if not inventory_contains(expected, inventory_output):
+                    rustup_error = (
+                        "rustup install did not make the expected toolchain available"
+                    )
+                else:
+                    expected_installed = True
+        else:
+            expected_installed = True
+    if (
+        rustup_path
+        and expected_installed
+        and not path_errors
+        and not rustup_error
+        and not override_error
+    ):
+        rustup_result = run([rustup_path, "show", "active-toolchain"], root)
+        active_output = output_of(rustup_result)
+        active = active_output.split()[0] if active_output else None
+        if rustup_result is None or rustup_result.returncode != 0:
+            rustup_error = "rustup did not report an active toolchain"
+        evidence = (
+            evidence_for("rustc", paths["rustc"], ["-Vv"], root),
+            evidence_for("cargo", paths["cargo"], ["-Vv"], root),
+            evidence_for(
+                "clippy", paths["cargo-clippy"], ["--version", "--verbose"], root
+            ),
+            evidence_for(
+                "rustfmt", paths["rustfmt"], ["--version", "--verbose"], root
+            ),
+        )
+
+    errors = evaluate(
+        expected,
+        rustup_available=rustup_path is not None,
+        rustup_error=rustup_error,
+        active_toolchain=active,
+        override=override,
+        proxy_directory=proxy_directory,
+        evidence=evidence,
+    )
+    if install_error:
+        errors.insert(0, install_error)
+
+    print(f"Rust toolchain preflight: expected {expected}")
+    print(f"  rustup: {rustup_path or '<missing>'}")
+    print(f"  active: {active or '<unavailable>'}")
+    if override:
+        print(f"  RUSTUP_TOOLCHAIN override: {override}")
+    for tool in evidence:
+        actual = tool.output.replace("\n", " | ") if tool.output else "<unavailable>"
+        print(f"  {tool.name}: path={tool.path or '<missing>'}; {actual}")
+    if errors:
+        print("Rust toolchain preflight failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print("Rust toolchain preflight passed")
+    return 0
+
+
+def self_test() -> None:
+    """Exercise declaration and mismatch boundaries without invoking Rust."""
+
+    expected = "1.98.0"
+    historical = "1.93.1"
+    expected_clippy = f"0.1.{expected.split('.')[1]}"
+    historical_clippy = f"0.1.{historical.split('.')[1]}"
+    with __import__("tempfile").TemporaryDirectory() as temporary:
+        toolchain = Path(temporary) / "rust-toolchain.toml"
+        toolchain.write_text(f'channel = "{expected}"\n', encoding="utf-8")
+        assert read_declared_channel(toolchain) == expected
+        for declaration in ('channel = "stable"\n',):
+            toolchain.write_text(declaration, encoding="utf-8")
+            try:
+                read_declared_channel(toolchain)
+            except PreflightError:
+                pass
+            else:
+                raise AssertionError(f"accepted invalid declaration {declaration!r}")
+        toolchain.write_text(f'channel = "{historical}"\n', encoding="utf-8")
+        assert read_declared_channel(toolchain) == historical
+        toolchain.write_text(
+            f'channel = "{expected}"\nchannel = "{expected}"\n', encoding="utf-8"
+        )
+        try:
+            read_declared_channel(toolchain)
+        except PreflightError:
+            pass
+        else:
+            raise AssertionError("accepted duplicate channel declarations")
+
+    with __import__("tempfile").TemporaryDirectory() as temporary:
+        existing = Path(temporary) / "cargo-home" / "bin"
+        existing.mkdir(parents=True)
+        assert same_directory(existing, existing)
+        case_variant = existing.with_name("BIN")
+        if case_variant.exists():
+            assert same_directory(existing, case_variant)
+        symlink = Path(temporary) / "proxy-link"
+        try:
+            symlink.symlink_to(existing, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pass
+        else:
+            assert same_directory(existing, symlink)
+        with patch.object(Path, "samefile", side_effect=PermissionError("denied")):
+            assert not same_directory(existing, existing)
+        with patch.object(
+            Path, "samefile", side_effect=FileNotFoundError("missing")
+        ), patch.object(Path, "resolve", side_effect=PermissionError("denied")):
+            assert not same_directory(existing, existing)
+        missing = Path(temporary) / "missing"
+        assert same_directory(missing, missing)
+        assert not same_directory(missing, Path(temporary) / "other-missing")
+
+    proxy = Path("/rustup/.cargo/bin")
+    evidence = (
+        ToolEvidence("rustc", str(proxy / "rustc"), "", historical, "rustc-hash"),
+        ToolEvidence("cargo", str(proxy / "cargo"), "", historical, None),
+        ToolEvidence(
+            "clippy", str(proxy / "cargo-clippy"), "", historical_clippy, "rustc-hash"
+        ),
+        ToolEvidence("rustfmt", str(proxy / "rustfmt"), "", None, "rustc-hash"),
+    )
+    errors = evaluate(
+        expected,
+        rustup_available=False,
+        active_toolchain=historical,
+        override=historical,
+        proxy_directory=proxy,
+        evidence=evidence,
+    )
+    assert any("rustup is missing" in error for error in errors)
+    assert any("RUSTUP_TOOLCHAIN override" in error for error in errors)
+    assert any("rustc release" in error for error in errors)
+    assert any("cargo release" in error for error in errors)
+    assert any("clippy release" in error for error in errors)
+    valid_evidence = (
+        ToolEvidence("rustc", str(proxy / "rustc"), "", expected, "abcdef1234567890"),
+        ToolEvidence("cargo", str(proxy / "cargo"), "", expected, "cargo-hash"),
+        ToolEvidence(
+            "clippy",
+            str(proxy / "cargo-clippy"),
+            "",
+            expected_clippy,
+            "abcdef1234567890",
+        ),
+        ToolEvidence(
+            "rustfmt", str(proxy / "rustfmt"), "", None, "abcdef1234567890"
+        ),
+    )
+    valid_errors = evaluate(
+        expected,
+        rustup_available=True,
+        active_toolchain=f"{expected}-x86_64-pc-windows-msvc",
+        override=expected,
+        proxy_directory=proxy,
+        evidence=valid_evidence,
+    )
+    assert not valid_errors
+    for clippy_commit, expected_error in (
+        ("abcdef1234", None),
+        ("different-clippy-commit", "clippy commit"),
+        (None, "clippy did not report a commit identity"),
+    ):
+        candidate_evidence = tuple(
+            ToolEvidence(
+                tool.name,
+                tool.path,
+                tool.output,
+                tool.release,
+                clippy_commit,
+            )
+            if tool.name == "clippy"
+            else tool
+            for tool in valid_evidence
+        )
+        candidate_errors = evaluate(
+            expected,
+            rustup_available=True,
+            active_toolchain=f"{expected}-x86_64-pc-windows-msvc",
+            override=expected,
+            proxy_directory=proxy,
+            evidence=candidate_evidence,
+        )
+        if expected_error is None:
+            assert not candidate_errors
+        else:
+            assert any(expected_error in error for error in candidate_errors)
+    precedence_errors = evaluate(
+        expected,
+        rustup_available=True,
+        active_toolchain=expected,
+        override=None,
+        proxy_directory=proxy,
+        evidence=(
+            ToolEvidence("rustc", str(proxy / "rustc"), "", expected, "rustc-hash"),
+            ToolEvidence(
+                "cargo", "/opt/homebrew/bin/cargo", "", expected, "cargo-hash"
+            ),
+            ToolEvidence(
+                "clippy", str(proxy / "cargo-clippy"), "", expected_clippy, "rustc-hash"
+            ),
+            ToolEvidence("rustfmt", str(proxy / "rustfmt"), "", None, "rustc-hash"),
+        ),
+    )
+    assert any("cargo is selected" in error for error in precedence_errors)
+    for target in (
+        "x86_64-unknown-linux-gnu",
+        "x86_64-pc-windows-msvc",
+        "x86_64-apple-darwin",
+        "aarch64-apple-darwin",
+    ):
+        assert version_matches(expected, f"{expected}-{target}")
+    assert not version_matches(expected, f"{expected}-evil")
+    assert not version_matches(expected, f"{expected}-evil-wrapper-code")
+    linux_hostile = f"{expected}-x86_64-unknown-linux-evil"
+    darwin_hostile = f"{expected}-aarch64-apple-darwin-evil"
+    for hostile in (linux_hostile, darwin_hostile):
+        assert not version_matches(expected, hostile)
+        assert not inventory_contains(expected, f"{hostile} (default)\n")
+    assert not version_matches(expected, "stable")
+    assert any(
+        "active rustup toolchain" in error
+        for error in evaluate(
+            expected,
+            rustup_available=True,
+            active_toolchain=linux_hostile,
+            override=expected,
+            proxy_directory=proxy,
+            evidence=(),
+        )
+    )
+
+    with __import__("tempfile").TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        cargo_home = root / "cargo"
+        proxy = cargo_home / "bin"
+        outside = root / "outside"
+        proxy.mkdir(parents=True)
+        outside.mkdir()
+        (root / "rust-toolchain.toml").write_text(
+            f'channel = "{expected}"\n', encoding="utf-8"
+        )
+        executable_names = ("rustup", "rustc", "cargo", "cargo-clippy", "rustfmt")
+        valid_paths = {name: str(proxy / name) for name in executable_names}
+        rustup_target = outside / "rustup-manager"
+        rustup_target.write_text("rustup manager\n", encoding="utf-8")
+
+        def link_to_rustup(path: Path) -> bool:
+            try:
+                path.symlink_to(rustup_target)
+                return True
+            except (OSError, NotImplementedError):
+                if path.exists() or path.is_symlink():
+                    path.unlink()
+                path.hardlink_to(rustup_target)
+                return False
+
+        proxy_links = [
+            link_to_rustup(Path(valid_paths[name]))
+            for name in ("rustc", "cargo", "cargo-clippy", "rustfmt")
+        ]
+        symlinked_proxies = all(proxy_links)
+        link_to_rustup(Path(valid_paths["rustup"]))
+        current_paths = valid_paths.copy()
+        requested: list[str] = []
+        calls: list[list[str]] = []
+        sentinels: dict[str, Path] = {}
+        manager_state = {
+            "installed": True,
+            "install_returncode": 0,
+            "install_timeout": False,
+        }
+
+        def fake_which(command: str) -> str | None:
+            requested.append(command)
+            return current_paths.get(command)
+
+        def identity_output(name: str) -> str:
+            if name == "rustup":
+                return f"{expected}-x86_64-pc-windows-msvc (default)\n"
+            if name == "rustc":
+                return (
+                    "rustc 1.98.0\n"
+                    "commit-hash: abcdef123456\n"
+                    "release: 1.98.0\n"
+                )
+            if name == "cargo":
+                return (
+                    "cargo 1.98.0\n"
+                    "release: 1.98.0\n"
+                    "commit-hash: abcdef123456\n"
+                )
+            if name == "cargo-clippy":
+                return "clippy 0.1.98 (abcdef123456 2026-08-18)\n"
+            return "rustfmt 1.9.0-stable (abcdef123456 2026-08-18)\n"
+
+        def tracking_run(
+            command: list[str], run_root: Path, *, timeout: int = 20
+        ) -> subprocess.CompletedProcess[str] | None:
+            del run_root, timeout
+            executable = os.path.normcase(str(Path(command[0])))
+            name = next(
+                name
+                for name, path in current_paths.items()
+                if os.path.normcase(str(Path(path))) == executable
+            )
+            calls.append(command)
+            if name in sentinels:
+                sentinels[name].write_text("invoked\n", encoding="utf-8")
+            if name == "rustup" and command[1:3] == ["toolchain", "list"]:
+                inventory = (
+                    f"{expected}-x86_64-pc-windows-msvc (default)\n"
+                    if manager_state["installed"]
+                    else "stable-x86_64-pc-windows-msvc (default)\n"
+                )
+                return subprocess.CompletedProcess(
+                    command, 0, stdout=inventory, stderr=""
+                )
+            if name == "rustup" and command[1:3] == ["toolchain", "install"]:
+                if manager_state["install_timeout"]:
+                    return None
+                returncode = manager_state["install_returncode"]
+                if returncode == 0:
+                    manager_state["installed"] = True
+                return subprocess.CompletedProcess(
+                    command, returncode, stdout="", stderr=""
+                )
+            return subprocess.CompletedProcess(
+                command, 0, stdout=identity_output(name), stderr=""
+            )
+
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=False) == 0
+        assert set(requested) == set(executable_names)
+        clippy_calls = [
+            call for call in calls if Path(call[0]).stem.lower() == "cargo-clippy"
+        ]
+        assert clippy_calls == [
+            [valid_paths["cargo-clippy"], "--version", "--verbose"]
+        ]
+        assert not any(
+            Path(call[0]).stem.lower() == "cargo" and "clippy" in call
+            for call in calls
+        )
+
+        homebrew_rustup = outside / "homebrew-rustup"
+        link_to_rustup(homebrew_rustup)
+        current_paths["rustup"] = str(homebrew_rustup)
+        requested.clear()
+        calls.clear()
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=False) == 0
+        assert any(call[0] == str(homebrew_rustup) for call in calls)
+        if symlinked_proxies:
+            assert all(
+                Path(valid_paths[name]).is_symlink()
+                for name in ("rustc", "cargo", "cargo-clippy", "rustfmt")
+            )
+
+        manager_state["installed"] = True
+        manager_state["install_returncode"] = 0
+        manager_state["install_timeout"] = False
+        current_paths = valid_paths.copy()
+        current_paths["rustup"] = str(homebrew_rustup)
+        requested.clear()
+        calls.clear()
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=True) == 0
+        assert calls[0][1:3] == ["toolchain", "list"]
+        assert calls[1][1:3] == ["toolchain", "install"]
+        assert calls[1][3] == expected
+        assert calls[2][1:3] == ["toolchain", "list"]
+        assert calls[3][1:3] == ["show", "active-toolchain"]
+
+        manager_state["install_returncode"] = 1
+        requested.clear()
+        calls.clear()
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=True) == 1
+        assert [call[1:3] for call in calls] == [
+            ["toolchain", "list"],
+            ["toolchain", "install"],
+        ]
+        manager_state["install_returncode"] = 0
+
+        current_paths = valid_paths.copy()
+        current_paths["rustup"] = str(homebrew_rustup)
+        requested.clear()
+        calls.clear()
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": historical},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=True) == 1
+        assert set(requested) == set(executable_names)
+        assert not calls, "invalid override allowed a Rustup subprocess"
+
+        hostile_install_sentinel = outside / "hostile-override-install-invoked"
+        sentinels = {"rustup": hostile_install_sentinel}
+        requested.clear()
+        calls.clear()
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": linux_hostile},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=True) == 1
+        assert set(requested) == set(executable_names)
+        assert not calls, "hostile target override allowed a Rustup subprocess"
+        assert not hostile_install_sentinel.exists(), (
+            "hostile target override reached Rustup install"
+        )
+        sentinels = {}
+
+        manager_state["installed"] = False
+        manager_state["install_returncode"] = 0
+        manager_state["install_timeout"] = False
+        requested.clear()
+        calls.clear()
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=False) == 1
+        assert [call[1:3] for call in calls] == [["toolchain", "list"]]
+
+        requested.clear()
+        calls.clear()
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=True) == 0
+        assert calls[0][1:3] == ["toolchain", "list"]
+        assert calls[1][1:3] == ["toolchain", "install"]
+        assert calls[1][3] == expected
+        assert calls[2][1:3] == ["toolchain", "list"]
+        assert calls[3][1:3] == ["show", "active-toolchain"]
+
+        manager_state["installed"] = False
+        manager_state["install_returncode"] = 1
+        requested.clear()
+        calls.clear()
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=True) == 1
+        assert [call[1:3] for call in calls] == [
+            ["toolchain", "list"],
+            ["toolchain", "install"],
+        ]
+
+        manager_state["install_returncode"] = 0
+        manager_state["install_timeout"] = True
+        requested.clear()
+        calls.clear()
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=True) == 1
+        assert [call[1:3] for call in calls] == [
+            ["toolchain", "list"],
+            ["toolchain", "install"],
+        ]
+        manager_state["installed"] = True
+        manager_state["install_timeout"] = False
+
+        windows_proxy_paths = valid_paths.copy()
+        proxy_bytes = rustup_target.read_bytes()
+        for name in ("rustc", "cargo", "cargo-clippy", "rustfmt"):
+            proxy_path = Path(windows_proxy_paths[name])
+            proxy_path.unlink()
+            proxy_path.write_bytes(proxy_bytes)
+        current_paths = windows_proxy_paths.copy()
+        current_paths["rustup"] = str(homebrew_rustup)
+        requested.clear()
+        calls.clear()
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=False) == 0
+        assert any(call[0] == str(homebrew_rustup) for call in calls)
+
+        with patch.object(Path, "stat", side_effect=PermissionError("denied")):
+            assert executable_digest(homebrew_rustup) is None
+            requested.clear()
+            calls.clear()
+            with patch.dict(
+                os.environ,
+                {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+                clear=False,
+            ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+                f"{__name__}.run", side_effect=tracking_run
+            ):
+                assert preflight(root, install=True) == 1
+        assert not calls, "stat failure allowed a Rustup probe"
+        with patch.object(Path, "open", side_effect=PermissionError("denied")):
+            assert executable_digest(homebrew_rustup) is None
+
+        fake_rustup = outside / "fake-rustup"
+        fake_rustup.write_text("rustup invalid\n", encoding="utf-8")
+        assert len(fake_rustup.read_bytes()) == len(rustup_target.read_bytes())
+        fake_rustup_sentinel = outside / "fake-rustup-invoked"
+        current_paths = valid_paths.copy()
+        current_paths["rustup"] = str(fake_rustup)
+        sentinels = {"rustup": fake_rustup_sentinel}
+        requested.clear()
+        calls.clear()
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=True) == 1
+        assert set(requested) == set(executable_names)
+        assert not calls, "untrusted rustup was probed or installed"
+        assert not fake_rustup_sentinel.exists(), "untrusted rustup was invoked"
+
+        direct_tool_names = ("rustc", "cargo", "cargo-clippy", "rustfmt")
+        for invalid_name in direct_tool_names:
+            current_paths = valid_paths.copy()
+            current_paths["rustup"] = str(homebrew_rustup)
+            invalid_path = outside / invalid_name
+            invalid_path.write_text("untrusted executable\n", encoding="utf-8")
+            current_paths[invalid_name] = str(invalid_path)
+            sentinels = {invalid_name: outside / f"{invalid_name}-invoked"}
+            requested.clear()
+            calls.clear()
+            with patch.dict(
+                os.environ,
+                {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+                clear=False,
+            ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+                f"{__name__}.run", side_effect=tracking_run
+            ):
+                assert preflight(root, install=True) == 1
+            assert set(requested) == set(executable_names)
+            assert not calls, f"{invalid_name} provenance allowed a probe"
+            assert not sentinels[invalid_name].exists(), (
+                f"out-of-proxy {invalid_name} was invoked"
+            )
+
+        current_paths = valid_paths.copy()
+        current_paths.pop("rustup")
+        requested.clear()
+        calls.clear()
+        with patch.dict(
+            os.environ,
+            {"CARGO_HOME": str(cargo_home), "RUSTUP_TOOLCHAIN": expected},
+            clear=False,
+        ), patch(f"{__name__}.shutil.which", side_effect=fake_which), patch(
+            f"{__name__}.run", side_effect=tracking_run
+        ):
+            assert preflight(root, install=True) == 1
+        assert set(requested) == set(executable_names)
+        assert not calls, "missing rustup was probed"
+    print("Rust toolchain preflight self-test passed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--install",
+        action="store_true",
+        help="install the declared toolchain through rustup without changing its default",
+    )
+    parser.add_argument(
+        "--self-test", action="store_true", help="run offline parser/mismatch tests"
+    )
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        return 0
+    return preflight(Path(__file__).resolve().parents[2], install=args.install)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/04-docs.yml
+++ b/.github/workflows/04-docs.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Setup Rust
+      - name: Rust toolchain preflight
         run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+          python3 .github/scripts/verify-rust-toolchain.py --self-test
+          python3 .github/scripts/verify-rust-toolchain.py --install
 
       - name: Repository source policy lints
         timeout-minutes: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,6 @@ permissions:
   issues: read
   pull-requests: read
 
-env:
-  RUSTUP_TOOLCHAIN: "1.93.1"
-
 jobs:
   verify:
     name: verify
@@ -33,10 +30,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Setup Rust
+      - name: Rust toolchain preflight
         run: |
-          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal --component clippy,rustfmt
-          rustup default "$RUSTUP_TOOLCHAIN"
+          python3 .github/scripts/verify-rust-toolchain.py --self-test
+          python3 .github/scripts/verify-rust-toolchain.py --install
 
       - name: Repository source policy lints
         timeout-minutes: 2
@@ -141,11 +138,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Setup Rust
+      - name: Rust toolchain preflight
         shell: bash
         run: |
-          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
-          rustup default "$RUSTUP_TOOLCHAIN"
+          python3 .github/scripts/verify-rust-toolchain.py --self-test
+          python3 .github/scripts/verify-rust-toolchain.py --install
 
       - name: Holistic classified worktree agent E2E
         timeout-minutes: 10

--- a/.github/workflows/optional-parser-pack.yml
+++ b/.github/workflows/optional-parser-pack.yml
@@ -28,9 +28,6 @@ concurrency:
   group: optional-parser-pack-${{ github.sha }}
   cancel-in-progress: false
 
-env:
-  RUSTUP_TOOLCHAIN: 1.93.1
-
 jobs:
   construct:
     if: >-
@@ -49,12 +46,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install pinned Rust toolchain
+      - name: Rust toolchain preflight
         shell: pwsh
         run: |
-          rustup toolchain install $env:RUSTUP_TOOLCHAIN --profile minimal
+          python3 .github/scripts/verify-rust-toolchain.py --self-test
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          rustup default $env:RUSTUP_TOOLCHAIN
+          python3 .github/scripts/verify-rust-toolchain.py --install
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Repository source policy lints
@@ -909,12 +906,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install pinned Rust toolchain
+      - name: Rust toolchain preflight
         shell: pwsh
         run: |
-          rustup toolchain install $env:RUSTUP_TOOLCHAIN --profile minimal
+          python3 .github/scripts/verify-rust-toolchain.py --self-test
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          rustup default $env:RUSTUP_TOOLCHAIN
+          python3 .github/scripts/verify-rust-toolchain.py --install
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Bind exact clean candidate identity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ permissions:
 
 env:
   RELEASE_VERSION: ${{ inputs.version }}
-  RUSTUP_TOOLCHAIN: "1.93.1"
 
 concurrency:
   group: projectatlas-release-${{ inputs.version }}
@@ -113,10 +112,10 @@ jobs:
             exit 1
           fi
 
-      - name: Setup Rust
+      - name: Rust toolchain preflight
         run: |
-          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal --component clippy,rustfmt
-          rustup default "$RUSTUP_TOOLCHAIN"
+          python3 .github/scripts/verify-rust-toolchain.py --self-test
+          python3 .github/scripts/verify-rust-toolchain.py --install
 
       - name: Repository source policy lints
         timeout-minutes: 2
@@ -227,10 +226,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Setup Rust
+      - name: Rust toolchain preflight
         run: |
-          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal
-          rustup default "$RUSTUP_TOOLCHAIN"
+          python3 .github/scripts/verify-rust-toolchain.py --self-test
+          python3 .github/scripts/verify-rust-toolchain.py --install
 
       - name: Build
         run: cargo build --locked -p projectatlas-cli --release
@@ -280,11 +279,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Setup Rust
+      - name: Rust toolchain preflight
         shell: pwsh
         run: |
-          rustup toolchain install "$env:RUSTUP_TOOLCHAIN" --profile minimal
-          rustup default "$env:RUSTUP_TOOLCHAIN"
+          python3 .github/scripts/verify-rust-toolchain.py --self-test
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python3 .github/scripts/verify-rust-toolchain.py --install
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Build
         shell: pwsh

--- a/crates/projectatlas-cli/src/derived_snapshot_archive.rs
+++ b/crates/projectatlas-cli/src/derived_snapshot_archive.rs
@@ -553,7 +553,7 @@ fn decode_hex_array<const N: usize>(value: &str, label: &str) -> Result<[u8; N],
         )));
     }
     let mut decoded = [0_u8; N];
-    for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+    for (index, pair) in value.as_bytes().as_chunks::<2>().0.iter().enumerate() {
         decoded[index] = decode_nibble(pair[0])
             .and_then(|high| decode_nibble(pair[1]).map(|low| (high << 4) | low))
             .ok_or_else(|| CliError::InvalidInput(format!("{label} is not hexadecimal")))?;

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -10072,6 +10072,7 @@ impl ProjectAtlasMcpServer {
     }
 }
 
+#[allow(clippy::unused_async_trait_impl)]
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for ProjectAtlasMcpServer {
     fn get_info(&self) -> ServerInfo {

--- a/crates/projectatlas-cli/src/optional_parser_lifecycle.rs
+++ b/crates/projectatlas-cli/src/optional_parser_lifecycle.rs
@@ -2108,10 +2108,9 @@ fn parse_windows_tombstone_name(name: &str) -> Option<(InstalledSlotCleanupState
     let (state, remainder) =
         if let Some(remainder) = name.strip_prefix(WINDOWS_REMOVING_TOMBSTONE_PREFIX) {
             (InstalledSlotCleanupState::ProfilePending, remainder)
-        } else if let Some(remainder) = name.strip_prefix(WINDOWS_CLEANED_TOMBSTONE_PREFIX) {
-            (InstalledSlotCleanupState::ProfileCleaned, remainder)
         } else {
-            return None;
+            let remainder = name.strip_prefix(WINDOWS_CLEANED_TOMBSTONE_PREFIX)?;
+            (InstalledSlotCleanupState::ProfileCleaned, remainder)
         };
     if remainder.len() <= WINDOWS_TOMBSTONE_ARTIFACT_PREFIX_HEX_CHARS {
         return None;

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -72,7 +72,7 @@ const SUPERVISOR_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 /// Absolute deadline shared by both fixtures for one artifact grammar admission.
 const ARTIFACT_ADMISSION_TIMEOUT: Duration = Duration::from_secs(15);
 /// Aggregate ceiling for one complete lifecycle/release artifact admission.
-const ARTIFACT_ADMISSION_AGGREGATE_TIMEOUT: Duration = Duration::from_secs(20 * 60);
+const ARTIFACT_ADMISSION_AGGREGATE_TIMEOUT: Duration = Duration::from_mins(20);
 /// Maximum interval without meaningful worker progress during artifact admission.
 const ARTIFACT_ADMISSION_NO_PROGRESS_TIMEOUT: Duration = Duration::from_secs(5);
 /// Test-only launch allowance for hostile fixtures that do not stall admission.
@@ -5846,7 +5846,7 @@ mod tests {
         assert_eq!(ARTIFACT_ADMISSION_TIMEOUT, Duration::from_secs(15));
         assert_eq!(
             ARTIFACT_ADMISSION_AGGREGATE_TIMEOUT,
-            Duration::from_secs(20 * 60)
+            Duration::from_mins(20)
         );
         assert_eq!(
             ARTIFACT_ADMISSION_NO_PROGRESS_TIMEOUT,

--- a/crates/projectatlas-cli/src/runtime.rs
+++ b/crates/projectatlas-cli/src/runtime.rs
@@ -121,7 +121,7 @@ pub(crate) const MAX_PURPOSE_REVIEW_INPUT_FILE_BYTES: u64 = 2 * 1_024 * 1_024;
 /// Stable serialized recommendation for host-owned purpose curator selection.
 pub(crate) const PURPOSE_CURATOR_RECOMMENDED_REASONING: &str = "lowest_reliable_host_supported";
 /// Default whole-operation deadline when no narrower parser limit is supplied.
-const DEFAULT_INDEX_WORK_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const DEFAULT_INDEX_WORK_TIMEOUT: Duration = Duration::from_mins(30);
 /// Maximum UTF-8 source bytes retained while one publication is staged.
 const MAX_STAGED_TEXT_BYTES: u64 = 512 * 1024 * 1024;
 /// Maximum aggregate retained string bytes across one in-memory publication batch.

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -123,6 +123,7 @@ const OPENSPEC_DIR_NAME: &str = "openspec";
 const AGENT_INTEGRATION_DOC_FILE_NAME: &str = "agent-integration.md";
 const WORKFLOW_DOC_FILE_NAME: &str = "workflow.md";
 const OPTIONAL_PARSER_PACK_WORKFLOW_FILE_NAME: &str = "optional-parser-pack.yml";
+const DOCS_WORKFLOW_FILE_NAME: &str = "04-docs.yml";
 const AUTO_RELEASE_WORKFLOW_FILE_NAME: &str = "03-auto-release.yml";
 const CARGO_LOCK_FILE_NAME: &str = "Cargo.lock";
 const FILTERED_CUSTOM_HARNESS_COMMAND: &str = "cargo test --locked -p projectatlas-cli --all-features task_errors_classify_only_typed_cancellation_as_canceled";
@@ -7403,7 +7404,7 @@ fn repository_guidance_keeps_atlas_state_local_and_legacy_export_optional()
         workspace_root
             .join(".github")
             .join("workflows")
-            .join("04-docs.yml"),
+            .join(DOCS_WORKFLOW_FILE_NAME),
     )?;
     let auto_release_workflow = fs::read_to_string(
         workspace_root
@@ -8553,6 +8554,8 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
     let mermaid_package = fs::read_to_string(mermaid_parser.join(PACKAGE_JSON_FILE_NAME))?;
     let mermaid_lock = fs::read_to_string(mermaid_parser.join("package-lock.json"))?;
     let ci = fs::read_to_string(workflows.join("ci.yml"))?;
+    let docs_workflow = fs::read_to_string(workflows.join(DOCS_WORKFLOW_FILE_NAME))?;
+    let optional_parser_workflow = fs::read_to_string(workflows.join("optional-parser-pack.yml"))?;
     let release = fs::read_to_string(workflows.join("release.yml"))?;
     let issueops_workflow = fs::read_to_string(workflows.join("issueops.yml"))?;
     let hook = fs::read_to_string(
@@ -8573,6 +8576,8 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
     let workflow_docs =
         fs::read_to_string(workspace_root.join("docs").join(WORKFLOW_DOC_FILE_NAME))?;
     let toolchain = fs::read_to_string(workspace_root.join("rust-toolchain.toml"))?;
+    let rust_toolchain_preflight =
+        fs::read_to_string(github.join("scripts").join("verify-rust-toolchain.py"))?;
     let issue_map = fs::read_to_string(
         workspace_root
             .join(OPENSPEC_DIR_NAME)
@@ -8638,6 +8643,60 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
         if !issueops.contains(required) {
             return Err(io::Error::other(format!(
                 "IssueOps is missing lean checklist behavior {required:?}"
+            ))
+            .into());
+        }
+    }
+    let rust_preflight_command = "python3 .github/scripts/verify-rust-toolchain.py --install";
+    for (name, workflow) in [
+        ("CI", ci.as_str()),
+        ("Docs", docs_workflow.as_str()),
+        ("optional-parser-pack", optional_parser_workflow.as_str()),
+        ("release", release.as_str()),
+    ] {
+        if !workflow.contains(rust_preflight_command) {
+            return Err(io::Error::other(format!(
+                "{name} workflow omitted the shared Rust toolchain preflight"
+            ))
+            .into());
+        }
+        let preflight = workflow
+            .find("- name: Rust toolchain preflight")
+            .ok_or_else(|| io::Error::other(format!("{name} omitted Rust preflight step")))?;
+        let first_cargo = workflow
+            .find("cargo ")
+            .ok_or_else(|| io::Error::other(format!("{name} omitted Rust command")))?;
+        if preflight > first_cargo {
+            return Err(
+                io::Error::other(format!("{name} Rust preflight must precede Rust work")).into(),
+            );
+        }
+        if workflow.contains("RUSTUP_TOOLCHAIN")
+            || workflow.contains("rustup default")
+            || workflow.contains("rustup toolchain install stable")
+        {
+            return Err(io::Error::other(format!(
+                "{name} retains a duplicated or floating Rust toolchain selection"
+            ))
+            .into());
+        }
+    }
+    if !hook.contains("python3 .github/scripts/verify-rust-toolchain.py") {
+        return Err(io::Error::other(
+            "local pre-push validation omitted the shared Rust toolchain preflight",
+        )
+        .into());
+    }
+    for required in [
+        "read_declared_channel",
+        "RUSTUP_TOOLCHAIN override",
+        "rustup is missing from PATH",
+        "Rust toolchain preflight passed",
+        "Rust toolchain preflight self-test passed",
+    ] {
+        if !rust_toolchain_preflight.contains(required) {
+            return Err(io::Error::other(format!(
+                "Rust toolchain preflight is missing boundary {required:?}"
             ))
             .into());
         }
@@ -9242,8 +9301,23 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
         )
         .into());
     }
-    if !toolchain.contains("channel = \"1.93.1\"") {
-        return Err(io::Error::other("Rust toolchain must be repository-owned and pinned").into());
+    let declared_channel = toolchain
+        .lines()
+        .find(|line| line.trim_start().starts_with("channel ="))
+        .and_then(|line| line.split('"').nth(1));
+    let declared_parts = declared_channel.map(|channel| channel.split('.').collect::<Vec<_>>());
+    if toolchain.matches("channel =").count() != 1
+        || declared_parts.as_ref().is_none_or(|parts| {
+            parts.len() != 3
+                || parts
+                    .iter()
+                    .any(|part| part.is_empty() || !part.bytes().all(|byte| byte.is_ascii_digit()))
+        })
+    {
+        return Err(io::Error::other(
+            "Rust toolchain must be repository-owned and pinned exactly once",
+        )
+        .into());
     }
 
     let rejected_terms = [
@@ -24938,10 +25012,7 @@ fn notify_watch_refreshes_symbols_after_file_change() -> Result<(), Box<dyn Erro
             if child.try_wait()?.is_none() {
                 child.kill()?;
             }
-            match child.wait() {
-                Ok(_status) => {}
-                Err(error) => return Err(error.into()),
-            }
+            let _status = child.wait()?;
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,
                 "projectatlas watch did not exit after file change",
@@ -33165,10 +33236,7 @@ fn run_mcp_stdio_with_env(
             if child.try_wait()?.is_none() {
                 child.kill()?;
             }
-            match child.wait() {
-                Ok(_status) => {}
-                Err(error) => return Err(error.into()),
-            }
+            let _status = child.wait()?;
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,
                 "projectatlas mcp did not exit after stdin closed",

--- a/crates/projectatlas-core/src/graph.rs
+++ b/crates/projectatlas-core/src/graph.rs
@@ -164,7 +164,7 @@ impl TryFrom<&str> for ProjectInstanceId {
             });
         }
         let mut bytes = [0_u8; 16];
-        for (index, pair) in compact.as_bytes().chunks_exact(2).enumerate() {
+        for (index, pair) in compact.as_bytes().as_chunks::<2>().0.iter().enumerate() {
             let high = decode_hex(pair[0]).ok_or(GraphContractError::InvalidProjectInstanceId {
                 reason: "identifier contains a non-hexadecimal digit",
             })?;

--- a/crates/projectatlas-db/src/derived_snapshot.rs
+++ b/crates/projectatlas-db/src/derived_snapshot.rs
@@ -1325,10 +1325,7 @@ fn required_index(
 
 /// Validate that a portable index addresses the supplied vector.
 fn require_vector_index(index: u32, length: usize, reason: &'static str) -> DbResult<()> {
-    if usize::try_from(index)
-        .ok()
-        .is_some_and(|index| index < length)
-    {
+    if usize::try_from(index).is_ok_and(|index| index < length) {
         Ok(())
     } else {
         invalid(reason)

--- a/crates/projectatlas-fs/src/lib.rs
+++ b/crates/projectatlas-fs/src/lib.rs
@@ -43,7 +43,7 @@ const DEFAULT_SCAN_MAX_ENTRIES: u64 = 1_000_000;
 /// Default maximum source bytes hashed by one scan.
 const DEFAULT_SCAN_MAX_SOURCE_BYTES: u64 = 16 * 1_024 * 1_024 * 1_024;
 /// Default deadline for the compatibility repository scan.
-const DEFAULT_SCAN_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const DEFAULT_SCAN_TIMEOUT: Duration = Duration::from_mins(30);
 /// Exact-byte hash read buffer size.
 const HASH_BUFFER_BYTES: usize = 8_192;
 /// Maximum linked-worktree `.git` pointer bytes inspected for policy discovery.

--- a/docs/v050-release-architecture.md
+++ b/docs/v050-release-architecture.md
@@ -208,6 +208,11 @@ flowchart LR
 
 ## Rust 1.98.0 toolchain upgrade and verification
 
+Rust 1.93.1 is retained only as historical reproduction evidence. Each intended
+stable upgrade is evaluated in its own issue and pull request; the repository
+pins a numeric version only after the complete local and hosted gates pass.
+Floating `stable` and workflow-local numeric pins are not release inputs.
+
 ```mermaid
 flowchart LR
   History["Historical reproduction<br/>Rust 1.93.1"] -. evidence only .-> Decision["Issue/PR selects intended stable"]

--- a/openspec/changes/complete-v050-release-readiness/tasks.md
+++ b/openspec/changes/complete-v050-release-readiness/tasks.md
@@ -105,10 +105,10 @@
 
 ## 16. Rust 1.98.0 deterministic upgrade (#482)
 
-- [ ] 16.1 Record Rust 1.93.1 as the historical reproduction baseline, update the sole repository toolchain declaration to exact stable Rust 1.98.0, and define the explicit stable-upgrade policy: evaluate each intended stable release in an issue/PR, pin a numeric version only after all gates pass, and never use floating stable in CI or release inputs.
-- [ ] 16.2 Route local developer validation, CI, optional-parser construction, packaging, installer-developer paths, and release workflows through the repository declaration; add one early preflight that reports expected and actual rustc, cargo, clippy, and rustfmt identity and fails before expensive or mutating jobs, with no duplicated version literals or host-global default change.
-- [ ] 16.3 Reconcile Rust 1.98.0-owned lock/build output and pass format, workspace/all-target/all-feature check, pedantic Clippy, unit/integration/doc/E2E, cargo-deny, feature/target, parser-pack, packaging, and installer smoke gates on Linux, Windows, macOS x64, and macOS Apple Silicon; cover missing Rustup, Homebrew/system Cargo precedence, explicit override, 1.93.1, and other mismatches.
-- [ ] 16.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
+- [x] 16.1 Record Rust 1.93.1 as the historical reproduction baseline, update the sole repository toolchain declaration to exact stable Rust 1.98.0, and define the explicit stable-upgrade policy: evaluate each intended stable release in an issue/PR, pin a numeric version only after all gates pass, and never use floating stable in CI or release inputs.
+- [x] 16.2 Route local developer validation, CI, optional-parser construction, packaging, installer-developer paths, and release workflows through the repository declaration; add one early preflight that reports expected and actual rustc, cargo, clippy, and rustfmt identity and fails before expensive or mutating jobs, with no duplicated version literals or host-global default change.
+- [x] 16.3 Reconcile Rust 1.98.0-owned lock/build output and pass format, workspace/all-target/all-feature check, pedantic Clippy, unit/integration/doc/E2E, cargo-deny, feature/target, parser-pack, packaging, and installer smoke gates on Linux, Windows, macOS x64, and macOS Apple Silicon; cover missing Rustup, Homebrew/system Cargo precedence, explicit override, 1.93.1, and other mismatches.
+- [x] 16.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
 
 ## 17. Truthful macOS Apple Silicon optional parser (#483)
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Purpose: Pin the Rust toolchain and components used by ProjectAtlas builds and generators.
 
 [toolchain]
-channel = "1.93.1"
+channel = "1.98.0"
 profile = "minimal"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Summary:
- Pins the repository and release Rust inputs to Rust 1.98.0 through the sole toolchain declaration and shared preflight.
- Rejects mismatched toolchain identity, PATH precedence, overrides, and out-of-proxy rustup before installation or mutation.
- Updates Rust 1.98 compatibility checks and release-readiness proof while preserving historical 1.93.1 evidence.

Validation:
- Python preflight compilation and self-test, including the out-of-proxy rustup no-invocation regression.
- Cargo formatting, strict repository Clippy, targeted workflow contract, and strict OpenSpec validation.

Closes #482