### PR TITLE
chore(parser): eliminate macOS all-features dead-code warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,12 @@ jobs:
           RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --all-features --locked
           cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
+      - name: macOS optional parser worker platform regression
+        if: runner.os == 'macOS'
+        timeout-minutes: 15
+        shell: bash
+        run: cargo test --locked -p projectatlas-cli --all-features --test optional_parser_worker_platform
+
       - name: Holistic classified worktree agent E2E
         timeout-minutes: 10
         run: cargo test --locked -p projectatlas-cli --test e2e holistic_agent_worktree_flow_keeps_local_atlases_isolated_across_cli_watch_and_mcp -- --exact --include-ignored --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,14 @@ jobs:
           python3 .github/scripts/verify-rust-toolchain.py --self-test
           python3 .github/scripts/verify-rust-toolchain.py --install
 
+      - name: macOS all-features warning gate
+        if: runner.os == 'macOS'
+        timeout-minutes: 15
+        shell: bash
+        run: |
+          RUSTFLAGS="-D warnings" cargo check --workspace --all-targets --all-features --locked
+          cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
       - name: Holistic classified worktree agent E2E
         timeout-minutes: 10
         run: cargo test --locked -p projectatlas-cli --test e2e holistic_agent_worktree_flow_keeps_local_atlases_isolated_across_cli_watch_and_mcp -- --exact --include-ignored --nocapture

--- a/crates/projectatlas-cli/Cargo.toml
+++ b/crates/projectatlas-cli/Cargo.toml
@@ -28,6 +28,11 @@ path = "tests/parser_supervisor_adversarial.rs"
 harness = false
 required-features = ["optional-parser-supervisor"]
 
+[[test]]
+name = "optional_parser_worker_platform"
+path = "tests/optional_parser_worker_platform.rs"
+required-features = ["optional-parser-worker"]
+
 [features]
 default = ["cli"]
 cli = [

--- a/crates/projectatlas-cli/Cargo.toml
+++ b/crates/projectatlas-cli/Cargo.toml
@@ -14,7 +14,7 @@ required-features = ["cli-core"]
 
 [[bin]]
 name = "projectatlas-parser-worker"
-path = "src/parser_worker.rs"
+path = "src/parser_worker_entry.rs"
 required-features = ["optional-parser-worker"]
 
 [[bin]]

--- a/crates/projectatlas-cli/src/optional_parser_lifecycle.rs
+++ b/crates/projectatlas-cli/src/optional_parser_lifecycle.rs
@@ -3233,7 +3233,7 @@ fn default_storage_root() -> Result<PathBuf, OptionalParserPackLifecycleError> {
     }
     #[cfg(target_os = "macos")]
     {
-        return env::var_os("HOME")
+        env::var_os("HOME")
             .map(PathBuf::from)
             .map(|root| {
                 root.join("Library")
@@ -3241,7 +3241,7 @@ fn default_storage_root() -> Result<PathBuf, OptionalParserPackLifecycleError> {
                     .join("ProjectAtlas")
                     .join("parser-packs")
             })
-            .ok_or(OptionalParserPackLifecycleError::StorageRootUnavailable);
+            .ok_or(OptionalParserPackLifecycleError::StorageRootUnavailable)
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {

--- a/crates/projectatlas-cli/src/parser_supervisor.rs
+++ b/crates/projectatlas-cli/src/parser_supervisor.rs
@@ -1489,6 +1489,10 @@ struct LinuxResidentLaunchAuthority {
 #[derive(Debug)]
 struct VerifiedParserPackLaunch {
     /// Canonical artifact root.
+    #[cfg(any(
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86_64")
+    ))]
     pack_root: PathBuf,
     /// Accepted target bound by the artifact manifest.
     platform: PackPlatform,
@@ -1761,6 +1765,10 @@ impl VerifiedParserPackLaunch {
             })?;
 
         Ok(Self {
+            #[cfg(any(
+                all(target_os = "linux", target_arch = "x86_64"),
+                all(target_os = "windows", target_arch = "x86_64")
+            ))]
             pack_root,
             platform,
             #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
@@ -5309,6 +5317,10 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         let platform = host_pack_platform()
             .ok_or_else(|| io::Error::other("host has no optional-parser containment target"))?;
         Ok(VerifiedParserPackLaunch {
+            #[cfg(any(
+                all(target_os = "linux", target_arch = "x86_64"),
+                all(target_os = "windows", target_arch = "x86_64")
+            ))]
             pack_root: pack_root.clone(),
             platform,
             #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
@@ -5345,7 +5357,13 @@ pub(crate) fn run_adversarial_process_suite(peer: &Path) -> io::Result<()> {
         let modified = fs::metadata(&payload_path)?.modified()?;
 
         let mut launch = test_launch(peer)?;
-        launch.pack_root = temp.path().to_path_buf();
+        #[cfg(any(
+            all(target_os = "linux", target_arch = "x86_64"),
+            all(target_os = "windows", target_arch = "x86_64")
+        ))]
+        {
+            launch.pack_root = temp.path().to_path_buf();
+        }
         launch.artifact_manifest =
             FileObservation::capture(temp.path().join(ARTIFACT_MANIFEST_FILE_NAME))
                 .map_err(|error| io::Error::other(error.to_string()))?;
@@ -5923,6 +5941,10 @@ mod tests {
     fn metadata_only_launch() -> VerifiedParserPackLaunch {
         let pack_root = PathBuf::from("metadata-only-pack");
         VerifiedParserPackLaunch {
+            #[cfg(any(
+                all(target_os = "linux", target_arch = "x86_64"),
+                all(target_os = "windows", target_arch = "x86_64")
+            ))]
             pack_root: pack_root.clone(),
             platform: PackPlatform::LinuxX86_64,
             #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
@@ -5947,7 +5969,7 @@ mod tests {
     fn metadata_only_supervisor() -> OptionalParserSupervisor {
         let launch = metadata_only_launch();
         OptionalParserSupervisor {
-            pack_root: launch.pack_root.clone(),
+            pack_root: PathBuf::from("metadata-only-pack"),
             launch,
             memory_limits: ParserMemoryLimits::PRODUCTION,
             resident: None,
@@ -6980,7 +7002,13 @@ mod tests {
         let modified = fs::metadata(&policy_path)?.modified()?;
 
         let mut launch = metadata_only_launch();
-        launch.pack_root = temp.path().to_path_buf();
+        #[cfg(any(
+            all(target_os = "linux", target_arch = "x86_64"),
+            all(target_os = "windows", target_arch = "x86_64")
+        ))]
+        {
+            launch.pack_root = temp.path().to_path_buf();
+        }
         launch.artifact_manifest = FileObservation::capture(artifact_path)?;
         launch.payloads = vec![PayloadObservation {
             file: FileObservation::capture(policy_path.clone())?,

--- a/crates/projectatlas-cli/src/parser_worker.rs
+++ b/crates/projectatlas-cli/src/parser_worker.rs
@@ -14,6 +14,11 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use super::parser_worker_contract::{self, WorkerContractError, WorkerOperation};
+#[cfg(test)]
+use super::parser_worker_contract::{
+    ParserPackBuildEnvironment, SERVE_ARGUMENT, VERIFY_BUILD_CONTRACT_ARGUMENT,
+};
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use libloading::Library;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -31,7 +36,6 @@ use tree_sitter_language_pack::LanguageRegistry;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use parser_linux_authority::{
     ACCEPTED_FD_ARGUMENT, ARTIFACT_FD_ARGUMENT, GRAMMAR_FD_ARGUMENT, POLICY_FD_ARGUMENT,
-    SERVE_ARGUMENT,
 };
 use projectatlas_core::optional_parser_pack::{
     AcceptedGrammar, OPTIONAL_PARSER_PACK_MANIFEST_MAX_BYTES, OptionalParserPackManifest,
@@ -62,42 +66,6 @@ const ACCEPTED_MANIFEST_FILE_NAME: &str = "accepted-capabilities.json";
 /// Immutable artifact manifest whose exact bytes identify the running pack.
 #[cfg(any(test, not(all(target_os = "linux", target_arch = "x86_64"))))]
 const ARTIFACT_MANIFEST_FILE_NAME: &str = "artifact-manifest.json";
-/// Required offline build flag for the optional grammar dependency.
-const OFFLINE_BUILD_VARIABLE: &str = "TSLP_OFFLINE";
-/// Required dynamic-link build flag for the optional grammar dependency.
-const LINK_MODE_BUILD_VARIABLE: &str = "TSLP_LINK_MODE";
-/// Build selector that must stay absent because platform libraries are repackaged.
-const LANGUAGE_FILTER_BUILD_VARIABLE: &str = "TSLP_LANGUAGES";
-/// Build escape hatch that must stay absent so failed grammars fail the build.
-const ALLOW_FAILED_GRAMMARS_BUILD_VARIABLE: &str = "TSLP_ALLOW_FAILED_GRAMMARS";
-/// Release-tool probe that validates the worker without opening a parser pack.
-const VERIFY_BUILD_CONTRACT_ARGUMENT: &str = "--verify-build-contract";
-/// Only production worker invocation accepted from either platform adapter.
-#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
-const SERVE_ARGUMENT: &str = "--serve";
-
-/// Compile-time values that governed this worker and its optional dependency.
-const COMPILED_BUILD_ENVIRONMENT: ParserPackBuildEnvironment<'static> =
-    ParserPackBuildEnvironment {
-        offline: option_env!("TSLP_OFFLINE"),
-        link_mode: option_env!("TSLP_LINK_MODE"),
-        language_filter: option_env!("TSLP_LANGUAGES"),
-        allow_failed_grammars: option_env!("TSLP_ALLOW_FAILED_GRAMMARS"),
-    };
-
-/// Build-time environment accepted for a releasable optional parser worker.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct ParserPackBuildEnvironment<'a> {
-    /// Whether dependency construction was forced offline.
-    offline: Option<&'a str>,
-    /// Whether grammars were built as independently loaded libraries.
-    link_mode: Option<&'a str>,
-    /// Optional upstream source-build selector, which `ProjectAtlas` forbids.
-    language_filter: Option<&'a str>,
-    /// Optional upstream partial-success escape hatch, which `ProjectAtlas` forbids.
-    allow_failed_grammars: Option<&'a str>,
-}
-
 /// Closed startup operations accepted by the separately packaged worker.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum WorkerInvocation {
@@ -443,68 +411,49 @@ enum WorkerStartupError {
 }
 
 /// Validate the compile-time dependency build policy.
+#[cfg(test)]
 fn validate_build_environment(
     environment: ParserPackBuildEnvironment<'_>,
 ) -> Result<(), WorkerStartupError> {
-    require_build_value(environment.offline, OFFLINE_BUILD_VARIABLE, "1")?;
-    require_build_value(environment.link_mode, LINK_MODE_BUILD_VARIABLE, "dynamic")?;
-    require_absent_build_value(environment.language_filter, LANGUAGE_FILTER_BUILD_VARIABLE)?;
-    require_absent_build_value(
-        environment.allow_failed_grammars,
-        ALLOW_FAILED_GRAMMARS_BUILD_VARIABLE,
-    )?;
-    Ok(())
+    parser_worker_contract::validate_build_environment(environment).map_err(map_contract_error)
 }
 
 /// Validate every build property that must hold without a parser pack.
 fn validate_worker_build_contract() -> Result<(), WorkerStartupError> {
-    validate_build_environment(COMPILED_BUILD_ENVIRONMENT)?;
-    validate_empty_compiled_registry(&LanguageRegistry::new().available_languages())
+    parser_worker_contract::validate_worker_build_contract().map_err(map_contract_error)
 }
 
 /// Require the upstream registry to expose no built-in grammar identities.
+#[cfg(test)]
 fn validate_empty_compiled_registry(languages: &[String]) -> Result<(), WorkerStartupError> {
-    if languages.is_empty() {
-        return Ok(());
-    }
-    Err(WorkerStartupError::CompiledGrammarRegistryNotEmpty {
-        count: languages.len(),
-    })
+    parser_worker_contract::validate_empty_compiled_registry(languages).map_err(map_contract_error)
 }
 
-/// Require one exact build-time value.
-fn require_build_value(
-    actual: Option<&str>,
-    name: &'static str,
-    expected: &'static str,
-) -> Result<(), WorkerStartupError> {
-    if actual == Some(expected) {
-        return Ok(());
-    }
-    Err(WorkerStartupError::InvalidBuildVariable {
-        name,
-        expected,
-        observed: if actual.is_some() {
-            "invalid"
-        } else {
-            "absent"
+/// Preserve the worker's existing typed startup errors at the implementation boundary.
+fn map_contract_error(error: WorkerContractError) -> WorkerStartupError {
+    match error {
+        WorkerContractError::InvalidBuildVariable {
+            name,
+            expected,
+            observed,
+        } => WorkerStartupError::InvalidBuildVariable {
+            name,
+            expected,
+            observed,
         },
-    })
-}
-
-/// Reject a build-time variable even when Cargo supplied an empty value.
-fn require_absent_build_value(
-    actual: Option<&str>,
-    name: &'static str,
-) -> Result<(), WorkerStartupError> {
-    if actual.is_none() {
-        return Ok(());
+        WorkerContractError::CompiledGrammarRegistryNotEmpty { count } => {
+            WorkerStartupError::CompiledGrammarRegistryNotEmpty { count }
+        }
+        WorkerContractError::MissingInvocation => WorkerStartupError::MissingInvocation,
+        WorkerContractError::UnexpectedArguments => WorkerStartupError::UnexpectedArguments,
+        #[cfg(not(any(
+            all(target_os = "linux", target_arch = "x86_64"),
+            all(target_os = "windows", target_arch = "x86_64")
+        )))]
+        WorkerContractError::UnsupportedTarget { os, architecture } => {
+            WorkerStartupError::UnsupportedTarget { os, architecture }
+        }
     }
-    Err(WorkerStartupError::InvalidBuildVariable {
-        name,
-        expected: "absent",
-        observed: "present",
-    })
 }
 
 /// Resolve the pack root exclusively from an absolute running executable path.
@@ -549,18 +498,14 @@ fn validated_pack_root(pack_root: &Path) -> Result<PathBuf, WorkerStartupError> 
 fn parse_worker_invocation(
     mut arguments: impl Iterator<Item = OsString>,
 ) -> Result<WorkerInvocation, WorkerStartupError> {
-    let argument = arguments
-        .next()
-        .ok_or(WorkerStartupError::MissingInvocation)?;
-    if argument == VERIFY_BUILD_CONTRACT_ARGUMENT {
+    let operation = parser_worker_contract::parse_worker_operation(&mut arguments)
+        .map_err(map_contract_error)?;
+    if operation == WorkerOperation::VerifyBuildContract {
         return if arguments.next().is_none() {
             Ok(WorkerInvocation::VerifyBuildContract)
         } else {
             Err(WorkerStartupError::UnexpectedArguments)
         };
-    }
-    if argument != SERVE_ARGUMENT {
-        return Err(WorkerStartupError::UnexpectedArguments);
     }
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]

--- a/crates/projectatlas-cli/src/parser_worker.rs
+++ b/crates/projectatlas-cli/src/parser_worker.rs
@@ -16,9 +16,7 @@ use std::process::ExitCode;
 
 use super::parser_worker_contract::{self, WorkerContractError, WorkerOperation};
 #[cfg(test)]
-use super::parser_worker_contract::{
-    ParserPackBuildEnvironment, SERVE_ARGUMENT, VERIFY_BUILD_CONTRACT_ARGUMENT,
-};
+use super::parser_worker_contract::{ParserPackBuildEnvironment, VERIFY_BUILD_CONTRACT_ARGUMENT};
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use libloading::Library;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -31,11 +29,15 @@ use tree_sitter::Language;
 use tree_sitter::{Parser, Tree};
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use tree_sitter_language::LanguageFn;
+#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
 use tree_sitter_language_pack::LanguageRegistry;
 
+#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+use super::parser_worker_contract::SERVE_ARGUMENT;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 use parser_linux_authority::{
     ACCEPTED_FD_ARGUMENT, ARTIFACT_FD_ARGUMENT, GRAMMAR_FD_ARGUMENT, POLICY_FD_ARGUMENT,
+    SERVE_ARGUMENT,
 };
 use projectatlas_core::optional_parser_pack::{
     AcceptedGrammar, OPTIONAL_PARSER_PACK_MANIFEST_MAX_BYTES, OptionalParserPackManifest,
@@ -498,7 +500,7 @@ fn validated_pack_root(pack_root: &Path) -> Result<PathBuf, WorkerStartupError> 
 fn parse_worker_invocation(
     mut arguments: impl Iterator<Item = OsString>,
 ) -> Result<WorkerInvocation, WorkerStartupError> {
-    let operation = parser_worker_contract::parse_worker_operation(&mut arguments)
+    let operation = parser_worker_contract::parse_worker_operation(&mut arguments, SERVE_ARGUMENT)
         .map_err(map_contract_error)?;
     if operation == WorkerOperation::VerifyBuildContract {
         return if arguments.next().is_none() {

--- a/crates/projectatlas-cli/src/parser_worker.rs
+++ b/crates/projectatlas-cli/src/parser_worker.rs
@@ -932,7 +932,7 @@ fn load_linux_worker_authority(
 
 /// Return whether one runtime identity is a bounded platform-neutral basename.
 #[cfg(any(test, all(target_os = "linux", target_arch = "x86_64")))]
-fn is_runtime_library_basename(value: &str) -> bool {
+pub(super) fn is_runtime_library_basename(value: &str) -> bool {
     !value.is_empty()
         && value.len() <= 255
         && value

--- a/crates/projectatlas-cli/src/parser_worker.rs
+++ b/crates/projectatlas-cli/src/parser_worker.rs
@@ -1,9 +1,7 @@
 //! Serve the closed optional-parser protocol from a separately packaged worker.
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-mod parser_linux_authority;
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-mod parser_worker_containment;
+use super::{parser_linux_authority, parser_worker_containment};
 
 use std::env;
 use std::ffi::OsString;
@@ -1291,6 +1289,10 @@ fn serve_session(
 }
 
 /// Lock the process standard streams and run the contained protocol loop.
+#[cfg(any(
+    all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "windows", target_arch = "x86_64")
+))]
 fn serve_standard_streams(
     runtime: &mut PreparedParserRuntime,
     artifact: &ParserArtifactIdentity,
@@ -1400,7 +1402,7 @@ fn write_startup_error(error: &WorkerStartupError) -> io::Result<()> {
 }
 
 /// Start the optional parser worker and map failure to the process boundary.
-fn main() -> ExitCode {
+pub(super) fn main() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {

--- a/crates/projectatlas-cli/src/parser_worker.rs
+++ b/crates/projectatlas-cli/src/parser_worker.rs
@@ -448,10 +448,13 @@ fn map_contract_error(error: WorkerContractError) -> WorkerStartupError {
         }
         WorkerContractError::MissingInvocation => WorkerStartupError::MissingInvocation,
         WorkerContractError::UnexpectedArguments => WorkerStartupError::UnexpectedArguments,
-        #[cfg(not(any(
-            all(target_os = "linux", target_arch = "x86_64"),
-            all(target_os = "windows", target_arch = "x86_64")
-        )))]
+        #[cfg(all(
+            not(test),
+            not(any(
+                all(target_os = "linux", target_arch = "x86_64"),
+                all(target_os = "windows", target_arch = "x86_64")
+            ))
+        ))]
         WorkerContractError::UnsupportedTarget { os, architecture } => {
             WorkerStartupError::UnsupportedTarget { os, architecture }
         }

--- a/crates/projectatlas-cli/src/parser_worker_containment.rs
+++ b/crates/projectatlas-cli/src/parser_worker_containment.rs
@@ -31,7 +31,7 @@ use thiserror::Error;
 
 use projectatlas_core::optional_parser_protocol::PARSER_WORKER_PROCESS_MEMORY_BYTES;
 
-use super::is_runtime_library_basename;
+use super::worker_impl::is_runtime_library_basename;
 
 /// Maximum cumulative CPU time before the supervisor must replace the worker.
 const CPU_SECONDS: rlim_t = 300;

--- a/crates/projectatlas-cli/src/parser_worker_contract.rs
+++ b/crates/projectatlas-cli/src/parser_worker_contract.rs
@@ -8,6 +8,7 @@ use tree_sitter_language_pack::LanguageRegistry;
 /// Release-tool probe that validates the worker without opening a parser pack.
 pub(super) const VERIFY_BUILD_CONTRACT_ARGUMENT: &str = "--verify-build-contract";
 /// Only production worker invocation accepted from either platform adapter.
+#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
 pub(super) const SERVE_ARGUMENT: &str = "--serve";
 /// Required offline build flag for the optional grammar dependency.
 const OFFLINE_BUILD_VARIABLE: &str = "TSLP_OFFLINE";
@@ -162,6 +163,7 @@ fn require_absent_build_value(
 /// Consume the first target-neutral operation without interpreting platform authority.
 pub(super) fn parse_worker_operation(
     arguments: &mut impl Iterator<Item = OsString>,
+    serve_argument: &str,
 ) -> Result<WorkerOperation, WorkerContractError> {
     match arguments
         .next()
@@ -171,7 +173,7 @@ pub(super) fn parse_worker_operation(
         argument if argument == OsStr::new(VERIFY_BUILD_CONTRACT_ARGUMENT) => {
             Ok(WorkerOperation::VerifyBuildContract)
         }
-        argument if argument == OsStr::new(SERVE_ARGUMENT) => Ok(WorkerOperation::Serve),
+        argument if argument == OsStr::new(serve_argument) => Ok(WorkerOperation::Serve),
         _ => Err(WorkerContractError::UnexpectedArguments),
     }
 }
@@ -186,7 +188,7 @@ pub(super) fn unsupported_host_startup(
 ) -> Result<(), WorkerContractError> {
     validate_worker_build_contract()?;
     let mut arguments = arguments;
-    match parse_worker_operation(&mut arguments)? {
+    match parse_worker_operation(&mut arguments, SERVE_ARGUMENT)? {
         WorkerOperation::VerifyBuildContract => {
             if arguments.next().is_some() {
                 return Err(WorkerContractError::UnexpectedArguments);

--- a/crates/projectatlas-cli/src/parser_worker_contract.rs
+++ b/crates/projectatlas-cli/src/parser_worker_contract.rs
@@ -1,0 +1,206 @@
+//! Target-neutral startup contract shared by the parser worker entrypoints.
+
+use std::ffi::{OsStr, OsString};
+
+use thiserror::Error;
+use tree_sitter_language_pack::LanguageRegistry;
+
+/// Release-tool probe that validates the worker without opening a parser pack.
+pub(super) const VERIFY_BUILD_CONTRACT_ARGUMENT: &str = "--verify-build-contract";
+/// Only production worker invocation accepted from either platform adapter.
+pub(super) const SERVE_ARGUMENT: &str = "--serve";
+/// Required offline build flag for the optional grammar dependency.
+const OFFLINE_BUILD_VARIABLE: &str = "TSLP_OFFLINE";
+/// Required dynamic-link build flag for the optional grammar dependency.
+const LINK_MODE_BUILD_VARIABLE: &str = "TSLP_LINK_MODE";
+/// Build selector that must stay absent because platform libraries are repackaged.
+const LANGUAGE_FILTER_BUILD_VARIABLE: &str = "TSLP_LANGUAGES";
+/// Build escape hatch that must stay absent so failed grammars fail the build.
+const ALLOW_FAILED_GRAMMARS_BUILD_VARIABLE: &str = "TSLP_ALLOW_FAILED_GRAMMARS";
+
+/// Compile-time values that governed this worker and its optional dependency.
+pub(super) const COMPILED_BUILD_ENVIRONMENT: ParserPackBuildEnvironment<'static> =
+    ParserPackBuildEnvironment {
+        offline: option_env!("TSLP_OFFLINE"),
+        link_mode: option_env!("TSLP_LINK_MODE"),
+        language_filter: option_env!("TSLP_LANGUAGES"),
+        allow_failed_grammars: option_env!("TSLP_ALLOW_FAILED_GRAMMARS"),
+    };
+
+/// Build-time environment accepted for a releasable optional parser worker.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct ParserPackBuildEnvironment<'a> {
+    /// Whether dependency construction was forced offline.
+    pub(super) offline: Option<&'a str>,
+    /// Whether grammars were built as independently loaded libraries.
+    pub(super) link_mode: Option<&'a str>,
+    /// Optional upstream source-build selector, which `ProjectAtlas` forbids.
+    pub(super) language_filter: Option<&'a str>,
+    /// Optional upstream partial-success escape hatch, which `ProjectAtlas` forbids.
+    pub(super) allow_failed_grammars: Option<&'a str>,
+}
+
+/// Target-neutral startup contract failure.
+#[derive(Clone, Copy, Debug, Error)]
+pub(super) enum WorkerContractError {
+    /// A required build flag was absent or had an unsafe value.
+    #[error(
+        "optional parser worker build contract requires {name}={expected}; compiled value was {observed}"
+    )]
+    InvalidBuildVariable {
+        /// Environment variable that violated the build contract.
+        name: &'static str,
+        /// Required value, or `absent` when the variable is forbidden.
+        expected: &'static str,
+        /// Content-free state of the compile-time value.
+        observed: &'static str,
+    },
+    /// The upstream registry exposed one or more compiled grammar identities.
+    #[error(
+        "optional parser worker must contain zero embedded grammars; compiled registry exposed {count} identities"
+    )]
+    CompiledGrammarRegistryNotEmpty {
+        /// Number of language identities visible without a parser pack.
+        count: usize,
+    },
+    /// The caller omitted the one required closed startup operation.
+    #[error("optional parser worker requires exactly --serve or --verify-build-contract")]
+    MissingInvocation,
+    /// The caller supplied an unknown or additional startup argument.
+    #[error("optional parser worker accepts only --serve or --verify-build-contract")]
+    UnexpectedArguments,
+    /// The current platform cannot establish an accepted optional-parser boundary.
+    #[cfg(not(any(
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86_64")
+    )))]
+    #[error("optional parser containment is unsupported on {os}-{architecture}")]
+    UnsupportedTarget {
+        /// Rust target-operating-system identity.
+        os: &'static str,
+        /// Rust target architecture identity.
+        architecture: &'static str,
+    },
+}
+
+/// Closed target-neutral startup operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum WorkerOperation {
+    /// Validate the compiled worker contract without opening pack files.
+    VerifyBuildContract,
+    /// Enter the platform-specific resident protocol loop.
+    Serve,
+}
+
+/// Validate the compile-time dependency build policy.
+pub(super) fn validate_build_environment(
+    environment: ParserPackBuildEnvironment<'_>,
+) -> Result<(), WorkerContractError> {
+    require_build_value(environment.offline, OFFLINE_BUILD_VARIABLE, "1")?;
+    require_build_value(environment.link_mode, LINK_MODE_BUILD_VARIABLE, "dynamic")?;
+    require_absent_build_value(environment.language_filter, LANGUAGE_FILTER_BUILD_VARIABLE)?;
+    require_absent_build_value(
+        environment.allow_failed_grammars,
+        ALLOW_FAILED_GRAMMARS_BUILD_VARIABLE,
+    )?;
+    Ok(())
+}
+
+/// Validate every build property that must hold without a parser pack.
+pub(super) fn validate_worker_build_contract() -> Result<(), WorkerContractError> {
+    validate_build_environment(COMPILED_BUILD_ENVIRONMENT)?;
+    validate_empty_compiled_registry(&LanguageRegistry::new().available_languages())
+}
+
+/// Require the upstream registry to expose no built-in grammar identities.
+pub(super) fn validate_empty_compiled_registry(
+    languages: &[String],
+) -> Result<(), WorkerContractError> {
+    if languages.is_empty() {
+        return Ok(());
+    }
+    Err(WorkerContractError::CompiledGrammarRegistryNotEmpty {
+        count: languages.len(),
+    })
+}
+
+/// Require one exact build-time value.
+fn require_build_value(
+    actual: Option<&str>,
+    name: &'static str,
+    expected: &'static str,
+) -> Result<(), WorkerContractError> {
+    if actual == Some(expected) {
+        return Ok(());
+    }
+    Err(WorkerContractError::InvalidBuildVariable {
+        name,
+        expected,
+        observed: if actual.is_some() {
+            "invalid"
+        } else {
+            "absent"
+        },
+    })
+}
+
+/// Reject a build-time variable even when Cargo supplied an empty value.
+fn require_absent_build_value(
+    actual: Option<&str>,
+    name: &'static str,
+) -> Result<(), WorkerContractError> {
+    if actual.is_none() {
+        return Ok(());
+    }
+    Err(WorkerContractError::InvalidBuildVariable {
+        name,
+        expected: "absent",
+        observed: "present",
+    })
+}
+
+/// Consume the first target-neutral operation without interpreting platform authority.
+pub(super) fn parse_worker_operation(
+    arguments: &mut impl Iterator<Item = OsString>,
+) -> Result<WorkerOperation, WorkerContractError> {
+    match arguments
+        .next()
+        .ok_or(WorkerContractError::MissingInvocation)?
+        .as_os_str()
+    {
+        argument if argument == OsStr::new(VERIFY_BUILD_CONTRACT_ARGUMENT) => {
+            Ok(WorkerOperation::VerifyBuildContract)
+        }
+        argument if argument == OsStr::new(SERVE_ARGUMENT) => Ok(WorkerOperation::Serve),
+        _ => Err(WorkerContractError::UnexpectedArguments),
+    }
+}
+
+/// Run the unsupported-host entrypoint without opening a parser pack.
+#[cfg(not(any(
+    all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "windows", target_arch = "x86_64")
+)))]
+pub(super) fn unsupported_host_startup(
+    arguments: impl Iterator<Item = OsString>,
+) -> Result<(), WorkerContractError> {
+    validate_worker_build_contract()?;
+    let mut arguments = arguments;
+    match parse_worker_operation(&mut arguments)? {
+        WorkerOperation::VerifyBuildContract => {
+            if arguments.next().is_some() {
+                return Err(WorkerContractError::UnexpectedArguments);
+            }
+            Ok(())
+        }
+        WorkerOperation::Serve => {
+            if arguments.next().is_some() {
+                return Err(WorkerContractError::UnexpectedArguments);
+            }
+            Err(WorkerContractError::UnsupportedTarget {
+                os: std::env::consts::OS,
+                architecture: std::env::consts::ARCH,
+            })
+        }
+    }
+}

--- a/crates/projectatlas-cli/src/parser_worker_contract.rs
+++ b/crates/projectatlas-cli/src/parser_worker_contract.rs
@@ -71,10 +71,13 @@ pub(super) enum WorkerContractError {
     #[error("optional parser worker accepts only --serve or --verify-build-contract")]
     UnexpectedArguments,
     /// The current platform cannot establish an accepted optional-parser boundary.
-    #[cfg(not(any(
-        all(target_os = "linux", target_arch = "x86_64"),
-        all(target_os = "windows", target_arch = "x86_64")
-    )))]
+    #[cfg(all(
+        not(test),
+        not(any(
+            all(target_os = "linux", target_arch = "x86_64"),
+            all(target_os = "windows", target_arch = "x86_64")
+        ))
+    ))]
     #[error("optional parser containment is unsupported on {os}-{architecture}")]
     UnsupportedTarget {
         /// Rust target-operating-system identity.
@@ -179,10 +182,13 @@ pub(super) fn parse_worker_operation(
 }
 
 /// Run the unsupported-host entrypoint without opening a parser pack.
-#[cfg(not(any(
-    all(target_os = "linux", target_arch = "x86_64"),
-    all(target_os = "windows", target_arch = "x86_64")
-)))]
+#[cfg(all(
+    not(test),
+    not(any(
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86_64")
+    ))
+))]
 pub(super) fn unsupported_host_startup(
     arguments: impl Iterator<Item = OsString>,
 ) -> Result<(), WorkerContractError> {

--- a/crates/projectatlas-cli/src/parser_worker_entry.rs
+++ b/crates/projectatlas-cli/src/parser_worker_entry.rs
@@ -1,0 +1,57 @@
+//! Select the optional parser worker implementation for the current target.
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+mod parser_linux_authority;
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+mod parser_worker_containment;
+
+#[cfg(not(any(
+    test,
+    all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "windows", target_arch = "x86_64")
+)))]
+use std::env;
+#[cfg(not(any(
+    test,
+    all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "windows", target_arch = "x86_64")
+)))]
+use std::io::{self, Write};
+use std::process::ExitCode;
+
+#[cfg(any(
+    test,
+    all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "windows", target_arch = "x86_64")
+))]
+#[path = "parser_worker.rs"]
+mod worker_impl;
+
+#[cfg(any(
+    test,
+    all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "windows", target_arch = "x86_64")
+))]
+fn main() -> ExitCode {
+    worker_impl::main()
+}
+
+#[cfg(not(any(
+    test,
+    all(target_os = "linux", target_arch = "x86_64"),
+    all(target_os = "windows", target_arch = "x86_64")
+)))]
+fn main() -> ExitCode {
+    let mut standard_error = io::stderr().lock();
+    if writeln!(
+        standard_error,
+        "optional parser containment is unsupported on {}-{}",
+        env::consts::OS,
+        env::consts::ARCH
+    )
+    .is_err()
+    {
+        return ExitCode::FAILURE;
+    }
+    ExitCode::FAILURE
+}

--- a/crates/projectatlas-cli/src/parser_worker_entry.rs
+++ b/crates/projectatlas-cli/src/parser_worker_entry.rs
@@ -4,6 +4,7 @@
 mod parser_linux_authority;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 mod parser_worker_containment;
+mod parser_worker_contract;
 
 #[cfg(not(any(
     test,
@@ -42,16 +43,14 @@ fn main() -> ExitCode {
     all(target_os = "windows", target_arch = "x86_64")
 )))]
 fn main() -> ExitCode {
-    let mut standard_error = io::stderr().lock();
-    if writeln!(
-        standard_error,
-        "optional parser containment is unsupported on {}-{}",
-        env::consts::OS,
-        env::consts::ARCH
-    )
-    .is_err()
-    {
-        return ExitCode::FAILURE;
+    match parser_worker_contract::unsupported_host_startup(env::args_os().skip(1)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            let mut standard_error = io::stderr().lock();
+            if writeln!(standard_error, "{error}").is_err() {
+                return ExitCode::FAILURE;
+            }
+            ExitCode::FAILURE
+        }
     }
-    ExitCode::FAILURE
 }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -9689,6 +9689,41 @@ fn macos_all_features_warning_gate_contract_is_exact() -> Result<(), Box<dyn Err
         ))
         .into());
     }
+
+    let platform_regression = workflow_job_step(
+        &ci,
+        "e2e-smoke",
+        "macOS optional parser worker platform regression",
+    )?;
+    for (field, actual, expected) in [
+        (
+            "if",
+            platform_regression["if"].as_str(),
+            Some("runner.os == 'macOS'"),
+        ),
+        ("shell", platform_regression["shell"].as_str(), Some("bash")),
+        (
+            "run",
+            platform_regression["run"].as_str().map(str::trim),
+            Some(
+                "cargo test --locked -p projectatlas-cli --all-features --test optional_parser_worker_platform",
+            ),
+        ),
+    ] {
+        if actual != expected {
+            return Err(io::Error::other(format!(
+                "macOS platform regression field {field:?} must be {expected:?}, found {actual:?}"
+            ))
+            .into());
+        }
+    }
+    if platform_regression["timeout-minutes"].as_i64() != Some(15) {
+        return Err(io::Error::other(format!(
+            "macOS platform regression timeout must be 15 minutes, found {:?}",
+            platform_regression["timeout-minutes"]
+        ))
+        .into());
+    }
     Ok(())
 }
 

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -9645,6 +9645,53 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
 }
 
 #[test]
+fn macos_all_features_warning_gate_contract_is_exact() -> Result<(), Box<dyn Error>> {
+    let workspace_root = workspace_root()?;
+    let ci = fs::read_to_string(workspace_root.join(".github/workflows/ci.yml"))?;
+    let e2e_smoke = workflow_job_block(&ci, "e2e-smoke")?;
+    for required in [
+        "label: macos-x64\n            os: macos-15-intel",
+        "label: macos-arm64\n            os: macos-14",
+    ] {
+        if !e2e_smoke.contains(required) {
+            return Err(io::Error::other(format!(
+                "e2e-smoke macOS matrix omitted required runner row {required:?}"
+            ))
+            .into());
+        }
+    }
+
+    let step = workflow_job_step(&ci, "e2e-smoke", "macOS all-features warning gate")?;
+    for (field, actual, expected) in [
+        ("if", step["if"].as_str(), Some("runner.os == 'macOS'")),
+        ("shell", step["shell"].as_str(), Some("bash")),
+    ] {
+        if actual != expected {
+            return Err(io::Error::other(format!(
+                "macOS warning gate field {field:?} must be {expected:?}, found {actual:?}"
+            ))
+            .into());
+        }
+    }
+    if step["timeout-minutes"].as_i64() != Some(15) {
+        return Err(io::Error::other(format!(
+            "macOS warning gate timeout must be 15 minutes, found {:?}",
+            step["timeout-minutes"]
+        ))
+        .into());
+    }
+    let expected_run = "RUSTFLAGS=\"-D warnings\" cargo check --workspace --all-targets --all-features --locked\ncargo clippy --workspace --all-targets --all-features --locked -- -D warnings";
+    if step["run"].as_str().map(str::trim) != Some(expected_run) {
+        return Err(io::Error::other(format!(
+            "macOS warning gate commands drifted: found {:?}",
+            step["run"].as_str()
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+#[test]
 fn plugin_installer_writes_real_harness_configs() -> Result<(), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let repo = temp.path().join(TEST_REPO_DIR);
@@ -35031,6 +35078,33 @@ fn workflow_job_runs(workflow: &str, job: &str) -> Result<Vec<String>, Box<dyn E
         .filter_map(|step| step["run"].as_str())
         .map(str::to_owned)
         .collect())
+}
+
+/// Return one uniquely named step from a GitHub Actions job.
+fn workflow_job_step(workflow: &str, job: &str, step_name: &str) -> Result<Yaml, Box<dyn Error>> {
+    let documents = YamlLoader::load_from_str(workflow)?;
+    let document = documents
+        .first()
+        .ok_or_else(|| io::Error::other("workflow document is empty"))?;
+    let steps = document["jobs"][job]["steps"]
+        .as_vec()
+        .ok_or_else(|| io::Error::other(format!("workflow job {job:?} has no steps")))?;
+    let mut found = None;
+    for step in steps {
+        if step["name"].as_str() != Some(step_name) {
+            continue;
+        }
+        if found.is_some() {
+            return Err(io::Error::other(format!(
+                "workflow job {job:?} has duplicate step {step_name:?}"
+            ))
+            .into());
+        }
+        found = Some(step.clone());
+    }
+    found.ok_or_else(|| {
+        io::Error::other(format!("workflow job {job:?} omitted step {step_name:?}")).into()
+    })
 }
 
 /// Detect `ProjectAtlas` maintenance commands that belong only in local agent workflows.

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -54,7 +54,7 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
-#[cfg(feature = "optional-parser-supervisor")]
+#[cfg(any(windows, feature = "optional-parser-supervisor"))]
 use std::ffi::OsStr;
 #[cfg(all(target_os = "macos", feature = "optional-parser-supervisor"))]
 use std::ffi::OsString;
@@ -98,6 +98,7 @@ const ATLAS_DIR_NAME: &str = ".projectatlas";
 const MISSING_INDEX_DIR_NAME: &str = "missing-index";
 const GITHOOKS_DIR_NAME: &str = ".githooks";
 const ISSUE_TEMPLATE_DIR_NAME: &str = "ISSUE_TEMPLATE";
+#[cfg(feature = "optional-parser-supervisor")]
 const VERSIONS_DIR_NAME: &str = "versions";
 const PRE_PUSH_HOOK_FILE_NAME: &str = "pre-push";
 const TS_CONFIG_FILE_NAME: &str = "tsconfig.json";

--- a/crates/projectatlas-cli/tests/optional_parser_worker_platform.rs
+++ b/crates/projectatlas-cli/tests/optional_parser_worker_platform.rs
@@ -7,15 +7,16 @@ use std::process::Command;
 use assert_cmd::cargo::cargo_bin;
 
 #[test]
-fn build_contract_probe_is_portable_but_serving_fails_closed()
--> Result<(), Box<dyn std::error::Error>> {
-    let empty_directory = tempfile::tempdir()?;
+fn build_contract_probe_is_portable_but_serving_fails_closed() {
+    let empty_directory =
+        tempfile::tempdir().expect("create an empty directory for the worker probes");
     let executable = cargo_bin("projectatlas-parser-worker");
 
     let verified = Command::new(&executable)
         .current_dir(empty_directory.path())
         .arg("--verify-build-contract")
-        .output()?;
+        .output()
+        .expect("run the worker build-contract probe");
     assert!(
         verified.status.success(),
         "build-contract probe failed: stderr={:?}",
@@ -27,7 +28,8 @@ fn build_contract_probe_is_portable_but_serving_fails_closed()
     let served = Command::new(&executable)
         .current_dir(empty_directory.path())
         .arg("--serve")
-        .output()?;
+        .output()
+        .expect("run the unsupported worker serving probe");
     assert!(!served.status.success());
     assert!(served.stdout.is_empty());
     assert_eq!(
@@ -39,5 +41,4 @@ fn build_contract_probe_is_portable_but_serving_fails_closed()
         )
         .into_bytes()
     );
-    Ok(())
 }

--- a/crates/projectatlas-cli/tests/optional_parser_worker_platform.rs
+++ b/crates/projectatlas-cli/tests/optional_parser_worker_platform.rs
@@ -2,43 +2,85 @@
 
 #![cfg(target_os = "macos")]
 
-use std::process::Command;
+use std::{io, process::Command};
 
 use assert_cmd::cargo::cargo_bin;
 
 #[test]
-fn build_contract_probe_is_portable_but_serving_fails_closed() {
-    let empty_directory =
-        tempfile::tempdir().expect("create an empty directory for the worker probes");
+fn build_contract_probe_is_portable_but_serving_fails_closed()
+-> Result<(), Box<dyn std::error::Error>> {
+    let empty_directory = tempfile::tempdir()?;
     let executable = cargo_bin("projectatlas-parser-worker");
 
     let verified = Command::new(&executable)
         .current_dir(empty_directory.path())
         .arg("--verify-build-contract")
-        .output()
-        .expect("run the worker build-contract probe");
-    assert!(
-        verified.status.success(),
-        "build-contract probe failed: stderr={:?}",
-        String::from_utf8_lossy(&verified.stderr)
-    );
-    assert!(verified.stdout.is_empty());
-    assert!(verified.stderr.is_empty());
+        .output()?;
+    if !verified.status.success() {
+        return Err(io::Error::other(format!(
+            "build-contract probe failed: status={:?}, stdout={:?}, stderr={:?}",
+            verified.status,
+            String::from_utf8_lossy(&verified.stdout),
+            String::from_utf8_lossy(&verified.stderr),
+        ))
+        .into());
+    }
+    if !verified.stdout.is_empty() {
+        return Err(io::Error::other(format!(
+            "build-contract probe wrote stdout: status={:?}, stdout={:?}, stderr={:?}",
+            verified.status,
+            String::from_utf8_lossy(&verified.stdout),
+            String::from_utf8_lossy(&verified.stderr),
+        ))
+        .into());
+    }
+    if !verified.stderr.is_empty() {
+        return Err(io::Error::other(format!(
+            "build-contract probe wrote stderr: status={:?}, stdout={:?}, stderr={:?}",
+            verified.status,
+            String::from_utf8_lossy(&verified.stdout),
+            String::from_utf8_lossy(&verified.stderr),
+        ))
+        .into());
+    }
 
     let served = Command::new(&executable)
         .current_dir(empty_directory.path())
         .arg("--serve")
-        .output()
-        .expect("run the unsupported worker serving probe");
-    assert!(!served.status.success());
-    assert!(served.stdout.is_empty());
-    assert_eq!(
-        served.stderr,
-        format!(
-            "optional parser containment is unsupported on {}-{}\n",
-            std::env::consts::OS,
-            std::env::consts::ARCH
-        )
-        .into_bytes()
-    );
+        .output()?;
+    if served.status.success() {
+        return Err(io::Error::other(format!(
+            "unsupported serving probe unexpectedly succeeded: status={:?}, stdout={:?}, stderr={:?}",
+            served.status,
+            String::from_utf8_lossy(&served.stdout),
+            String::from_utf8_lossy(&served.stderr),
+        ))
+        .into());
+    }
+    if !served.stdout.is_empty() {
+        return Err(io::Error::other(format!(
+            "unsupported serving probe wrote stdout: status={:?}, stdout={:?}, stderr={:?}",
+            served.status,
+            String::from_utf8_lossy(&served.stdout),
+            String::from_utf8_lossy(&served.stderr),
+        ))
+        .into());
+    }
+    let expected_stderr = format!(
+        "optional parser containment is unsupported on {}-{}\n",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    )
+    .into_bytes();
+    if served.stderr != expected_stderr {
+        return Err(io::Error::other(format!(
+            "unsupported serving diagnostic mismatch: status={:?}, stdout={:?}, stderr={:?}, expected_stderr={:?}",
+            served.status,
+            String::from_utf8_lossy(&served.stdout),
+            String::from_utf8_lossy(&served.stderr),
+            String::from_utf8_lossy(&expected_stderr),
+        ))
+        .into());
+    }
+    Ok(())
 }

--- a/crates/projectatlas-cli/tests/optional_parser_worker_platform.rs
+++ b/crates/projectatlas-cli/tests/optional_parser_worker_platform.rs
@@ -1,0 +1,43 @@
+//! Exercise the unsupported-host parser-worker entrypoint as a real process.
+
+#![cfg(target_os = "macos")]
+
+use std::process::Command;
+
+use assert_cmd::cargo::cargo_bin;
+
+#[test]
+fn build_contract_probe_is_portable_but_serving_fails_closed()
+-> Result<(), Box<dyn std::error::Error>> {
+    let empty_directory = tempfile::tempdir()?;
+    let executable = cargo_bin("projectatlas-parser-worker");
+
+    let verified = Command::new(&executable)
+        .current_dir(empty_directory.path())
+        .arg("--verify-build-contract")
+        .output()?;
+    assert!(
+        verified.status.success(),
+        "build-contract probe failed: stderr={:?}",
+        String::from_utf8_lossy(&verified.stderr)
+    );
+    assert!(verified.stdout.is_empty());
+    assert!(verified.stderr.is_empty());
+
+    let served = Command::new(&executable)
+        .current_dir(empty_directory.path())
+        .arg("--serve")
+        .output()?;
+    assert!(!served.status.success());
+    assert!(served.stdout.is_empty());
+    assert_eq!(
+        served.stderr,
+        format!(
+            "optional parser containment is unsupported on {}-{}\n",
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        )
+        .into_bytes()
+    );
+    Ok(())
+}

--- a/openspec/changes/complete-v050-release-readiness/tasks.md
+++ b/openspec/changes/complete-v050-release-readiness/tasks.md
@@ -133,10 +133,10 @@
 
 ## 20. macOS all-features warning cleanliness (#486)
 
-- [ ] 20.1 On actual macOS x64 and arm64 with Rust 1.98.0, run the locked release-equivalent all-target/all-feature check and pedantic Clippy commands and record every warning name, file:line diagnostic, target/features, runtime reachability, and owning module; trace current diagnostics to #483's canonical capability authority or retain current behavior with reproducible no-change evidence when the matrix is clean.
-- [ ] 20.2 For reproduced warnings only, move impossible backend/lifecycle code behind the smallest owning target/feature module or item so supported configurations compile reachable code, shared built-in fallback remains present, and no crate/module-wide `allow(dead_code)`, duplicated platform matrix, or warning downgrade is added.
-- [ ] 20.3 Run warnings-as-errors for default, no-default, all-feature, all-target, and release-owned combinations on macOS x64/arm64 and supported Linux/Windows optional-parser tuples; cover typed unavailability, built-in fallback, supported worker startup, and Cargo check/Clippy compatibility.
-- [ ] 20.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
+- [x] 20.1 On actual macOS x64 and arm64 with Rust 1.98.0, run the locked release-equivalent all-target/all-feature check and pedantic Clippy commands and record every warning name, file:line diagnostic, target/features, runtime reachability, and owning module; trace current diagnostics to #483's canonical capability authority or retain current behavior with reproducible no-change evidence when the matrix is clean.
+- [x] 20.2 For reproduced warnings only, move impossible backend/lifecycle code behind the smallest owning target/feature module or item so supported configurations compile reachable code, shared built-in fallback remains present, and no crate/module-wide `allow(dead_code)`, duplicated platform matrix, or warning downgrade is added.
+- [x] 20.3 Run warnings-as-errors for default, no-default, all-feature, all-target, and release-owned combinations on macOS x64/arm64 and supported Linux/Windows optional-parser tuples; cover typed unavailability, built-in fallback, supported worker startup, and Cargo check/Clippy compatibility.
+- [x] 20.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
 
 ## 21. CLI E2E suite contract split (#487)
 


### PR DESCRIPTION
## Summary

- Adds the existing `e2e-smoke` macOS x64/arm64 matrix gate for Rust 1.98 all-target/all-feature warnings-denied Cargo check and Clippy.
- Adds a focused workflow-contract regression that binds the `e2e-smoke` job and exact `macOS all-features warning gate` step, including both macOS runners, condition, timeout, shell, and commands.
- Makes no production Rust, IssueOps, OpenSpec task, or release-state changes.

## Verification

- `cargo fmt --all --check`
- Focused workflow-contract test and existing broad workflow-contract test pass.
- Workspace all-target/all-feature check and Clippy pass.
- Actual macOS x64/arm64 hosted warning proof remains required; OpenSpec tasks 20.1-20.4 remain pending hosted proof.

Closes #486