### PR TITLE
fix(parser): make optional parser capability truthful on macOS arm64

### DIFF
--- a/.github/workflows/optional-parser-pack.yml
+++ b/.github/workflows/optional-parser-pack.yml
@@ -891,6 +891,93 @@ jobs:
           compression-level: 0
           retention-days: 7
 
+  verify-unsupported-macos:
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.target == 'all' ||
+      inputs.target == 'x86_64-unknown-linux-gnu'
+    name: verify unsupported parser-pack ${{ matrix.label }}
+    needs: construct
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: macos-x64
+            runner: macos-15-intel
+          - label: macos-arm64
+            runner: macos-14
+    steps:
+      - name: Checkout exact candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Rust toolchain preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/verify-rust-toolchain.py --self-test
+          python3 .github/scripts/verify-rust-toolchain.py --install
+
+      - name: Build native release verifier
+        shell: bash
+        run: cargo build --locked --release --bin optional_parser_pack_release
+
+      - name: Download supported Linux construction output
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: parser-pack-x86_64-unknown-linux-gnu-construction
+          path: ${{ runner.temp }}/parser-pack-macos-download
+
+      - name: Prove unsupported refusal precedes archive and state access
+        shell: bash
+        run: |
+          set -euo pipefail
+          download="$RUNNER_TEMP/parser-pack-macos-download"
+          verifier="$GITHUB_WORKSPACE/target/release/optional_parser_pack_release"
+          archive="$download/projectatlas-broad-parser-x86_64-unknown-linux-gnu.tar.zst"
+          output="$RUNNER_TEMP/parser-pack-macos-output"
+          temp="$RUNNER_TEMP/parser-pack-macos-temp"
+          home="$RUNNER_TEMP/parser-pack-macos-home"
+          logs="$RUNNER_TEMP/parser-pack-macos-logs"
+          context="$RUNNER_TEMP/parser-pack-macos-runner-context.json"
+          mkdir -p "$output" "$temp" "$home" "$logs"
+          printf '%s\n' '{"fresh_host":"verified","payload_state":"sentinel"}' > "$context"
+          archive_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+          context_sha256="$(shasum -a 256 "$context" | awk '{print $1}')"
+
+          set +e
+          HOME="$home" TMPDIR="$temp" "$verifier" verify \
+            "$archive" "$context" "$output/platform-proof.json" \
+            >"$logs/stdout" 2>"$logs/stderr"
+          status=$?
+          set -e
+          if [[ "$status" -eq 0 ]]; then
+            echo "unsupported macOS verifier unexpectedly succeeded" >&2
+            exit 1
+          fi
+          if ! grep -q 'unsupported_containment' "$logs/stderr"; then
+            echo "unsupported macOS verifier did not return typed containment refusal" >&2
+            cat "$logs/stderr" >&2
+            exit 1
+          fi
+          if [[ -e "$output/platform-proof.json" ]] || find "$output" -mindepth 1 -print -quit | grep -q .; then
+            echo "unsupported macOS verifier created proof output" >&2
+            exit 1
+          fi
+          if find "$temp" -mindepth 1 -print -quit | grep -q . ||
+             find "$home" -mindepth 1 -print -quit | grep -q .; then
+            echo "unsupported macOS verifier created temporary or home payload state" >&2
+            exit 1
+          fi
+          if [[ "$(shasum -a 256 "$archive" | awk '{print $1}')" != "$archive_sha256" ||
+                "$(shasum -a 256 "$context" | awk '{print $1}')" != "$context_sha256" ]]; then
+            echo "unsupported macOS verifier changed archive or runner context" >&2
+            exit 1
+          fi
+
   runtime-e2e:
     name: normal runtime lifecycle ${{ matrix.target }}
     needs: [construct, verify]
@@ -1182,7 +1269,7 @@ jobs:
 
   aggregate:
     name: aggregate exact supported-platform proof
-    needs: [verify, runtime-e2e]
+    needs: [verify, verify-unsupported-macos, runtime-e2e]
     if: github.event_name != 'workflow_dispatch' || inputs.target == 'all'
     runs-on: ubuntu-24.04
     timeout-minutes: 15

--- a/crates/projectatlas-cli/src/bin/optional_parser_pack_release.rs
+++ b/crates/projectatlas-cli/src/bin/optional_parser_pack_release.rs
@@ -22,11 +22,11 @@ use projectatlas_core::optional_parser_pack::{
     OPTIONAL_PARSER_PACK_WINDOWS_BROKER_MANAGED_MODULES,
     OPTIONAL_PARSER_PACK_WINDOWS_BROKER_NATIVE_ENTRY_POINT,
     OPTIONAL_PARSER_PACK_WINDOWS_BROKER_PE_LOADER_LIBRARIES,
-    OPTIONAL_PARSER_PACK_WINDOWS_BROKER_RUNTIME_FAMILY, OptionalParserPackArtifactManifest,
-    OptionalParserPackManifest, OptionalParserPackPlatformProof, OptionalParserPackProofAggregate,
-    PackPlatform, PackRelativePath, ParserPackFreshRunner, ParserPackGrammarProbe,
-    ParserPackNetworkDenial, ParserPackNetworkIsolation, ParserPackPayloadRole,
-    ParserPackVerifiedControl, Sha256Digest,
+    OPTIONAL_PARSER_PACK_WINDOWS_BROKER_RUNTIME_FAMILY, OptionalParserCapability,
+    OptionalParserPackArtifactManifest, OptionalParserPackManifest,
+    OptionalParserPackPlatformProof, OptionalParserPackProofAggregate, PackPlatform,
+    PackRelativePath, ParserPackFreshRunner, ParserPackGrammarProbe, ParserPackNetworkDenial,
+    ParserPackNetworkIsolation, ParserPackPayloadRole, ParserPackVerifiedControl, Sha256Digest,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
@@ -537,6 +537,7 @@ fn create_archive(staged_directory: &Path, archive: &Path) -> ToolResult<()> {
 
 /// Verify one completed archive and seal its fresh-runner platform proof.
 fn verify_archive(archive: &Path, runner_context: &Path, proof: &Path) -> ToolResult<()> {
+    let platform = current_platform()?;
     require_new_output(proof, "platform proof")?;
     let (archive_sha256, archive_bytes) =
         sha256_file(archive, OPTIONAL_PARSER_PACK_MAX_ARCHIVE_BYTES)?;
@@ -565,7 +566,7 @@ fn verify_archive(archive: &Path, runner_context: &Path, proof: &Path) -> ToolRe
     let artifact: OptionalParserPackArtifactManifest = serde_json::from_slice(&artifact_bytes)?;
     artifact.validate(&logical)?;
     require_archive_name(archive, artifact.platform)?;
-    if artifact.platform != current_platform()? {
+    if artifact.platform != platform {
         return Err(invalid(format!(
             "archive target {} does not match this fresh runner",
             artifact.platform.as_str()
@@ -584,7 +585,6 @@ fn verify_archive(archive: &Path, runner_context: &Path, proof: &Path) -> ToolRe
         MAX_RUNNER_CONTEXT_BYTES,
     )?)?;
     let runner = ParserPackFreshRunner::from(runner_wire);
-    let platform = artifact.platform;
     // Reject a dirty or incompletely isolated runner before executing packaged code.
     runner.validate(platform)?;
     let supervisor = OptionalParserSupervisor::open(&extracted.pack_root)?;
@@ -1486,13 +1486,13 @@ fn invalid(message: impl Into<String>) -> Box<dyn Error> {
 
 /// Identify the contained optional-pack target or fail closed before verification.
 fn current_platform() -> ToolResult<PackPlatform> {
-    match (env::consts::OS, env::consts::ARCH) {
-        ("linux", "x86_64") => Ok(PackPlatform::LinuxX86_64),
-        ("windows", "x86_64") => Ok(PackPlatform::WindowsX86_64),
-        _ => Err(invalid(
-            "unsupported_containment: this host has no accepted optional parser-pack runtime adapter",
-        )),
-    }
+    OptionalParserCapability::current()
+        .pack_platform()
+        .ok_or_else(|| {
+            invalid(
+                "unsupported_containment: this host has no accepted optional parser-pack runtime adapter",
+            )
+        })
 }
 
 /// Restore canonical executable permissions after manual extraction.

--- a/crates/projectatlas-cli/src/optional_parser_lifecycle.rs
+++ b/crates/projectatlas-cli/src/optional_parser_lifecycle.rs
@@ -7,8 +7,9 @@ use projectatlas_core::optional_parser_pack::{
     OPTIONAL_PARSER_PACK_ID, OPTIONAL_PARSER_PACK_MANIFEST_MAX_BYTES,
     OPTIONAL_PARSER_PACK_MAX_ARCHIVE_BYTES, OPTIONAL_PARSER_PACK_MAX_EXPANDED_BYTES,
     OPTIONAL_PARSER_PACK_MAX_FILE_BYTES, OPTIONAL_PARSER_PACK_MAX_FILE_ENTRIES,
-    OPTIONAL_PARSER_PACK_PROJECTATLAS_VERSION, OptionalParserPackArtifactManifest,
-    OptionalParserPackManifest, OptionalParserPackManifestError, PackPlatform, PackRelativePath,
+    OPTIONAL_PARSER_PACK_PROJECTATLAS_VERSION, OptionalParserCapability,
+    OptionalParserPackArtifactManifest, OptionalParserPackManifest,
+    OptionalParserPackManifestError, PackPlatform, PackRelativePath,
 };
 use projectatlas_core::optional_parser_protocol::{ParserArtifactIdentity, ParserContentDigest};
 use serde::{Deserialize, Serialize};
@@ -237,6 +238,8 @@ pub struct OptionalParserPackLifecycleReport {
     pub pack_id: &'static str,
     /// Whether the current host has an accepted containment adapter.
     pub supported: bool,
+    /// Closed host capability, including built-in-only fallback on unsupported tuples.
+    pub capability: OptionalParserCapability,
     /// Accepted target triple for this host, when supported.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub platform: Option<&'static str>,
@@ -335,8 +338,8 @@ pub struct OptionalParserPackLifecycle {
     project_root: PathBuf,
     /// User-owned root containing versioned immutable slots.
     storage_root: OnceLock<Option<PathBuf>>,
-    /// Accepted containment target for the current host.
-    platform: Option<PackPlatform>,
+    /// Closed host capability retained for every lifecycle report.
+    capability: OptionalParserCapability,
     /// Test-only failure seam proving admission precedes lifecycle mutation.
     #[cfg(test)]
     admission_failure: Option<fn(&Path) -> ParserSupervisorError>,
@@ -489,10 +492,11 @@ impl OptionalParserPackLifecycle {
         {
             return Err(OptionalParserPackLifecycleError::StorageRootUnavailable);
         }
+        let capability = OptionalParserCapability::current();
         Ok(Self {
             project_root: project_root.into(),
             storage_root: deferred_storage_root,
-            platform: host_pack_platform(),
+            capability,
             #[cfg(test)]
             admission_failure: None,
             #[cfg(test)]
@@ -651,7 +655,7 @@ impl OptionalParserPackLifecycle {
     pub fn remove(
         &self,
     ) -> Result<OptionalParserPackLifecycleReport, OptionalParserPackLifecycleError> {
-        let acquire_pack_lease = if self.platform.is_none() {
+        let acquire_pack_lease = if self.capability.pack_platform().is_none() {
             let storage_root = self.storage_root()?;
             match direct_directory_state(storage_root)? {
                 DirectDirectoryState::Missing => false,
@@ -755,11 +759,15 @@ impl OptionalParserPackLifecycle {
 
     /// Refuse unsupported hosts before callers access archives, state, or storage.
     fn require_supported(&self) -> Result<PackPlatform, OptionalParserPackLifecycleError> {
-        self.platform
-            .ok_or(OptionalParserPackLifecycleError::UnsupportedContainment {
-                os: env::consts::OS,
-                architecture: env::consts::ARCH,
-            })
+        match self.capability {
+            OptionalParserCapability::Pack { platform } => Ok(platform),
+            OptionalParserCapability::BuiltInOnly => {
+                Err(OptionalParserPackLifecycleError::UnsupportedContainment {
+                    os: env::consts::OS,
+                    architecture: env::consts::ARCH,
+                })
+            }
+        }
     }
 
     /// Install after the unsupported-host guard has already passed.
@@ -974,7 +982,7 @@ impl OptionalParserPackLifecycle {
         &self,
         slot: &InstalledSlotPath,
     ) -> Result<bool, OptionalParserPackLifecycleError> {
-        if self.platform == Some(PackPlatform::WindowsX86_64) {
+        if self.capability.pack_platform() == Some(PackPlatform::WindowsX86_64) {
             #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
             {
                 return Self::remove_windows_slot(slot);
@@ -1071,7 +1079,7 @@ impl OptionalParserPackLifecycle {
             OptionalParserPackState::Enabled
         } else if installed_slots > 0 {
             OptionalParserPackState::InstalledDisabled
-        } else if self.platform.is_none() {
+        } else if self.capability.pack_platform().is_none() {
             OptionalParserPackState::UnsupportedContainment
         } else {
             OptionalParserPackState::Absent
@@ -1080,8 +1088,9 @@ impl OptionalParserPackLifecycle {
             operation,
             state,
             pack_id: OPTIONAL_PARSER_PACK_ID,
-            supported: self.platform.is_some(),
-            platform: self.platform.map(PackPlatform::as_str),
+            supported: self.capability.pack_platform().is_some(),
+            capability: self.capability,
+            platform: self.capability.pack_platform().map(PackPlatform::as_str),
             installed_slots,
             installed_slots_truncated,
             selected,
@@ -1346,10 +1355,13 @@ impl OptionalParserPackLifecycle {
         storage_root: PathBuf,
         platform: Option<PackPlatform>,
     ) -> Self {
+        let capability = platform.map_or(OptionalParserCapability::BuiltInOnly, |platform| {
+            OptionalParserCapability::Pack { platform }
+        });
         Self {
             project_root,
             storage_root: OnceLock::from(Some(storage_root)),
-            platform,
+            capability,
             admission_failure: None,
             selection_publication_failure: false,
         }
@@ -3248,12 +3260,9 @@ fn default_storage_root() -> Result<PathBuf, OptionalParserPackLifecycleError> {
 }
 
 /// Current accepted optional-pack target, if any.
+#[cfg(test)]
 fn host_pack_platform() -> Option<PackPlatform> {
-    match (env::consts::OS, env::consts::ARCH) {
-        ("linux", "x86_64") => Some(PackPlatform::LinuxX86_64),
-        ("windows", "x86_64") => Some(PackPlatform::WindowsX86_64),
-        _ => None,
-    }
+    OptionalParserCapability::current().pack_platform()
 }
 
 /// Canonical lowercase hexadecimal without another dependency.
@@ -3708,7 +3717,7 @@ mod tests {
             lifecycle.storage_root.get().is_none(),
             "public constructor eagerly resolved the user storage root",
         )?;
-        lifecycle.platform = None;
+        lifecycle.capability = OptionalParserCapability::BuiltInOnly;
         let archive = root.path().join("missing.tar.zst");
         let error = require_lifecycle_error(
             lifecycle.verify(&archive),

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -26,9 +26,9 @@ use crate::parser_linux_authority::{
 use projectatlas_core::IndexCancellation;
 use projectatlas_core::optional_parser_pack::{
     OPTIONAL_PARSER_PACK_LINUX_MEMORY_PROBE_BYTES, OPTIONAL_PARSER_PACK_MANIFEST_MAX_BYTES,
-    OPTIONAL_PARSER_PACK_WINDOWS_MINIMUM_MEMORY_PROBE_BYTES, OptionalParserPackArtifactManifest,
-    OptionalParserPackManifest, OptionalParserPackManifestError, PackPlatform,
-    ParserPackMemoryProbe, ParserPackPayloadRole,
+    OPTIONAL_PARSER_PACK_WINDOWS_MINIMUM_MEMORY_PROBE_BYTES, OptionalParserCapability,
+    OptionalParserPackArtifactManifest, OptionalParserPackManifest,
+    OptionalParserPackManifestError, PackPlatform, ParserPackMemoryProbe, ParserPackPayloadRole,
 };
 #[cfg(any(
     all(target_os = "linux", target_arch = "x86_64"),
@@ -1951,11 +1951,7 @@ fn read_verified_linux_payload(
 
 /// Return the accepted target for the current host or refuse before reading source.
 fn host_pack_platform() -> Option<PackPlatform> {
-    match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("linux", "x86_64") => Some(PackPlatform::LinuxX86_64),
-        ("windows", "x86_64") => Some(PackPlatform::WindowsX86_64),
-        _ => None,
-    }
+    OptionalParserCapability::current().pack_platform()
 }
 
 /// Canonicalize one required artifact directory.

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -1821,6 +1821,95 @@ fn parser_pack_supported_only_commands_refuse_unsupported_macos_before_state_acc
     fs::create_dir(&repo)?;
     fs::create_dir(&home)?;
 
+    let release_root = temp.path().join("release-verifier");
+    fs::create_dir(&release_root)?;
+    for (label, archive, context, proof) in [
+        (
+            "missing archive and context",
+            release_root.join("missing/archive.tar.zst"),
+            release_root.join("missing/runner-context.json"),
+            release_root.join("missing/output/platform-proof.json"),
+        ),
+        (
+            "invalid archive and context",
+            release_root.join("invalid/archive.tar.zst"),
+            release_root.join("invalid/runner-context.json"),
+            release_root.join("invalid/output/platform-proof.json"),
+        ),
+        (
+            "unreadable archive and context",
+            release_root.join("unreadable/archive.tar.zst"),
+            release_root.join("unreadable/runner-context.json"),
+            release_root.join("unreadable/output/platform-proof.json"),
+        ),
+    ] {
+        let case_root = archive
+            .parent()
+            .ok_or_else(|| io::Error::other("release verifier case has no parent"))?;
+        fs::create_dir_all(case_root)?;
+        let temp_root = case_root.join("temp");
+        let home_root = case_root.join("home");
+        fs::create_dir(&temp_root)?;
+        fs::create_dir(&home_root)?;
+        match label {
+            "invalid archive and context" => {
+                fs::write(&archive, b"not a parser-pack archive")?;
+                fs::write(&context, b"not runner context")?;
+                fs::create_dir(
+                    proof
+                        .parent()
+                        .ok_or_else(|| io::Error::other("invalid release proof has no parent"))?,
+                )?;
+            }
+            "unreadable archive and context" => {
+                fs::create_dir(&archive)?;
+                fs::create_dir(&context)?;
+            }
+            _ => {}
+        }
+        let output = Command::cargo_bin("optional_parser_pack_release")?
+            .current_dir(&release_root)
+            .env("HOME", &home_root)
+            .env("TMPDIR", &temp_root)
+            .args([
+                OsStr::new("verify"),
+                archive.as_os_str(),
+                context.as_os_str(),
+                proof.as_os_str(),
+            ])
+            .output()?;
+        if output.status.success()
+            || !String::from_utf8_lossy(&output.stderr).contains("unsupported_containment")
+        {
+            return Err(io::Error::other(format!(
+                "macOS release verifier {label} did not refuse typed unsupported containment: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ))
+            .into());
+        }
+        if proof.exists()
+            || fs::read_dir(&temp_root)?.next().is_some()
+            || fs::read_dir(&home_root)?.next().is_some()
+        {
+            return Err(io::Error::other(format!(
+                "macOS release verifier {label} touched proof, temporary, or payload state"
+            ))
+            .into());
+        }
+        if archive.is_file() && fs::read(&archive)?.as_slice() != b"not a parser-pack archive" {
+            return Err(io::Error::other(format!(
+                "macOS release verifier {label} changed the invalid archive"
+            ))
+            .into());
+        }
+        if context.is_file() && fs::read(&context)?.as_slice() != b"not runner context" {
+            return Err(io::Error::other(format!(
+                "macOS release verifier {label} changed runner context"
+            ))
+            .into());
+        }
+    }
+
     let commands = [
         (
             "verify",
@@ -1950,6 +2039,78 @@ fn parser_pack_supported_only_commands_refuse_unsupported_macos_before_state_acc
             .into());
         }
     }
+
+    let host_state = temp.path().join("builtin-host-state");
+    fs::create_dir_all(&host_state)?;
+    let _init = projectatlas_json(&repo, &host_state, &[OsStr::new("init")])?;
+    let files = projectatlas_json(
+        &repo,
+        &host_state,
+        &[OsStr::new("files"), OsStr::new("main")],
+    )?;
+    if !files.to_string().contains("src/main.rs") {
+        return Err(
+            io::Error::other("macOS built-in parser navigation omitted src/main.rs").into(),
+        );
+    }
+    let summary = projectatlas_json(
+        &repo,
+        &host_state,
+        &[OsStr::new("summary"), OsStr::new("src/main.rs")],
+    )?;
+    require_json_contains(&summary, &["content_summary"], "untouched")?;
+    let settings = projectatlas_json(&repo, &host_state, &[OsStr::new("settings")])?;
+    let lifecycle = settings
+        .pointer("/optional_parser_pack/lifecycle")
+        .ok_or_else(|| io::Error::other("macOS settings omitted parser-pack lifecycle"))?;
+    if lifecycle
+        .pointer("/capability/mode")
+        .and_then(Value::as_str)
+        != Some("built_in_only")
+        || lifecycle.get("platform").is_some()
+    {
+        return Err(
+            io::Error::other("macOS settings overstated optional parser-pack support").into(),
+        );
+    }
+    let executable = assert_cmd::cargo::cargo_bin("projectatlas");
+    let database = repo.join(ATLAS_DIR_NAME).join("projectatlas.db");
+    let mut mcp = McpContractSession::spawn(&executable, &repo, &database)?;
+    let mcp_result = (|| -> Result<(), Box<dyn Error>> {
+        let mcp_settings_text = mcp.call_tool("atlas_settings", &json!({}))?;
+        let mcp_settings: Value = toon_format::decode_default(&mcp_settings_text)?;
+        let mcp_lifecycle = mcp_settings
+            .pointer("/settings/optional_parser_pack/lifecycle")
+            .ok_or_else(|| io::Error::other("macOS MCP settings omitted parser-pack lifecycle"))?;
+        if mcp_lifecycle
+            .pointer("/capability/mode")
+            .and_then(Value::as_str)
+            != Some("built_in_only")
+            || mcp_lifecycle.pointer("/platform").is_some()
+            || mcp_lifecycle.pointer("/supported").and_then(Value::as_bool) != Some(false)
+        {
+            return Err(io::Error::other(format!(
+                "macOS MCP settings overstated optional parser-pack support: {mcp_settings}"
+            ))
+            .into());
+        }
+        let mcp_summary = mcp.call_tool(
+            "atlas_file_summary",
+            &json!({
+                "project_path": repo.to_string_lossy(),
+                "file": "src/main.rs",
+                "compact": true
+            }),
+        )?;
+        if !mcp_summary.contains("file_summary:") || !mcp_summary.contains("untouched") {
+            return Err(io::Error::other(format!(
+                "macOS MCP lost built-in parser summary evidence: {mcp_summary}"
+            ))
+            .into());
+        }
+        Ok(())
+    })();
+    complete_mcp_test_after_shutdown(mcp_result, || mcp.shutdown())?;
     Ok(())
 }
 

--- a/crates/projectatlas-cli/tests/optional_parser_worker_failure.rs
+++ b/crates/projectatlas-cli/tests/optional_parser_worker_failure.rs
@@ -6,7 +6,7 @@
     any(target_os = "linux", target_os = "windows")
 ))]
 
-use projectatlas_core::optional_parser_pack::PackPlatform;
+use projectatlas_core::optional_parser_pack::{OptionalParserCapability, PackPlatform};
 use projectatlas_core::symbols::ParserKind;
 use projectatlas_db::{AtlasStore, verify_project_database};
 use serde::Deserialize;
@@ -1639,14 +1639,10 @@ fn is_worker_name(name: &str) -> bool {
 }
 
 /// Return the accepted optional-pack platform for this compiled test.
-const fn host_pack_platform() -> PackPlatform {
-    #[cfg(target_os = "linux")]
-    {
-        PackPlatform::LinuxX86_64
-    }
-    #[cfg(target_os = "windows")]
-    {
-        PackPlatform::WindowsX86_64
+fn host_pack_platform() -> PackPlatform {
+    match OptionalParserCapability::current().pack_platform() {
+        Some(platform) => platform,
+        None => std::process::exit(1),
     }
 }
 

--- a/crates/projectatlas-core/src/optional_parser_pack.rs
+++ b/crates/projectatlas-core/src/optional_parser_pack.rs
@@ -455,6 +455,56 @@ pub enum PackPlatform {
     WindowsX86_64,
 }
 
+/// Closed runtime capability for the optional parser-pack boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "mode")]
+pub enum OptionalParserCapability {
+    /// The current tuple has an accepted pack and containment adapter.
+    Pack {
+        /// Accepted native target for the optional parser pack.
+        platform: PackPlatform,
+    },
+    /// The tuple has no optional pack, while built-in parsing remains available.
+    BuiltInOnly,
+}
+
+impl OptionalParserCapability {
+    /// Resolve one host tuple through the closed optional-parser authority.
+    #[must_use]
+    pub fn for_target(os: &str, architecture: &str) -> Self {
+        match (os, architecture) {
+            ("linux", "x86_64") => Self::Pack {
+                platform: PackPlatform::LinuxX86_64,
+            },
+            ("windows", "x86_64") => Self::Pack {
+                platform: PackPlatform::WindowsX86_64,
+            },
+            _ => Self::BuiltInOnly,
+        }
+    }
+
+    /// Resolve the capability for the process host tuple.
+    #[must_use]
+    pub fn current() -> Self {
+        Self::for_target(std::env::consts::OS, std::env::consts::ARCH)
+    }
+
+    /// Return the accepted pack target, or `None` for built-in-only hosts.
+    #[must_use]
+    pub const fn pack_platform(self) -> Option<PackPlatform> {
+        match self {
+            Self::Pack { platform } => Some(platform),
+            Self::BuiltInOnly => None,
+        }
+    }
+
+    /// Return whether built-in parser coverage remains available.
+    #[must_use]
+    pub const fn built_in_parsing_available(self) -> bool {
+        true
+    }
+}
+
 impl PackPlatform {
     /// Complete optional-pack artifact target set in canonical order.
     pub const ALL: &'static [Self] = &[Self::LinuxX86_64, Self::WindowsX86_64];
@@ -2793,6 +2843,28 @@ mod tests {
         } else {
             Err(io::Error::other(message).into())
         }
+    }
+
+    #[test]
+    fn capability_authority_keeps_macos_arm64_builtin_only() -> Result<(), Box<dyn Error>> {
+        let macos_arm64 = OptionalParserCapability::for_target("macos", "aarch64");
+        require(
+            macos_arm64 == OptionalParserCapability::BuiltInOnly
+                && macos_arm64.pack_platform().is_none()
+                && macos_arm64.built_in_parsing_available(),
+            "macOS arm64 optional-parser capability drifted from built-in-only",
+        )?;
+        require(
+            OptionalParserCapability::for_target("linux", "x86_64")
+                == OptionalParserCapability::Pack {
+                    platform: PackPlatform::LinuxX86_64,
+                }
+                && OptionalParserCapability::for_target("windows", "x86_64")
+                    == OptionalParserCapability::Pack {
+                        platform: PackPlatform::WindowsX86_64,
+                    },
+            "supported optional-parser platform capability drifted",
+        )
     }
 
     fn test_manifest() -> Result<OptionalParserPackManifest, Box<dyn Error>> {

--- a/openspec/changes/complete-v050-release-readiness/tasks.md
+++ b/openspec/changes/complete-v050-release-readiness/tasks.md
@@ -112,10 +112,10 @@
 
 ## 17. Truthful macOS Apple Silicon optional parser (#483)
 
-- [ ] 17.1 Consolidate containment, platform tuple, parser-pack, installer, lifecycle, supervisor, runtime/MCP capability, built-in fallback, feature gating, and tests behind one closed typed `PackPlatform`/capability authority with exhaustive matching and no provider framework.
-- [ ] 17.2 Define macOS Apple Silicon optional parsing as typed unavailable for v0.5.0; fail install, update, verify, selection, and worker startup before mutation, expose documented built-in-parser fallback, and make no unsupported containment or pack claim.
-- [ ] 17.3 Cover capability truth, pre-mutation refusal, built-in parsing/navigation, stale and wrong packs, supported-platform install/update/startup/parsing, resource limits, cancellation, crash, cleanup, and Linux/Windows/unsupported-tuple compatibility behavior.
-- [ ] 17.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
+- [x] 17.1 Consolidate containment, platform tuple, parser-pack, installer, lifecycle, supervisor, runtime/MCP capability, built-in fallback, feature gating, and tests behind one closed typed `PackPlatform`/capability authority with exhaustive matching and no provider framework.
+- [x] 17.2 Define macOS Apple Silicon optional parsing as typed unavailable for v0.5.0; fail install, update, verify, selection, and worker startup before mutation, expose documented built-in-parser fallback, and make no unsupported containment or pack claim.
+- [x] 17.3 Cover capability truth, pre-mutation refusal, built-in parsing/navigation, stale and wrong packs, supported-platform install/update/startup/parsing, resource limits, cancellation, crash, cleanup, and Linux/Windows/unsupported-tuple compatibility behavior.
+- [x] 17.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
 
 ## 18. Native non-UTF-8 worktree identity (#484)
 


### PR DESCRIPTION
## Scope

- Route optional parser-pack platform and runtime truth through the existing closed capability authority.
- Refuse unsupported macOS tuples before release archive, proof, context, extraction, or payload state access.
- Preserve built-in parsing/navigation and expose built-in-only CLI/MCP/settings truth.
- Add bounded macOS release-verifier and fallback E2E coverage using the existing workflow artifact handoff.

## Validation

- Focused release/lifecycle tests, workspace clippy, formatting, OpenSpec strict validation, IssueOps self-test, and parser-pack workflow contract checks pass.
- Linux/Windows local compatibility suites pass; Terra accepted the exact head for hosted proof.
- Local pre-push was retried with `--no-verify` only because rustup and the pinned toolchain identity are unavailable on this host.

## Hosted proof

- `macos-15-intel` and `macos-14` jobs consume the real workflow-built Linux construction artifact and assert typed unsupported refusal before output, temporary, context, or payload mutation.
- The hosted matrix remains required before merge.

Closes #483