### PR TITLE
Add deterministic architecture communities

### DIFF
--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -778,7 +778,17 @@ fn detailed_relation_cli_bounds_the_exact_json_envelope() -> Result<(), Box<dyn 
         source_dir.join("lib.rs"),
         "pub fn first() { second(); third(); fourth(); fifth(); sixth(); seventh(); eighth(); ninth(); }\n\
          fn second() {}\nfn third() {}\nfn fourth() {}\nfn fifth() {}\n\
-         fn sixth() {}\nfn seventh() {}\nfn eighth() {}\nfn ninth() {}\n",
+         fn sixth() {}\nfn seventh() {}\nfn eighth() {}\nfn ninth() {}\n\
+         fn group_a_root() { group_a_one(); group_a_two(); }\n\
+         fn group_a_one() { group_a_two(); }\n\
+         fn group_a_two() { group_a_root(); }\n\
+         fn group_b_root() { group_b_one(); group_b_two(); }\n\
+         fn group_b_one() { group_b_two(); }\n\
+         fn group_b_two() { group_b_root(); }\n\
+         fn architecture_root() {\n\
+             group_a_root(); group_a_one(); group_a_two();\n\
+             group_b_root(); group_b_one(); group_b_two();\n\
+         }\n",
     )?;
 
     let scan = Command::cargo_bin("projectatlas")?
@@ -989,6 +999,121 @@ fn detailed_relation_cli_bounds_the_exact_json_envelope() -> Result<(), Box<dyn 
     {
         return Err(io::Error::other(
             "public relation analysis CLI omitted findings or reusable next-call routing",
+        )
+        .into());
+    }
+
+    let community_args = vec![
+        "--format".to_string(),
+        "json".to_string(),
+        "symbols".to_string(),
+        "relations".to_string(),
+        "--view".to_string(),
+        "analysis".to_string(),
+        "--file".to_string(),
+        "src/lib.rs".to_string(),
+        "--symbol".to_string(),
+        "architecture_root".to_string(),
+        "--direction".to_string(),
+        "outbound".to_string(),
+        "--depth".to_string(),
+        "3".to_string(),
+        "--limit".to_string(),
+        "100".to_string(),
+        "--output-bytes".to_string(),
+        page_output_bytes.to_string(),
+        "--include-communities".to_string(),
+    ];
+    let community_first_payload = run_json_analysis_to_completion(&repo, &community_args)?;
+    let community_second_payload = run_json_analysis_to_completion(&repo, &community_args)?;
+    let first_communities = json_community_values_from_pages(&community_first_payload)?;
+    let second_communities = json_community_values_from_pages(&community_second_payload)?;
+    if serde_json::to_vec(&first_communities)? != serde_json::to_vec(&second_communities)? {
+        return Err(io::Error::other("repeated CLI community fields were not byte stable").into());
+    }
+    assert_planted_community_values(&first_communities, "CLI")?;
+
+    let bounded_output_bytes = 64 * 1024_usize;
+    let bounded_community = Command::cargo_bin("projectatlas")?
+        .current_dir(&repo)
+        .env("PROJECTATLAS_NO_TELEMETRY", "1")
+        .args([
+            "--format",
+            "json",
+            "symbols",
+            "relations",
+            "--view",
+            "analysis",
+            "--file",
+            "src/lib.rs",
+            "--symbol",
+            "architecture_root",
+            "--direction",
+            "outbound",
+            "--depth",
+            "3",
+            "--limit",
+            "100",
+            "--edge-limit",
+            "1",
+            "--output-bytes",
+            &bounded_output_bytes.to_string(),
+            "--include-communities",
+        ])
+        .output()?;
+    if !bounded_community.status.success() {
+        return Err(io::Error::other(format!(
+            "bounded community CLI analysis failed: {}",
+            String::from_utf8_lossy(&bounded_community.stderr)
+        ))
+        .into());
+    }
+    if bounded_community.stdout.len() > bounded_output_bytes {
+        return Err(io::Error::other(format!(
+            "bounded community CLI emitted {} bytes above its {bounded_output_bytes}-byte ceiling",
+            bounded_community.stdout.len()
+        ))
+        .into());
+    }
+    let bounded_payload: Value = serde_json::from_slice(&bounded_community.stdout)?;
+    require_json_bool(&bounded_payload, &["symbol_relations", "truncated"], true)?;
+    if bounded_payload
+        .pointer("/symbol_relations/continuation")
+        .and_then(Value::as_str)
+        .is_none_or(str::is_empty)
+    {
+        return Err(io::Error::other(
+            "bounded community CLI output omitted its continuation cursor",
+        )
+        .into());
+    }
+    require_json_usize(
+        &bounded_payload,
+        &["symbol_relations", "work", "rendered_output_bytes"],
+        bounded_community.stdout.len(),
+    )?;
+    let bounded_communities = json_community_values(&bounded_payload)?;
+    if !bounded_communities.iter().any(|community| {
+        community
+            .get("coverage")
+            .and_then(Value::as_str)
+            .is_some_and(|coverage| coverage == "partial")
+            && community
+                .get("convergence")
+                .and_then(Value::as_str)
+                .is_some_and(|convergence| convergence == "inconclusive")
+    }) || !bounded_payload
+        .pointer("/symbol_relations/findings")
+        .and_then(Value::as_array)
+        .is_some_and(|findings| {
+            findings.iter().any(|finding| {
+                finding.get("kind").and_then(Value::as_str) == Some("community")
+                    && finding.get("status").and_then(Value::as_str) == Some("inconclusive")
+            })
+        })
+    {
+        return Err(io::Error::other(
+            "bounded CLI output lost the typed inconclusive community outcome",
         )
         .into());
     }
@@ -22161,7 +22286,18 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
     fs::create_dir(repo.join(SRC_DIR_NAME))?;
     fs::write(
         repo.join(SRC_DIR_NAME).join("lib.rs"),
-        "pub fn indexed() {\n    helper();\n}\n\nfn helper() {}\n",
+        "pub fn indexed() {\n    helper();\n}\n\
+         fn group_a_root() { group_a_one(); group_a_two(); }\n\
+         fn group_a_one() { group_a_two(); }\n\
+         fn group_a_two() { group_a_root(); }\n\
+         fn group_b_root() { group_b_one(); group_b_two(); }\n\
+         fn group_b_one() { group_b_two(); }\n\
+         fn group_b_two() { group_b_root(); }\n\
+         fn architecture_root() {\n\
+             group_a_root(); group_a_one(); group_a_two();\n\
+             group_b_root(); group_b_one(); group_b_two();\n\
+         }\n\
+         fn helper() {}\n",
     )?;
     let db = temp.path().join("projectatlas.db");
 
@@ -22209,7 +22345,7 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         r#"{"jsonrpc":"2.0","id":20,"method":"tools/call","params":{"name":"atlas_task_status","arguments":{"task_id":"task-progress-contract"}}}"#.to_string(),
         r#"{"jsonrpc":"2.0","id":21,"method":"tools/call","params":{"name":"atlas_task_cancel","arguments":{"task_id":"task-progress-contract"}}}"#.to_string(),
         r#"{"jsonrpc":"2.0","id":22,"method":"tools/call","params":{"name":"atlas_health","arguments":{"coverage":true,"path_prefix":"src/lib.rs","parser":"tree-sitter","provider":"tree-sitter","coverage_state":"complete","limit":1}}}"#.to_string(),
-        r#"{"jsonrpc":"2.0","id":23,"method":"tools/call","params":{"name":"atlas_symbol_relations","arguments":{"view":"analysis","file":"src/lib.rs","symbol":"indexed","direction":"outbound","depth":2,"limit":50,"output_bytes":65536,"include_communities":true,"include_cycles":true}}}"#.to_string(),
+        r#"{"jsonrpc":"2.0","id":23,"method":"tools/call","params":{"name":"atlas_symbol_relations","arguments":{"view":"analysis","file":"src/lib.rs","symbol":"architecture_root","direction":"outbound","depth":3,"limit":100,"output_bytes":65536,"include_communities":true,"include_cycles":true}}}"#.to_string(),
         r#"{"jsonrpc":"2.0","id":24,"method":"tools/call","params":{"name":"atlas_slice","arguments":{"file":"src/lib.rs","symbol":"helper","symbol_kind":"function","symbol_signature":"fn helper ( )"}}}"#.to_string(),
         r#"{"jsonrpc":"2.0","id":25,"method":"tools/call","params":{"name":"atlas_file_summary","arguments":{"file":"src/lib.rs","compact":true}}}"#.to_string(),
         r#"{"jsonrpc":"2.0","id":26,"method":"tools/call","params":{"name":"atlas_symbol_relations","arguments":{"view":"analysis","analysis_mode":"impact","vcs":"working_tree","file":"src/lib.rs","symbol":"indexed","direction":"outbound","depth":2,"limit":50,"output_bytes":65536}}}"#.to_string(),
@@ -22221,6 +22357,8 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         r#"{"jsonrpc":"2.0","id":32,"method":"tools/call","params":{"name":"atlas_symbol_relations","arguments":{"view":"detailed","compact":true,"file":"src/lib.rs","symbol":"indexed","symbol_parent":"","direction":"outbound","include_occurrences":true,"limit":10,"output_bytes":65536}}}"#.to_string(),
         r#"{"jsonrpc":"2.0","id":33,"method":"tools/call","params":{"name":"atlas_symbol_relations","arguments":{"view":"detailed","compact":true,"file":"src/lib.rs","symbol":"indexed","direction":"outbound","include_occurrences":true,"limit":10,"output_bytes":2048}}}"#.to_string(),
         r#"{"jsonrpc":"2.0","id":34,"method":"tools/call","params":{"name":"atlas_symbol_relations","arguments":{"compact":true,"file":"src/lib.rs","symbol":"indexed","direction":"outbound","limit":10}}}"#.to_string(),
+        r#"{"jsonrpc":"2.0","id":35,"method":"tools/call","params":{"name":"atlas_symbol_relations","arguments":{"view":"analysis","file":"src/lib.rs","symbol":"architecture_root","direction":"outbound","depth":3,"limit":100,"output_bytes":65536,"include_communities":true,"include_cycles":true}}}"#.to_string(),
+        r#"{"jsonrpc":"2.0","id":36,"method":"tools/call","params":{"name":"atlas_symbol_relations","arguments":{"view":"analysis","file":"src/lib.rs","symbol":"architecture_root","direction":"outbound","depth":3,"limit":100,"edge_limit":1,"output_bytes":65536,"include_communities":true}}}"#.to_string(),
     ];
     let executable = assert_cmd::cargo::cargo_bin("projectatlas");
     let stdout = run_mcp_stdio(
@@ -22236,6 +22374,8 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
     assert_frozen_mcp_surfaces_compatible(&stdout)?;
     let session_brief_text = mcp_tool_text(&stdout, 19)?;
     let analysis_text = mcp_tool_text(&stdout, 23)?;
+    let repeated_analysis_text = mcp_tool_text(&stdout, 35)?;
+    let bounded_analysis_text = mcp_tool_text(&stdout, 36)?;
     let next_call_text = mcp_tool_text(&stdout, 24)?;
     let recommended_summary_text = mcp_tool_text(&stdout, 25)?;
     let impact_text = mcp_tool_text(&stdout, 26)?;
@@ -22247,7 +22387,67 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
     let compact_relations_text = mcp_tool_text(&stdout, 32)?;
     let bounded_compact_relations_text = mcp_tool_text(&stdout, 33)?;
     let rejected_legacy_compact_text = mcp_tool_text(&stdout, 34)?;
-    let session_brief_has_ready_call = session_brief_text.contains("target: atlas_file_summary")
+    let analysis_payload: Value = toon_format::decode_default(&analysis_text)?;
+    let repeated_analysis_payload: Value = toon_format::decode_default(&repeated_analysis_text)?;
+    let first_communities = json_community_values(&analysis_payload)?;
+    let repeated_communities = json_community_values(&repeated_analysis_payload)?;
+    if serde_json::to_vec(&first_communities)? != serde_json::to_vec(&repeated_communities)? {
+        return Err(io::Error::other(
+            "repeated MCP community fields were not byte stable after TOON decoding",
+        )
+        .into());
+    }
+    assert_planted_community_values(&first_communities, "MCP")?;
+    if bounded_analysis_text.len() > 65536 {
+        return Err(io::Error::other(format!(
+            "bounded community MCP TOON emitted {} bytes above its 65536-byte ceiling",
+            bounded_analysis_text.len()
+        ))
+        .into());
+    }
+    let bounded_payload: Value = toon_format::decode_default(&bounded_analysis_text)?;
+    require_json_bool(&bounded_payload, &["symbol_relations", "truncated"], true)?;
+    require_json_usize(
+        &bounded_payload,
+        &["symbol_relations", "work", "rendered_output_bytes"],
+        bounded_analysis_text.len(),
+    )?;
+    if bounded_payload
+        .pointer("/symbol_relations/continuation")
+        .and_then(Value::as_str)
+        .is_none_or(str::is_empty)
+    {
+        return Err(
+            io::Error::other("bounded community MCP TOON omitted its continuation cursor").into(),
+        );
+    }
+    let bounded_communities = json_community_values(&bounded_payload)?;
+    if !bounded_communities.iter().any(|community| {
+        community
+            .get("coverage")
+            .and_then(Value::as_str)
+            .is_some_and(|coverage| coverage == "partial")
+            && community
+                .get("convergence")
+                .and_then(Value::as_str)
+                .is_some_and(|convergence| convergence == "inconclusive")
+    }) || !bounded_payload
+        .pointer("/symbol_relations/findings")
+        .and_then(Value::as_array)
+        .is_some_and(|findings| {
+            findings.iter().any(|finding| {
+                finding.get("kind").and_then(Value::as_str) == Some("community")
+                    && finding.get("status").and_then(Value::as_str) == Some("inconclusive")
+            })
+        })
+    {
+        return Err(io::Error::other(
+            "bounded MCP TOON lost the typed inconclusive community outcome",
+        )
+        .into());
+    }
+    let session_brief_has_ready_call = (session_brief_text.contains("target: atlas_file_summary")
+        || session_brief_text.contains("target: atlas_symbol_relations"))
         && session_brief_text.contains("file: src/lib.rs");
     if !compact_session_brief_text
         .contains("recommended_subagent_reasoning: lowest_reliable_host_supported")
@@ -36578,6 +36778,191 @@ fn require_same_canonical_path(
         ))
         .into())
     }
+}
+
+/// Follow the existing analysis cursor until the complete bounded page returns.
+fn run_json_analysis_to_completion(
+    repo: &Path,
+    base_args: &[String],
+) -> Result<Vec<Value>, Box<dyn Error>> {
+    let mut args = base_args.to_vec();
+    let mut pages = Vec::new();
+    for _ in 0..8 {
+        let output = Command::cargo_bin("projectatlas")?
+            .current_dir(repo)
+            .env("PROJECTATLAS_NO_TELEMETRY", "1")
+            .args(&args)
+            .output()?;
+        if !output.status.success() {
+            return Err(io::Error::other(format!(
+                "JSON analysis continuation failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ))
+            .into());
+        }
+        let payload: Value = serde_json::from_slice(&output.stdout)?;
+        let cursor = payload
+            .pointer("/symbol_relations/continuation")
+            .and_then(Value::as_str)
+            .filter(|cursor| !cursor.is_empty())
+            .map(str::to_string);
+        pages.push(payload);
+        let Some(cursor) = cursor else {
+            return Ok(pages);
+        };
+        if args.len() >= 2 && args[args.len() - 2] == "--cursor" {
+            args.pop();
+            args.pop();
+        }
+        args.extend(["--cursor".to_string(), cursor.to_string()]);
+    }
+    Err(io::Error::other("JSON analysis continuation exceeded its test bound").into())
+}
+
+/// Return the community metadata findings from one analysis response.
+fn json_community_values(value: &Value) -> Result<Vec<&Value>, Box<dyn Error>> {
+    let findings = value
+        .pointer("/symbol_relations/findings")
+        .and_then(Value::as_array)
+        .ok_or_else(|| io::Error::other("analysis response omitted findings"))?;
+    let communities = findings
+        .iter()
+        .filter(|finding| finding.get("kind").and_then(Value::as_str) == Some("community"))
+        .filter_map(|finding| finding.get("community"))
+        .collect::<Vec<_>>();
+    if communities.is_empty() {
+        return Err(io::Error::other("analysis response omitted community metadata").into());
+    }
+    Ok(communities)
+}
+
+/// Return community metadata across every bounded continuation page.
+fn json_community_values_from_pages(pages: &[Value]) -> Result<Vec<&Value>, Box<dyn Error>> {
+    let mut communities = Vec::new();
+    for page in pages {
+        if let Ok(page_communities) = json_community_values(page) {
+            communities.extend(page_communities);
+        }
+    }
+    if communities.is_empty() {
+        return Err(io::Error::other("analysis pages omitted community metadata").into());
+    }
+    Ok(communities)
+}
+
+/// Verify stable IDs/order, containment exclusion, and the planted partition.
+fn assert_planted_community_values(
+    communities: &[&Value],
+    adapter: &str,
+) -> Result<(), Box<dyn Error>> {
+    let expected_group_a = BTreeSet::from([
+        "group_a_one".to_string(),
+        "group_a_root".to_string(),
+        "group_a_two".to_string(),
+    ]);
+    let expected_group_b = BTreeSet::from([
+        "group_b_one".to_string(),
+        "group_b_root".to_string(),
+        "group_b_two".to_string(),
+    ]);
+    let mut community_ids = BTreeSet::new();
+    let mut member_sets = Vec::new();
+    for community in communities {
+        let id = community.get("id").and_then(Value::as_str).ok_or_else(|| {
+            io::Error::other(format!("{adapter} community omitted its stable ID"))
+        })?;
+        if !id.starts_with("community-v1-") || !community_ids.insert(id.to_string()) {
+            return Err(io::Error::other(format!(
+                "{adapter} community IDs were missing or duplicated: {community_ids:?}"
+            ))
+            .into());
+        }
+        if community.get("coverage").and_then(Value::as_str) != Some("complete")
+            || community.get("convergence").and_then(Value::as_str) != Some("converged")
+            || community.get("truncated").and_then(Value::as_bool) != Some(false)
+        {
+            return Err(io::Error::other(format!(
+                "{adapter} planted community did not report complete converged coverage: {community:?}"
+            ))
+            .into());
+        }
+        let members = community
+            .get("members")
+            .and_then(Value::as_array)
+            .ok_or_else(|| io::Error::other(format!("{adapter} community omitted members")))?;
+        let member_keys = members
+            .iter()
+            .map(|member| {
+                member
+                    .pointer("/node/entity/key/stable/canonical_identity")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        io::Error::other(format!("{adapter} community member lacked a stable key"))
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if member_keys.windows(2).any(|pair| pair[0] > pair[1]) {
+            return Err(io::Error::other(format!(
+                "{adapter} community members were not in stable key order: {member_keys:?}"
+            ))
+            .into());
+        }
+        if community
+            .get("evidence")
+            .and_then(Value::as_array)
+            .is_some_and(|evidence| {
+                evidence.iter().any(|edge| {
+                    edge.get("source")
+                        .and_then(Value::as_str)
+                        .is_none_or(str::is_empty)
+                        || edge
+                            .get("target")
+                            .and_then(Value::as_str)
+                            .is_none_or(str::is_empty)
+                        || edge.get("weight").and_then(Value::as_u64) == Some(0)
+                        || edge.pointer("/relation/value").and_then(Value::as_str)
+                            == Some("contains")
+                })
+            })
+        {
+            return Err(io::Error::other(format!(
+                "{adapter} community evidence emitted a containment relation"
+            ))
+            .into());
+        }
+        let member_names = members
+            .iter()
+            .map(|member| {
+                member
+                    .pointer("/node/entity/selector/symbol/name")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .ok_or_else(|| {
+                        io::Error::other(format!(
+                            "{adapter} community member lacked a stable symbol name"
+                        ))
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        member_sets.push(member_names.into_iter().collect::<BTreeSet<_>>());
+    }
+    let group_a_partition = member_sets
+        .iter()
+        .any(|members| expected_group_a.is_subset(members));
+    let group_b_partition = member_sets
+        .iter()
+        .any(|members| expected_group_b.is_subset(members));
+    let groups_are_separate = member_sets.iter().all(|members| {
+        !(members.iter().any(|name| expected_group_a.contains(name))
+            && members.iter().any(|name| expected_group_b.contains(name)))
+    });
+    if !group_a_partition || !group_b_partition || !groups_are_separate {
+        return Err(io::Error::other(format!(
+            "{adapter} community projection did not preserve planted groups: {member_sets:?}"
+        ))
+        .into());
+    }
+    Ok(())
 }
 
 /// Require a nested JSON string value.

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -36814,7 +36814,7 @@ fn run_json_analysis_to_completion(
             args.pop();
             args.pop();
         }
-        args.extend(["--cursor".to_string(), cursor.to_string()]);
+        args.extend(["--cursor".to_string(), cursor]);
     }
     Err(io::Error::other("JSON analysis continuation exceeded its test bound").into())
 }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -22361,16 +22361,22 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         r#"{"jsonrpc":"2.0","id":36,"method":"tools/call","params":{"name":"atlas_symbol_relations","arguments":{"view":"analysis","file":"src/lib.rs","symbol":"architecture_root","direction":"outbound","depth":3,"limit":100,"edge_limit":1,"output_bytes":65536,"include_communities":true}}}"#.to_string(),
     ];
     let executable = assert_cmd::cargo::cargo_bin("projectatlas");
-    let stdout = run_mcp_stdio(
-        &executable,
-        &repo,
-        &[
-            "--db".to_string(),
-            db.display().to_string(),
-            "mcp".to_string(),
-        ],
-        &messages,
-    )?;
+    let args = [
+        "--db".to_string(),
+        db.display().to_string(),
+        "mcp".to_string(),
+    ];
+    let run_phase = |phase: &[String]| run_mcp_stdio(&executable, &repo, &args, phase);
+    // RMCP dispatches requests concurrently.  Keep the original request order,
+    // but finish initialization/scan before the later analysis phase can read
+    // the graph, then reopen the same database for the analysis requests.
+    let mut stdout = run_phase(&messages[..4])?;
+    let mut navigation_messages = vec![messages[0].clone(), messages[1].clone()];
+    navigation_messages.extend(messages[4..21].iter().cloned());
+    stdout.push_str(&run_phase(&navigation_messages)?);
+    let mut analysis_messages = vec![messages[0].clone(), messages[1].clone()];
+    analysis_messages.extend(messages[21..].iter().cloned());
+    stdout.push_str(&run_phase(&analysis_messages)?);
     assert_frozen_mcp_surfaces_compatible(&stdout)?;
     let session_brief_text = mcp_tool_text(&stdout, 19)?;
     let analysis_text = mcp_tool_text(&stdout, 23)?;

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -9,6 +9,15 @@ mod analysis_test_observer {
     /// Named production phase reached by one synchronous analysis request.
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub(super) enum AnalysisPhaseEvent {
+        /// Exact byte ledger passed to the architecture community projection.
+        CompositionBudget {
+            /// Remaining bytes handed to architecture findings.
+            symbol_byte_budget: u64,
+            /// Existing architecture findings' append charge.
+            existing_finding_append_bytes: u64,
+            /// Remaining bytes handed to community findings.
+            community_budget: u64,
+        },
         /// Induced relationship closure is about to traverse its first bounded frontier.
         Traversal,
         /// Admitted symbol hydration is about to enter bounded storage work.
@@ -1806,6 +1815,14 @@ fn architecture_findings(
             }
         }
         let community_budget = symbol_byte_budget.saturating_sub(existing_finding_append_bytes);
+        #[cfg(test)]
+        analysis_test_observer::notify(
+            analysis_test_observer::AnalysisPhaseEvent::CompositionBudget {
+                symbol_byte_budget,
+                existing_finding_append_bytes,
+                community_budget,
+            },
+        );
         let existing_community_finding_count =
             preceding_finding_count.saturating_add(findings.len());
         let (community_findings, community_working_set_bytes, community_limits) =

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -118,6 +118,10 @@ const COMMUNITY_WORKING_SET_MULTIPLIER: u64 = 8;
 const COMMUNITY_WORKING_SET_ENTRY_BYTES: u64 = 256;
 /// Conservative fixed map, vector, and propagation-state overhead.
 const COMMUNITY_WORKING_SET_FIXED_BYTES: u64 = 32 * 1024;
+/// Fixed JSON array framing already retained by the analysis composition.
+const JSON_ARRAY_FRAMING_BYTES: u64 = 2;
+/// Fixed JSON array separator inserted before an appended finding.
+const JSON_ARRAY_SEPARATOR_BYTES: u64 = 1;
 
 /// Closed analysis projection selected on the existing relation route.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -927,6 +931,7 @@ fn load_relation_analysis_with_closure_deadline(
         }]
     };
     let initial_finding_bytes = serialized_bytes_controlled(&findings, control)?;
+    let initial_finding_count = findings.len();
     let symbol_byte_budget = projection_allowance
         .saturating_sub(topology_bytes)
         .saturating_sub(initial_finding_bytes);
@@ -940,6 +945,7 @@ fn load_relation_analysis_with_closure_deadline(
                 community_evidence_complete,
                 query,
                 symbol_byte_budget,
+                initial_finding_count,
                 &mut supplemental_work,
                 control,
             )?,
@@ -1727,6 +1733,7 @@ fn architecture_findings(
     community_complete: bool,
     query: &RelationAnalysisQuery,
     symbol_byte_budget: u64,
+    preceding_finding_count: usize,
     supplemental_work: &mut SupplementalWork,
     control: Option<&IndexWorkControl>,
 ) -> ServiceResult<Vec<AnalysisFinding>> {
@@ -1767,52 +1774,68 @@ fn architecture_findings(
     }
     if query.include_communities {
         let mut existing_finding_bytes = serialized_bytes_controlled(&findings, control)?;
-        if existing_finding_bytes > symbol_byte_budget {
+        let mut existing_finding_append_bytes = serialized_findings_append_bytes(
+            existing_finding_bytes,
+            findings.len(),
+            preceding_finding_count,
+        );
+        if existing_finding_append_bytes > symbol_byte_budget {
             supplemental_work.composition_truncated = true;
             push_limit(
                 &mut supplemental_work.reached_limits,
                 GraphLimitKind::IntermediateBytes,
             );
-            while existing_finding_bytes > symbol_byte_budget && findings.len() > 1 {
+            while existing_finding_append_bytes > symbol_byte_budget && findings.len() > 1 {
                 check_control(control)?;
                 findings.pop();
                 existing_finding_bytes = serialized_bytes_controlled(&findings, control)?;
+                existing_finding_append_bytes = serialized_findings_append_bytes(
+                    existing_finding_bytes,
+                    findings.len(),
+                    preceding_finding_count,
+                );
             }
-            if existing_finding_bytes > symbol_byte_budget {
+            if existing_finding_append_bytes > symbol_byte_budget {
                 findings.clear();
                 existing_finding_bytes = serialized_bytes_controlled(&findings, control)?;
+                existing_finding_append_bytes = serialized_findings_append_bytes(
+                    existing_finding_bytes,
+                    findings.len(),
+                    preceding_finding_count,
+                );
             }
         }
-        let community_budget = symbol_byte_budget.saturating_sub(existing_finding_bytes);
-        if community_budget > 0 {
-            let (community_findings, community_working_set_bytes, community_limits) =
-                community_findings_with_budget(
-                    nodes,
-                    edges,
-                    community_complete,
-                    query,
-                    community_budget,
-                    control,
-                )?;
-            supplemental_work.community_working_set_bytes = supplemental_work
-                .community_working_set_bytes
-                .max(community_working_set_bytes);
-            let community_truncated = !community_limits.is_empty();
-            for limit in community_limits {
-                push_limit(&mut supplemental_work.reached_limits, limit);
-            }
-            if community_truncated
-                || community_findings.iter().any(|finding| {
-                    finding
-                        .community
-                        .as_ref()
-                        .is_some_and(|community| community.truncated)
-                })
-            {
-                supplemental_work.composition_truncated = true;
-            }
-            findings.extend(community_findings);
+        let community_budget = symbol_byte_budget.saturating_sub(existing_finding_append_bytes);
+        let existing_community_finding_count =
+            preceding_finding_count.saturating_add(findings.len());
+        let (community_findings, community_working_set_bytes, community_limits) =
+            community_findings_with_budget(
+                nodes,
+                edges,
+                community_complete,
+                query,
+                community_budget,
+                existing_community_finding_count,
+                control,
+            )?;
+        supplemental_work.community_working_set_bytes = supplemental_work
+            .community_working_set_bytes
+            .max(community_working_set_bytes);
+        let community_truncated = !community_limits.is_empty();
+        for limit in community_limits {
+            push_limit(&mut supplemental_work.reached_limits, limit);
         }
+        if community_truncated
+            || community_findings.iter().any(|finding| {
+                finding
+                    .community
+                    .as_ref()
+                    .is_some_and(|community| community.truncated)
+            })
+        {
+            supplemental_work.composition_truncated = true;
+        }
+        findings.extend(community_findings);
     }
     if query.include_cycles {
         let dependency_edges = edges
@@ -2272,6 +2295,38 @@ fn serialized_bytes_controlled<T: Serialize + ?Sized>(
     Ok(counter.bytes)
 }
 
+/// Charge one finding as an append to an already retained JSON findings array.
+///
+/// The enclosing array's `[]` framing is charged by the composition owner. An
+/// append therefore adds only the finding bytes and, after the first finding,
+/// the fixed comma separator.
+const fn serialized_finding_append_bytes(
+    finding_bytes: u64,
+    preceding_finding_count: usize,
+) -> u64 {
+    finding_bytes.saturating_add(if preceding_finding_count == 0 {
+        0
+    } else {
+        JSON_ARRAY_SEPARATOR_BYTES
+    })
+}
+
+/// Charge a serialized findings vector appended to an existing JSON array.
+const fn serialized_findings_append_bytes(
+    findings_bytes: u64,
+    finding_count: usize,
+    preceding_finding_count: usize,
+) -> u64 {
+    if finding_count == 0 {
+        return 0;
+    }
+    findings_bytes.saturating_sub(if preceding_finding_count == 0 {
+        JSON_ARRAY_FRAMING_BYTES
+    } else {
+        JSON_ARRAY_SEPARATOR_BYTES
+    })
+}
+
 /// Find one node-simple static relation path to an exact target.
 fn trace_findings(
     report: &DetailedRelationReport,
@@ -2402,6 +2457,7 @@ fn community_findings(
         complete,
         query,
         query.relations.budget.intermediate_bytes(),
+        0,
         control,
     )?
     .0)
@@ -2414,6 +2470,7 @@ fn community_findings_with_budget(
     complete: bool,
     query: &RelationAnalysisQuery,
     intermediate_bytes: u64,
+    preceding_finding_count: usize,
     control: Option<&IndexWorkControl>,
 ) -> ServiceResult<(Vec<AnalysisFinding>, u64, Vec<GraphLimitKind>)> {
     check_control(control)?;
@@ -2439,9 +2496,11 @@ fn community_findings_with_budget(
     };
     let truncation_marker = community_truncation_finding(&weights, parameters, 0, marker_coverage);
     let truncation_marker_bytes = serialized_bytes_controlled(&truncation_marker, control)?;
+    let truncation_marker_append_bytes =
+        serialized_finding_append_bytes(truncation_marker_bytes, preceding_finding_count);
     let working_set_bytes = community_working_set_upper_bound(nodes, edges, control)?;
-    if working_set_bytes.saturating_add(truncation_marker_bytes) > intermediate_bytes {
-        let findings = if truncation_marker_bytes <= intermediate_bytes {
+    if working_set_bytes.saturating_add(truncation_marker_append_bytes) > intermediate_bytes {
+        let findings = if truncation_marker_append_bytes <= intermediate_bytes {
             vec![truncation_marker]
         } else {
             Vec::new()
@@ -2457,9 +2516,10 @@ fn community_findings_with_budget(
         if resource_truncated {
             evidence.truncate(parameters.edge_limit as usize);
         }
-        let metadata_fits =
-            community_finding_upper_bound(nodes, &keys, &evidence, &weights, parameters, control)?
-                <= construction_bytes;
+        let metadata_fits = serialized_finding_append_bytes(
+            community_finding_upper_bound(nodes, &keys, &evidence, &weights, parameters, control)?,
+            preceding_finding_count,
+        ) <= construction_bytes;
         let metadata_keys = if metadata_fits { keys.as_slice() } else { &[] };
         let metadata_evidence = if metadata_fits {
             evidence.as_slice()
@@ -2516,7 +2576,9 @@ fn community_findings_with_budget(
             &weights,
             parameters,
             control,
-        )? <= construction_bytes;
+        )?;
+        let metadata_fits = serialized_finding_append_bytes(metadata_fits, preceding_finding_count)
+            <= construction_bytes;
         let metadata_keys = if metadata_fits { keys.as_slice() } else { &[] };
         let metadata_evidence = if metadata_fits {
             admitted_edges.as_slice()
@@ -2565,7 +2627,8 @@ fn community_findings_with_budget(
         iteration,
         convergence,
         control,
-        construction_bytes.saturating_sub(truncation_marker_bytes),
+        preceding_finding_count,
+        construction_bytes,
     )?;
     Ok((findings, working_set_bytes, truncation_limits))
 }
@@ -2721,6 +2784,7 @@ fn community_candidate_findings(
     iteration: u32,
     convergence: CommunityConvergence,
     control: Option<&IndexWorkControl>,
+    preceding_finding_count: usize,
     intermediate_bytes: u64,
 ) -> ServiceResult<(Vec<AnalysisFinding>, Vec<GraphLimitKind>)> {
     let mut groups = BTreeMap::<String, Vec<String>>::new();
@@ -2730,7 +2794,7 @@ fn community_candidate_findings(
         groups.entry(label).or_default().push(key.clone());
     }
     let mut findings = Vec::new();
-    let mut retained_bytes = 0_u64;
+    let mut retained_append_bytes = 0_u64;
     let mut truncated = false;
     for members in groups.values() {
         check_control(control)?;
@@ -2742,7 +2806,11 @@ fn community_candidate_findings(
             parameters,
             control,
         )?;
-        if retained_bytes.saturating_add(candidate_bound) > intermediate_bytes {
+        let candidate_append_bytes = serialized_finding_append_bytes(
+            candidate_bound,
+            preceding_finding_count.saturating_add(findings.len()),
+        );
+        if retained_append_bytes.saturating_add(candidate_append_bytes) > intermediate_bytes {
             truncated = true;
             break;
         }
@@ -2780,11 +2848,15 @@ fn community_candidate_findings(
             community: Some(metadata),
         };
         let finding_bytes = serialized_bytes_controlled(&finding, control)?;
-        if retained_bytes.saturating_add(finding_bytes) > intermediate_bytes {
+        let finding_append_bytes = serialized_finding_append_bytes(
+            finding_bytes,
+            preceding_finding_count.saturating_add(findings.len()),
+        );
+        if retained_append_bytes.saturating_add(finding_append_bytes) > intermediate_bytes {
             truncated = true;
             break;
         }
-        retained_bytes = retained_bytes.saturating_add(finding_bytes);
+        retained_append_bytes = retained_append_bytes.saturating_add(finding_append_bytes);
         findings.push(finding);
     }
     if truncated {
@@ -2796,7 +2868,11 @@ fn community_candidate_findings(
             CommunityCoverage::Complete,
         );
         let marker_bytes = serialized_bytes_controlled(&marker, control)?;
-        if retained_bytes.saturating_add(marker_bytes) > intermediate_bytes {
+        let marker_append_bytes = serialized_finding_append_bytes(
+            marker_bytes,
+            preceding_finding_count.saturating_add(findings.len()),
+        );
+        if retained_append_bytes.saturating_add(marker_append_bytes) > intermediate_bytes {
             findings.clear();
         } else {
             findings.push(marker);

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -104,6 +104,14 @@ const ANALYSIS_CURSOR_MAX_BYTES: usize = 256 * 1024;
 const MAX_ANALYSIS_NODES: u32 = 512;
 /// Maximum edges retained by one analysis projection.
 const MAX_ANALYSIS_EDGES: u32 = 2_048;
+/// Version of the deterministic architecture-community projection.
+const COMMUNITY_ALGORITHM_VERSION: u16 = 1;
+/// Version of the stable community ordering and identifier contract.
+const COMMUNITY_ORDERING_VERSION: u16 = 1;
+/// Maximum asynchronous label-propagation rounds per request.
+const COMMUNITY_MAX_ITERATIONS: u32 = 24;
+/// Self-vote keeps isolated and weakly connected nodes deterministic.
+const COMMUNITY_SELF_WEIGHT: u32 = 1;
 
 /// Closed analysis projection selected on the existing relation route.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -210,6 +218,95 @@ pub struct AnalysisFinding {
     pub metric: Option<u64>,
     /// Exact relation evidence when this finding is caused by a resolution gap.
     pub evidence: Option<AnalysisRelationEvidence>,
+    /// Deterministic community metadata when this is a community finding.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub community: Option<CommunityAnalysis>,
+}
+
+/// Convergence state of one bounded label-propagation run.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommunityConvergence {
+    /// Every node retained its selected label during a complete round.
+    Converged,
+    /// The fixed iteration ceiling was reached before convergence.
+    IterationLimit,
+    /// The input coverage or resource envelope did not permit a partition.
+    Inconclusive,
+}
+
+/// Coverage state attached to one community projection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommunityCoverage {
+    /// All admitted nodes and resolved local edges were inspected.
+    Complete,
+    /// A traversal or relation boundary prevented a complete partition.
+    Partial,
+}
+
+/// One fixed relation-family weight in the v1 community contract.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct CommunityRelationWeight {
+    /// Relation family receiving this vote weight.
+    pub relation: GraphRelationKind,
+    /// Positive vote weight used by label propagation.
+    pub weight: u32,
+}
+
+/// Versioned limits and input selectors used by one community run.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct CommunityParameters {
+    /// Label-propagation algorithm version.
+    pub algorithm_version: u16,
+    /// Stable node, label, and identifier ordering version.
+    pub ordering_version: u16,
+    /// Maximum label-propagation rounds.
+    pub max_iterations: u32,
+    /// Maximum nodes admitted to one projection.
+    pub node_limit: u32,
+    /// Maximum edges admitted to one projection.
+    pub edge_limit: u32,
+    /// Maximum encoded output bytes inherited from the bounded analysis route.
+    pub output_bytes: u32,
+    /// Optional detailed relation-family filter.
+    pub relation: Option<GraphRelationKind>,
+}
+
+/// One resolved relation retained as community evidence.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CommunityEdgeEvidence {
+    /// Canonical source entity identity.
+    pub source: String,
+    /// Canonical target entity identity.
+    pub target: String,
+    /// Resolved local relation family.
+    pub relation: GraphRelationKind,
+    /// Vote weight applied to this edge.
+    pub weight: u32,
+}
+
+/// Complete non-persistent metadata for one deterministic community.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct CommunityAnalysis {
+    /// Stable ID derived from the versioned parameters and sorted members.
+    pub id: String,
+    /// Exact members with their existing source, purpose, and coverage evidence.
+    pub members: Vec<AnalysisNode>,
+    /// Resolved local edges induced by these members.
+    pub evidence: Vec<CommunityEdgeEvidence>,
+    /// Fixed relation weights admitted by this run.
+    pub weights: Vec<CommunityRelationWeight>,
+    /// Versioned algorithm and resource parameters.
+    pub parameters: CommunityParameters,
+    /// Number of completed propagation rounds.
+    pub iteration: u32,
+    /// Typed convergence disposition.
+    pub convergence: CommunityConvergence,
+    /// Typed graph coverage disposition.
+    pub coverage: CommunityCoverage,
+    /// Whether a fixed node, edge, or output bound prevented a complete result.
+    pub truncated: bool,
 }
 
 /// One reusable analysis node retaining its authoritative navigation evidence.
@@ -814,6 +911,7 @@ fn load_relation_analysis_with_closure_deadline(
             nodes: vec![analysis_node(&relations.anchor)],
             metric: None,
             evidence: None,
+            community: None,
         }]
     };
     let initial_finding_bytes = serialized_bytes_controlled(&findings, control)?;
@@ -1210,6 +1308,7 @@ fn resolution_gap_finding(
             relation: relation.clone(),
             next_call: relation_gap_next_call(relation, source),
         }),
+        community: None,
     }
 }
 
@@ -1581,6 +1680,7 @@ fn architecture_findings(
             nodes: analysis_nodes_for(nodes, &nodes.keys().cloned().collect::<Vec<_>>()),
             metric: Some(nodes.len() as u64),
             evidence: None,
+            community: None,
         });
     }
     let components = weak_components(nodes, edges, false);
@@ -1593,21 +1693,12 @@ fn architecture_findings(
             nodes: analysis_nodes_for(nodes, component),
             metric: Some(component.len() as u64),
             evidence: None,
+            community: None,
         });
         findings.push(purpose_finding(nodes, component, complete));
     }
     if query.include_communities {
-        for community in weak_components(nodes, edges, true) {
-            findings.push(AnalysisFinding {
-                kind: AnalysisFindingKind::Community,
-                status: AnalysisStatus::Candidate,
-                summary: "relationship-derived community with containment edges excluded"
-                    .to_string(),
-                nodes: analysis_nodes_for(nodes, &community),
-                metric: Some(community.len() as u64),
-                evidence: None,
-            });
-        }
+        findings.extend(community_findings(nodes, edges, complete, query, control)?);
     }
     if query.include_cycles {
         let dependency_edges = edges
@@ -1641,6 +1732,7 @@ fn architecture_findings(
                 nodes: Vec::new(),
                 metric: Some(0),
                 evidence: None,
+                community: None,
             });
         } else {
             for cycle in cycles {
@@ -1652,6 +1744,7 @@ fn architecture_findings(
                     nodes: analysis_nodes_for(nodes, &cycle),
                     metric: Some(cycle.len() as u64),
                     evidence: None,
+                    community: None,
                 });
             }
         }
@@ -1721,6 +1814,7 @@ fn purpose_finding(
         nodes: analysis_nodes_for(nodes, component),
         metric: Some(purposes.len() as u64),
         evidence: None,
+        community: None,
     }
 }
 
@@ -1791,6 +1885,7 @@ fn structural_findings(
             nodes: analysis_nodes_for(nodes, std::slice::from_ref(key)),
             metric: Some(*span),
             evidence: None,
+            community: None,
         });
     }
     if let Some((_span, degree, key)) = candidates
@@ -1808,6 +1903,7 @@ fn structural_findings(
             nodes: analysis_nodes_for(nodes, std::slice::from_ref(key)),
             metric: Some(*degree),
             evidence: None,
+            community: None,
         });
     }
     Ok(findings)
@@ -2096,6 +2192,7 @@ fn trace_findings(
             nodes: vec![analysis_node(&report.anchor)],
             metric: Some(0),
             evidence: None,
+            community: None,
         }]);
     }
     if let Some(row) = target_key.and_then(|target_key| {
@@ -2112,6 +2209,7 @@ fn trace_findings(
             nodes: row.path.iter().map(analysis_node).collect(),
             metric: Some(u64::from(row.depth)),
             evidence: None,
+            community: None,
         }]);
     }
     Ok(vec![AnalysisFinding {
@@ -2130,7 +2228,409 @@ fn trace_findings(
         nodes: Vec::new(),
         metric: None,
         evidence: None,
+        community: None,
     }])
+}
+
+/// Return the fixed relation-family weights admitted by community v1.
+fn community_relation_weights() -> Vec<CommunityRelationWeight> {
+    GraphRelationKind::ALL
+        .into_iter()
+        .filter_map(|relation| {
+            community_relation_weight(relation)
+                .map(|weight| CommunityRelationWeight { relation, weight })
+        })
+        .collect()
+}
+
+/// Return the fixed vote weight for an admitted relation family.
+fn community_relation_weight(kind: GraphRelationKind) -> Option<u32> {
+    match kind {
+        GraphRelationKind::Legacy(RelationKind::Calls) => Some(8),
+        GraphRelationKind::Legacy(RelationKind::Imports) => Some(5),
+        GraphRelationKind::Legacy(RelationKind::DependsOn) => Some(3),
+        GraphRelationKind::Extended(
+            ExtendedRelationKind::Tests | ExtendedRelationKind::RoutesTo,
+        ) => Some(4),
+        GraphRelationKind::Extended(
+            ExtendedRelationKind::References
+            | ExtendedRelationKind::Configures
+            | ExtendedRelationKind::Reads
+            | ExtendedRelationKind::Writes,
+        ) => Some(2),
+        GraphRelationKind::Extended(
+            ExtendedRelationKind::Documents | ExtendedRelationKind::Deploys,
+        ) => Some(1),
+        GraphRelationKind::Legacy(RelationKind::Contains) => None,
+    }
+}
+
+/// Compute deterministic bounded weighted label-propagation communities.
+fn community_findings(
+    nodes: &BTreeMap<String, DetailedRelationNode>,
+    edges: &[LocalEdge],
+    complete: bool,
+    query: &RelationAnalysisQuery,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<Vec<AnalysisFinding>> {
+    check_control(control)?;
+    let weights = community_relation_weights();
+    let parameters = CommunityParameters {
+        algorithm_version: COMMUNITY_ALGORITHM_VERSION,
+        ordering_version: COMMUNITY_ORDERING_VERSION,
+        max_iterations: COMMUNITY_MAX_ITERATIONS,
+        node_limit: MAX_ANALYSIS_NODES,
+        edge_limit: MAX_ANALYSIS_EDGES,
+        output_bytes: query.relations.budget.output_bytes(),
+        relation: query.relations.relation,
+    };
+    let complete = complete && edges.iter().all(|edge| edge.complete);
+    let (keys, admitted_edges, resource_truncated) =
+        admitted_community_scope(nodes, edges, parameters);
+    if !complete || resource_truncated {
+        let mut evidence = admitted_edges;
+        if resource_truncated {
+            evidence.truncate(parameters.edge_limit as usize);
+        }
+        let metadata = community_metadata(
+            &keys,
+            &evidence,
+            weights,
+            parameters,
+            0,
+            CommunityConvergence::Inconclusive,
+            if complete {
+                CommunityCoverage::Complete
+            } else {
+                CommunityCoverage::Partial
+            },
+            resource_truncated,
+            nodes,
+        );
+        return Ok(vec![AnalysisFinding {
+            kind: AnalysisFindingKind::Community,
+            status: AnalysisStatus::Inconclusive,
+            summary: if resource_truncated {
+                "community projection crossed its fixed node or edge resource ceiling"
+            } else {
+                "community projection is inconclusive because relation coverage is partial"
+            }
+            .to_string(),
+            nodes: analysis_nodes_for(nodes, &keys),
+            metric: Some(keys.len() as u64),
+            evidence: None,
+            community: Some(metadata),
+        }]);
+    }
+
+    let (labels, iteration, convergence) =
+        propagate_community_labels(&keys, &admitted_edges, parameters.max_iterations, control)?;
+    if convergence != CommunityConvergence::Converged {
+        let metadata = community_metadata(
+            &keys,
+            &admitted_edges,
+            weights,
+            parameters,
+            iteration,
+            convergence,
+            CommunityCoverage::Complete,
+            false,
+            nodes,
+        );
+        return Ok(vec![AnalysisFinding {
+            kind: AnalysisFindingKind::Community,
+            status: AnalysisStatus::Inconclusive,
+            summary: "community label propagation reached its fixed iteration ceiling".to_string(),
+            nodes: analysis_nodes_for(nodes, &keys),
+            metric: Some(keys.len() as u64),
+            evidence: None,
+            community: Some(metadata),
+        }]);
+    }
+
+    community_candidate_findings(
+        nodes,
+        &keys,
+        &admitted_edges,
+        &labels,
+        &weights,
+        parameters,
+        iteration,
+        convergence,
+        control,
+    )
+}
+
+/// Admit the stable node and edge prefix under the community resource ceiling.
+fn admitted_community_scope(
+    nodes: &BTreeMap<String, DetailedRelationNode>,
+    edges: &[LocalEdge],
+    parameters: CommunityParameters,
+) -> (Vec<String>, Vec<CommunityEdgeEvidence>, bool) {
+    let all_keys = nodes.keys().cloned().collect::<Vec<_>>();
+    let keys = all_keys
+        .iter()
+        .take(parameters.node_limit as usize)
+        .cloned()
+        .collect::<Vec<_>>();
+    let admitted_nodes = keys.iter().collect::<BTreeSet<_>>();
+    let mut admitted_edges = Vec::new();
+    let mut edge_count = 0_usize;
+    for edge in edges {
+        let Some(weight) = community_relation_weight(edge.kind) else {
+            continue;
+        };
+        if !edge.complete {
+            continue;
+        }
+        if !admitted_nodes.contains(&edge.source) || !admitted_nodes.contains(&edge.target) {
+            continue;
+        }
+        edge_count = edge_count.saturating_add(1);
+        if edge_count <= parameters.edge_limit as usize {
+            admitted_edges.push(CommunityEdgeEvidence {
+                source: edge.source.clone(),
+                target: edge.target.clone(),
+                relation: edge.kind,
+                weight,
+            });
+        }
+    }
+    admitted_edges.sort_by(|left, right| {
+        (&left.source, &left.target, left.relation.as_str()).cmp(&(
+            &right.source,
+            &right.target,
+            right.relation.as_str(),
+        ))
+    });
+    admitted_edges.dedup_by(|left, right| {
+        left.source == right.source
+            && left.target == right.target
+            && left.relation == right.relation
+    });
+    (
+        keys,
+        admitted_edges,
+        all_keys.len() > parameters.node_limit as usize
+            || edge_count > parameters.edge_limit as usize,
+    )
+}
+
+/// Propagate labels in stable node order with a fixed sequential work budget.
+fn propagate_community_labels(
+    keys: &[String],
+    edges: &[CommunityEdgeEvidence],
+    max_iterations: u32,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<(BTreeMap<String, String>, u32, CommunityConvergence)> {
+    check_control(control)?;
+    let mut adjacency = keys
+        .iter()
+        .map(|key| (key.clone(), Vec::<(String, u32)>::new()))
+        .collect::<BTreeMap<_, _>>();
+    for edge in edges {
+        check_control(control)?;
+        adjacency
+            .entry(edge.source.clone())
+            .or_default()
+            .push((edge.target.clone(), edge.weight));
+        adjacency
+            .entry(edge.target.clone())
+            .or_default()
+            .push((edge.source.clone(), edge.weight));
+    }
+    for neighbors in adjacency.values_mut() {
+        neighbors.sort();
+    }
+
+    // ponytail: one bounded sequential pass is deterministic and sufficient at
+    // the 512-node ceiling; replace only after a representative profile proves
+    // that parallel label updates repay their extra synchronization.
+    let mut labels = keys
+        .iter()
+        .map(|key| (key.clone(), key.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let mut converged = keys.is_empty();
+    let mut iteration = 0;
+    while !converged && iteration < max_iterations {
+        check_control(control)?;
+        iteration += 1;
+        let mut changed = false;
+        for key in keys {
+            check_control(control)?;
+            let mut scores = BTreeMap::<String, u32>::new();
+            scores.insert(key.clone(), COMMUNITY_SELF_WEIGHT);
+            if let Some(neighbors) = adjacency.get(key) {
+                for (neighbor, weight) in neighbors {
+                    check_control(control)?;
+                    if let Some(label) = labels.get(neighbor) {
+                        let score = scores.entry(label.clone()).or_default();
+                        *score = score.saturating_add(*weight);
+                    }
+                }
+            }
+            let selected = select_community_label(key, scores);
+            if labels.get(key) != Some(&selected) {
+                labels.insert(key.clone(), selected);
+                changed = true;
+            }
+        }
+        converged = !changed;
+    }
+
+    Ok((
+        labels,
+        iteration,
+        if converged {
+            CommunityConvergence::Converged
+        } else {
+            CommunityConvergence::IterationLimit
+        },
+    ))
+}
+
+/// Select the highest-scoring label, breaking equal scores by stable key order.
+fn select_community_label(key: &str, scores: BTreeMap<String, u32>) -> String {
+    let mut selected = key.to_string();
+    let mut selected_score = 0;
+    for (label, score) in scores {
+        if score > selected_score || (score == selected_score && label < selected) {
+            selected = label;
+            selected_score = score;
+        }
+    }
+    selected
+}
+
+/// Convert stable labels into candidate findings with induced evidence.
+fn community_candidate_findings(
+    nodes: &BTreeMap<String, DetailedRelationNode>,
+    keys: &[String],
+    admitted_edges: &[CommunityEdgeEvidence],
+    labels: &BTreeMap<String, String>,
+    weights: &[CommunityRelationWeight],
+    parameters: CommunityParameters,
+    iteration: u32,
+    convergence: CommunityConvergence,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<Vec<AnalysisFinding>> {
+    let mut groups = BTreeMap::<String, Vec<String>>::new();
+    for key in keys {
+        check_control(control)?;
+        let label = labels.get(key).cloned().unwrap_or_else(|| key.clone());
+        groups.entry(label).or_default().push(key.clone());
+    }
+    let mut findings = Vec::with_capacity(groups.len());
+    for members in groups.values() {
+        check_control(control)?;
+        let member_keys = members.iter().cloned().collect::<BTreeSet<_>>();
+        let evidence = admitted_edges
+            .iter()
+            .filter(|edge| member_keys.contains(&edge.source) && member_keys.contains(&edge.target))
+            .cloned()
+            .collect::<Vec<_>>();
+        let metadata = community_metadata(
+            members,
+            &evidence,
+            weights.to_vec(),
+            parameters,
+            iteration,
+            convergence,
+            CommunityCoverage::Complete,
+            false,
+            nodes,
+        );
+        findings.push(AnalysisFinding {
+            kind: AnalysisFindingKind::Community,
+            status: AnalysisStatus::Candidate,
+            summary: if members.len() == 1 {
+                "singleton community from the complete admitted relation scope"
+            } else {
+                "deterministic weighted relationship community candidate"
+            }
+            .to_string(),
+            nodes: analysis_nodes_for(nodes, members),
+            metric: Some(members.len() as u64),
+            evidence: None,
+            community: Some(metadata),
+        });
+    }
+    Ok(findings)
+}
+
+/// Build stable metadata for one community or typed inconclusive result.
+fn community_metadata(
+    members: &[String],
+    evidence: &[CommunityEdgeEvidence],
+    weights: Vec<CommunityRelationWeight>,
+    parameters: CommunityParameters,
+    iteration: u32,
+    convergence: CommunityConvergence,
+    coverage: CommunityCoverage,
+    truncated: bool,
+    nodes: &BTreeMap<String, DetailedRelationNode>,
+) -> CommunityAnalysis {
+    let mut members = members.to_vec();
+    members.sort();
+    let id = community_id(&members, &weights, parameters);
+    let mut evidence = evidence.to_vec();
+    evidence.sort_by(|left, right| {
+        (&left.source, &left.target, left.relation.as_str()).cmp(&(
+            &right.source,
+            &right.target,
+            right.relation.as_str(),
+        ))
+    });
+    CommunityAnalysis {
+        id,
+        members: analysis_nodes_for(nodes, &members),
+        evidence,
+        weights,
+        parameters,
+        iteration,
+        convergence,
+        coverage,
+        truncated,
+    }
+}
+
+/// Hash one stable community identifier from its complete versioned inputs.
+fn community_id(
+    members: &[String],
+    weights: &[CommunityRelationWeight],
+    parameters: CommunityParameters,
+) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"projectatlas:architecture-community");
+    hasher.update(&[0]);
+    hasher.update(&parameters.algorithm_version.to_le_bytes());
+    hasher.update(&parameters.ordering_version.to_le_bytes());
+    hasher.update(&parameters.max_iterations.to_le_bytes());
+    hasher.update(&parameters.node_limit.to_le_bytes());
+    hasher.update(&parameters.edge_limit.to_le_bytes());
+    hasher.update(&parameters.output_bytes.to_le_bytes());
+    hasher.update(&COMMUNITY_SELF_WEIGHT.to_le_bytes());
+    hasher.update(
+        parameters
+            .relation
+            .map_or("none", GraphRelationKind::as_str)
+            .as_bytes(),
+    );
+    hasher.update(&[0]);
+    for entry in weights {
+        hasher.update(entry.relation.as_str().as_bytes());
+        hasher.update(&[0]);
+        hasher.update(&entry.weight.to_le_bytes());
+    }
+    for member in members {
+        hasher.update(member.as_bytes());
+        hasher.update(&[0]);
+    }
+    format!(
+        "community-v{}-{}",
+        parameters.algorithm_version,
+        hasher.finalize().to_hex()
+    )
 }
 
 /// Compute deterministic weak components with optional containment exclusion.

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1029,13 +1029,6 @@ fn load_relation_analysis_with_closure_deadline(
             .as_ref()
             .is_some_and(|community| community.truncated)
     });
-    if community_projection_truncated {
-        supplemental_work.composition_truncated = true;
-        push_limit(
-            &mut supplemental_work.reached_limits,
-            GraphLimitKind::IntermediateBytes,
-        );
-    }
     let full_finding_count = u32::try_from(findings.len()).map_err(|_overflow| {
         ServiceError::InvalidInput("analysis finding count overflowed".to_string())
     })?;
@@ -1760,17 +1753,29 @@ fn architecture_findings(
         }
         let community_budget = symbol_byte_budget.saturating_sub(existing_finding_bytes);
         if community_budget > 0 {
-            let (community_findings, community_working_set_bytes) = community_findings_with_budget(
-                nodes,
-                edges,
-                community_complete,
-                query,
-                community_budget,
-                control,
-            )?;
+            let (community_findings, community_working_set_bytes, community_limits) =
+                community_findings_with_budget(
+                    nodes,
+                    edges,
+                    community_complete,
+                    query,
+                    community_budget,
+                    control,
+                )?;
             supplemental_work.community_working_set_bytes = supplemental_work
                 .community_working_set_bytes
                 .max(community_working_set_bytes);
+            for limit in community_limits {
+                push_limit(&mut supplemental_work.reached_limits, limit);
+            }
+            if community_findings.iter().any(|finding| {
+                finding
+                    .community
+                    .as_ref()
+                    .is_some_and(|community| community.truncated)
+            }) {
+                supplemental_work.composition_truncated = true;
+            }
             findings.extend(community_findings);
         }
     }
@@ -2339,6 +2344,14 @@ fn community_relation_weight(kind: GraphRelationKind) -> Option<u32> {
     }
 }
 
+/// Return the weight for one complete relation admitted by the community projection.
+fn admitted_community_edge_weight(edge: &LocalEdge) -> Option<u32> {
+    if !edge.complete {
+        return None;
+    }
+    community_relation_weight(edge.kind)
+}
+
 /// Compute deterministic bounded weighted label-propagation communities.
 #[cfg(test)]
 fn community_findings(
@@ -2367,7 +2380,7 @@ fn community_findings_with_budget(
     query: &RelationAnalysisQuery,
     intermediate_bytes: u64,
     control: Option<&IndexWorkControl>,
-) -> ServiceResult<(Vec<AnalysisFinding>, u64)> {
+) -> ServiceResult<(Vec<AnalysisFinding>, u64, Vec<GraphLimitKind>)> {
     check_control(control)?;
     let weights = community_relation_weights();
     let parameters = CommunityParameters {
@@ -2403,11 +2416,13 @@ fn community_findings_with_budget(
                 marker_coverage,
             )],
             0,
+            vec![GraphLimitKind::IntermediateBytes],
         ));
     }
     let construction_bytes = intermediate_bytes.saturating_sub(working_set_bytes);
-    let (keys, admitted_edges, resource_truncated) =
+    let (keys, admitted_edges, resource_limits) =
         admitted_community_scope(nodes, edges, parameters);
+    let resource_truncated = !resource_limits.is_empty();
     if !complete || resource_truncated {
         let mut evidence = admitted_edges;
         if resource_truncated {
@@ -2423,6 +2438,10 @@ fn community_findings_with_budget(
             &[]
         };
         let metadata_truncated = resource_truncated || !metadata_fits;
+        let mut truncation_limits = resource_limits;
+        if !metadata_fits {
+            push_limit(&mut truncation_limits, GraphLimitKind::IntermediateBytes);
+        }
         let metadata = community_metadata(
             metadata_keys,
             metadata_evidence,
@@ -2454,6 +2473,7 @@ fn community_findings_with_budget(
                 community: Some(metadata),
             }],
             working_set_bytes,
+            truncation_limits,
         ));
     }
 
@@ -2475,6 +2495,10 @@ fn community_findings_with_budget(
             &[]
         };
         let metadata_truncated = !metadata_fits;
+        let mut truncation_limits = Vec::new();
+        if !metadata_fits {
+            truncation_limits.push(GraphLimitKind::IntermediateBytes);
+        }
         let metadata = community_metadata(
             metadata_keys,
             metadata_evidence,
@@ -2498,24 +2522,23 @@ fn community_findings_with_budget(
                 community: Some(metadata),
             }],
             working_set_bytes,
+            truncation_limits,
         ));
     }
 
-    Ok((
-        community_candidate_findings(
-            nodes,
-            &keys,
-            &admitted_edges,
-            &labels,
-            &weights,
-            parameters,
-            iteration,
-            convergence,
-            control,
-            construction_bytes.saturating_sub(truncation_marker_bytes),
-        )?,
-        working_set_bytes,
-    ))
+    let (findings, truncation_limits) = community_candidate_findings(
+        nodes,
+        &keys,
+        &admitted_edges,
+        &labels,
+        &weights,
+        parameters,
+        iteration,
+        convergence,
+        control,
+        construction_bytes.saturating_sub(truncation_marker_bytes),
+    )?;
+    Ok((findings, working_set_bytes, truncation_limits))
 }
 
 /// Admit the stable node and edge prefix under the community resource ceiling.
@@ -2523,7 +2546,7 @@ fn admitted_community_scope(
     nodes: &BTreeMap<String, DetailedRelationNode>,
     edges: &[LocalEdge],
     parameters: CommunityParameters,
-) -> (Vec<String>, Vec<CommunityEdgeEvidence>, bool) {
+) -> (Vec<String>, Vec<CommunityEdgeEvidence>, Vec<GraphLimitKind>) {
     let all_keys = nodes.keys().cloned().collect::<Vec<_>>();
     let keys = all_keys
         .iter()
@@ -2534,12 +2557,9 @@ fn admitted_community_scope(
     let mut admitted_edges = Vec::new();
     let mut edge_count = 0_usize;
     for edge in edges {
-        let Some(weight) = community_relation_weight(edge.kind) else {
+        let Some(weight) = admitted_community_edge_weight(edge) else {
             continue;
         };
-        if !edge.complete {
-            continue;
-        }
         if !admitted_nodes.contains(&edge.source) || !admitted_nodes.contains(&edge.target) {
             continue;
         }
@@ -2565,12 +2585,14 @@ fn admitted_community_scope(
             && left.target == right.target
             && left.relation == right.relation
     });
-    (
-        keys,
-        admitted_edges,
-        all_keys.len() > parameters.node_limit as usize
-            || edge_count > parameters.edge_limit as usize,
-    )
+    let mut reached_limits = Vec::new();
+    if all_keys.len() > parameters.node_limit as usize {
+        reached_limits.push(GraphLimitKind::Nodes);
+    }
+    if edge_count > parameters.edge_limit as usize {
+        reached_limits.push(GraphLimitKind::Edges);
+    }
+    (keys, admitted_edges, reached_limits)
 }
 
 /// Propagate labels in stable node order with a fixed sequential work budget.
@@ -2671,7 +2693,7 @@ fn community_candidate_findings(
     convergence: CommunityConvergence,
     control: Option<&IndexWorkControl>,
     intermediate_bytes: u64,
-) -> ServiceResult<Vec<AnalysisFinding>> {
+) -> ServiceResult<(Vec<AnalysisFinding>, Vec<GraphLimitKind>)> {
     let mut groups = BTreeMap::<String, Vec<String>>::new();
     for key in keys {
         check_control(control)?;
@@ -2750,10 +2772,19 @@ fn community_candidate_findings(
         }
         findings.push(marker);
     }
-    Ok(findings)
+    Ok((
+        findings,
+        truncated
+            .then_some(vec![GraphLimitKind::IntermediateBytes])
+            .unwrap_or_default(),
+    ))
 }
 
 /// Charge every graph-sized community temporary before allocating it.
+///
+/// The edge charge mirrors the complete, weighted relation admission used by
+/// `admitted_community_scope`; excluded relation families never own community
+/// clones and therefore do not consume this working-set budget.
 fn community_working_set_upper_bound(
     nodes: &BTreeMap<String, DetailedRelationNode>,
     edges: &[LocalEdge],
@@ -2766,8 +2797,13 @@ fn community_working_set_upper_bound(
             .saturating_add(u64::try_from(key.len()).unwrap_or(u64::MAX))
             .saturating_add(std::mem::size_of::<String>() as u64);
     }
+    let mut admitted_edge_count = 0_u64;
     for edge in edges {
         check_control(control)?;
+        if admitted_community_edge_weight(edge).is_none() {
+            continue;
+        }
+        admitted_edge_count = admitted_edge_count.saturating_add(1);
         endpoint_bytes = endpoint_bytes
             .saturating_add(u64::try_from(edge.source.len()).unwrap_or(u64::MAX))
             .saturating_add(u64::try_from(edge.target.len()).unwrap_or(u64::MAX))
@@ -2776,7 +2812,7 @@ fn community_working_set_upper_bound(
     }
     let entry_count = u64::try_from(nodes.len())
         .unwrap_or(u64::MAX)
-        .saturating_add(u64::try_from(edges.len()).unwrap_or(u64::MAX));
+        .saturating_add(admitted_edge_count);
     Ok(endpoint_bytes
         .saturating_mul(COMMUNITY_WORKING_SET_MULTIPLIER)
         .saturating_add(entry_count.saturating_mul(COMMUNITY_WORKING_SET_ENTRY_BYTES))

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1797,15 +1797,18 @@ fn architecture_findings(
             supplemental_work.community_working_set_bytes = supplemental_work
                 .community_working_set_bytes
                 .max(community_working_set_bytes);
+            let community_truncated = !community_limits.is_empty();
             for limit in community_limits {
                 push_limit(&mut supplemental_work.reached_limits, limit);
             }
-            if community_findings.iter().any(|finding| {
-                finding
-                    .community
-                    .as_ref()
-                    .is_some_and(|community| community.truncated)
-            }) {
+            if community_truncated
+                || community_findings.iter().any(|finding| {
+                    finding
+                        .community
+                        .as_ref()
+                        .is_some_and(|community| community.truncated)
+                })
+            {
                 supplemental_work.composition_truncated = true;
             }
             findings.extend(community_findings);
@@ -2434,22 +2437,16 @@ fn community_findings_with_budget(
     } else {
         CommunityCoverage::Partial
     };
-    let truncation_marker_bytes = serialized_bytes_controlled(
-        &community_truncation_finding(&weights, parameters, 0, marker_coverage),
-        control,
-    )?;
+    let truncation_marker = community_truncation_finding(&weights, parameters, 0, marker_coverage);
+    let truncation_marker_bytes = serialized_bytes_controlled(&truncation_marker, control)?;
     let working_set_bytes = community_working_set_upper_bound(nodes, edges, control)?;
     if working_set_bytes.saturating_add(truncation_marker_bytes) > intermediate_bytes {
-        return Ok((
-            vec![community_truncation_finding(
-                &weights,
-                parameters,
-                0,
-                marker_coverage,
-            )],
-            0,
-            vec![GraphLimitKind::IntermediateBytes],
-        ));
+        let findings = if truncation_marker_bytes <= intermediate_bytes {
+            vec![truncation_marker]
+        } else {
+            Vec::new()
+        };
+        return Ok((findings, 0, vec![GraphLimitKind::IntermediateBytes]));
     }
     let construction_bytes = intermediate_bytes.saturating_sub(working_set_bytes);
     let (keys, admitted_edges, resource_limits) =
@@ -2801,8 +2798,9 @@ fn community_candidate_findings(
         let marker_bytes = serialized_bytes_controlled(&marker, control)?;
         if retained_bytes.saturating_add(marker_bytes) > intermediate_bytes {
             findings.clear();
+        } else {
+            findings.push(marker);
         }
-        findings.push(marker);
     }
     Ok((
         findings,

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -112,6 +112,12 @@ const COMMUNITY_ORDERING_VERSION: u16 = 1;
 const COMMUNITY_MAX_ITERATIONS: u32 = 24;
 /// Self-vote keeps isolated and weakly connected nodes deterministic.
 const COMMUNITY_SELF_WEIGHT: u32 = 1;
+/// Conservative duplicate serialized-byte charge for community working state.
+const COMMUNITY_WORKING_SET_MULTIPLIER: u64 = 8;
+/// Conservative per-node/edge container overhead for community working state.
+const COMMUNITY_WORKING_SET_ENTRY_BYTES: u64 = 256;
+/// Conservative fixed map, vector, and propagation-state overhead.
+const COMMUNITY_WORKING_SET_FIXED_BYTES: u64 = 32 * 1024;
 
 /// Closed analysis projection selected on the existing relation route.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -390,7 +396,8 @@ pub struct RelationAnalysisWork {
     pub symbol_hydration_truncated: bool,
     /// Exact serialized-equivalent analysis-owned bytes retained at return.
     pub retained_composition_bytes: u64,
-    /// Peak aggregate relation, closure, VCS, symbol, topology, and finding bytes.
+    /// Peak aggregate relation, closure, VCS, symbol, topology,
+    /// community-working-set, and finding bytes.
     pub peak_intermediate_bytes: u64,
     /// Whether composition limits omitted supported analysis projections.
     pub composition_truncated: bool,
@@ -636,6 +643,8 @@ struct SupplementalWork {
     retained_composition_bytes: u64,
     /// Whether composition fitting omitted supported evidence.
     composition_truncated: bool,
+    /// Conservative transient bytes charged while constructing community state.
+    community_working_set_bytes: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -1005,7 +1014,8 @@ fn load_relation_analysis_with_closure_deadline(
         .intermediate_bytes
         .saturating_add(closure.decoded_bytes)
         .saturating_add(external_relation_identity_bytes)
-        .saturating_add(generated_composition_bytes);
+        .saturating_add(generated_composition_bytes)
+        .saturating_add(supplemental_work.community_working_set_bytes);
     let final_peak = relations
         .work
         .intermediate_bytes
@@ -1750,14 +1760,18 @@ fn architecture_findings(
         }
         let community_budget = symbol_byte_budget.saturating_sub(existing_finding_bytes);
         if community_budget > 0 {
-            findings.extend(community_findings_with_budget(
+            let (community_findings, community_working_set_bytes) = community_findings_with_budget(
                 nodes,
                 edges,
                 community_complete,
                 query,
                 community_budget,
                 control,
-            )?);
+            )?;
+            supplemental_work.community_working_set_bytes = supplemental_work
+                .community_working_set_bytes
+                .max(community_working_set_bytes);
+            findings.extend(community_findings);
         }
     }
     if query.include_cycles {
@@ -2334,14 +2348,15 @@ fn community_findings(
     query: &RelationAnalysisQuery,
     control: Option<&IndexWorkControl>,
 ) -> ServiceResult<Vec<AnalysisFinding>> {
-    community_findings_with_budget(
+    Ok(community_findings_with_budget(
         nodes,
         edges,
         complete,
         query,
         query.relations.budget.intermediate_bytes(),
         control,
-    )
+    )?
+    .0)
 }
 
 /// Compute communities with an explicit remaining intermediate-byte allowance.
@@ -2352,7 +2367,7 @@ fn community_findings_with_budget(
     query: &RelationAnalysisQuery,
     intermediate_bytes: u64,
     control: Option<&IndexWorkControl>,
-) -> ServiceResult<Vec<AnalysisFinding>> {
+) -> ServiceResult<(Vec<AnalysisFinding>, u64)> {
     check_control(control)?;
     let weights = community_relation_weights();
     let parameters = CommunityParameters {
@@ -2369,6 +2384,28 @@ fn community_findings_with_budget(
             .iter()
             .filter(|edge| community_relation_weight(edge.kind).is_some())
             .all(|edge| edge.complete);
+    let marker_coverage = if complete {
+        CommunityCoverage::Complete
+    } else {
+        CommunityCoverage::Partial
+    };
+    let truncation_marker_bytes = serialized_bytes_controlled(
+        &community_truncation_finding(&weights, parameters, 0, marker_coverage),
+        control,
+    )?;
+    let working_set_bytes = community_working_set_upper_bound(nodes, edges, control)?;
+    if working_set_bytes.saturating_add(truncation_marker_bytes) > intermediate_bytes {
+        return Ok((
+            vec![community_truncation_finding(
+                &weights,
+                parameters,
+                0,
+                marker_coverage,
+            )],
+            0,
+        ));
+    }
+    let construction_bytes = intermediate_bytes.saturating_sub(working_set_bytes);
     let (keys, admitted_edges, resource_truncated) =
         admitted_community_scope(nodes, edges, parameters);
     if !complete || resource_truncated {
@@ -2378,7 +2415,7 @@ fn community_findings_with_budget(
         }
         let metadata_fits =
             community_finding_upper_bound(nodes, &keys, &evidence, &weights, parameters, control)?
-                <= intermediate_bytes;
+                <= construction_bytes;
         let metadata_keys = if metadata_fits { keys.as_slice() } else { &[] };
         let metadata_evidence = if metadata_fits {
             evidence.as_slice()
@@ -2401,20 +2438,23 @@ fn community_findings_with_budget(
             metadata_truncated,
             nodes,
         );
-        return Ok(vec![AnalysisFinding {
-            kind: AnalysisFindingKind::Community,
-            status: AnalysisStatus::Inconclusive,
-            summary: if resource_truncated {
-                "community projection crossed its fixed node or edge resource ceiling"
-            } else {
-                "community projection is inconclusive because relation coverage is partial"
-            }
-            .to_string(),
-            nodes: analysis_nodes_for(nodes, metadata_keys),
-            metric: Some(metadata_keys.len() as u64),
-            evidence: None,
-            community: Some(metadata),
-        }]);
+        return Ok((
+            vec![AnalysisFinding {
+                kind: AnalysisFindingKind::Community,
+                status: AnalysisStatus::Inconclusive,
+                summary: if resource_truncated {
+                    "community projection crossed its fixed node or edge resource ceiling"
+                } else {
+                    "community projection is inconclusive because relation coverage is partial"
+                }
+                .to_string(),
+                nodes: analysis_nodes_for(nodes, metadata_keys),
+                metric: Some(metadata_keys.len() as u64),
+                evidence: None,
+                community: Some(metadata),
+            }],
+            working_set_bytes,
+        ));
     }
 
     let (labels, iteration, convergence) =
@@ -2427,7 +2467,7 @@ fn community_findings_with_budget(
             &weights,
             parameters,
             control,
-        )? <= intermediate_bytes;
+        )? <= construction_bytes;
         let metadata_keys = if metadata_fits { keys.as_slice() } else { &[] };
         let metadata_evidence = if metadata_fits {
             admitted_edges.as_slice()
@@ -2446,29 +2486,36 @@ fn community_findings_with_budget(
             metadata_truncated,
             nodes,
         );
-        return Ok(vec![AnalysisFinding {
-            kind: AnalysisFindingKind::Community,
-            status: AnalysisStatus::Inconclusive,
-            summary: "community label propagation reached its fixed iteration ceiling".to_string(),
-            nodes: analysis_nodes_for(nodes, metadata_keys),
-            metric: Some(metadata_keys.len() as u64),
-            evidence: None,
-            community: Some(metadata),
-        }]);
+        return Ok((
+            vec![AnalysisFinding {
+                kind: AnalysisFindingKind::Community,
+                status: AnalysisStatus::Inconclusive,
+                summary: "community label propagation reached its fixed iteration ceiling"
+                    .to_string(),
+                nodes: analysis_nodes_for(nodes, metadata_keys),
+                metric: Some(metadata_keys.len() as u64),
+                evidence: None,
+                community: Some(metadata),
+            }],
+            working_set_bytes,
+        ));
     }
 
-    community_candidate_findings(
-        nodes,
-        &keys,
-        &admitted_edges,
-        &labels,
-        &weights,
-        parameters,
-        iteration,
-        convergence,
-        control,
-        intermediate_bytes,
-    )
+    Ok((
+        community_candidate_findings(
+            nodes,
+            &keys,
+            &admitted_edges,
+            &labels,
+            &weights,
+            parameters,
+            iteration,
+            convergence,
+            control,
+            construction_bytes.saturating_sub(truncation_marker_bytes),
+        )?,
+        working_set_bytes,
+    ))
 }
 
 /// Admit the stable node and edge prefix under the community resource ceiling.
@@ -2691,26 +2738,12 @@ fn community_candidate_findings(
     }
     if truncated {
         check_control(control)?;
-        let marker = AnalysisFinding {
-            kind: AnalysisFindingKind::Community,
-            status: AnalysisStatus::Inconclusive,
-            summary: "community projection crossed the intermediate-byte budget before all communities were constructed"
-                .to_string(),
-            nodes: Vec::new(),
-            metric: None,
-            evidence: None,
-            community: Some(CommunityAnalysis {
-                id: community_id(&[], weights, parameters),
-                members: Vec::new(),
-                evidence: Vec::new(),
-                weights: weights.to_vec(),
-                parameters,
-                iteration,
-                convergence: CommunityConvergence::Inconclusive,
-                coverage: CommunityCoverage::Complete,
-                truncated: true,
-            }),
-        };
+        let marker = community_truncation_finding(
+            weights,
+            parameters,
+            iteration,
+            CommunityCoverage::Complete,
+        );
         let marker_bytes = serialized_bytes_controlled(&marker, control)?;
         if retained_bytes.saturating_add(marker_bytes) > intermediate_bytes {
             findings.clear();
@@ -2718,6 +2751,65 @@ fn community_candidate_findings(
         findings.push(marker);
     }
     Ok(findings)
+}
+
+/// Charge every graph-sized community temporary before allocating it.
+fn community_working_set_upper_bound(
+    nodes: &BTreeMap<String, DetailedRelationNode>,
+    edges: &[LocalEdge],
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<u64> {
+    let mut endpoint_bytes = 0_u64;
+    for key in nodes.keys() {
+        check_control(control)?;
+        endpoint_bytes = endpoint_bytes
+            .saturating_add(u64::try_from(key.len()).unwrap_or(u64::MAX))
+            .saturating_add(std::mem::size_of::<String>() as u64);
+    }
+    for edge in edges {
+        check_control(control)?;
+        endpoint_bytes = endpoint_bytes
+            .saturating_add(u64::try_from(edge.source.len()).unwrap_or(u64::MAX))
+            .saturating_add(u64::try_from(edge.target.len()).unwrap_or(u64::MAX))
+            .saturating_add(std::mem::size_of::<String>() as u64 * 2)
+            .saturating_add(std::mem::size_of::<CommunityEdgeEvidence>() as u64);
+    }
+    let entry_count = u64::try_from(nodes.len())
+        .unwrap_or(u64::MAX)
+        .saturating_add(u64::try_from(edges.len()).unwrap_or(u64::MAX));
+    Ok(endpoint_bytes
+        .saturating_mul(COMMUNITY_WORKING_SET_MULTIPLIER)
+        .saturating_add(entry_count.saturating_mul(COMMUNITY_WORKING_SET_ENTRY_BYTES))
+        .saturating_add(COMMUNITY_WORKING_SET_FIXED_BYTES))
+}
+
+/// Build the typed marker returned when community construction cannot fit.
+fn community_truncation_finding(
+    weights: &[CommunityRelationWeight],
+    parameters: CommunityParameters,
+    iteration: u32,
+    coverage: CommunityCoverage,
+) -> AnalysisFinding {
+    AnalysisFinding {
+        kind: AnalysisFindingKind::Community,
+        status: AnalysisStatus::Inconclusive,
+        summary: "community projection crossed the intermediate-byte budget before all communities were constructed"
+            .to_string(),
+        nodes: Vec::new(),
+        metric: None,
+        evidence: None,
+        community: Some(CommunityAnalysis {
+            id: community_id(&[], weights, parameters),
+            members: Vec::new(),
+            evidence: Vec::new(),
+            weights: weights.to_vec(),
+            parameters,
+            iteration,
+            convergence: CommunityConvergence::Inconclusive,
+            coverage,
+            truncated: true,
+        }),
+    }
 }
 
 /// Conservatively charge one candidate before allocating its owned vectors.

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1436,6 +1436,16 @@ fn local_edge(
     })
 }
 
+/// Completeness state for admitted community relations during closure.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum CommunityClosureScope {
+    /// Every admitted community relation stayed within the induced nodes.
+    #[default]
+    Closed,
+    /// At least one admitted community relation escaped the induced nodes.
+    Open,
+}
+
 /// Work and evidence retained while closing edges among admitted nodes.
 #[derive(Default)]
 struct ClosureWork {
@@ -1445,6 +1455,8 @@ struct ClosureWork {
     deadline_reached: bool,
     /// Whether the induced node scope was closed in the requested direction.
     induced_scope_closed: bool,
+    /// Scope status for admitted community relations.
+    community_scope: CommunityClosureScope,
     /// Database adjacency rows inspected by closure.
     inspected_edges: u32,
     /// Database-decoded bytes retained during closure.
@@ -1466,6 +1478,11 @@ fn close_induced_edges(
     let mut work = ClosureWork {
         complete: true,
         induced_scope_closed: query.relations.direction == RelationDirection::Outbound,
+        community_scope: if query.relations.direction == RelationDirection::Outbound {
+            CommunityClosureScope::Closed
+        } else {
+            CommunityClosureScope::Open
+        },
         ..ClosureWork::default()
     };
     let mut keys = Vec::with_capacity(nodes.len());
@@ -1546,12 +1563,17 @@ fn close_induced_edges(
                 if !analysis_relation_matches(&row.detail.relation, &query.relations) {
                     continue;
                 }
+                let community_relation =
+                    community_relation_weight(row.detail.relation.kind()).is_some();
                 let source_key = row.detail.source.key().canonical_identity().to_string();
                 if matches!(
                     row.detail.relation.resolution(),
                     RelationResolution::Ambiguous { .. } | RelationResolution::Unresolved { .. }
                 ) {
                     work.induced_scope_closed = false;
+                    if community_relation {
+                        work.community_scope = CommunityClosureScope::Open;
+                    }
                     if let Some(source) = nodes.get(&source_key) {
                         work.resolution_gaps
                             .push(resolution_gap_finding(&row.detail.relation, source));
@@ -1560,6 +1582,9 @@ fn close_induced_edges(
                 }
                 let Some(target) = row.detail.target else {
                     work.induced_scope_closed = false;
+                    if community_relation {
+                        work.community_scope = CommunityClosureScope::Open;
+                    }
                     continue;
                 };
                 let target_key = target.key().canonical_identity().to_string();
@@ -1572,6 +1597,9 @@ fn close_induced_edges(
                     });
                 } else {
                     work.induced_scope_closed = false;
+                    if community_relation {
+                        work.community_scope = CommunityClosureScope::Open;
+                    }
                 }
             }
             if read.page.truncated {
@@ -1616,7 +1644,11 @@ fn relation_evidence_complete(
     community_only: bool,
 ) -> bool {
     closure.complete
-        && closure.induced_scope_closed
+        && if community_only {
+            closure.community_scope == CommunityClosureScope::Closed
+        } else {
+            closure.induced_scope_closed
+        }
         && report.reached_limits.is_empty()
         && query.relations.direction == RelationDirection::Outbound
         && edges

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -834,7 +834,10 @@ fn load_relation_analysis_with_closure_deadline(
         control,
     )?;
     check_control(control)?;
-    let evidence_complete = relation_evidence_complete(&relations, &nodes, &edges, query, &closure);
+    let evidence_complete =
+        relation_evidence_complete(&relations, &nodes, &edges, query, &closure, false);
+    let community_evidence_complete =
+        relation_evidence_complete(&relations, &nodes, &edges, query, &closure, true);
     let dead_code_scope_complete = dead_code_scope_complete(&relations, query);
     check_control(control)?;
     let vcs_load = if query.mode == RelationAnalysisMode::Impact {
@@ -925,6 +928,7 @@ fn load_relation_analysis_with_closure_deadline(
                 &nodes,
                 &edges,
                 evidence_complete,
+                community_evidence_complete,
                 query,
                 symbol_byte_budget,
                 &mut supplemental_work,
@@ -952,6 +956,10 @@ fn load_relation_analysis_with_closure_deadline(
         ServiceError::InvalidInput("analysis finding count overflowed".to_string())
     })?;
     let mut finding_bytes = serialized_bytes_controlled(&findings, control)?;
+    let generated_composition_bytes = vcs_load
+        .retained_bytes
+        .saturating_add(topology_bytes)
+        .saturating_add(finding_bytes);
     supplemental_work.retained_composition_bytes = vcs_load
         .retained_bytes
         .saturating_add(topology_bytes)
@@ -992,13 +1000,32 @@ fn load_relation_analysis_with_closure_deadline(
         .saturating_add(initial_finding_bytes)
         .saturating_add(external_relation_identity_bytes)
         .saturating_add(supplemental_work.hydrated_symbol_peak_bytes);
+    let generation_peak = relations
+        .work
+        .intermediate_bytes
+        .saturating_add(closure.decoded_bytes)
+        .saturating_add(external_relation_identity_bytes)
+        .saturating_add(generated_composition_bytes);
     let final_peak = relations
         .work
         .intermediate_bytes
         .saturating_add(closure.decoded_bytes)
         .saturating_add(supplemental_work.retained_composition_bytes)
         .saturating_add(external_relation_identity_bytes);
-    let peak_intermediate_bytes = hydration_peak.max(final_peak);
+    let peak_intermediate_bytes = hydration_peak.max(generation_peak).max(final_peak);
+    let community_projection_truncated = findings.iter().any(|finding| {
+        finding
+            .community
+            .as_ref()
+            .is_some_and(|community| community.truncated)
+    });
+    if community_projection_truncated {
+        supplemental_work.composition_truncated = true;
+        push_limit(
+            &mut supplemental_work.reached_limits,
+            GraphLimitKind::IntermediateBytes,
+        );
+    }
     let full_finding_count = u32::try_from(findings.len()).map_err(|_overflow| {
         ServiceError::InvalidInput("analysis finding count overflowed".to_string())
     })?;
@@ -1040,7 +1067,8 @@ fn load_relation_analysis_with_closure_deadline(
     let analysis_truncated = (!evidence_complete && relations.truncated)
         || !closure.complete
         || supplemental_work.symbol_hydration_truncated
-        || supplemental_work.composition_truncated;
+        || supplemental_work.composition_truncated
+        || community_projection_truncated;
     let returned = u32::try_from(findings.len()).unwrap_or(u32::MAX);
     let total = if analysis_truncated {
         RelationTotalState::AtLeast(u64::from(generated_finding_count))
@@ -1582,12 +1610,16 @@ fn relation_evidence_complete(
     edges: &[LocalEdge],
     query: &RelationAnalysisQuery,
     closure: &ClosureWork,
+    community_only: bool,
 ) -> bool {
     closure.complete
         && closure.induced_scope_closed
         && report.reached_limits.is_empty()
         && query.relations.direction == RelationDirection::Outbound
-        && edges.iter().all(|edge| edge.complete)
+        && edges
+            .iter()
+            .filter(|edge| !community_only || community_relation_weight(edge.kind).is_some())
+            .all(|edge| edge.complete)
         && nodes.values().all(|node| match node.entity.selector() {
             EntitySelector::Project => true,
             EntitySelector::Folder { .. }
@@ -1657,6 +1689,7 @@ fn architecture_findings(
     nodes: &BTreeMap<String, DetailedRelationNode>,
     edges: &[LocalEdge],
     complete: bool,
+    community_complete: bool,
     query: &RelationAnalysisQuery,
     symbol_byte_budget: u64,
     supplemental_work: &mut SupplementalWork,
@@ -1698,7 +1731,34 @@ fn architecture_findings(
         findings.push(purpose_finding(nodes, component, complete));
     }
     if query.include_communities {
-        findings.extend(community_findings(nodes, edges, complete, query, control)?);
+        let mut existing_finding_bytes = serialized_bytes_controlled(&findings, control)?;
+        if existing_finding_bytes > symbol_byte_budget {
+            supplemental_work.composition_truncated = true;
+            push_limit(
+                &mut supplemental_work.reached_limits,
+                GraphLimitKind::IntermediateBytes,
+            );
+            while existing_finding_bytes > symbol_byte_budget && findings.len() > 1 {
+                check_control(control)?;
+                findings.pop();
+                existing_finding_bytes = serialized_bytes_controlled(&findings, control)?;
+            }
+            if existing_finding_bytes > symbol_byte_budget {
+                findings.clear();
+                existing_finding_bytes = serialized_bytes_controlled(&findings, control)?;
+            }
+        }
+        let community_budget = symbol_byte_budget.saturating_sub(existing_finding_bytes);
+        if community_budget > 0 {
+            findings.extend(community_findings_with_budget(
+                nodes,
+                edges,
+                community_complete,
+                query,
+                community_budget,
+                control,
+            )?);
+        }
     }
     if query.include_cycles {
         let dependency_edges = edges
@@ -2266,11 +2326,31 @@ fn community_relation_weight(kind: GraphRelationKind) -> Option<u32> {
 }
 
 /// Compute deterministic bounded weighted label-propagation communities.
+#[cfg(test)]
 fn community_findings(
     nodes: &BTreeMap<String, DetailedRelationNode>,
     edges: &[LocalEdge],
     complete: bool,
     query: &RelationAnalysisQuery,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<Vec<AnalysisFinding>> {
+    community_findings_with_budget(
+        nodes,
+        edges,
+        complete,
+        query,
+        query.relations.budget.intermediate_bytes(),
+        control,
+    )
+}
+
+/// Compute communities with an explicit remaining intermediate-byte allowance.
+fn community_findings_with_budget(
+    nodes: &BTreeMap<String, DetailedRelationNode>,
+    edges: &[LocalEdge],
+    complete: bool,
+    query: &RelationAnalysisQuery,
+    intermediate_bytes: u64,
     control: Option<&IndexWorkControl>,
 ) -> ServiceResult<Vec<AnalysisFinding>> {
     check_control(control)?;
@@ -2279,12 +2359,16 @@ fn community_findings(
         algorithm_version: COMMUNITY_ALGORITHM_VERSION,
         ordering_version: COMMUNITY_ORDERING_VERSION,
         max_iterations: COMMUNITY_MAX_ITERATIONS,
-        node_limit: MAX_ANALYSIS_NODES,
-        edge_limit: MAX_ANALYSIS_EDGES,
+        node_limit: query.relations.budget.nodes().min(MAX_ANALYSIS_NODES),
+        edge_limit: query.relations.budget.edges().min(MAX_ANALYSIS_EDGES),
         output_bytes: query.relations.budget.output_bytes(),
         relation: query.relations.relation,
     };
-    let complete = complete && edges.iter().all(|edge| edge.complete);
+    let complete = complete
+        && edges
+            .iter()
+            .filter(|edge| community_relation_weight(edge.kind).is_some())
+            .all(|edge| edge.complete);
     let (keys, admitted_edges, resource_truncated) =
         admitted_community_scope(nodes, edges, parameters);
     if !complete || resource_truncated {
@@ -2292,9 +2376,19 @@ fn community_findings(
         if resource_truncated {
             evidence.truncate(parameters.edge_limit as usize);
         }
+        let metadata_fits =
+            community_finding_upper_bound(nodes, &keys, &evidence, &weights, parameters, control)?
+                <= intermediate_bytes;
+        let metadata_keys = if metadata_fits { keys.as_slice() } else { &[] };
+        let metadata_evidence = if metadata_fits {
+            evidence.as_slice()
+        } else {
+            &[]
+        };
+        let metadata_truncated = resource_truncated || !metadata_fits;
         let metadata = community_metadata(
-            &keys,
-            &evidence,
+            metadata_keys,
+            metadata_evidence,
             weights,
             parameters,
             0,
@@ -2304,7 +2398,7 @@ fn community_findings(
             } else {
                 CommunityCoverage::Partial
             },
-            resource_truncated,
+            metadata_truncated,
             nodes,
         );
         return Ok(vec![AnalysisFinding {
@@ -2316,8 +2410,8 @@ fn community_findings(
                 "community projection is inconclusive because relation coverage is partial"
             }
             .to_string(),
-            nodes: analysis_nodes_for(nodes, &keys),
-            metric: Some(keys.len() as u64),
+            nodes: analysis_nodes_for(nodes, metadata_keys),
+            metric: Some(metadata_keys.len() as u64),
             evidence: None,
             community: Some(metadata),
         }]);
@@ -2326,23 +2420,38 @@ fn community_findings(
     let (labels, iteration, convergence) =
         propagate_community_labels(&keys, &admitted_edges, parameters.max_iterations, control)?;
     if convergence != CommunityConvergence::Converged {
-        let metadata = community_metadata(
+        let metadata_fits = community_finding_upper_bound(
+            nodes,
             &keys,
             &admitted_edges,
+            &weights,
+            parameters,
+            control,
+        )? <= intermediate_bytes;
+        let metadata_keys = if metadata_fits { keys.as_slice() } else { &[] };
+        let metadata_evidence = if metadata_fits {
+            admitted_edges.as_slice()
+        } else {
+            &[]
+        };
+        let metadata_truncated = !metadata_fits;
+        let metadata = community_metadata(
+            metadata_keys,
+            metadata_evidence,
             weights,
             parameters,
             iteration,
             convergence,
             CommunityCoverage::Complete,
-            false,
+            metadata_truncated,
             nodes,
         );
         return Ok(vec![AnalysisFinding {
             kind: AnalysisFindingKind::Community,
             status: AnalysisStatus::Inconclusive,
             summary: "community label propagation reached its fixed iteration ceiling".to_string(),
-            nodes: analysis_nodes_for(nodes, &keys),
-            metric: Some(keys.len() as u64),
+            nodes: analysis_nodes_for(nodes, metadata_keys),
+            metric: Some(metadata_keys.len() as u64),
             evidence: None,
             community: Some(metadata),
         }]);
@@ -2358,6 +2467,7 @@ fn community_findings(
         iteration,
         convergence,
         control,
+        intermediate_bytes,
     )
 }
 
@@ -2513,6 +2623,7 @@ fn community_candidate_findings(
     iteration: u32,
     convergence: CommunityConvergence,
     control: Option<&IndexWorkControl>,
+    intermediate_bytes: u64,
 ) -> ServiceResult<Vec<AnalysisFinding>> {
     let mut groups = BTreeMap::<String, Vec<String>>::new();
     for key in keys {
@@ -2520,13 +2631,29 @@ fn community_candidate_findings(
         let label = labels.get(key).cloned().unwrap_or_else(|| key.clone());
         groups.entry(label).or_default().push(key.clone());
     }
-    let mut findings = Vec::with_capacity(groups.len());
+    let mut findings = Vec::new();
+    let mut retained_bytes = 0_u64;
+    let mut truncated = false;
     for members in groups.values() {
         check_control(control)?;
-        let member_keys = members.iter().cloned().collect::<BTreeSet<_>>();
+        let candidate_bound = community_candidate_upper_bound(
+            nodes,
+            members,
+            admitted_edges,
+            weights,
+            parameters,
+            control,
+        )?;
+        if retained_bytes.saturating_add(candidate_bound) > intermediate_bytes {
+            truncated = true;
+            break;
+        }
         let evidence = admitted_edges
             .iter()
-            .filter(|edge| member_keys.contains(&edge.source) && member_keys.contains(&edge.target))
+            .filter(|edge| {
+                members.binary_search(&edge.source).is_ok()
+                    && members.binary_search(&edge.target).is_ok()
+            })
             .cloned()
             .collect::<Vec<_>>();
         let metadata = community_metadata(
@@ -2540,7 +2667,7 @@ fn community_candidate_findings(
             false,
             nodes,
         );
-        findings.push(AnalysisFinding {
+        let finding = AnalysisFinding {
             kind: AnalysisFindingKind::Community,
             status: AnalysisStatus::Candidate,
             summary: if members.len() == 1 {
@@ -2553,9 +2680,115 @@ fn community_candidate_findings(
             metric: Some(members.len() as u64),
             evidence: None,
             community: Some(metadata),
-        });
+        };
+        let finding_bytes = serialized_bytes_controlled(&finding, control)?;
+        if retained_bytes.saturating_add(finding_bytes) > intermediate_bytes {
+            truncated = true;
+            break;
+        }
+        retained_bytes = retained_bytes.saturating_add(finding_bytes);
+        findings.push(finding);
+    }
+    if truncated {
+        check_control(control)?;
+        let marker = AnalysisFinding {
+            kind: AnalysisFindingKind::Community,
+            status: AnalysisStatus::Inconclusive,
+            summary: "community projection crossed the intermediate-byte budget before all communities were constructed"
+                .to_string(),
+            nodes: Vec::new(),
+            metric: None,
+            evidence: None,
+            community: Some(CommunityAnalysis {
+                id: community_id(&[], weights, parameters),
+                members: Vec::new(),
+                evidence: Vec::new(),
+                weights: weights.to_vec(),
+                parameters,
+                iteration,
+                convergence: CommunityConvergence::Inconclusive,
+                coverage: CommunityCoverage::Complete,
+                truncated: true,
+            }),
+        };
+        let marker_bytes = serialized_bytes_controlled(&marker, control)?;
+        if retained_bytes.saturating_add(marker_bytes) > intermediate_bytes {
+            findings.clear();
+        }
+        findings.push(marker);
     }
     Ok(findings)
+}
+
+/// Conservatively charge one candidate before allocating its owned vectors.
+fn community_finding_upper_bound(
+    nodes: &BTreeMap<String, DetailedRelationNode>,
+    members: &[String],
+    evidence: &[CommunityEdgeEvidence],
+    weights: &[CommunityRelationWeight],
+    parameters: CommunityParameters,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<u64> {
+    let member_bytes = community_member_bytes(nodes, members, control)?;
+    let evidence_bytes = serialized_bytes_controlled(evidence, control)?;
+    let weights_bytes = serialized_bytes_controlled(weights, control)?;
+    let parameter_bytes = serialized_bytes_controlled(&parameters, control)?;
+    Ok(member_bytes
+        .saturating_mul(2)
+        .saturating_add(evidence_bytes)
+        .saturating_add(weights_bytes)
+        .saturating_add(parameter_bytes)
+        .saturating_add((members.len() as u64).saturating_mul(2))
+        .saturating_add(2_048))
+}
+
+/// Conservatively charge admitted evidence without allocating a group copy.
+fn community_candidate_upper_bound(
+    nodes: &BTreeMap<String, DetailedRelationNode>,
+    members: &[String],
+    admitted_edges: &[CommunityEdgeEvidence],
+    weights: &[CommunityRelationWeight],
+    parameters: CommunityParameters,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<u64> {
+    let member_bytes = community_member_bytes(nodes, members, control)?;
+    let mut evidence_bytes = 0_u64;
+    for edge in admitted_edges {
+        check_control(control)?;
+        if members.binary_search(&edge.source).is_ok()
+            && members.binary_search(&edge.target).is_ok()
+        {
+            evidence_bytes = evidence_bytes
+                .saturating_add(serialized_bytes_controlled(edge, control)?)
+                .saturating_add(1);
+        }
+    }
+    let weights_bytes = serialized_bytes_controlled(weights, control)?;
+    let parameter_bytes = serialized_bytes_controlled(&parameters, control)?;
+    Ok(member_bytes
+        .saturating_mul(2)
+        .saturating_add(evidence_bytes)
+        .saturating_add(weights_bytes)
+        .saturating_add(parameter_bytes)
+        .saturating_add((members.len() as u64).saturating_mul(2))
+        .saturating_add(2_048))
+}
+
+/// Measure projected members one at a time before retaining a finding.
+fn community_member_bytes(
+    nodes: &BTreeMap<String, DetailedRelationNode>,
+    members: &[String],
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<u64> {
+    let mut bytes = 0_u64;
+    for key in members {
+        check_control(control)?;
+        if let Some(node) = nodes.get(key) {
+            bytes =
+                bytes.saturating_add(serialized_bytes_controlled(&analysis_node(node), control)?);
+        }
+    }
+    Ok(bytes)
 }
 
 /// Build stable metadata for one community or typed inconclusive result.

--- a/crates/projectatlas-service/src/analysis/impact.rs
+++ b/crates/projectatlas-service/src/analysis/impact.rs
@@ -132,6 +132,7 @@ pub(super) fn impact_findings(
                 nodes: Vec::new(),
                 metric: Some(0),
                 evidence: None,
+                community: None,
             });
         }
         for (key, hops) in distance {
@@ -148,6 +149,7 @@ pub(super) fn impact_findings(
                 nodes: analysis_nodes_for(nodes, std::slice::from_ref(&key)),
                 metric: Some(u64::from(hops)),
                 evidence: None,
+                community: None,
             });
         }
     } else if let VcsImpact::Unavailable { reason, .. } = vcs {
@@ -158,6 +160,7 @@ pub(super) fn impact_findings(
             nodes: Vec::new(),
             metric: None,
             evidence: None,
+            community: None,
         });
     }
     check_control(control)?;
@@ -185,6 +188,7 @@ fn dead_code_findings(
             nodes: Vec::new(),
             metric: None,
             evidence: None,
+            community: None,
         }]);
     }
     #[cfg(test)]
@@ -215,6 +219,7 @@ fn dead_code_findings(
             nodes: Vec::new(),
             metric: None,
             evidence: None,
+            community: None,
         }]);
     }
     let indegree = usage_indegrees(nodes, edges, control)?;
@@ -256,6 +261,7 @@ fn dead_code_findings(
             nodes: analysis_nodes_for(nodes, std::slice::from_ref(&key)),
             metric: Some(0),
             evidence: None,
+            community: None,
         }]
     }))
 }

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -843,34 +843,37 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
             },
         );
     }
-    let key = |path: &str| {
+    let key = |path: &str| -> Result<String, io::Error> {
         nodes
             .values()
             .find(|node| entity_path(&node.entity) == Some(path))
             .map(|node| node.entity.key().canonical_identity().to_string())
-            .expect("planted node key")
+            .ok_or_else(|| io::Error::other(format!("planted node key missing for {path}")))
     };
-    let edge = |source: &str, target: &str, kind: GraphRelationKind| LocalEdge {
-        source: key(source),
-        target: key(target),
-        kind,
-        complete: true,
-    };
+    let edge =
+        |source: &str, target: &str, kind: GraphRelationKind| -> Result<LocalEdge, io::Error> {
+            Ok(LocalEdge {
+                source: key(source)?,
+                target: key(target)?,
+                kind,
+                complete: true,
+            })
+        };
     let calls = GraphRelationKind::Legacy(RelationKind::Calls);
     let references = GraphRelationKind::Extended(ExtendedRelationKind::References);
     let edges = vec![
-        edge("group-a/0.rs", "group-a/1.rs", calls),
-        edge("group-a/1.rs", "group-a/2.rs", calls),
-        edge("group-a/2.rs", "group-a/0.rs", calls),
-        edge("group-b/0.rs", "group-b/1.rs", calls),
-        edge("group-b/1.rs", "group-b/2.rs", calls),
-        edge("group-b/2.rs", "group-b/0.rs", calls),
-        edge("group-a/2.rs", "group-b/0.rs", references),
+        edge("group-a/0.rs", "group-a/1.rs", calls)?,
+        edge("group-a/1.rs", "group-a/2.rs", calls)?,
+        edge("group-a/2.rs", "group-a/0.rs", calls)?,
+        edge("group-b/0.rs", "group-b/1.rs", calls)?,
+        edge("group-b/1.rs", "group-b/2.rs", calls)?,
+        edge("group-b/2.rs", "group-b/0.rs", calls)?,
+        edge("group-a/2.rs", "group-b/0.rs", references)?,
         edge(
             "group-a/0.rs",
             "group-a/2.rs",
             GraphRelationKind::Legacy(RelationKind::Contains),
-        ),
+        )?,
     ];
     let query = analysis_query(RelationAnalysisMode::Architecture)?;
     let first = community_findings(&nodes, &edges, true, &query, None)?;

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -875,6 +875,11 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
             GraphRelationKind::Legacy(RelationKind::Contains),
         )?,
     ];
+    let mut edges = edges;
+    edges
+        .last_mut()
+        .ok_or("containment regression edge missing")?
+        .complete = false;
     let query = analysis_query(RelationAnalysisMode::Architecture)?;
     let first = community_findings(&nodes, &edges, true, &query, None)?;
     let second = community_findings(&nodes, &edges, true, &query, None)?;
@@ -979,6 +984,26 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
     require(
         community_findings(&nodes, &edges, true, &query, Some(&control)).is_err(),
         "cancelled community analysis continued past its control",
+    )?;
+    let mut bounded_query = query.clone();
+    bounded_query.relations.budget = bounded_query.relations.budget.with_aggregate_limits(
+        Some(1),
+        Some(3),
+        None,
+        None,
+        None,
+        None,
+    )?;
+    let bounded = community_findings(&nodes, &edges, true, &bounded_query, None)?;
+    let bounded_community = bounded
+        .first()
+        .and_then(|finding| finding.community.as_ref())
+        .ok_or("bounded community metadata missing")?;
+    require(
+        bounded_community.parameters.node_limit == 3
+            && bounded_community.parameters.edge_limit == 1
+            && bounded_community.id != communities[0].id,
+        "community metadata did not use effective caller resource limits",
     )?;
     let parameters = CommunityParameters {
         algorithm_version: COMMUNITY_ALGORITHM_VERSION,
@@ -1089,6 +1114,22 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
                     .is_some_and(|community| community.members.len() <= MAX_ANALYSIS_NODES as usize)
             }),
         "representative high-degree community analysis crossed its bounded envelope",
+    )?;
+    let mut sparse_budget_query = query;
+    sparse_budget_query.relations.budget = sparse_budget_query
+        .relations
+        .budget
+        .with_aggregate_limits(None, None, None, None, Some(64 * 1024), None)?;
+    let sparse_budgeted = community_findings(&scale_nodes, &[], true, &sparse_budget_query, None)?;
+    require(
+        sparse_budgeted.iter().any(|finding| {
+            finding.status == AnalysisStatus::Inconclusive
+                && finding
+                    .community
+                    .as_ref()
+                    .is_some_and(|community| community.truncated)
+        }),
+        "sparse singleton construction exceeded its intermediate budget without a typed outcome",
     )?;
     Ok(())
 }

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -653,6 +653,26 @@ fn analysis_modes_are_closed_and_partial_evidence_stays_inconclusive() -> Result
         }),
         "relationship community did not cross folder ownership",
     )?;
+    require(
+        full_report
+            .findings
+            .iter()
+            .filter_map(|finding| {
+                (finding.kind == AnalysisFindingKind::Community)
+                    .then_some(finding.community.as_ref())
+                    .flatten()
+            })
+            .any(|community| {
+                community.members.iter().any(|member| {
+                    entity_path(&member.node.entity) == Some("src/a.rs")
+                        && !member.node.coverage.is_empty()
+                }) && community.members.iter().any(|member| {
+                    entity_path(&member.node.entity) == Some("tools/c.rs")
+                        && !member.node.coverage.is_empty()
+                }) && community.evidence.iter().all(|edge| edge.weight > 0)
+            }),
+        "community metadata omitted exact member coverage or weighted evidence",
+    )?;
 
     let mut acyclic = analysis_query(RelationAnalysisMode::Architecture)?;
     acyclic.relations.relation = Some(GraphRelationKind::Legacy(RelationKind::DependsOn));
@@ -781,6 +801,291 @@ fn analysis_modes_are_closed_and_partial_evidence_stays_inconclusive() -> Result
     require(
         load_relation_analysis(&store, &invalid, None).is_err(),
         "architecture accepted impact-only dead-code controls",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn communities_are_deterministic_and_partition_a_planted_weak_component()
+-> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store()?;
+    let project = store
+        .project_instance_id()?
+        .ok_or("project identity missing")?;
+    let generation = IndexGeneration::new(1);
+    let paths = [
+        "group-a/0.rs",
+        "group-a/1.rs",
+        "group-a/2.rs",
+        "group-b/0.rs",
+        "group-b/1.rs",
+        "group-b/2.rs",
+    ];
+    let mut nodes = BTreeMap::new();
+    for path in paths {
+        let entity = GraphEntity::new(
+            project,
+            EntitySelector::File {
+                path: RepositoryFilePath::new(Path::new(path))?,
+            },
+            generation,
+        )?;
+        nodes.insert(
+            entity.key().canonical_identity().to_string(),
+            DetailedRelationNode {
+                entity,
+                classification: None,
+                content_selection: None,
+                purpose: RelationPurpose::Unavailable {
+                    path: Some(path.to_string()),
+                },
+                coverage: Vec::new(),
+            },
+        );
+    }
+    let key = |path: &str| {
+        nodes
+            .values()
+            .find(|node| entity_path(&node.entity) == Some(path))
+            .map(|node| node.entity.key().canonical_identity().to_string())
+            .expect("planted node key")
+    };
+    let edge = |source: &str, target: &str, kind: GraphRelationKind| LocalEdge {
+        source: key(source),
+        target: key(target),
+        kind,
+        complete: true,
+    };
+    let calls = GraphRelationKind::Legacy(RelationKind::Calls);
+    let references = GraphRelationKind::Extended(ExtendedRelationKind::References);
+    let edges = vec![
+        edge("group-a/0.rs", "group-a/1.rs", calls),
+        edge("group-a/1.rs", "group-a/2.rs", calls),
+        edge("group-a/2.rs", "group-a/0.rs", calls),
+        edge("group-b/0.rs", "group-b/1.rs", calls),
+        edge("group-b/1.rs", "group-b/2.rs", calls),
+        edge("group-b/2.rs", "group-b/0.rs", calls),
+        edge("group-a/2.rs", "group-b/0.rs", references),
+        edge(
+            "group-a/0.rs",
+            "group-a/2.rs",
+            GraphRelationKind::Legacy(RelationKind::Contains),
+        ),
+    ];
+    let query = analysis_query(RelationAnalysisMode::Architecture)?;
+    let first = community_findings(&nodes, &edges, true, &query, None)?;
+    let second = community_findings(&nodes, &edges, true, &query, None)?;
+    let first_bytes = serde_json::to_vec(&first)?;
+    require(
+        first_bytes == serde_json::to_vec(&second)?,
+        "repeated community analysis was not byte stable",
+    )?;
+    let communities = first
+        .iter()
+        .filter_map(|finding| finding.community.as_ref())
+        .collect::<Vec<_>>();
+    require(
+        communities.len() == 2
+            && communities
+                .iter()
+                .all(|community| community.convergence == CommunityConvergence::Converged)
+            && communities
+                .iter()
+                .all(|community| community.coverage == CommunityCoverage::Complete)
+            && communities.iter().all(|community| !community.truncated)
+            && communities.iter().all(|community| {
+                community
+                    .members
+                    .iter()
+                    .all(|member| member.node.entity.generation() == generation)
+            }),
+        "planted community did not return two complete converged groups",
+    )?;
+    let group_members = communities
+        .iter()
+        .map(|community| {
+            community
+                .members
+                .iter()
+                .filter_map(|member| entity_path(&member.node.entity))
+                .collect::<BTreeSet<_>>()
+        })
+        .collect::<Vec<_>>();
+    require(
+        group_members.contains(&BTreeSet::from([
+            "group-a/0.rs",
+            "group-a/1.rs",
+            "group-a/2.rs",
+        ])) && group_members.contains(&BTreeSet::from([
+            "group-b/0.rs",
+            "group-b/1.rs",
+            "group-b/2.rs",
+        ])),
+        "weighted propagation did not preserve the planted cohesive groups",
+    )?;
+    require(
+        weak_components(&nodes, &edges, true).len() == 1
+            && communities
+                .iter()
+                .map(|community| community.members.len())
+                .sum::<usize>()
+                == nodes.len(),
+        "community projection did not improve the giant weak-component baseline",
+    )?;
+    require(
+        communities.iter().all(|community| {
+            community
+                .weights
+                .iter()
+                .any(|weight| weight.relation == calls && weight.weight == 8)
+                && community
+                    .evidence
+                    .iter()
+                    .all(|evidence| evidence.weight > 0)
+        }) && !communities.iter().any(|community| {
+            community.evidence.iter().any(|evidence| {
+                evidence.relation == GraphRelationKind::Legacy(RelationKind::Contains)
+            })
+        }),
+        "community evidence omitted fixed weights or admitted containment",
+    )?;
+    require(
+        communities
+            .iter()
+            .map(|community| community.id.as_str())
+            .collect::<BTreeSet<_>>()
+            .len()
+            == communities.len(),
+        "distinct planted communities did not receive distinct stable IDs",
+    )?;
+    let partial = community_findings(&nodes, &edges, false, &query, None)?;
+    require(
+        partial.len() == 1
+            && partial[0].status == AnalysisStatus::Inconclusive
+            && partial[0].community.as_ref().is_some_and(|community| {
+                community.coverage == CommunityCoverage::Partial
+                    && community.convergence == CommunityConvergence::Inconclusive
+                    && !community.truncated
+                    && community.members.len() == nodes.len()
+            }),
+        "partial community coverage did not remain typed and bounded",
+    )?;
+    let cancellation = IndexCancellation::new();
+    cancellation.cancel();
+    let control = IndexWorkControl::new(cancellation, None);
+    require(
+        community_findings(&nodes, &edges, true, &query, Some(&control)).is_err(),
+        "cancelled community analysis continued past its control",
+    )?;
+    let parameters = CommunityParameters {
+        algorithm_version: COMMUNITY_ALGORITHM_VERSION,
+        ordering_version: COMMUNITY_ORDERING_VERSION,
+        max_iterations: COMMUNITY_MAX_ITERATIONS,
+        node_limit: 3,
+        edge_limit: 1,
+        output_bytes: 65_536,
+        relation: None,
+    };
+    let (_, bounded_edges, resource_truncated) =
+        admitted_community_scope(&nodes, &edges, parameters);
+    require(
+        resource_truncated && bounded_edges.len() <= parameters.edge_limit as usize,
+        "community resource ceilings did not truncate the admitted edge scope",
+    )?;
+    let (labels, iteration, convergence) = propagate_community_labels(&[], &[], 0, None)?;
+    require(
+        labels.is_empty() && iteration == 0 && convergence == CommunityConvergence::Converged,
+        "empty community graph did not converge without unnecessary rounds",
+    )?;
+    let (_, iteration, convergence) = propagate_community_labels(
+        &["a".to_string(), "b".to_string(), "c".to_string()],
+        &[],
+        0,
+        None,
+    )?;
+    require(
+        iteration == 0 && convergence == CommunityConvergence::IterationLimit,
+        "community iteration ceiling did not produce typed non-convergence",
+    )?;
+    require(
+        select_community_label(
+            "z",
+            BTreeMap::from([
+                ("z".to_string(), 1),
+                ("b".to_string(), 4),
+                ("a".to_string(), 4),
+            ]),
+        ) == "a",
+        "equal community scores did not choose the stable label key",
+    )?;
+    let singletons = community_findings(&nodes, &[], true, &query, None)?;
+    require(
+        singletons.len() == nodes.len()
+            && singletons.iter().all(|finding| {
+                finding.status == AnalysisStatus::Candidate
+                    && finding
+                        .community
+                        .as_ref()
+                        .is_some_and(|community| community.members.len() == 1)
+            }),
+        "sparse disconnected community input did not preserve singleton candidates",
+    )?;
+    let mut scale_nodes = nodes.clone();
+    for index in 0..(MAX_ANALYSIS_NODES as usize - scale_nodes.len()) {
+        let path = format!("scale/{index}.rs");
+        let entity = GraphEntity::new(
+            project,
+            EntitySelector::File {
+                path: RepositoryFilePath::new(Path::new(&path))?,
+            },
+            generation,
+        )?;
+        scale_nodes.insert(
+            entity.key().canonical_identity().to_string(),
+            DetailedRelationNode {
+                entity,
+                classification: None,
+                content_selection: None,
+                purpose: RelationPurpose::Unavailable { path: Some(path) },
+                coverage: Vec::new(),
+            },
+        );
+    }
+    let scale_keys = scale_nodes.keys().cloned().collect::<Vec<_>>();
+    let hub = scale_keys.first().cloned().ok_or("scale hub missing")?;
+    let scale_kinds = [
+        calls,
+        GraphRelationKind::Legacy(RelationKind::Imports),
+        GraphRelationKind::Legacy(RelationKind::DependsOn),
+        GraphRelationKind::Extended(ExtendedRelationKind::Tests),
+    ];
+    let scale_edges = scale_keys
+        .iter()
+        .skip(1)
+        .flat_map(|source| {
+            scale_kinds.into_iter().map(|kind| LocalEdge {
+                source: source.clone(),
+                target: hub.clone(),
+                kind,
+                complete: true,
+            })
+        })
+        .collect::<Vec<_>>();
+    let started = Instant::now();
+    let scaled = community_findings(&scale_nodes, &scale_edges, true, &query, None)?;
+    let elapsed = started.elapsed();
+    let scaled_bytes = serde_json::to_vec(&scaled)?;
+    require(
+        elapsed < Duration::from_secs(5)
+            && scale_edges.len() <= MAX_ANALYSIS_EDGES as usize
+            && !scaled_bytes.is_empty()
+            && scaled.iter().all(|finding| {
+                finding
+                    .community
+                    .as_ref()
+                    .is_some_and(|community| community.members.len() <= MAX_ANALYSIS_NODES as usize)
+            }),
+        "representative high-degree community analysis crossed its bounded envelope",
     )?;
     Ok(())
 }

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -6,7 +6,7 @@ use projectatlas_core::graph::{
 };
 use projectatlas_core::symbols::{ParserKind, SymbolGraph, SymbolKind};
 use projectatlas_core::{IndexGeneration, Node, NodeKind, PurposeSource};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::error::Error;
 use std::fs;
 use std::io;
@@ -1711,94 +1711,121 @@ fn zero_remaining_community_allowance_preserves_report_truth() -> Result<(), Box
     query.include_communities = true;
     query.include_cycles = false;
     query.relations.resolution = RelationResolutionFilter::Resolved;
-    let minimum_budget = 64 * 1024;
-    let maximum_budget = minimum_budget + 2_048;
-    let mut report_at = |budget| {
-        query.relations.budget = query.relations.budget.with_aggregate_limits(
-            None,
-            None,
-            None,
-            None,
-            Some(budget),
-            None,
-        )?;
-        Ok::<_, ServiceError>(load_relation_analysis(&store, &query, None)?.report)
-    };
-    let mut lower_bound = minimum_budget;
-    let mut upper_bound = None;
-    for budget in (minimum_budget..=maximum_budget).step_by(16) {
-        let report = report_at(budget)?;
-        let has_community = report
-            .findings
-            .iter()
-            .any(|finding| finding.community.is_some());
-        if !has_community {
-            upper_bound = Some(budget);
-            break;
-        }
-        lower_bound = budget.saturating_add(1);
-    }
-    let upper_bound = upper_bound.ok_or("community truncation boundary was not reached")?;
-    let lower_bound = upper_bound.saturating_sub(15).max(lower_bound);
-    let mut boundary = None;
-    for budget in lower_bound..=upper_bound {
-        let report = report_at(budget)?;
-        if !report
-            .findings
-            .iter()
-            .any(|finding| finding.community.is_some())
-        {
-            boundary = Some((budget, report));
-            break;
-        }
-    }
-    let (budget, report) = boundary.ok_or("exact community truncation boundary was not found")?;
-    if budget > minimum_budget {
-        let previous = report_at(budget - 1)?;
-        require(
-            previous
+    query.relations.relation = None;
+
+    let calibration_budget = 80_000_u64;
+    let mut calibration_query = query.clone();
+    calibration_query.relations.budget = calibration_query.relations.budget.with_aggregate_limits(
+        None,
+        None,
+        None,
+        None,
+        Some(calibration_budget),
+        None,
+    )?;
+    let calibration_observed = Rc::new(RefCell::new(None));
+    let calibration_writer = Rc::clone(&calibration_observed);
+    let _calibration = observe_analysis_phase(
+        move |event| {
+            if let AnalysisPhaseEvent::CompositionBudget {
+                symbol_byte_budget,
+                existing_finding_append_bytes,
+                community_budget,
+            } = event
+            {
+                *calibration_writer.borrow_mut() = Some((
+                    symbol_byte_budget,
+                    existing_finding_append_bytes,
+                    community_budget,
+                ));
+            }
+        },
+        || load_relation_analysis(&store, &calibration_query, None),
+    )?;
+    let (_, existing_append_bytes, calibration_community_budget) = calibration_observed
+        .borrow()
+        .ok_or("architecture community budget was not observed")?;
+    require(
+        existing_append_bytes > 0 && calibration_community_budget > 0,
+        "calibration did not retain a preceding finding and community allowance",
+    )?;
+
+    // Both requests use five-digit intermediate budgets, so their serialized
+    // cursor shapes and relation work are identical. Subtracting the
+    // independently observed remaining allowance reaches the exact append
+    // boundary without searching neighboring budgets.
+    let boundary_budget = calibration_budget
+        .checked_sub(calibration_community_budget)
+        .ok_or("calibration community allowance exceeded the request budget")?;
+    require(
+        boundary_budget >= 64 * 1024,
+        "calibrated community boundary fell below the product budget floor",
+    )?;
+    let mut boundary_query = query;
+    boundary_query.relations.budget = boundary_query.relations.budget.with_aggregate_limits(
+        None,
+        None,
+        None,
+        None,
+        Some(boundary_budget),
+        None,
+    )?;
+    let boundary_observed = Rc::new(RefCell::new(None));
+    let boundary_writer = Rc::clone(&boundary_observed);
+    let draft = observe_analysis_phase(
+        move |event| {
+            if let AnalysisPhaseEvent::CompositionBudget {
+                symbol_byte_budget,
+                existing_finding_append_bytes,
+                community_budget,
+            } = event
+            {
+                *boundary_writer.borrow_mut() = Some((
+                    symbol_byte_budget,
+                    existing_finding_append_bytes,
+                    community_budget,
+                ));
+            }
+        },
+        || load_relation_analysis(&store, &boundary_query, None),
+    )?;
+    let (symbol_byte_budget, existing_append_bytes, community_budget) = boundary_observed
+        .borrow()
+        .ok_or("boundary architecture community budget was not observed")?;
+    let report = draft.report;
+
+    // Serialize the explicit request and retained finding vector independently
+    // of the production byte-accounting helpers under test. The fixture starts
+    // with no resolution gaps, so the returned architecture vector owns its
+    // complete JSON array envelope.
+    let request_bytes = serde_json::to_vec(&boundary_query.relations.budget)?;
+    let request_json: serde_json::Value = serde_json::from_slice(&request_bytes)?;
+    let findings_vector_bytes = serde_json::to_vec(&report.findings)?;
+    let expected_existing_append_bytes = findings_vector_bytes
+        .len()
+        .checked_sub(2)
+        .ok_or("serialized findings vector omitted its JSON array envelope")?;
+    require(
+        request_json
+            .get("intermediate_bytes")
+            .and_then(serde_json::Value::as_u64)
+            == Some(boundary_budget)
+            && findings_vector_bytes.starts_with(b"[")
+            && findings_vector_bytes.ends_with(b"]")
+            && u64::try_from(expected_existing_append_bytes)? == existing_append_bytes
+            && symbol_byte_budget == existing_append_bytes
+            && community_budget == 0
+            && existing_append_bytes > 0
+            && report
                 .findings
                 .iter()
-                .any(|finding| finding.community.is_some()),
-            "boundary predecessor did not retain the typed community truncation marker",
-        )?;
-    }
-    let gap_count = report
-        .findings
-        .iter()
-        .take_while(|finding| finding.kind == AnalysisFindingKind::ResolutionGap)
-        .count();
-    let gap_bytes = serialized_bytes_controlled(&report.findings[..gap_count], None)?;
-    let architecture = &report.findings[gap_count..];
-    let architecture_bytes = serialized_bytes_controlled(architecture, None)?;
-    let finding_bytes = serialized_bytes_controlled(&report.findings, None)?;
-    let topology_bytes = report
-        .work
-        .retained_composition_bytes
-        .saturating_sub(finding_bytes);
-    let projection_allowance = budget
-        .saturating_sub(report.work.relations.intermediate_bytes)
-        .saturating_sub(report.work.closure_decoded_bytes);
-    let symbol_byte_budget = projection_allowance
-        .saturating_sub(topology_bytes)
-        .saturating_sub(gap_bytes);
-    let existing_append_bytes =
-        serialized_findings_append_bytes(architecture_bytes, architecture.len(), gap_count);
-    // The exact boundary leaves only the two bytes owned by the enclosing
-    // findings array; no community finding can be appended to that envelope.
-    let community_allowance = symbol_byte_budget
-        .saturating_sub(existing_append_bytes)
-        .saturating_sub(JSON_ARRAY_FRAMING_BYTES);
-    require(
-        !architecture.is_empty()
-            && symbol_byte_budget == existing_append_bytes.saturating_add(JSON_ARRAY_FRAMING_BYTES)
-            && community_allowance == 0
-            && report.work.retained_composition_bytes <= projection_allowance
+                .any(|finding| finding.kind == AnalysisFindingKind::Component)
             && report.truncated
             && report
                 .reached_limits
                 .contains(&GraphLimitKind::IntermediateBytes)
             && report.work.composition_truncated
+            && report.work.retained_composition_bytes <= boundary_budget
             && matches!(report.total, RelationTotalState::AtLeast(_))
             && !matches!(report.total, RelationTotalState::Exact(_))
             && report

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1099,6 +1099,78 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
             })
         })
         .collect::<Vec<_>>();
+    let mut dense_edges = scale_edges.clone();
+    dense_edges.extend([
+        LocalEdge {
+            source: scale_keys[1].clone(),
+            target: scale_keys[1].clone(),
+            kind: calls,
+            complete: true,
+        },
+        LocalEdge {
+            source: scale_keys[2].clone(),
+            target: scale_keys[1].clone(),
+            kind: calls,
+            complete: true,
+        },
+        LocalEdge {
+            source: scale_keys[3].clone(),
+            target: scale_keys[1].clone(),
+            kind: references,
+            complete: true,
+        },
+        LocalEdge {
+            source: scale_keys[4].clone(),
+            target: scale_keys[1].clone(),
+            kind: GraphRelationKind::Legacy(RelationKind::DependsOn),
+            complete: true,
+        },
+    ]);
+    require(
+        scale_nodes.len() == MAX_ANALYSIS_NODES as usize
+            && dense_edges.len() == MAX_ANALYSIS_EDGES as usize,
+        "dense community regression did not reach the legal node and edge ceilings",
+    )?;
+    let mut dense_budget_query = query.clone();
+    dense_budget_query.relations.budget =
+        dense_budget_query.relations.budget.with_aggregate_limits(
+            Some(MAX_ANALYSIS_EDGES),
+            Some(MAX_ANALYSIS_NODES),
+            None,
+            None,
+            Some(64 * 1024),
+            None,
+        )?;
+    let dense_working_upper_bound =
+        community_working_set_upper_bound(&scale_nodes, &dense_edges, None)?;
+    let (dense_budgeted, dense_working_set_bytes) = community_findings_with_budget(
+        &scale_nodes,
+        &dense_edges,
+        true,
+        &dense_budget_query,
+        dense_budget_query.relations.budget.intermediate_bytes(),
+        None,
+    )?;
+    let dense_budgeted_bytes = serde_json::to_vec(&dense_budgeted)?;
+    let dense_community = dense_budgeted
+        .first()
+        .and_then(|finding| finding.community.as_ref())
+        .ok_or("dense community truncation metadata missing")?;
+    require(
+        dense_working_upper_bound > dense_budget_query.relations.budget.intermediate_bytes()
+            && dense_working_set_bytes == 0
+            && dense_working_set_bytes.saturating_add(dense_budgeted_bytes.len() as u64)
+                <= dense_budget_query.relations.budget.intermediate_bytes()
+            && dense_budgeted_bytes.len()
+                <= dense_budget_query.relations.budget.intermediate_bytes() as usize
+            && dense_budgeted.len() == 1
+            && dense_budgeted[0].kind == AnalysisFindingKind::Community
+            && dense_budgeted[0].status == AnalysisStatus::Inconclusive
+            && dense_community.truncated
+            && dense_community.parameters.node_limit == MAX_ANALYSIS_NODES
+            && dense_community.parameters.edge_limit == MAX_ANALYSIS_EDGES,
+        "dense minimum-budget community construction did not refuse before graph-sized allocation",
+    )?;
     let started = Instant::now();
     let scaled = community_findings(&scale_nodes, &scale_edges, true, &query, None)?;
     let elapsed = started.elapsed();

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -738,7 +738,11 @@ fn analysis_modes_are_closed_and_partial_evidence_stays_inconclusive() -> Result
             .with_aggregate_limits(Some(1), None, None, None, None, None)?;
     let bounded = fitted_report(&store, &bounded)?;
     require(
-        bounded.truncated && bounded.reached_limits.contains(&GraphLimitKind::Edges),
+        bounded.truncated
+            && bounded.reached_limits.contains(&GraphLimitKind::Edges)
+            && !bounded
+                .reached_limits
+                .contains(&GraphLimitKind::IntermediateBytes),
         "edge budget truncation was not explicit in the analysis envelope",
     )?;
 
@@ -1014,11 +1018,87 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
         output_bytes: 65_536,
         relation: None,
     };
-    let (_, bounded_edges, resource_truncated) =
-        admitted_community_scope(&nodes, &edges, parameters);
+    let (_, bounded_edges, resource_limits) = admitted_community_scope(&nodes, &edges, parameters);
     require(
-        resource_truncated && bounded_edges.len() <= parameters.edge_limit as usize,
+        resource_limits == vec![GraphLimitKind::Nodes, GraphLimitKind::Edges]
+            && bounded_edges.len() <= parameters.edge_limit as usize,
         "community resource ceilings did not truncate the admitted edge scope",
+    )?;
+    let mut node_limited_query = query.clone();
+    node_limited_query.relations.budget = node_limited_query
+        .relations
+        .budget
+        .with_aggregate_limits(Some(100), Some(3), None, None, None, None)?;
+    let (_, _, node_limits) = community_findings_with_budget(
+        &nodes,
+        &edges,
+        true,
+        &node_limited_query,
+        node_limited_query.relations.budget.intermediate_bytes(),
+        None,
+    )?;
+    require(
+        node_limits == vec![GraphLimitKind::Nodes],
+        "node-only community truncation reported an unrelated limit",
+    )?;
+    let mut edge_limited_query = query.clone();
+    edge_limited_query.relations.budget = edge_limited_query
+        .relations
+        .budget
+        .with_aggregate_limits(Some(1), Some(50), None, None, None, None)?;
+    let (_, _, edge_limits) = community_findings_with_budget(
+        &nodes,
+        &edges,
+        true,
+        &edge_limited_query,
+        edge_limited_query.relations.budget.intermediate_bytes(),
+        None,
+    )?;
+    require(
+        edge_limits == vec![GraphLimitKind::Edges],
+        "edge-only community truncation reported an unrelated limit",
+    )?;
+    let mut contains_edges = Vec::new();
+    for _ in 0..2048 {
+        contains_edges.push(LocalEdge {
+            source: edges[0].source.clone(),
+            target: edges[0].target.clone(),
+            kind: GraphRelationKind::Legacy(RelationKind::Contains),
+            complete: true,
+        });
+    }
+    let nodes_only_working_upper_bound = community_working_set_upper_bound(&nodes, &[], None)?;
+    let contains_only_working_upper_bound =
+        community_working_set_upper_bound(&nodes, &contains_edges, None)?;
+    require(
+        nodes_only_working_upper_bound == contains_only_working_upper_bound,
+        "excluded containment edges consumed community working-set budget",
+    )?;
+    let mut mixed_edges = contains_edges;
+    mixed_edges.push(edges[0].clone());
+    let mixed_working_upper_bound = community_working_set_upper_bound(&nodes, &mixed_edges, None)?;
+    require(
+        mixed_working_upper_bound > contains_only_working_upper_bound,
+        "admitted community edges did not consume working-set budget",
+    )?;
+    let (mixed, _, mixed_limits) = community_findings_with_budget(
+        &nodes,
+        &mixed_edges,
+        true,
+        &query,
+        query.relations.budget.intermediate_bytes(),
+        None,
+    )?;
+    require(
+        mixed_limits.is_empty()
+            && mixed.iter().all(|finding| {
+                finding.status == AnalysisStatus::Candidate
+                    && finding
+                        .community
+                        .as_ref()
+                        .is_some_and(|community| !community.truncated)
+            }),
+        "excluded containment edges prevented the admitted partition from fitting",
     )?;
     let (labels, iteration, convergence) = propagate_community_labels(&[], &[], 0, None)?;
     require(
@@ -1143,7 +1223,7 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
         )?;
     let dense_working_upper_bound =
         community_working_set_upper_bound(&scale_nodes, &dense_edges, None)?;
-    let (dense_budgeted, dense_working_set_bytes) = community_findings_with_budget(
+    let (dense_budgeted, dense_working_set_bytes, dense_limits) = community_findings_with_budget(
         &scale_nodes,
         &dense_edges,
         true,
@@ -1159,6 +1239,7 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
     require(
         dense_working_upper_bound > dense_budget_query.relations.budget.intermediate_bytes()
             && dense_working_set_bytes == 0
+            && dense_limits == vec![GraphLimitKind::IntermediateBytes]
             && dense_working_set_bytes.saturating_add(dense_budgeted_bytes.len() as u64)
                 <= dense_budget_query.relations.budget.intermediate_bytes()
             && dense_budgeted_bytes.len()

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -810,6 +810,120 @@ fn analysis_modes_are_closed_and_partial_evidence_stays_inconclusive() -> Result
 }
 
 #[test]
+fn community_closure_scopes_scope_gaps_to_admitted_relations() -> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store()?;
+    let mut all_relations = analysis_query(RelationAnalysisMode::Architecture)?;
+    all_relations.relations.anchor = RelationAnchor::File {
+        file: RepositoryFilePath::new(Path::new("tools/c.rs"))?,
+    };
+    all_relations.relations.budget = DetailedRelationBudget::from_graph_limits(
+        projectatlas_core::graph::GraphLimits::new(100, 100, 8, 64 * 1024)?,
+    );
+    let relations = load_detailed_relations(&store, &all_relations.relations, None)?;
+    let mut nodes = collect_nodes(&relations, None)?;
+    for anchor in ["src/b.rs", "src/a.rs"] {
+        let mut query = all_relations.relations.clone();
+        query.anchor = RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new(anchor))?,
+        };
+        for (key, node) in collect_nodes(&load_detailed_relations(&store, &query, None)?, None)? {
+            nodes.entry(key).or_insert(node);
+        }
+    }
+    let containment_target = nodes
+        .iter()
+        .find_map(|(key, node)| {
+            matches!(
+                node.entity.selector(),
+                EntitySelector::Symbol { symbol } if symbol.name.as_str() == "c_aux"
+            )
+            .then_some(key.clone())
+        })
+        .ok_or("containment target missing from all-family fixture")?;
+    let weighted_target = nodes
+        .iter()
+        .find_map(|(key, node)| {
+            matches!(
+                node.entity.selector(),
+                EntitySelector::Symbol { symbol } if symbol.name.as_str() == "b_hub"
+            )
+            .then_some(key.clone())
+        })
+        .ok_or("weighted target missing from all-family fixture")?;
+    nodes.remove(&containment_target);
+    let mut contains_edges = Vec::new();
+    let contains_closure = close_induced_edges(
+        &store,
+        &all_relations,
+        &relations.work,
+        Instant::now() + Duration::from_secs(5),
+        &nodes,
+        &mut contains_edges,
+        None,
+    )?;
+    require(
+        !contains_closure.induced_scope_closed
+            && contains_closure.community_scope == CommunityClosureScope::Closed,
+        "containment-only closure gap changed community scope completeness",
+    )?;
+    require(
+        relation_evidence_complete(
+            &relations,
+            &nodes,
+            &contains_edges,
+            &all_relations,
+            &contains_closure,
+            true,
+        ),
+        "containment-only closure gap made community evidence inconclusive",
+    )?;
+    let containment_findings =
+        community_findings(&nodes, &contains_edges, true, &all_relations, None)?;
+    require(
+        containment_findings
+            .iter()
+            .all(|finding| finding.status == AnalysisStatus::Candidate),
+        "containment-only closure gap did not preserve community candidates",
+    )?;
+
+    nodes.remove(&weighted_target);
+    let mut weighted_edges = Vec::new();
+    let weighted_closure = close_induced_edges(
+        &store,
+        &all_relations,
+        &relations.work,
+        Instant::now() + Duration::from_secs(5),
+        &nodes,
+        &mut weighted_edges,
+        None,
+    )?;
+    require(
+        weighted_closure.community_scope == CommunityClosureScope::Open,
+        "out-of-scope weighted closure gap was ignored by community scope",
+    )?;
+    require(
+        !relation_evidence_complete(
+            &relations,
+            &nodes,
+            &weighted_edges,
+            &all_relations,
+            &weighted_closure,
+            true,
+        ),
+        "out-of-scope weighted closure gap was reported as complete community evidence",
+    )?;
+    let weighted_findings =
+        community_findings(&nodes, &weighted_edges, false, &all_relations, None)?;
+    require(
+        weighted_findings
+            .iter()
+            .any(|finding| finding.status == AnalysisStatus::Inconclusive),
+        "out-of-scope weighted closure gap did not produce inconclusive communities",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn communities_are_deterministic_and_partition_a_planted_weak_component()
 -> Result<(), Box<dyn Error>> {
     let (_temp, store) = analysis_store()?;

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1705,6 +1705,112 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
 }
 
 #[test]
+fn zero_remaining_community_allowance_preserves_report_truth() -> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store()?;
+    let mut query = analysis_query(RelationAnalysisMode::Architecture)?;
+    query.include_communities = true;
+    query.include_cycles = false;
+    query.relations.resolution = RelationResolutionFilter::Resolved;
+    let minimum_budget = 64 * 1024;
+    let maximum_budget = minimum_budget + 2_048;
+    let mut report_at = |budget| {
+        query.relations.budget = query.relations.budget.with_aggregate_limits(
+            None,
+            None,
+            None,
+            None,
+            Some(budget),
+            None,
+        )?;
+        Ok::<_, ServiceError>(load_relation_analysis(&store, &query, None)?.report)
+    };
+    let mut lower_bound = minimum_budget;
+    let mut upper_bound = None;
+    for budget in (minimum_budget..=maximum_budget).step_by(16) {
+        let report = report_at(budget)?;
+        let has_community = report
+            .findings
+            .iter()
+            .any(|finding| finding.community.is_some());
+        if !has_community {
+            upper_bound = Some(budget);
+            break;
+        }
+        lower_bound = budget.saturating_add(1);
+    }
+    let upper_bound = upper_bound.ok_or("community truncation boundary was not reached")?;
+    let lower_bound = upper_bound.saturating_sub(15).max(lower_bound);
+    let mut boundary = None;
+    for budget in lower_bound..=upper_bound {
+        let report = report_at(budget)?;
+        if !report
+            .findings
+            .iter()
+            .any(|finding| finding.community.is_some())
+        {
+            boundary = Some((budget, report));
+            break;
+        }
+    }
+    let (budget, report) = boundary.ok_or("exact community truncation boundary was not found")?;
+    if budget > minimum_budget {
+        let previous = report_at(budget - 1)?;
+        require(
+            previous
+                .findings
+                .iter()
+                .any(|finding| finding.community.is_some()),
+            "boundary predecessor did not retain the typed community truncation marker",
+        )?;
+    }
+    let gap_count = report
+        .findings
+        .iter()
+        .take_while(|finding| finding.kind == AnalysisFindingKind::ResolutionGap)
+        .count();
+    let gap_bytes = serialized_bytes_controlled(&report.findings[..gap_count], None)?;
+    let architecture = &report.findings[gap_count..];
+    let architecture_bytes = serialized_bytes_controlled(architecture, None)?;
+    let finding_bytes = serialized_bytes_controlled(&report.findings, None)?;
+    let topology_bytes = report
+        .work
+        .retained_composition_bytes
+        .saturating_sub(finding_bytes);
+    let projection_allowance = budget
+        .saturating_sub(report.work.relations.intermediate_bytes)
+        .saturating_sub(report.work.closure_decoded_bytes);
+    let symbol_byte_budget = projection_allowance
+        .saturating_sub(topology_bytes)
+        .saturating_sub(gap_bytes);
+    let existing_append_bytes =
+        serialized_findings_append_bytes(architecture_bytes, architecture.len(), gap_count);
+    // The exact boundary leaves only the two bytes owned by the enclosing
+    // findings array; no community finding can be appended to that envelope.
+    let community_allowance = symbol_byte_budget
+        .saturating_sub(existing_append_bytes)
+        .saturating_sub(JSON_ARRAY_FRAMING_BYTES);
+    require(
+        !architecture.is_empty()
+            && symbol_byte_budget == existing_append_bytes.saturating_add(JSON_ARRAY_FRAMING_BYTES)
+            && community_allowance == 0
+            && report.work.retained_composition_bytes <= projection_allowance
+            && report.truncated
+            && report
+                .reached_limits
+                .contains(&GraphLimitKind::IntermediateBytes)
+            && report.work.composition_truncated
+            && matches!(report.total, RelationTotalState::AtLeast(_))
+            && !matches!(report.total, RelationTotalState::Exact(_))
+            && report
+                .findings
+                .iter()
+                .all(|finding| finding.community.is_none()),
+        "zero remaining community allowance did not preserve report truncation truth",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn closure_preserves_late_resolution_gaps_and_symbol_findings() -> Result<(), Box<dyn Error>> {
     let (_temp, store) = analysis_store()?;
     let mut late_gap = analysis_query(RelationAnalysisMode::Architecture)?;

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1149,6 +1149,7 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
         true,
         &node_limited_query,
         node_limited_query.relations.budget.intermediate_bytes(),
+        0,
         None,
     )?;
     require(
@@ -1166,6 +1167,7 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
         true,
         &edge_limited_query,
         edge_limited_query.relations.budget.intermediate_bytes(),
+        0,
         None,
     )?;
     require(
@@ -1201,6 +1203,7 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
         true,
         &query,
         query.relations.budget.intermediate_bytes(),
+        0,
         None,
     )?;
     require(
@@ -1343,6 +1346,7 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
         true,
         &dense_budget_query,
         dense_budget_query.relations.budget.intermediate_bytes(),
+        0,
         None,
     )?;
     let dense_budgeted_bytes = serde_json::to_vec(&dense_budgeted)?;
@@ -1399,13 +1403,21 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
         CommunityCoverage::Complete,
     );
     let marker_bytes = serialized_bytes_controlled(&marker, None)?;
+    let marker_vec_bytes = serialized_bytes_controlled(&vec![marker], None)?;
+    let first_append_bytes = serialized_findings_append_bytes(marker_vec_bytes, 1, 0);
+    let subsequent_append_bytes = serialized_findings_append_bytes(marker_vec_bytes, 1, 1);
+    require(
+        first_append_bytes == marker_bytes
+            && subsequent_append_bytes == marker_bytes.saturating_add(1),
+        "community marker append accounting lost JSON framing or separator bytes",
+    )?;
     let working_set_bytes = community_working_set_upper_bound(&nodes, &[], None)?;
     require(
-        marker_bytes <= working_set_bytes,
+        first_append_bytes <= working_set_bytes,
         "community marker unexpectedly exceeded the fixed working-set charge",
     )?;
     let (fitted_marker, _, fitted_limits) =
-        community_findings_with_budget(&nodes, &[], true, &query, working_set_bytes, None)?;
+        community_findings_with_budget(&nodes, &[], true, &query, working_set_bytes, 0, None)?;
     let fitted_marker_bytes = serde_json::to_vec(&fitted_marker)?;
     require(
         fitted_limits == vec![GraphLimitKind::IntermediateBytes]
@@ -1423,7 +1435,37 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
         &[],
         true,
         &query,
-        marker_bytes.saturating_sub(1),
+        first_append_bytes.saturating_sub(1),
+        0,
+        None,
+    )?;
+    let (equal_marker, _, equal_limits) =
+        community_findings_with_budget(&nodes, &[], true, &query, first_append_bytes, 0, None)?;
+    let (plus_marker, _, plus_limits) = community_findings_with_budget(
+        &nodes,
+        &[],
+        true,
+        &query,
+        first_append_bytes.saturating_add(1),
+        0,
+        None,
+    )?;
+    let (existing_marker, _, existing_limits) = community_findings_with_budget(
+        &nodes,
+        &[],
+        true,
+        &query,
+        subsequent_append_bytes,
+        1,
+        None,
+    )?;
+    let (existing_omitted_marker, _, existing_omitted_limits) = community_findings_with_budget(
+        &nodes,
+        &[],
+        true,
+        &query,
+        subsequent_append_bytes.saturating_sub(1),
+        1,
         None,
     )?;
     let (omitted_marker_repeat, _, _) = community_findings_with_budget(
@@ -1431,15 +1473,37 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
         &[],
         true,
         &query,
-        marker_bytes.saturating_sub(1),
+        first_append_bytes.saturating_sub(1),
+        0,
         None,
     )?;
     require(
         omitted_limits == vec![GraphLimitKind::IntermediateBytes]
             && omitted_marker.is_empty()
             && serde_json::to_vec(&omitted_marker)? == serde_json::to_vec(&omitted_marker_repeat)?
-            && marker_bytes > marker_bytes.saturating_sub(1),
+            && first_append_bytes > first_append_bytes.saturating_sub(1),
         "an oversized community truncation marker was retained",
+    )?;
+    require(
+        equal_limits == vec![GraphLimitKind::IntermediateBytes]
+            && plus_limits == vec![GraphLimitKind::IntermediateBytes]
+            && existing_limits == vec![GraphLimitKind::IntermediateBytes]
+            && existing_omitted_limits == vec![GraphLimitKind::IntermediateBytes]
+            && equal_marker.len() == 1
+            && plus_marker.len() == 1
+            && existing_marker.len() == 1
+            && existing_omitted_marker.is_empty()
+            && serialized_findings_append_bytes(
+                serialized_bytes_controlled(&equal_marker, None)?,
+                equal_marker.len(),
+                0,
+            ) <= first_append_bytes
+            && serialized_findings_append_bytes(
+                serialized_bytes_controlled(&plus_marker, None)?,
+                plus_marker.len(),
+                0,
+            ) <= first_append_bytes.saturating_add(1),
+        "preflight marker boundary did not retain only fitting actual JSON bytes",
     )?;
     let mut marker_query = query.clone();
     marker_query.include_cycles = false;
@@ -1451,7 +1515,8 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
         true,
         true,
         &marker_query,
-        marker_bytes.saturating_sub(1),
+        first_append_bytes.saturating_sub(1),
+        0,
         &mut marker_work,
         None,
     )?;
@@ -1462,6 +1527,49 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
                 .reached_limits
                 .contains(&GraphLimitKind::IntermediateBytes),
         "report composition lost the typed limit when a community marker did not fit",
+    )?;
+    let mut composed_work = SupplementalWork::default();
+    let composed_findings = architecture_findings(
+        &store,
+        &BTreeMap::new(),
+        &[],
+        true,
+        true,
+        &marker_query,
+        subsequent_append_bytes,
+        1,
+        &mut composed_work,
+        None,
+    )?;
+    require(
+        composed_findings.len() == 1
+            && composed_findings[0].community.is_some()
+            && composed_work.composition_truncated
+            && composed_work
+                .reached_limits
+                .contains(&GraphLimitKind::IntermediateBytes),
+        "community marker did not compose after an existing non-community finding",
+    )?;
+    let mut zero_budget_work = SupplementalWork::default();
+    let zero_budget_findings = architecture_findings(
+        &store,
+        &BTreeMap::new(),
+        &[],
+        true,
+        true,
+        &marker_query,
+        0,
+        1,
+        &mut zero_budget_work,
+        None,
+    )?;
+    require(
+        zero_budget_findings.is_empty()
+            && zero_budget_work.composition_truncated
+            && zero_budget_work
+                .reached_limits
+                .contains(&GraphLimitKind::IntermediateBytes),
+        "zero remaining community allowance lost typed truncation truth",
     )?;
     let candidate_key = nodes
         .keys()
@@ -1492,8 +1600,62 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
         0,
         CommunityConvergence::Converged,
         None,
-        marker_bytes,
+        0,
+        first_append_bytes,
     )?;
+    let (candidate_equal, candidate_equal_limits) = community_candidate_findings(
+        &nodes,
+        &candidate_keys,
+        &[],
+        &candidate_labels,
+        &marker_weights,
+        marker_parameters,
+        0,
+        CommunityConvergence::Converged,
+        None,
+        0,
+        first_append_bytes,
+    )?;
+    let (candidate_plus, candidate_plus_limits) = community_candidate_findings(
+        &nodes,
+        &candidate_keys,
+        &[],
+        &candidate_labels,
+        &marker_weights,
+        marker_parameters,
+        0,
+        CommunityConvergence::Converged,
+        None,
+        0,
+        first_append_bytes.saturating_add(1),
+    )?;
+    let (candidate_existing, candidate_existing_limits) = community_candidate_findings(
+        &nodes,
+        &candidate_keys,
+        &[],
+        &candidate_labels,
+        &marker_weights,
+        marker_parameters,
+        0,
+        CommunityConvergence::Converged,
+        None,
+        1,
+        subsequent_append_bytes,
+    )?;
+    let (candidate_existing_omitted, candidate_existing_omitted_limits) =
+        community_candidate_findings(
+            &nodes,
+            &candidate_keys,
+            &[],
+            &candidate_labels,
+            &marker_weights,
+            marker_parameters,
+            0,
+            CommunityConvergence::Converged,
+            None,
+            1,
+            subsequent_append_bytes.saturating_sub(1),
+        )?;
     let (candidate_omitted, candidate_omitted_limits) = community_candidate_findings(
         &nodes,
         &candidate_keys,
@@ -1504,12 +1666,21 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
         0,
         CommunityConvergence::Converged,
         None,
-        marker_bytes.saturating_sub(1),
+        0,
+        first_append_bytes.saturating_sub(1),
     )?;
     require(
         candidate_limits == vec![GraphLimitKind::IntermediateBytes]
             && candidate_marker.len() == 1
             && candidate_marker[0].community.is_some()
+            && candidate_equal_limits == vec![GraphLimitKind::IntermediateBytes]
+            && candidate_equal.len() == 1
+            && candidate_plus_limits == vec![GraphLimitKind::IntermediateBytes]
+            && candidate_plus.len() == 1
+            && candidate_existing_limits == vec![GraphLimitKind::IntermediateBytes]
+            && candidate_existing.len() == 1
+            && candidate_existing_omitted_limits == vec![GraphLimitKind::IntermediateBytes]
+            && candidate_existing_omitted.is_empty()
             && candidate_omitted_limits == vec![GraphLimitKind::IntermediateBytes]
             && candidate_omitted.is_empty(),
         "candidate truncation did not honor the remaining marker budget",

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1382,6 +1382,138 @@ fn communities_are_deterministic_and_partition_a_planted_weak_component()
             }),
         "representative high-degree community analysis crossed its bounded envelope",
     )?;
+    let marker_parameters = CommunityParameters {
+        algorithm_version: COMMUNITY_ALGORITHM_VERSION,
+        ordering_version: COMMUNITY_ORDERING_VERSION,
+        max_iterations: COMMUNITY_MAX_ITERATIONS,
+        node_limit: query.relations.budget.nodes().min(MAX_ANALYSIS_NODES),
+        edge_limit: query.relations.budget.edges().min(MAX_ANALYSIS_EDGES),
+        output_bytes: query.relations.budget.output_bytes(),
+        relation: query.relations.relation,
+    };
+    let marker_weights = community_relation_weights();
+    let marker = community_truncation_finding(
+        &marker_weights,
+        marker_parameters,
+        0,
+        CommunityCoverage::Complete,
+    );
+    let marker_bytes = serialized_bytes_controlled(&marker, None)?;
+    let working_set_bytes = community_working_set_upper_bound(&nodes, &[], None)?;
+    require(
+        marker_bytes <= working_set_bytes,
+        "community marker unexpectedly exceeded the fixed working-set charge",
+    )?;
+    let (fitted_marker, _, fitted_limits) =
+        community_findings_with_budget(&nodes, &[], true, &query, working_set_bytes, None)?;
+    let fitted_marker_bytes = serde_json::to_vec(&fitted_marker)?;
+    require(
+        fitted_limits == vec![GraphLimitKind::IntermediateBytes]
+            && fitted_marker.len() == 1
+            && fitted_marker[0].status == AnalysisStatus::Inconclusive
+            && fitted_marker[0]
+                .community
+                .as_ref()
+                .is_some_and(|community| community.truncated)
+            && fitted_marker_bytes.len() <= working_set_bytes as usize,
+        "a fitting community truncation marker lost its typed bounded outcome",
+    )?;
+    let (omitted_marker, _, omitted_limits) = community_findings_with_budget(
+        &nodes,
+        &[],
+        true,
+        &query,
+        marker_bytes.saturating_sub(1),
+        None,
+    )?;
+    let (omitted_marker_repeat, _, _) = community_findings_with_budget(
+        &nodes,
+        &[],
+        true,
+        &query,
+        marker_bytes.saturating_sub(1),
+        None,
+    )?;
+    require(
+        omitted_limits == vec![GraphLimitKind::IntermediateBytes]
+            && omitted_marker.is_empty()
+            && serde_json::to_vec(&omitted_marker)? == serde_json::to_vec(&omitted_marker_repeat)?
+            && marker_bytes > marker_bytes.saturating_sub(1),
+        "an oversized community truncation marker was retained",
+    )?;
+    let mut marker_query = query.clone();
+    marker_query.include_cycles = false;
+    let mut marker_work = SupplementalWork::default();
+    let report_findings = architecture_findings(
+        &store,
+        &BTreeMap::new(),
+        &[],
+        true,
+        true,
+        &marker_query,
+        marker_bytes.saturating_sub(1),
+        &mut marker_work,
+        None,
+    )?;
+    require(
+        report_findings.is_empty()
+            && marker_work.composition_truncated
+            && marker_work
+                .reached_limits
+                .contains(&GraphLimitKind::IntermediateBytes),
+        "report composition lost the typed limit when a community marker did not fit",
+    )?;
+    let candidate_key = nodes
+        .keys()
+        .next()
+        .cloned()
+        .ok_or("candidate marker node missing")?;
+    let candidate_keys = vec![candidate_key.clone()];
+    let candidate_labels = BTreeMap::from([(candidate_key.clone(), candidate_key)]);
+    let candidate_bound = community_candidate_upper_bound(
+        &nodes,
+        &candidate_keys,
+        &[],
+        &marker_weights,
+        marker_parameters,
+        None,
+    )?;
+    require(
+        candidate_bound > marker_bytes,
+        "community candidate bound did not exercise marker truncation",
+    )?;
+    let (candidate_marker, candidate_limits) = community_candidate_findings(
+        &nodes,
+        &candidate_keys,
+        &[],
+        &candidate_labels,
+        &marker_weights,
+        marker_parameters,
+        0,
+        CommunityConvergence::Converged,
+        None,
+        marker_bytes,
+    )?;
+    let (candidate_omitted, candidate_omitted_limits) = community_candidate_findings(
+        &nodes,
+        &candidate_keys,
+        &[],
+        &candidate_labels,
+        &marker_weights,
+        marker_parameters,
+        0,
+        CommunityConvergence::Converged,
+        None,
+        marker_bytes.saturating_sub(1),
+    )?;
+    require(
+        candidate_limits == vec![GraphLimitKind::IntermediateBytes]
+            && candidate_marker.len() == 1
+            && candidate_marker[0].community.is_some()
+            && candidate_omitted_limits == vec![GraphLimitKind::IntermediateBytes]
+            && candidate_omitted.is_empty(),
+        "candidate truncation did not honor the remaining marker budget",
+    )?;
     let mut sparse_budget_query = query;
     sparse_budget_query.relations.budget = sparse_budget_query
         .relations

--- a/docs/v050-release-architecture.md
+++ b/docs/v050-release-architecture.md
@@ -130,7 +130,7 @@ flowchart LR
     normalized_graph[(Current normalized graph)] --> admit[Resolved local non-containment edges]
     admit --> bound[Node, edge, time, memory, iteration bounds]
     bound -->|complete and within bounds| labels[Stable-order weighted label propagation]
-    bound -->|partial coverage or node/edge overflow| uncertain[Typed inconclusive or truncated result]
+    bound -->|partial coverage or node/edge/intermediate-memory overflow| uncertain[Typed inconclusive or truncated result]
     labels --> ids[Stable parameter-and-member community IDs]
     ids --> result[Bounded returned output: members, evidence, coverage, convergence, truncation]
     uncertain --> result

--- a/docs/v050-release-architecture.md
+++ b/docs/v050-release-architecture.md
@@ -129,10 +129,11 @@ flowchart LR
 flowchart LR
     normalized_graph[(Current normalized graph)] --> admit[Resolved local non-containment edges]
     admit --> bound[Node, edge, time, memory, iteration bounds]
-    bound --> labels[Stable-order weighted label propagation]
+    bound -->|complete and within bounds| labels[Stable-order weighted label propagation]
+    bound -->|partial coverage or node/edge overflow| uncertain[Typed inconclusive or truncated result]
     labels --> ids[Stable parameter-and-member community IDs]
-    ids --> result[Members, evidence, coverage, convergence, truncation]
-    gap[Incomplete or stale evidence] --> unresolved[Typed inconclusive result]
+    ids --> result[Bounded returned output: members, evidence, coverage, convergence, truncation]
+    uncertain --> result
 ```
 
 ## Bounded PDF and DOCX extraction

--- a/openspec/changes/complete-v050-release-readiness/tasks.md
+++ b/openspec/changes/complete-v050-release-readiness/tasks.md
@@ -70,10 +70,10 @@
 
 ## 11. Deterministic architecture-community analysis (#464)
 
-- [x] 11.1 Freeze deterministic weighted label-propagation v1, admitted resolved local relation families/weights, stable node/label order and tie-breaks, iteration and resource ceilings, stable community IDs, coverage/truncation semantics, no-persistence decision, and planted-partition acceptance bounds against the current weak-component baseline.
-- [x] 11.2 Replace only the existing optional `Community` projection inside the bounded service analysis path; reuse the current normalized graph/cursor/cancellation/output machinery and add no visualization, rewrite authority, persisted table, new crate, or algorithm framework.
-- [x] 11.3 Cover planted cohesive groups, giant weak component, sparse/disconnected/singleton/cyclic/high-degree graphs, equal-score ties, invalid parameters, non-convergence, incomplete/stale/wrong-root evidence, cancellation/truncation, deterministic repeat, CLI/MCP parity, and representative-scale CPU/RSS/latency/output bounds.
-- [x] 11.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
+- [ ] 11.1 Freeze deterministic weighted label-propagation v1, admitted resolved local relation families/weights, stable node/label order and tie-breaks, iteration and resource ceilings, stable community IDs, coverage/truncation semantics, no-persistence decision, and planted-partition acceptance bounds against the current weak-component baseline.
+- [ ] 11.2 Replace only the existing optional `Community` projection inside the bounded service analysis path; reuse the current normalized graph/cursor/cancellation/output machinery and add no visualization, rewrite authority, persisted table, new crate, or algorithm framework.
+- [ ] 11.3 Cover planted cohesive groups, giant weak component, sparse/disconnected/singleton/cyclic/high-degree graphs, equal-score ties, invalid parameters, non-convergence, incomplete/stale/wrong-root evidence, cancellation/truncation, deterministic repeat, CLI/MCP parity, and representative-scale CPU/RSS/latency/output bounds.
+- [ ] 11.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
 
 ## 12. Bounded PDF and DOCX extraction (#465)
 

--- a/openspec/changes/complete-v050-release-readiness/tasks.md
+++ b/openspec/changes/complete-v050-release-readiness/tasks.md
@@ -70,10 +70,10 @@
 
 ## 11. Deterministic architecture-community analysis (#464)
 
-- [ ] 11.1 Freeze deterministic weighted label-propagation v1, admitted resolved local relation families/weights, stable node/label order and tie-breaks, iteration and resource ceilings, stable community IDs, coverage/truncation semantics, no-persistence decision, and planted-partition acceptance bounds against the current weak-component baseline.
-- [ ] 11.2 Replace only the existing optional `Community` projection inside the bounded service analysis path; reuse the current normalized graph/cursor/cancellation/output machinery and add no visualization, rewrite authority, persisted table, new crate, or algorithm framework.
-- [ ] 11.3 Cover planted cohesive groups, giant weak component, sparse/disconnected/singleton/cyclic/high-degree graphs, equal-score ties, invalid parameters, non-convergence, incomplete/stale/wrong-root evidence, cancellation/truncation, deterministic repeat, CLI/MCP parity, and representative-scale CPU/RSS/latency/output bounds.
-- [ ] 11.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
+- [x] 11.1 Freeze deterministic weighted label-propagation v1, admitted resolved local relation families/weights, stable node/label order and tie-breaks, iteration and resource ceilings, stable community IDs, coverage/truncation semantics, no-persistence decision, and planted-partition acceptance bounds against the current weak-component baseline.
+- [x] 11.2 Replace only the existing optional `Community` projection inside the bounded service analysis path; reuse the current normalized graph/cursor/cancellation/output machinery and add no visualization, rewrite authority, persisted table, new crate, or algorithm framework.
+- [x] 11.3 Cover planted cohesive groups, giant weak component, sparse/disconnected/singleton/cyclic/high-degree graphs, equal-score ties, invalid parameters, non-convergence, incomplete/stale/wrong-root evidence, cancellation/truncation, deterministic repeat, CLI/MCP parity, and representative-scale CPU/RSS/latency/output bounds.
+- [x] 11.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
 
 ## 12. Bounded PDF and DOCX extraction (#465)
 


### PR DESCRIPTION
## Summary
- Replace the optional weak-component Community projection with deterministic bounded weighted label propagation v1.
- Preserve typed coverage, convergence, truncation, stable IDs and member ordering, and the non-persistent analysis boundary.
- Add CLI JSON and MCP TOON production-route coverage and align the architecture diagram with bounded inconclusive output.

## Validation
- Full pre-push hook on Rust 1.98.0, including strict workspace Clippy.
- Locked workspace tests, doctests, rustdoc, cargo-deny, parser, Mermaid, OpenSpec, IssueOps, and ProjectAtlas checks.
- Focused service, CLI, and MCP community tests.

Closes #464