### PR TITLE
test(windows): stabilize Codex MCP owner fixture readiness under suite contention

### DIFF
--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -199,6 +199,9 @@ const CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT: Duration = Duration::from_secs(
 #[cfg(windows)]
 const CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY: Duration = Duration::from_secs(4);
 #[cfg(windows)]
+// Delay the polling caller, not the child operation, so a completed helper is observed late.
+const CODEX_OWNER_LATE_COMPLETION_TEST_DELAY: Duration = Duration::from_secs(2);
+#[cfg(windows)]
 // Delay the readiness poll past the deadline after the fixture has published, without
 // changing process-global state, proving the admission guard through the real helper.
 const CODEX_OWNER_OBSERVATION_TEST_DELAY: Duration = Duration::from_secs(31);
@@ -36209,12 +36212,15 @@ fn cleanup_codex_owner_processes_after_spawn_failure(
     };
     let child_cleanup_result = match child_identity {
         Some(identity) => {
-            stop_windows_fixture_process_until(&identity, cleanup_deadline, child_stop_delay)
+            stop_windows_fixture_process_until(&identity, cleanup_deadline, child_stop_delay, None)
         }
         None => match read_codex_owner_identity_record(&retained_identity_file) {
-            Ok(identity) => {
-                stop_windows_fixture_process_until(&identity, cleanup_deadline, child_stop_delay)
-            }
+            Ok(identity) => stop_windows_fixture_process_until(
+                &identity,
+                cleanup_deadline,
+                child_stop_delay,
+                None,
+            ),
             Err(error) => Err(io::Error::other(format!(
                 "no retained child identity was available after capture failure ({}): {error}",
                 capture_failures.join("; ")
@@ -36357,7 +36363,7 @@ fn cleanup_codex_owner_processes(
 ) -> Result<(), Box<dyn Error>> {
     let cleanup_deadline = codex_owner_cleanup_deadline(Instant::now());
     let child_cleanup_result =
-        stop_windows_fixture_process_until(child_identity, cleanup_deadline, None);
+        stop_windows_fixture_process_until(child_identity, cleanup_deadline, None, None);
     let kill_result = parent.kill();
     let wait_result = parent.wait();
     let mut failures = Vec::new();
@@ -36411,6 +36417,7 @@ fn read_codex_owner_child_identity_with_test_delay(
         published.process_id,
         capture_timeout,
         test_delay,
+        None,
     )?;
     if captured.process_id != published.process_id
         || captured.creation_file_time_utc != published.creation_file_time_utc
@@ -36990,6 +36997,7 @@ fn capture_windows_process_identity(
         process_id,
         CODEX_OWNER_FAILURE_CLEANUP_BUDGET,
         None,
+        None,
     )
 }
 
@@ -36998,6 +37006,7 @@ fn capture_windows_process_identity_with_timeout(
     process_id: u32,
     timeout: Duration,
     test_delay: Option<Duration>,
+    observation_delay: Option<Duration>,
 ) -> Result<WindowsProcessIdentity, Box<dyn Error>> {
     if timeout.is_zero() {
         return Err(io::Error::other(format!(
@@ -37024,9 +37033,22 @@ fn capture_windows_process_identity_with_timeout(
     }
     let mut capture = command.spawn()?;
     let started = Instant::now();
+    if let Some(delay) = observation_delay {
+        thread::sleep(delay);
+    }
     let output = loop {
         match capture.try_wait() {
-            Ok(Some(_)) => break capture.wait_with_output()?,
+            Ok(Some(_)) => {
+                let observed_elapsed = started.elapsed();
+                let output = capture.wait_with_output()?;
+                if observed_elapsed >= timeout {
+                    return Err(io::Error::other(format!(
+                        "Windows fixture identity capture completed after {timeout:?} deadline (observed after {observed_elapsed:?})"
+                    ))
+                    .into());
+                }
+                break output;
+            }
             Ok(None) if started.elapsed() >= timeout => {
                 let kill_result = capture.kill();
                 let wait_result = capture.wait();
@@ -37121,7 +37143,7 @@ fn windows_process_is_alive(identity: &WindowsProcessIdentity) -> Result<bool, B
 #[cfg(windows)]
 fn stop_windows_fixture_process(identity: &WindowsProcessIdentity) -> Result<(), Box<dyn Error>> {
     let deadline = Instant::now() + CODEX_OWNER_CHILD_STOP_BUDGET;
-    stop_windows_fixture_process_until(identity, deadline, None)
+    stop_windows_fixture_process_until(identity, deadline, None, None)
 }
 
 #[cfg(windows)]
@@ -37129,6 +37151,7 @@ fn stop_windows_fixture_process_until(
     identity: &WindowsProcessIdentity,
     deadline: Instant,
     test_delay: Option<Duration>,
+    observation_delay: Option<Duration>,
 ) -> Result<(), Box<dyn Error>> {
     let mut command = StdCommand::new("powershell");
     command
@@ -37154,9 +37177,28 @@ fn stop_windows_fixture_process_until(
     }
     let mut stop = command.spawn()?;
     let started = Instant::now();
+    if let Some(delay) = observation_delay {
+        thread::sleep(delay);
+    }
     let status = loop {
         match stop.try_wait() {
-            Ok(Some(status)) => break status,
+            Ok(Some(status)) => {
+                let observed_elapsed = started.elapsed();
+                if Instant::now() >= deadline {
+                    let wait_result = stop.wait();
+                    let reap_detail = wait_result
+                        .err()
+                        .map(|error| format!("; late stop-helper reap failed: {error}"))
+                        .unwrap_or_default();
+                    return Err(io::Error::other(format!(
+                        "timed out stopping Windows fixture process {} after {:?}; stop helper completed after deadline (observed after {observed_elapsed:?}){reap_detail}",
+                        identity.process_id,
+                        observed_elapsed
+                    ))
+                    .into());
+                }
+                break status;
+            }
             Ok(None) if Instant::now() >= deadline => {
                 let kill_result = stop.kill();
                 let wait_result = stop.wait();
@@ -37223,6 +37265,7 @@ fn windows_fixture_identity_capture_is_bounded() -> Result<(), Box<dyn Error>> {
         identity.process_id,
         CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT,
         Some(CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY),
+        None,
     );
     let elapsed = started.elapsed();
     let cleanup_result = if windows_process_is_alive(&identity)? {
@@ -37238,6 +37281,52 @@ fn windows_fixture_identity_capture_is_bounded() -> Result<(), Box<dyn Error>> {
     {
         return Err(io::Error::other(format!(
             "stalled Windows fixture identity capture was not bounded: elapsed={elapsed:?} timeout={CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} result={result:?}"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+#[test]
+#[cfg(windows)]
+fn windows_fixture_identity_capture_rejects_late_completion() -> Result<(), Box<dyn Error>> {
+    let mut process = StdCommand::new("powershell")
+        .arg("-NoProfile")
+        .arg("-NonInteractive")
+        .arg("-Command")
+        .arg("Start-Sleep -Seconds 30")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let identity = match capture_windows_process_identity(process.id()) {
+        Ok(identity) => identity,
+        Err(error) => {
+            drop(process.kill());
+            drop(process.wait());
+            return Err(error);
+        }
+    };
+    let result = capture_windows_process_identity_with_timeout(
+        identity.process_id,
+        CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT,
+        None,
+        Some(CODEX_OWNER_LATE_COMPLETION_TEST_DELAY),
+    );
+    let child_alive = windows_process_is_alive(&identity)?;
+    let cleanup_result = if child_alive {
+        stop_windows_fixture_process(&identity)
+    } else {
+        Ok(())
+    };
+    process.wait()?;
+    cleanup_result?;
+    let Err(error) = result else {
+        return Err(io::Error::other("late identity capture completion was accepted").into());
+    };
+    if !error.to_string().contains("completed after") {
+        return Err(io::Error::other(format!(
+            "late identity capture did not exercise the completion-after-deadline branch: {error}"
         ))
         .into());
     }
@@ -37270,6 +37359,7 @@ fn windows_fixture_stop_helper_is_bounded_and_child_safe() -> Result<(), Box<dyn
         &identity,
         deadline,
         Some(CODEX_OWNER_STOP_HELPER_TEST_DELAY),
+        None,
     );
     let elapsed = started.elapsed();
     let child_alive = windows_process_is_alive(&identity)?;
@@ -37295,6 +37385,53 @@ fn windows_fixture_stop_helper_is_bounded_and_child_safe() -> Result<(), Box<dyn
         .into());
     }
     wait_result?;
+    Ok(())
+}
+
+#[test]
+#[cfg(windows)]
+fn windows_fixture_stop_helper_rejects_late_completion() -> Result<(), Box<dyn Error>> {
+    let mut process = StdCommand::new("powershell")
+        .arg("-NoProfile")
+        .arg("-NonInteractive")
+        .arg("-Command")
+        .arg("Start-Sleep -Seconds 30")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let identity = match capture_windows_process_identity(process.id()) {
+        Ok(identity) => identity,
+        Err(error) => {
+            drop(process.kill());
+            drop(process.wait());
+            return Err(error);
+        }
+    };
+    let deadline = Instant::now() + CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT;
+    let result = stop_windows_fixture_process_until(
+        &identity,
+        deadline,
+        None,
+        Some(CODEX_OWNER_LATE_COMPLETION_TEST_DELAY),
+    );
+    let child_alive = windows_process_is_alive(&identity)?;
+    if child_alive {
+        drop(process.kill());
+    }
+    process.wait()?;
+    if child_alive
+        || result.as_ref().is_ok()
+        || !result
+            .as_ref()
+            .err()
+            .is_some_and(|error| error.to_string().contains("completed after deadline"))
+    {
+        return Err(io::Error::other(format!(
+            "late stop-helper completion did not fail closed or clean its child: child_alive={child_alive} result={result:?}"
+        ))
+        .into());
+    }
     Ok(())
 }
 

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -189,6 +189,10 @@ const CODEX_OWNER_CHILD_STOP_BUDGET: Duration = Duration::from_secs(5);
 // Allow normal scheduling variance without allowing a late readiness retry to hide.
 const CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE: Duration = Duration::from_secs(2);
 #[cfg(windows)]
+const CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT: Duration = Duration::from_secs(1);
+#[cfg(windows)]
+const CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY: Duration = Duration::from_secs(4);
+#[cfg(windows)]
 // Early owner exit must be observed before readiness expires; this bound allows only
 // the same scheduler margin as the bounded publication contract.
 fn codex_owner_early_exit_max_elapsed() -> Duration {
@@ -201,6 +205,9 @@ const CODEX_OWNER_PUBLICATION_DELAY_ENV: &str =
     "PROJECTATLAS_TEST_CODEX_OWNER_PUBLICATION_DELAY_MS";
 #[cfg(windows)]
 const CODEX_OWNER_PUBLICATION_MODE_ENV: &str = "PROJECTATLAS_TEST_CODEX_OWNER_PUBLICATION_MODE";
+#[cfg(windows)]
+const CODEX_OWNER_IDENTITY_CAPTURE_DELAY_ENV: &str =
+    "PROJECTATLAS_TEST_CODEX_OWNER_IDENTITY_CAPTURE_DELAY_MS";
 #[cfg(windows)]
 const OBSOLETE_PROJECTATLAS_FIXTURE_SOURCE_FILE_NAME: &str = "obsolete-projectatlas.cs";
 
@@ -36078,9 +36085,19 @@ fn cleanup_codex_owner_processes_after_spawn_failure(
     mut failures: Vec<String>,
 ) -> Result<(), Box<dyn Error>> {
     let retained_identity_file = codex_owner_retained_identity_path(child_identity_file);
-    let child_cleanup_result = read_codex_owner_child_identity(child_identity_file, stable_runtime)
-        .or_else(|_| read_codex_owner_child_identity(&retained_identity_file, stable_runtime))
-        .and_then(|identity| stop_windows_fixture_process(&identity));
+    let child_cleanup_result = read_codex_owner_child_identity(
+        child_identity_file,
+        stable_runtime,
+        CODEX_OWNER_FAILURE_CLEANUP_BUDGET,
+    )
+    .or_else(|_| {
+        read_codex_owner_child_identity(
+            &retained_identity_file,
+            stable_runtime,
+            CODEX_OWNER_FAILURE_CLEANUP_BUDGET,
+        )
+    })
+    .and_then(|identity| stop_windows_fixture_process(&identity));
     if let Err(error) = child_cleanup_result {
         failures.push(format!("could not retire its owned child safely: {error}"));
     }
@@ -36227,9 +36244,11 @@ fn codex_owner_unexpected_acceptance_error(
 fn read_codex_owner_child_identity(
     child_identity_file: &Path,
     stable_runtime: &Path,
+    capture_timeout: Duration,
 ) -> Result<WindowsProcessIdentity, Box<dyn Error>> {
     let published = read_codex_owner_identity_record(child_identity_file)?;
-    let captured = capture_windows_process_identity(published.process_id)?;
+    let captured =
+        capture_windows_process_identity_with_timeout(published.process_id, capture_timeout, None)?;
     if captured.process_id != published.process_id
         || captured.creation_file_time_utc != published.creation_file_time_utc
     {
@@ -36374,7 +36393,8 @@ fn spawn_codex_owned_obsolete_mcp(
             }
         }
         if child_pid_file.is_file() {
-            match read_codex_owner_child_identity(child_pid_file, stable_runtime) {
+            let capture_timeout = deadline.saturating_duration_since(Instant::now());
+            match read_codex_owner_child_identity(child_pid_file, stable_runtime, capture_timeout) {
                 Ok(captured) => return Ok((parent, captured)),
                 Err(error) => {
                     return Err(codex_owner_spawn_error(
@@ -36654,15 +36674,83 @@ struct WindowsProcessIdentity {
 fn capture_windows_process_identity(
     process_id: u32,
 ) -> Result<WindowsProcessIdentity, Box<dyn Error>> {
-    let output = StdCommand::new("powershell")
+    capture_windows_process_identity_with_timeout(
+        process_id,
+        CODEX_OWNER_FAILURE_CLEANUP_BUDGET,
+        None,
+    )
+}
+
+#[cfg(windows)]
+fn capture_windows_process_identity_with_timeout(
+    process_id: u32,
+    timeout: Duration,
+    test_delay: Option<Duration>,
+) -> Result<WindowsProcessIdentity, Box<dyn Error>> {
+    let mut command = StdCommand::new("powershell");
+    command
         .arg("-NoProfile")
         .arg("-NonInteractive")
         .arg("-Command")
         .arg(
-            "$process = Get-Process -Id $env:PROJECTATLAS_FIXTURE_PID -ErrorAction Stop; [pscustomobject]@{ process_id = [uint32]$process.Id; creation_file_time_utc = $process.StartTime.ToUniversalTime().ToFileTimeUtc(); executable_path = [System.IO.Path]::GetFullPath($process.Path) } | ConvertTo-Json -Compress",
+            "$delay = 0; if ($env:PROJECTATLAS_TEST_CODEX_OWNER_IDENTITY_CAPTURE_DELAY_MS) { $delay = [int]$env:PROJECTATLAS_TEST_CODEX_OWNER_IDENTITY_CAPTURE_DELAY_MS }; if ($delay -gt 0) { Start-Sleep -Milliseconds $delay }; $process = Get-Process -Id $env:PROJECTATLAS_FIXTURE_PID -ErrorAction Stop; [pscustomobject]@{ process_id = [uint32]$process.Id; creation_file_time_utc = $process.StartTime.ToUniversalTime().ToFileTimeUtc(); executable_path = [System.IO.Path]::GetFullPath($process.Path) } | ConvertTo-Json -Compress",
         )
         .env("PROJECTATLAS_FIXTURE_PID", process_id.to_string())
-        .output()?;
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(delay) = test_delay {
+        command.env(
+            CODEX_OWNER_IDENTITY_CAPTURE_DELAY_ENV,
+            delay.as_millis().to_string(),
+        );
+    }
+    let mut capture = command.spawn()?;
+    let started = Instant::now();
+    let output = loop {
+        match capture.try_wait() {
+            Ok(Some(_)) => break capture.wait_with_output()?,
+            Ok(None) if started.elapsed() >= timeout => {
+                let kill_result = capture.kill();
+                let wait_result = capture.wait();
+                let mut cleanup = Vec::new();
+                if let Err(error) = kill_result
+                    && error.kind() != io::ErrorKind::InvalidInput
+                {
+                    cleanup.push(format!("could not terminate identity capture: {error}"));
+                }
+                if let Err(error) = wait_result {
+                    cleanup.push(format!("could not reap identity capture: {error}"));
+                }
+                let cleanup_detail = if cleanup.is_empty() {
+                    String::new()
+                } else {
+                    format!("; {}", cleanup.join("; "))
+                };
+                return Err(io::Error::other(format!(
+                    "timed out capturing Windows fixture process identity {process_id} after {timeout:?}{cleanup_detail}"
+                ))
+                .into());
+            }
+            Ok(None) => {
+                let remaining = timeout.saturating_sub(started.elapsed());
+                thread::sleep(remaining.min(Duration::from_millis(25)));
+            }
+            Err(error) => {
+                let kill_result = capture.kill();
+                let wait_result = capture.wait();
+                let cleanup_detail = match (kill_result, wait_result) {
+                    (Ok(()), Ok(_)) => String::new(),
+                    (kill, wait) => {
+                        format!("; identity-capture cleanup kill={kill:?} wait={wait:?}")
+                    }
+                };
+                return Err(io::Error::other(format!(
+                    "failed to observe Windows fixture identity capture {process_id}: {error}{cleanup_detail}"
+                ))
+                .into());
+            }
+        }
+    };
     if !output.status.success() {
         return Err(io::Error::other(format!(
             "failed to capture Windows fixture process identity {process_id}:\n{}",
@@ -36735,6 +36823,52 @@ fn stop_windows_fixture_process(identity: &WindowsProcessIdentity) -> Result<(),
         return Err(io::Error::other(format!(
             "refused to stop Windows fixture process {} without its exact captured identity",
             identity.process_id
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+#[test]
+#[cfg(windows)]
+fn windows_fixture_identity_capture_is_bounded() -> Result<(), Box<dyn Error>> {
+    let mut process = StdCommand::new("powershell")
+        .arg("-NoProfile")
+        .arg("-NonInteractive")
+        .arg("-Command")
+        .arg("Start-Sleep -Seconds 30")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let identity = match capture_windows_process_identity(process.id()) {
+        Ok(identity) => identity,
+        Err(error) => {
+            drop(process.kill());
+            drop(process.wait());
+            return Err(error);
+        }
+    };
+    let started = Instant::now();
+    let result = capture_windows_process_identity_with_timeout(
+        identity.process_id,
+        CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT,
+        Some(CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY),
+    );
+    let elapsed = started.elapsed();
+    let cleanup_result = if windows_process_is_alive(&identity)? {
+        stop_windows_fixture_process(&identity)
+    } else {
+        Ok(())
+    };
+    process.wait()?;
+    cleanup_result?;
+    if result.is_ok()
+        || elapsed
+            > CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE
+    {
+        return Err(io::Error::other(format!(
+            "stalled Windows fixture identity capture was not bounded: elapsed={elapsed:?} timeout={CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} result={result:?}"
         ))
         .into());
     }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -199,6 +199,10 @@ const CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT: Duration = Duration::from_secs(
 #[cfg(windows)]
 const CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY: Duration = Duration::from_secs(4);
 #[cfg(windows)]
+// Delay the readiness poll past the deadline after the fixture has published, without
+// changing process-global state, proving the admission guard through the real helper.
+const CODEX_OWNER_OBSERVATION_TEST_DELAY: Duration = Duration::from_secs(31);
+#[cfg(windows)]
 const CODEX_OWNER_COMPOSED_STOP_DELAY: Duration = Duration::from_secs(3);
 #[cfg(windows)]
 const CODEX_OWNER_STOP_HELPER_TEST_DELAY: Duration = Duration::from_secs(6);
@@ -36502,7 +36506,7 @@ fn spawn_codex_owned_obsolete_mcp(
     publication_delay: Option<Duration>,
     publication_mode: Option<&str>,
 ) -> Result<(Child, WindowsProcessIdentity), Box<dyn Error>> {
-    spawn_codex_owned_obsolete_mcp_with_identity_capture_delay(
+    spawn_codex_owned_obsolete_mcp_with_test_delays(
         codex_fixture,
         stable_runtime,
         db,
@@ -36511,11 +36515,12 @@ fn spawn_codex_owned_obsolete_mcp(
         publication_delay,
         publication_mode,
         None,
+        None,
     )
 }
 
 #[cfg(windows)]
-fn spawn_codex_owned_obsolete_mcp_with_identity_capture_delay(
+fn spawn_codex_owned_obsolete_mcp_with_test_delays(
     codex_fixture: &Path,
     stable_runtime: &Path,
     db: &Path,
@@ -36524,6 +36529,7 @@ fn spawn_codex_owned_obsolete_mcp_with_identity_capture_delay(
     publication_delay: Option<Duration>,
     publication_mode: Option<&str>,
     identity_capture_delay: Option<Duration>,
+    observation_delay: Option<Duration>,
 ) -> Result<(Child, WindowsProcessIdentity), Box<dyn Error>> {
     let mut command = StdCommand::new(codex_fixture);
     command
@@ -36548,6 +36554,9 @@ fn spawn_codex_owned_obsolete_mcp_with_identity_capture_delay(
     let mut parent = command.spawn()?;
     let started = Instant::now();
     let deadline = started + CODEX_OWNER_READINESS_TIMEOUT;
+    if let Some(delay) = observation_delay {
+        thread::sleep(delay);
+    }
     loop {
         match parent.try_wait() {
             Ok(Some(status)) => {
@@ -36575,10 +36584,22 @@ fn spawn_codex_owned_obsolete_mcp_with_identity_capture_delay(
             }
         }
         if child_pid_file.is_file() {
-            // Once publication is observed, give exact identity validation its own bounded
-            // allowance.  The file may have been published before this poll crossed the
-            // readiness deadline, so classifying it as missing before validation would reject
-            // a valid owner under ordinary scheduler contention.
+            let observed_at = Instant::now();
+            if observed_at >= deadline {
+                let elapsed = started.elapsed();
+                return Err(codex_owner_spawn_error(
+                    &mut parent,
+                    codex_fixture,
+                    child_pid_file,
+                    stable_runtime,
+                    format!(
+                        "Codex MCP owner fixture published its child PID after the readiness deadline (readiness_elapsed_ms={})",
+                        elapsed.as_millis()
+                    ),
+                ));
+            }
+            // Publication must be observed inside readiness. Once observed, give exact
+            // identity validation its own bounded allowance.
             match read_codex_owner_child_identity_with_test_delay(
                 child_pid_file,
                 stable_runtime,
@@ -36644,7 +36665,7 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
         + Duration::from_secs(1);
     let deadline_validation_started = Instant::now();
     let (deadline_validation_parent, deadline_validation_identity) =
-        spawn_codex_owned_obsolete_mcp_with_identity_capture_delay(
+        spawn_codex_owned_obsolete_mcp_with_test_delays(
             &codex_fixture,
             &runtime,
             &db,
@@ -36653,6 +36674,7 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
             Some(deadline_validation_publication_delay),
             None,
             Some(CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY),
+            None,
         )?;
     let deadline_validation_elapsed = deadline_validation_started.elapsed();
     if deadline_validation_elapsed < CODEX_OWNER_READINESS_TIMEOUT
@@ -37276,7 +37298,7 @@ fn windows_fixture_stop_helper_is_bounded_and_child_safe() -> Result<(), Box<dyn
 
 #[test]
 #[cfg(windows)]
-fn windows_fixture_late_publication_is_atomic_but_past_readiness() -> Result<(), Box<dyn Error>> {
+fn windows_fixture_identity_observed_after_readiness_is_rejected() -> Result<(), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let runtime = temp
         .path()
@@ -37288,14 +37310,16 @@ fn windows_fixture_late_publication_is_atomic_but_past_readiness() -> Result<(),
     compile_codex_mcp_owner_fixture(&codex_fixture)?;
 
     let started = Instant::now();
-    let result = spawn_codex_owned_obsolete_mcp(
+    let result = spawn_codex_owned_obsolete_mcp_with_test_delays(
         &codex_fixture,
         &runtime,
         &db,
         None,
         &identity_file,
-        Some(CODEX_OWNER_READINESS_TIMEOUT + Duration::from_secs(1)),
+        Some(CODEX_OWNER_DELAYED_PUBLICATION),
         Some("late-publication"),
+        None,
+        Some(CODEX_OWNER_OBSERVATION_TEST_DELAY),
     );
     let elapsed = started.elapsed();
     let error = match result {
@@ -37325,23 +37349,22 @@ fn windows_fixture_late_publication_is_atomic_but_past_readiness() -> Result<(),
         .map(Duration::from_millis)
         .ok_or_else(|| {
             io::Error::other(format!(
-                "late publication timeout omitted its readiness elapsed diagnostic: {text}"
+                "late-observed identity timeout omitted its readiness elapsed diagnostic: {text}"
             ))
         })?;
     if elapsed < CODEX_OWNER_READINESS_TIMEOUT
         || elapsed > total_upper_bound
-        || readiness_elapsed < CODEX_OWNER_READINESS_TIMEOUT
+        || readiness_elapsed <= CODEX_OWNER_READINESS_TIMEOUT
         || readiness_elapsed
             > CODEX_OWNER_READINESS_TIMEOUT + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE
-        || (!text.contains("did not publish its child PID within 30s")
-            && !text.contains("readiness deadline"))
+        || !text.contains("published its child PID after the readiness deadline")
         || !text.contains(&format!("owner={}", codex_fixture.display()))
         || !text.contains(&format!("identity_file={}", identity_file.display()))
         || !text.contains(&format!("expected_runtime={}", runtime.display()))
         || windows_process_is_alive(&retained_identity)?
     {
         return Err(io::Error::other(format!(
-            "late publication was accepted or not bounded: elapsed={elapsed:?} readiness_elapsed={readiness_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} readiness_scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} cleanup_deadline={total_upper_bound:?}\n{text}"
+            "late-observed identity was accepted or not bounded: elapsed={elapsed:?} readiness_elapsed={readiness_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} readiness_scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} cleanup_deadline={total_upper_bound:?}\n{text}"
         ))
         .into());
     }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -36107,6 +36107,54 @@ fn stop_codex_owner_after_spawn_failure(
 }
 
 #[cfg(windows)]
+/// Retire the exact published child, then kill and reap its owned parent.
+fn cleanup_codex_owner_processes(
+    mut parent: Child,
+    child_identity: &WindowsProcessIdentity,
+) -> Result<(), Box<dyn Error>> {
+    let child_cleanup_result = stop_windows_fixture_process(child_identity);
+    let kill_result = parent.kill();
+    let wait_result = parent.wait();
+    let mut failures = Vec::new();
+    if let Err(error) = child_cleanup_result {
+        failures.push(format!(
+            "could not retire the published child safely: {error}"
+        ));
+    }
+    if let Err(error) = kill_result
+        && error.kind() != io::ErrorKind::InvalidInput
+    {
+        failures.push(format!(
+            "could not terminate the held owner process: {error}"
+        ));
+    }
+    if let Err(error) = wait_result {
+        failures.push(format!("could not reap the held owner process: {error}"));
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(io::Error::other(failures.join("; ")).into())
+    }
+}
+
+#[cfg(windows)]
+/// Preserve a negative assertion while cleaning up an unexpectedly accepted owner.
+fn codex_owner_unexpected_acceptance_error(
+    mode: &str,
+    parent: Child,
+    child_identity: &WindowsProcessIdentity,
+) -> Box<dyn Error> {
+    let cleanup_result = cleanup_codex_owner_processes(parent, child_identity);
+    let mut message = format!("{mode} owner fixture publication was accepted");
+    if let Err(error) = cleanup_result {
+        message.push_str("; fixture cleanup also failed: ");
+        message.push_str(&error.to_string());
+    }
+    io::Error::other(message).into()
+}
+
+#[cfg(windows)]
 fn read_codex_owner_child_identity(
     child_identity_file: &Path,
     stable_runtime: &Path,
@@ -36346,10 +36394,15 @@ public static class Program
             None,
             Some(mode),
         );
-        let Err(error) = result else {
-            return Err(
-                io::Error::other(format!("{mode} owner fixture publication was accepted")).into(),
-            );
+        let error = match result {
+            Ok((parent, child_identity)) => {
+                return Err(codex_owner_unexpected_acceptance_error(
+                    mode,
+                    parent,
+                    &child_identity,
+                ));
+            }
+            Err(error) => error,
         };
         let elapsed = started.elapsed();
         let text = error.to_string();
@@ -36367,6 +36420,31 @@ public static class Program
         }
     }
 
+    // Exercise the same branch a negative fixture would take if validation regressed.
+    let accepted_identity_file = temp.path().join("unexpected-acceptance.pid");
+    let accepted = spawn_codex_owned_obsolete_mcp(
+        &codex_fixture,
+        &runtime,
+        &db,
+        Some(&atlas_dir.join("config.toml")),
+        &accepted_identity_file,
+        None,
+        None,
+    )?;
+    let accepted_identity = accepted.1.clone();
+    let unexpected_error =
+        codex_owner_unexpected_acceptance_error("mismatched", accepted.0, &accepted_identity);
+    let unexpected_error_text = unexpected_error.to_string();
+    if windows_process_is_alive(&accepted_identity)?
+        || !unexpected_error_text.contains("mismatched owner fixture publication was accepted")
+        || unexpected_error_text.contains("fixture cleanup also failed")
+    {
+        return Err(io::Error::other(format!(
+            "unexpectedly accepted negative owner fixture did not clean up its owned processes: {unexpected_error}"
+        ))
+        .into());
+    }
+
     let identity_file = temp.path().join("timeout.pid");
     let timeout_started = Instant::now();
     let result = spawn_codex_owned_obsolete_mcp(
@@ -36378,8 +36456,15 @@ public static class Program
         None,
         Some("timeout"),
     );
-    let Err(error) = result else {
-        return Err(io::Error::other("owner fixture without publication was accepted").into());
+    let error = match result {
+        Ok((parent, child_identity)) => {
+            return Err(codex_owner_unexpected_acceptance_error(
+                "timeout",
+                parent,
+                &child_identity,
+            ));
+        }
+        Err(error) => error,
     };
     let timeout_elapsed = timeout_started.elapsed();
     let timeout_upper_bound = CODEX_OWNER_READINESS_TIMEOUT + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -216,6 +216,9 @@ const CODEX_OWNER_PUBLICATION_DELAY_ENV: &str =
 #[cfg(windows)]
 const CODEX_OWNER_PUBLICATION_MODE_ENV: &str = "PROJECTATLAS_TEST_CODEX_OWNER_PUBLICATION_MODE";
 #[cfg(windows)]
+const CODEX_OWNER_RETAINED_IDENTITY_DELAY_ENV: &str =
+    "PROJECTATLAS_TEST_CODEX_OWNER_RETAINED_IDENTITY_DELAY_MS";
+#[cfg(windows)]
 const CODEX_OWNER_IDENTITY_CAPTURE_DELAY_ENV: &str =
     "PROJECTATLAS_TEST_CODEX_OWNER_IDENTITY_CAPTURE_DELAY_MS";
 #[cfg(windows)]
@@ -263,6 +266,16 @@ public static class Program
                 string retainedIdentityPath = identityPath + ".owner";
                 string retainedIdentityTemporaryPath = retainedIdentityPath + ".tmp";
                 // Retain exact fixture ownership even when normal publication is withheld.
+                string retainedIdentityDelay = Environment.GetEnvironmentVariable(
+                    "PROJECTATLAS_TEST_CODEX_OWNER_RETAINED_IDENTITY_DELAY_MS"
+                );
+                int retainedIdentityDelayMilliseconds;
+                if (!String.IsNullOrWhiteSpace(retainedIdentityDelay)
+                    && Int32.TryParse(retainedIdentityDelay, out retainedIdentityDelayMilliseconds)
+                    && retainedIdentityDelayMilliseconds > 0)
+                {
+                    Thread.Sleep(retainedIdentityDelayMilliseconds);
+                }
                 string creationTime = child.StartTime.ToUniversalTime()
                     .ToFileTimeUtc()
                     .ToString();
@@ -36769,13 +36782,18 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
         .arg(&runtime)
         .arg(&db)
         .env(CODEX_OWNER_PUBLICATION_MODE_ENV, "timeout-ignore-stop")
+        .env(
+            CODEX_OWNER_RETAINED_IDENTITY_DELAY_ENV,
+            CODEX_OWNER_DELAYED_PUBLICATION.as_millis().to_string(),
+        )
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
     let mut composed_parent = composed_command.spawn()?;
     let composed_retained_identity_file =
         codex_owner_retained_identity_path(&composed_identity_file);
-    let retained_deadline = Instant::now() + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
+    let retained_started = Instant::now();
+    let retained_deadline = retained_started + CODEX_OWNER_READINESS_TIMEOUT;
     while !composed_retained_identity_file.is_file() && Instant::now() < retained_deadline {
         if let Some(status) = composed_parent.try_wait()? {
             return Err(io::Error::other(format!(
@@ -36787,11 +36805,31 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
         thread::sleep(remaining.min(Duration::from_millis(25)));
     }
     if !composed_retained_identity_file.is_file() {
-        drop(composed_parent.kill());
-        drop(composed_parent.wait());
+        let cleanup_result = stop_codex_owner_after_spawn_failure(
+            &mut composed_parent,
+            &composed_identity_file,
+            &runtime,
+        );
         return Err(io::Error::other(
-            "composed timeout owner did not publish retained child identity",
+            format!(
+                "composed timeout owner did not publish retained child identity within {CODEX_OWNER_READINESS_TIMEOUT:?}; cleanup={cleanup_result:?}"
+            ),
         )
+        .into());
+    }
+    let retained_elapsed = retained_started.elapsed();
+    if retained_elapsed < CODEX_OWNER_DELAYED_PUBLICATION
+        || retained_elapsed
+            > CODEX_OWNER_READINESS_TIMEOUT + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE
+    {
+        let cleanup_result = stop_codex_owner_after_spawn_failure(
+            &mut composed_parent,
+            &composed_identity_file,
+            &runtime,
+        );
+        return Err(io::Error::other(format!(
+            "composed timeout owner retained identity did not exercise delayed startup: elapsed={retained_elapsed:?} delay={CODEX_OWNER_DELAYED_PUBLICATION:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} cleanup={cleanup_result:?}"
+        ))
         .into());
     }
     let composed_result = stop_codex_owner_after_spawn_failure_with_test_delays(

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -193,6 +193,8 @@ const CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT: Duration = Duration::from_secs(
 #[cfg(windows)]
 const CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY: Duration = Duration::from_secs(4);
 #[cfg(windows)]
+const CODEX_OWNER_STOP_HELPER_TEST_DELAY: Duration = Duration::from_secs(6);
+#[cfg(windows)]
 // Early owner exit must be observed before readiness expires; this bound allows only
 // the same scheduler margin as the bounded publication contract.
 fn codex_owner_early_exit_max_elapsed() -> Duration {
@@ -209,7 +211,11 @@ const CODEX_OWNER_PUBLICATION_MODE_ENV: &str = "PROJECTATLAS_TEST_CODEX_OWNER_PU
 const CODEX_OWNER_IDENTITY_CAPTURE_DELAY_ENV: &str =
     "PROJECTATLAS_TEST_CODEX_OWNER_IDENTITY_CAPTURE_DELAY_MS";
 #[cfg(windows)]
+const CODEX_OWNER_STOP_DELAY_ENV: &str = "PROJECTATLAS_TEST_CODEX_OWNER_STOP_DELAY_MS";
+#[cfg(windows)]
 const OBSOLETE_PROJECTATLAS_FIXTURE_SOURCE_FILE_NAME: &str = "obsolete-projectatlas.cs";
+#[cfg(windows)]
+const OBSOLETE_PROJECTATLAS_FIXTURE_EXECUTABLE_FILE_NAME: &str = "obsolete-projectatlas.exe";
 
 #[cfg(windows)]
 const CODEX_MCP_OWNER_FIXTURE_SOURCE: &str = r#"using System;
@@ -35947,6 +35953,49 @@ fn compile_codex_mcp_owner_fixture(output: &Path) -> Result<(), Box<dyn Error>> 
 }
 
 #[cfg(windows)]
+fn compile_obsolete_projectatlas_fixture(output: &Path) -> Result<(), Box<dyn Error>> {
+    let source = output.with_extension("cs");
+    fs::write(
+        &source,
+        r#"using System;
+using System.Threading;
+
+public static class Program
+{
+    public static int Main(string[] arguments)
+    {
+        if (Array.IndexOf(arguments, "mcp") >= 0)
+        {
+            Thread.Sleep(Timeout.Infinite);
+            return 0;
+        }
+        return 2;
+    }
+}
+"#,
+    )?;
+    let compile_output = StdCommand::new("powershell")
+        .arg("-NoProfile")
+        .arg("-ExecutionPolicy")
+        .arg("Bypass")
+        .arg("-Command")
+        .arg(
+            "Add-Type -Path $env:PROJECTATLAS_FIXTURE_SOURCE -OutputAssembly $env:PROJECTATLAS_FIXTURE_RUNTIME -OutputType ConsoleApplication",
+        )
+        .env("PROJECTATLAS_FIXTURE_SOURCE", &source)
+        .env("PROJECTATLAS_FIXTURE_RUNTIME", output)
+        .output()?;
+    if !compile_output.status.success() {
+        return Err(io::Error::other(format!(
+            "failed to compile obsolete ProjectAtlas fixture runtime:\n{}",
+            String::from_utf8_lossy(&compile_output.stderr)
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
 fn write_installer_with_test_codex_identity_seam(
     installer: &Path,
     output: &Path,
@@ -36078,26 +36127,32 @@ fn codex_owner_retained_identity_path(child_identity_file: &Path) -> PathBuf {
 }
 
 #[cfg(windows)]
+fn codex_owner_cleanup_deadline(started: Instant) -> Instant {
+    started + CODEX_OWNER_FAILURE_CLEANUP_BUDGET + CODEX_OWNER_CHILD_STOP_BUDGET
+}
+
+#[cfg(windows)]
 fn cleanup_codex_owner_processes_after_spawn_failure(
     parent: &mut Child,
     child_identity_file: &Path,
     stable_runtime: &Path,
     mut failures: Vec<String>,
+    cleanup_deadline: Instant,
 ) -> Result<(), Box<dyn Error>> {
     let retained_identity_file = codex_owner_retained_identity_path(child_identity_file);
     let child_cleanup_result = read_codex_owner_child_identity(
         child_identity_file,
         stable_runtime,
-        CODEX_OWNER_FAILURE_CLEANUP_BUDGET,
+        cleanup_deadline.saturating_duration_since(Instant::now()),
     )
     .or_else(|_| {
         read_codex_owner_child_identity(
             &retained_identity_file,
             stable_runtime,
-            CODEX_OWNER_FAILURE_CLEANUP_BUDGET,
+            cleanup_deadline.saturating_duration_since(Instant::now()),
         )
     })
-    .and_then(|identity| stop_windows_fixture_process(&identity));
+    .and_then(|identity| stop_windows_fixture_process_until(&identity, cleanup_deadline, None));
     if let Err(error) = child_cleanup_result {
         failures.push(format!("could not retire its owned child safely: {error}"));
     }
@@ -36130,12 +36185,14 @@ fn codex_owner_observation_failure(
     child_identity_file: &Path,
     stable_runtime: &Path,
     error: impl std::fmt::Display,
+    cleanup_deadline: Instant,
 ) -> Result<(), Box<dyn Error>> {
     match cleanup_codex_owner_processes_after_spawn_failure(
         parent,
         child_identity_file,
         stable_runtime,
         Vec::new(),
+        cleanup_deadline,
     ) {
         Ok(()) => Ok(()),
         Err(cleanup_error) => Err(io::Error::other(format!(
@@ -36154,7 +36211,9 @@ fn stop_codex_owner_after_spawn_failure(
     let mut stop_file = child_identity_file.as_os_str().to_os_string();
     stop_file.push(".stop");
     let stop_result = fs::write(PathBuf::from(stop_file), b"stop");
-    let deadline = Instant::now() + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
+    let cleanup_started = Instant::now();
+    let cleanup_deadline = codex_owner_cleanup_deadline(cleanup_started);
+    let observation_deadline = cleanup_started + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
     let mut observation_error = None;
     if stop_result.is_ok() {
         loop {
@@ -36166,15 +36225,22 @@ fn stop_codex_owner_after_spawn_failure(
                     break;
                 }
             }
-            if Instant::now() >= deadline {
+            if Instant::now() >= observation_deadline {
                 break;
             }
-            thread::sleep(Duration::from_millis(25));
+            let remaining = observation_deadline.saturating_duration_since(Instant::now());
+            thread::sleep(remaining.min(Duration::from_millis(25)));
         }
     }
 
     if let Some(error) = observation_error {
-        codex_owner_observation_failure(parent, child_identity_file, stable_runtime, error)?;
+        codex_owner_observation_failure(
+            parent,
+            child_identity_file,
+            stable_runtime,
+            error,
+            cleanup_deadline,
+        )?;
         return Ok(());
     }
 
@@ -36189,6 +36255,7 @@ fn stop_codex_owner_after_spawn_failure(
         child_identity_file,
         stable_runtime,
         failures,
+        cleanup_deadline,
     )
 }
 
@@ -36198,7 +36265,9 @@ fn cleanup_codex_owner_processes(
     mut parent: Child,
     child_identity: &WindowsProcessIdentity,
 ) -> Result<(), Box<dyn Error>> {
-    let child_cleanup_result = stop_windows_fixture_process(child_identity);
+    let cleanup_deadline = codex_owner_cleanup_deadline(Instant::now());
+    let child_cleanup_result =
+        stop_windows_fixture_process_until(child_identity, cleanup_deadline, None);
     let kill_result = parent.kill();
     let wait_result = parent.wait();
     let mut failures = Vec::new();
@@ -36392,21 +36461,6 @@ fn spawn_codex_owned_obsolete_mcp(
                 ));
             }
         }
-        if child_pid_file.is_file() {
-            let capture_timeout = deadline.saturating_duration_since(Instant::now());
-            match read_codex_owner_child_identity(child_pid_file, stable_runtime, capture_timeout) {
-                Ok(captured) => return Ok((parent, captured)),
-                Err(error) => {
-                    return Err(codex_owner_spawn_error(
-                        &mut parent,
-                        codex_fixture,
-                        child_pid_file,
-                        stable_runtime,
-                        format!("failed to validate published child identity: {error}"),
-                    ));
-                }
-            }
-        }
         if Instant::now() >= deadline {
             let elapsed = started.elapsed();
             return Err(codex_owner_spawn_error(
@@ -36419,6 +36473,30 @@ fn spawn_codex_owned_obsolete_mcp(
                     elapsed.as_millis()
                 ),
             ));
+        }
+        if child_pid_file.is_file() {
+            let capture_timeout = deadline.saturating_duration_since(Instant::now());
+            match read_codex_owner_child_identity(child_pid_file, stable_runtime, capture_timeout) {
+                Ok(captured) if Instant::now() < deadline => return Ok((parent, captured)),
+                Ok(_) => {
+                    return Err(codex_owner_spawn_error(
+                        &mut parent,
+                        codex_fixture,
+                        child_pid_file,
+                        stable_runtime,
+                        "published child identity validation completed after the readiness deadline",
+                    ));
+                }
+                Err(error) => {
+                    return Err(codex_owner_spawn_error(
+                        &mut parent,
+                        codex_fixture,
+                        child_pid_file,
+                        stable_runtime,
+                        format!("failed to validate published child identity: {error}"),
+                    ));
+                }
+            }
         }
         thread::sleep(Duration::from_millis(25));
     }
@@ -36437,47 +36515,10 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
         "[project]\nroot = \".\"\n\n[scan]\nexclude_dir_names = [\".git\", \".projectatlas\", \"target\"]\n",
     )?;
     let db = atlas_dir.join("projectatlas.db");
-    let runtime = temp.path().join("obsolete-projectatlas.exe");
-    let runtime_source = temp
+    let runtime = temp
         .path()
-        .join(OBSOLETE_PROJECTATLAS_FIXTURE_SOURCE_FILE_NAME);
-    fs::write(
-        &runtime_source,
-        r#"using System;
-using System.Threading;
-
-public static class Program
-{
-    public static int Main(string[] arguments)
-    {
-        if (Array.IndexOf(arguments, "mcp") >= 0)
-        {
-            Thread.Sleep(Timeout.Infinite);
-            return 0;
-        }
-        return 2;
-    }
-}
-"#,
-    )?;
-    let compile_output = StdCommand::new("powershell")
-        .arg("-NoProfile")
-        .arg("-ExecutionPolicy")
-        .arg("Bypass")
-        .arg("-Command")
-        .arg(
-            "Add-Type -Path $env:PROJECTATLAS_FIXTURE_SOURCE -OutputAssembly $env:PROJECTATLAS_FIXTURE_RUNTIME -OutputType ConsoleApplication",
-        )
-        .env("PROJECTATLAS_FIXTURE_SOURCE", &runtime_source)
-        .env("PROJECTATLAS_FIXTURE_RUNTIME", &runtime)
-        .output()?;
-    if !compile_output.status.success() {
-        return Err(io::Error::other(format!(
-            "failed to compile obsolete ProjectAtlas fixture runtime:\n{}",
-            String::from_utf8_lossy(&compile_output.stderr)
-        ))
-        .into());
-    }
+        .join(OBSOLETE_PROJECTATLAS_FIXTURE_EXECUTABLE_FILE_NAME);
+    compile_obsolete_projectatlas_fixture(&runtime)?;
     let codex_fixture = temp.path().join(CODEX_FIXTURE_EXECUTABLE_FILE_NAME);
     compile_codex_mcp_owner_fixture(&codex_fixture)?;
 
@@ -36583,11 +36624,14 @@ public static class Program
     )?;
     // Inject only the observation decision while exercising the same child-first cleanup path;
     // the production caller retains the actual observation error in its spawn diagnostic.
+    let observation_cleanup_deadline =
+        Instant::now() + CODEX_OWNER_FAILURE_CLEANUP_BUDGET + CODEX_OWNER_CHILD_STOP_BUDGET;
     let observation_cleanup_result = codex_owner_observation_failure(
         &mut observation_parent,
         &observation_identity_file,
         &runtime,
         "synthetic parent observation failure",
+        observation_cleanup_deadline,
     );
     if observation_parent.try_wait()?.is_none()
         || windows_process_is_alive(&observation_identity)?
@@ -36687,6 +36731,12 @@ fn capture_windows_process_identity_with_timeout(
     timeout: Duration,
     test_delay: Option<Duration>,
 ) -> Result<WindowsProcessIdentity, Box<dyn Error>> {
+    if timeout.is_zero() {
+        return Err(io::Error::other(format!(
+            "Windows fixture identity capture budget expired before probing process {process_id}"
+        ))
+        .into());
+    }
     let mut command = StdCommand::new("powershell");
     command
         .arg("-NoProfile")
@@ -36802,12 +36852,23 @@ fn windows_process_is_alive(identity: &WindowsProcessIdentity) -> Result<bool, B
 
 #[cfg(windows)]
 fn stop_windows_fixture_process(identity: &WindowsProcessIdentity) -> Result<(), Box<dyn Error>> {
-    let status = StdCommand::new("powershell")
+    let deadline = Instant::now() + CODEX_OWNER_CHILD_STOP_BUDGET;
+    stop_windows_fixture_process_until(identity, deadline, None)
+}
+
+#[cfg(windows)]
+fn stop_windows_fixture_process_until(
+    identity: &WindowsProcessIdentity,
+    deadline: Instant,
+    test_delay: Option<Duration>,
+) -> Result<(), Box<dyn Error>> {
+    let mut command = StdCommand::new("powershell");
+    command
         .arg("-NoProfile")
         .arg("-NonInteractive")
         .arg("-Command")
         .arg(
-            "$process = Get-Process -Id $env:PROJECTATLAS_FIXTURE_PID -ErrorAction SilentlyContinue; if ($null -eq $process) { exit 0 }; $result = 0; try { $heldHandle = $process.Handle; $creation = $process.StartTime.ToUniversalTime().ToFileTimeUtc(); $path = [System.IO.Path]::GetFullPath($process.Path); if ($creation -ne [long]$env:PROJECTATLAS_FIXTURE_CREATION -or -not [string]::Equals($path, [System.IO.Path]::GetFullPath($env:PROJECTATLAS_FIXTURE_PATH), [System.StringComparison]::OrdinalIgnoreCase)) { $result = 3 } elseif (-not $process.HasExited) { $process.Kill(); if (-not $process.WaitForExit(5000)) { $result = 5 } } } catch { if (-not $process.HasExited) { $result = 4 } } finally { $process.Dispose() }; exit $result",
+            "$process = Get-Process -Id $env:PROJECTATLAS_FIXTURE_PID -ErrorAction SilentlyContinue; if ($null -eq $process) { exit 0 }; $result = 0; try { $heldHandle = $process.Handle; $creation = $process.StartTime.ToUniversalTime().ToFileTimeUtc(); $path = [System.IO.Path]::GetFullPath($process.Path); if ($creation -ne [long]$env:PROJECTATLAS_FIXTURE_CREATION -or -not [string]::Equals($path, [System.IO.Path]::GetFullPath($env:PROJECTATLAS_FIXTURE_PATH), [System.StringComparison]::OrdinalIgnoreCase)) { $result = 3 } elseif (-not $process.HasExited) { $process.Kill(); if ($env:PROJECTATLAS_TEST_CODEX_OWNER_STOP_DELAY_MS) { Start-Sleep -Milliseconds ([int]$env:PROJECTATLAS_TEST_CODEX_OWNER_STOP_DELAY_MS) }; if (-not $process.WaitForExit(5000)) { $result = 5 } } } catch { if (-not $process.HasExited) { $result = 4 } } finally { $process.Dispose() }; exit $result",
         )
         .env(
             "PROJECTATLAS_FIXTURE_PID",
@@ -36818,7 +36879,47 @@ fn stop_windows_fixture_process(identity: &WindowsProcessIdentity) -> Result<(),
             identity.creation_file_time_utc.to_string(),
         )
         .env("PROJECTATLAS_FIXTURE_PATH", &identity.executable_path)
-        .status()?;
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if let Some(delay) = test_delay {
+        command.env(CODEX_OWNER_STOP_DELAY_ENV, delay.as_millis().to_string());
+    }
+    let mut stop = command.spawn()?;
+    let started = Instant::now();
+    let status = loop {
+        match stop.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() >= deadline => {
+                let kill_result = stop.kill();
+                let wait_result = stop.wait();
+                let cleanup_detail = match (kill_result, wait_result) {
+                    (Ok(()), Ok(_)) => String::new(),
+                    (kill, wait) => {
+                        format!("; stop-helper cleanup kill={kill:?} wait={wait:?}")
+                    }
+                };
+                return Err(io::Error::other(format!(
+                    "timed out stopping Windows fixture process {} after {:?}{cleanup_detail}",
+                    identity.process_id,
+                    started.elapsed()
+                ))
+                .into());
+            }
+            Ok(None) => {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                thread::sleep(remaining.min(Duration::from_millis(25)));
+            }
+            Err(error) => {
+                let kill_result = stop.kill();
+                let wait_result = stop.wait();
+                return Err(io::Error::other(format!(
+                    "failed to observe Windows fixture stop helper for {}: {error}; cleanup kill={kill_result:?} wait={wait_result:?}",
+                    identity.process_id
+                ))
+                .into());
+            }
+        }
+    };
     if !status.success() {
         return Err(io::Error::other(format!(
             "refused to stop Windows fixture process {} without its exact captured identity",
@@ -36873,6 +36974,171 @@ fn windows_fixture_identity_capture_is_bounded() -> Result<(), Box<dyn Error>> {
         .into());
     }
     Ok(())
+}
+
+#[test]
+#[cfg(windows)]
+fn windows_fixture_stop_helper_is_bounded_and_child_safe() -> Result<(), Box<dyn Error>> {
+    let mut process = StdCommand::new("powershell")
+        .arg("-NoProfile")
+        .arg("-NonInteractive")
+        .arg("-Command")
+        .arg("Start-Sleep -Seconds 30")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let identity = match capture_windows_process_identity(process.id()) {
+        Ok(identity) => identity,
+        Err(error) => {
+            drop(process.kill());
+            drop(process.wait());
+            return Err(error);
+        }
+    };
+    let started = Instant::now();
+    let deadline = started + CODEX_OWNER_CHILD_STOP_BUDGET;
+    let result = stop_windows_fixture_process_until(
+        &identity,
+        deadline,
+        Some(CODEX_OWNER_STOP_HELPER_TEST_DELAY),
+    );
+    let elapsed = started.elapsed();
+    let child_alive = windows_process_is_alive(&identity)?;
+    let wait_result = if child_alive {
+        let kill_result = process.kill();
+        let wait_result = process.wait();
+        if let Err(error) = kill_result
+            && error.kind() != io::ErrorKind::InvalidInput
+        {
+            return Err(error.into());
+        }
+        wait_result
+    } else {
+        process.wait()
+    };
+    if result.is_ok()
+        || child_alive
+        || elapsed > CODEX_OWNER_CHILD_STOP_BUDGET + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE
+    {
+        return Err(io::Error::other(format!(
+            "stalled Windows fixture stop helper was not bounded or left its child alive: elapsed={elapsed:?} timeout={CODEX_OWNER_CHILD_STOP_BUDGET:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} child_alive={child_alive} result={result:?}"
+        ))
+        .into());
+    }
+    wait_result?;
+    Ok(())
+}
+
+#[test]
+#[cfg(windows)]
+fn windows_fixture_late_publication_is_atomic_but_past_readiness() -> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let runtime = temp
+        .path()
+        .join(OBSOLETE_PROJECTATLAS_FIXTURE_EXECUTABLE_FILE_NAME);
+    let codex_fixture = temp.path().join(CODEX_FIXTURE_EXECUTABLE_FILE_NAME);
+    let db = temp.path().join("projectatlas.db");
+    let identity_file = temp.path().join("late-publication.pid");
+    compile_obsolete_projectatlas_fixture(&runtime)?;
+    compile_codex_mcp_owner_fixture(&codex_fixture)?;
+
+    let mut command = StdCommand::new(&codex_fixture);
+    command
+        .arg(&identity_file)
+        .arg(&runtime)
+        .arg(&db)
+        .env(
+            CODEX_OWNER_PUBLICATION_DELAY_ENV,
+            (CODEX_OWNER_READINESS_TIMEOUT + Duration::from_secs(1))
+                .as_millis()
+                .to_string(),
+        )
+        .env(CODEX_OWNER_PUBLICATION_MODE_ENV, "late-publication")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut parent = command.spawn()?;
+    let started = Instant::now();
+    let result = (|| -> Result<(Duration, WindowsProcessIdentity), Box<dyn Error>> {
+        let readiness_deadline = started + CODEX_OWNER_READINESS_TIMEOUT;
+        while Instant::now() < readiness_deadline {
+            if identity_file.is_file() {
+                return Err(io::Error::other(
+                    "late owner fixture published its identity before the readiness deadline",
+                )
+                .into());
+            }
+            if let Some(status) = parent.try_wait()? {
+                return Err(io::Error::other(format!(
+                    "late owner fixture exited before its delayed publication: {status}"
+                ))
+                .into());
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+        if identity_file.is_file() {
+            return Err(io::Error::other(
+                "late owner fixture publication raced into the readiness deadline",
+            )
+            .into());
+        }
+
+        let publication_deadline = readiness_deadline + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
+        while !identity_file.is_file() && Instant::now() < publication_deadline {
+            if let Some(status) = parent.try_wait()? {
+                return Err(io::Error::other(format!(
+                    "late owner fixture exited before its delayed publication: {status}"
+                ))
+                .into());
+            }
+            let remaining = publication_deadline.saturating_duration_since(Instant::now());
+            thread::sleep(remaining.min(Duration::from_millis(25)));
+        }
+        if !identity_file.is_file() {
+            return Err(io::Error::other(format!(
+                "late owner fixture did not publish atomically after the readiness deadline: elapsed={:?}",
+                started.elapsed()
+            ))
+            .into());
+        }
+        let publication_elapsed = started.elapsed();
+        let captured = read_codex_owner_child_identity(
+            &identity_file,
+            &runtime,
+            CODEX_OWNER_FAILURE_CLEANUP_BUDGET,
+        )?;
+        Ok((publication_elapsed, captured))
+    })();
+
+    match result {
+        Ok((publication_elapsed, identity)) => {
+            cleanup_codex_owner_processes(parent, &identity)?;
+            if publication_elapsed <= CODEX_OWNER_READINESS_TIMEOUT {
+                return Err(io::Error::other(format!(
+                    "late owner fixture publication was not past readiness: elapsed={publication_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?}"
+                ))
+                .into());
+            }
+            Ok(())
+        }
+        Err(error) => {
+            let cleanup_result = cleanup_codex_owner_processes_after_spawn_failure(
+                &mut parent,
+                &identity_file,
+                &runtime,
+                Vec::new(),
+                codex_owner_cleanup_deadline(Instant::now()),
+            );
+            if let Err(cleanup_error) = cleanup_result {
+                return Err(io::Error::other(format!(
+                    "late publication regression failed and fixture cleanup also failed: {error}; {cleanup_error}"
+                ))
+                .into());
+            }
+            Err(error)
+        }
+    }
 }
 
 #[test]

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -36655,14 +36655,16 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
     let codex_fixture = temp.path().join(CODEX_FIXTURE_EXECUTABLE_FILE_NAME);
     compile_codex_mcp_owner_fixture(&codex_fixture)?;
 
-    // Exercise the production readiness helper when publication is observed before the
+    // Exercise the production readiness helper when publication is observed well before the
     // deadline but bounded identity validation finishes just after it.  The dedicated
     // capture allowance must accept the valid identity; using the old remaining-time
-    // allowance rejects this same causal path.
+    // allowance rejects this same causal path.  Keep fixture startup at the existing six-second
+    // delay, then use the production helper's observation seam to wake the polling loop near the
+    // deadline so startup is not the constrained portion of this regression.
     let deadline_validation_identity_file = temp.path().join("deadline-validation.pid");
-    let deadline_validation_publication_delay = CODEX_OWNER_READINESS_TIMEOUT
-        .saturating_sub(CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY)
-        + Duration::from_secs(1);
+    let deadline_validation_publication_delay = CODEX_OWNER_DELAYED_PUBLICATION;
+    let deadline_validation_observation_delay =
+        CODEX_OWNER_READINESS_TIMEOUT.saturating_sub(CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE);
     let deadline_validation_started = Instant::now();
     let (deadline_validation_parent, deadline_validation_identity) =
         spawn_codex_owned_obsolete_mcp_with_test_delays(
@@ -36674,7 +36676,7 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
             Some(deadline_validation_publication_delay),
             None,
             Some(CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY),
-            None,
+            Some(deadline_validation_observation_delay),
         )?;
     let deadline_validation_elapsed = deadline_validation_started.elapsed();
     if deadline_validation_elapsed < CODEX_OWNER_READINESS_TIMEOUT
@@ -36688,7 +36690,7 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
             &deadline_validation_identity,
         );
         return Err(io::Error::other(format!(
-            "deadline-observed publication did not use its bounded identity allowance: elapsed={deadline_validation_elapsed:?} publication_delay={deadline_validation_publication_delay:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} identity_capture_budget={CODEX_OWNER_IDENTITY_CAPTURE_BUDGET:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} cleanup={cleanup_result:?}"
+            "deadline-observed publication did not use its bounded identity allowance: elapsed={deadline_validation_elapsed:?} publication_delay={deadline_validation_publication_delay:?} observation_delay={deadline_validation_observation_delay:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} identity_capture_budget={CODEX_OWNER_IDENTITY_CAPTURE_BUDGET:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} cleanup={cleanup_result:?}"
         ))
         .into());
     }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -183,7 +183,10 @@ const CODEX_OWNER_READINESS_TIMEOUT: Duration = Duration::from_secs(30);
 // The failure path gives the owner this bounded window to observe the stop marker and exit.
 const CODEX_OWNER_FAILURE_CLEANUP_BUDGET: Duration = Duration::from_secs(5);
 #[cfg(windows)]
-const CODEX_OWNER_EARLY_EXIT_MAX_ELAPSED: Duration = Duration::from_secs(5);
+// Allow normal scheduling variance without allowing a late readiness retry to hide.
+const CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE: Duration = Duration::from_secs(2);
+#[cfg(windows)]
+const CODEX_OWNER_EARLY_EXIT_MAX_ELAPSED: Duration = Duration::from_secs(10);
 #[cfg(windows)]
 const CODEX_OWNER_DELAYED_PUBLICATION: Duration = Duration::from_secs(6);
 #[cfg(windows)]
@@ -36258,7 +36261,8 @@ fn spawn_codex_owned_obsolete_mcp(
                 child_pid_file,
                 stable_runtime,
                 format!(
-                    "Codex MCP owner fixture did not publish its child PID within {CODEX_OWNER_READINESS_TIMEOUT:?} (elapsed={elapsed:?})"
+                    "Codex MCP owner fixture did not publish its child PID within {CODEX_OWNER_READINESS_TIMEOUT:?} (elapsed={elapsed:?} readiness_elapsed_ms={})",
+                    elapsed.as_millis()
                 ),
             ));
         }
@@ -36380,8 +36384,23 @@ public static class Program
     let timeout_elapsed = timeout_started.elapsed();
     let timeout_upper_bound = CODEX_OWNER_READINESS_TIMEOUT + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
     let text = error.to_string();
+    let timeout_readiness_elapsed = text
+        .split("readiness_elapsed_ms=")
+        .nth(1)
+        .and_then(|value| value.split(')').next())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .ok_or_else(|| {
+            io::Error::other(format!(
+                "true owner fixture timeout omitted its pre-cleanup readiness elapsed diagnostic:\n{text}"
+            ))
+        })?;
+    let timeout_readiness_upper_bound =
+        CODEX_OWNER_READINESS_TIMEOUT + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE;
     if timeout_elapsed < CODEX_OWNER_READINESS_TIMEOUT
         || timeout_elapsed > timeout_upper_bound
+        || timeout_readiness_elapsed < CODEX_OWNER_READINESS_TIMEOUT
+        || timeout_readiness_elapsed > timeout_readiness_upper_bound
         || !text.contains("did not publish its child PID within 30s")
         || !text.contains("elapsed=")
         || !text.contains(&format!("owner={}", codex_fixture.display()))
@@ -36390,7 +36409,7 @@ public static class Program
         || text.contains("fixture cleanup also failed")
     {
         return Err(io::Error::other(format!(
-            "true owner fixture timeout was not bounded and diagnostic: elapsed={timeout_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} cleanup_budget={CODEX_OWNER_FAILURE_CLEANUP_BUDGET:?} upper_bound={timeout_upper_bound:?}\n{text}"
+            "true owner fixture timeout was not bounded and diagnostic: total_elapsed={timeout_elapsed:?} readiness_elapsed={timeout_readiness_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} cleanup_budget={CODEX_OWNER_FAILURE_CLEANUP_BUDGET:?} total_upper_bound={timeout_upper_bound:?} readiness_upper_bound={timeout_readiness_upper_bound:?}\n{text}"
         ))
         .into());
     }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -178,6 +178,18 @@ const WINDOWS_POWERSHELL_EXECUTABLE: &str = "powershell.exe";
 static WINDOWS_RELEASE_ASSET_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(windows)]
+const CODEX_OWNER_READINESS_TIMEOUT: Duration = Duration::from_secs(30);
+#[cfg(windows)]
+const CODEX_OWNER_DELAYED_PUBLICATION: Duration = Duration::from_secs(6);
+#[cfg(windows)]
+const CODEX_OWNER_PUBLICATION_DELAY_ENV: &str =
+    "PROJECTATLAS_TEST_CODEX_OWNER_PUBLICATION_DELAY_MS";
+#[cfg(windows)]
+const CODEX_OWNER_PUBLICATION_MODE_ENV: &str = "PROJECTATLAS_TEST_CODEX_OWNER_PUBLICATION_MODE";
+#[cfg(windows)]
+const OBSOLETE_PROJECTATLAS_FIXTURE_SOURCE_FILE_NAME: &str = "obsolete-projectatlas.cs";
+
+#[cfg(windows)]
 const CODEX_MCP_OWNER_FIXTURE_SOURCE: &str = r#"using System;
 using System.Diagnostics;
 using System.IO;
@@ -212,13 +224,43 @@ public static class Program
             {
                 string identityPath = arguments[0];
                 string temporaryIdentityPath = identityPath + ".tmp";
-                File.WriteAllLines(temporaryIdentityPath, new[]
+                string publicationMode = Environment.GetEnvironmentVariable(
+                    "PROJECTATLAS_TEST_CODEX_OWNER_PUBLICATION_MODE"
+                );
+                if (publicationMode == "early-exit")
+                    return 3;
+                string publicationDelay = Environment.GetEnvironmentVariable(
+                    "PROJECTATLAS_TEST_CODEX_OWNER_PUBLICATION_DELAY_MS"
+                );
+                int delayMilliseconds;
+                if (!String.IsNullOrWhiteSpace(publicationDelay)
+                    && Int32.TryParse(publicationDelay, out delayMilliseconds)
+                    && delayMilliseconds > 0)
                 {
-                    child.Id.ToString(),
-                    child.StartTime.ToUniversalTime().ToFileTimeUtc().ToString(),
-                    childPath
-                });
-                File.Move(temporaryIdentityPath, identityPath);
+                    Thread.Sleep(delayMilliseconds);
+                }
+                if (publicationMode != "timeout")
+                {
+                    string creationTime = child.StartTime.ToUniversalTime()
+                        .ToFileTimeUtc()
+                        .ToString();
+                    if (publicationMode == "malformed")
+                    {
+                        File.WriteAllText(temporaryIdentityPath, "not-an-identity");
+                    }
+                    else
+                    {
+                        if (publicationMode == "mismatched")
+                            creationTime = (Int64.Parse(creationTime) + 1).ToString();
+                        File.WriteAllLines(temporaryIdentityPath, new[]
+                        {
+                            child.Id.ToString(),
+                            creationTime,
+                            childPath
+                        });
+                    }
+                    File.Move(temporaryIdentityPath, identityPath);
+                }
                 while (!child.WaitForExit(25))
                 {
                     if (File.Exists(identityPath + ".stop"))
@@ -229,6 +271,7 @@ public static class Program
                     }
                 }
                 Thread.Sleep(Timeout.Infinite);
+                return 0;
             }
             finally
             {
@@ -239,7 +282,6 @@ public static class Program
                 }
             }
         }
-        return 0;
     }
 }
 "#;
@@ -11258,7 +11300,9 @@ fn windows_installer_obsolete_mcp_handoff_retires_only_exact_child_and_reports_r
             .ok_or_else(|| io::Error::other("stable runtime parent missing"))?,
     )?;
 
-    let fixture_source = temp.path().join("obsolete-projectatlas.cs");
+    let fixture_source = temp
+        .path()
+        .join(OBSOLETE_PROJECTATLAS_FIXTURE_SOURCE_FILE_NAME);
     fs::write(
         &fixture_source,
         r#"using System;
@@ -11502,17 +11546,29 @@ public static class Program
             .output()
     };
 
+    let readiness_started = Instant::now();
     let (mut codex_owner, obsolete_mcp_pid) = spawn_codex_owned_obsolete_mcp(
         &codex_owner_fixture,
         &stable_runtime,
         &db,
         Some(&atlas_dir.join("config.toml")),
         &child_pid_file,
+        Some(CODEX_OWNER_DELAYED_PUBLICATION),
+        None,
     )?;
+    let readiness_elapsed = readiness_started.elapsed();
+    let delayed_publication_crossed_former_budget = readiness_elapsed > Duration::from_secs(5)
+        && readiness_elapsed < CODEX_OWNER_READINESS_TIMEOUT;
     let mut second_codex_owner = None;
     let mut second_obsolete_mcp_pid = None;
     let mut non_codex_child = None;
     let test_result = (|| -> Result<(), Box<dyn Error>> {
+        if !delayed_publication_crossed_former_budget {
+            return Err(io::Error::other(format!(
+                "delayed Codex owner publication did not cross the former five-second boundary within the readiness budget: elapsed={readiness_elapsed:?} budget={CODEX_OWNER_READINESS_TIMEOUT:?}"
+            ))
+            .into());
+        }
         let unsigned_output = run_production_installer()?;
         let unsigned_text = format!(
             "{}\n{}",
@@ -11661,6 +11717,8 @@ public static class Program
             &db,
             Some(&atlas_dir.join("config.toml")),
             &temp.path().join("retry-obsolete-mcp.pid"),
+            None,
+            None,
         )?;
         second_codex_owner = Some(owner);
         second_obsolete_mcp_pid = Some(child_pid.clone());
@@ -12219,6 +12277,8 @@ public static class Program
         &db,
         Some(&atlas_dir.join("config.toml")),
         &first_child_pid_file,
+        None,
+        None,
     )?;
     let mut second_owner = None;
     let mut second_obsolete_mcp_pid = None;
@@ -12486,6 +12546,8 @@ public static class Program
             &db,
             Some(&atlas_dir.join("config.toml")),
             &temp.path().join("second-obsolete-mcp.pid"),
+            None,
+            None,
         )?;
         second_owner = Some(owner);
         second_obsolete_mcp_pid = Some(process_id);
@@ -36089,14 +36151,24 @@ fn read_codex_owner_child_identity(
 #[cfg(windows)]
 fn codex_owner_spawn_error(
     parent: &mut Child,
+    codex_fixture: &Path,
     child_identity_file: &Path,
     stable_runtime: &Path,
     error: impl std::fmt::Display,
 ) -> Box<dyn Error> {
     match stop_codex_owner_after_spawn_failure(parent, child_identity_file, stable_runtime) {
-        Ok(()) => io::Error::other(error.to_string()).into(),
+        Ok(()) => io::Error::other(format!(
+            "{error}; owner={}; identity_file={}; expected_runtime={}",
+            codex_fixture.display(),
+            child_identity_file.display(),
+            stable_runtime.display()
+        ))
+        .into(),
         Err(cleanup_error) => io::Error::other(format!(
-            "{error}; fixture cleanup also failed: {cleanup_error}"
+            "{error}; owner={}; identity_file={}; expected_runtime={}; fixture cleanup also failed: {cleanup_error}",
+            codex_fixture.display(),
+            child_identity_file.display(),
+            stable_runtime.display()
         ))
         .into(),
     }
@@ -36109,6 +36181,8 @@ fn spawn_codex_owned_obsolete_mcp(
     db: &Path,
     config: Option<&Path>,
     child_pid_file: &Path,
+    publication_delay: Option<Duration>,
+    publication_mode: Option<&str>,
 ) -> Result<(Child, WindowsProcessIdentity), Box<dyn Error>> {
     let mut command = StdCommand::new(codex_fixture);
     command
@@ -36121,13 +36195,24 @@ fn spawn_codex_owned_obsolete_mcp(
     if let Some(config) = config {
         command.arg(config).arg("--config").arg("model=\"o3\"");
     }
+    if let Some(delay) = publication_delay {
+        command.env(
+            CODEX_OWNER_PUBLICATION_DELAY_ENV,
+            delay.as_millis().to_string(),
+        );
+    }
+    if let Some(mode) = publication_mode {
+        command.env(CODEX_OWNER_PUBLICATION_MODE_ENV, mode);
+    }
     let mut parent = command.spawn()?;
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let started = Instant::now();
+    let deadline = started + CODEX_OWNER_READINESS_TIMEOUT;
     loop {
         match parent.try_wait() {
             Ok(Some(status)) => {
                 return Err(codex_owner_spawn_error(
                     &mut parent,
+                    codex_fixture,
                     child_pid_file,
                     stable_runtime,
                     format!(
@@ -36139,6 +36224,7 @@ fn spawn_codex_owned_obsolete_mcp(
             Err(error) => {
                 return Err(codex_owner_spawn_error(
                     &mut parent,
+                    codex_fixture,
                     child_pid_file,
                     stable_runtime,
                     format!("failed to inspect Codex MCP owner fixture: {error}"),
@@ -36151,23 +36237,154 @@ fn spawn_codex_owned_obsolete_mcp(
                 Err(error) => {
                     return Err(codex_owner_spawn_error(
                         &mut parent,
+                        codex_fixture,
                         child_pid_file,
                         stable_runtime,
-                        error,
+                        format!("failed to validate published child identity: {error}"),
                     ));
                 }
             }
         }
         if Instant::now() >= deadline {
+            let elapsed = started.elapsed();
             return Err(codex_owner_spawn_error(
                 &mut parent,
+                codex_fixture,
                 child_pid_file,
                 stable_runtime,
-                "Codex MCP owner fixture did not publish its child PID",
+                format!(
+                    "Codex MCP owner fixture did not publish its child PID within {CODEX_OWNER_READINESS_TIMEOUT:?} (elapsed={elapsed:?})"
+                ),
             ));
         }
         thread::sleep(Duration::from_millis(25));
     }
+}
+
+#[test]
+#[cfg(windows)]
+fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Result<(), Box<dyn Error>>
+{
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join(TEST_REPO_DIR);
+    let atlas_dir = repo.join(ATLAS_DIR_NAME);
+    fs::create_dir_all(&atlas_dir)?;
+    fs::write(
+        atlas_dir.join("config.toml"),
+        "[project]\nroot = \".\"\n\n[scan]\nexclude_dir_names = [\".git\", \".projectatlas\", \"target\"]\n",
+    )?;
+    let db = atlas_dir.join("projectatlas.db");
+    let runtime = temp.path().join("obsolete-projectatlas.exe");
+    let runtime_source = temp
+        .path()
+        .join(OBSOLETE_PROJECTATLAS_FIXTURE_SOURCE_FILE_NAME);
+    fs::write(
+        &runtime_source,
+        r#"using System;
+using System.Threading;
+
+public static class Program
+{
+    public static int Main(string[] arguments)
+    {
+        if (Array.IndexOf(arguments, "mcp") >= 0)
+        {
+            Thread.Sleep(Timeout.Infinite);
+            return 0;
+        }
+        return 2;
+    }
+}
+"#,
+    )?;
+    let compile_output = StdCommand::new("powershell")
+        .arg("-NoProfile")
+        .arg("-ExecutionPolicy")
+        .arg("Bypass")
+        .arg("-Command")
+        .arg(
+            "Add-Type -Path $env:PROJECTATLAS_FIXTURE_SOURCE -OutputAssembly $env:PROJECTATLAS_FIXTURE_RUNTIME -OutputType ConsoleApplication",
+        )
+        .env("PROJECTATLAS_FIXTURE_SOURCE", &runtime_source)
+        .env("PROJECTATLAS_FIXTURE_RUNTIME", &runtime)
+        .output()?;
+    if !compile_output.status.success() {
+        return Err(io::Error::other(format!(
+            "failed to compile obsolete ProjectAtlas fixture runtime:\n{}",
+            String::from_utf8_lossy(&compile_output.stderr)
+        ))
+        .into());
+    }
+    let codex_fixture = temp.path().join(CODEX_FIXTURE_EXECUTABLE_FILE_NAME);
+    compile_codex_mcp_owner_fixture(&codex_fixture)?;
+
+    for (index, (mode, expected)) in [
+        ("early-exit", "exited before publishing"),
+        ("malformed", "failed to validate published child identity"),
+        ("mismatched", "owner-published child identity differed"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let identity_file = temp.path().join(format!("{mode}-{index}.pid"));
+        let result = spawn_codex_owned_obsolete_mcp(
+            &codex_fixture,
+            &runtime,
+            &db,
+            Some(&atlas_dir.join("config.toml")),
+            &identity_file,
+            None,
+            Some(mode),
+        );
+        let Err(error) = result else {
+            return Err(
+                io::Error::other(format!("{mode} owner fixture publication was accepted")).into(),
+            );
+        };
+        let text = error.to_string();
+        if !text.contains(expected)
+            || !text.contains(&format!("owner={}", codex_fixture.display()))
+            || !text.contains(&format!("identity_file={}", identity_file.display()))
+            || !text.contains(&format!("expected_runtime={}", runtime.display()))
+            || text.contains("fixture cleanup also failed")
+        {
+            return Err(io::Error::other(format!(
+                "{mode} owner fixture failure was not bounded and diagnostic:\n{text}"
+            ))
+            .into());
+        }
+    }
+
+    let identity_file = temp.path().join("timeout.pid");
+    let timeout_started = Instant::now();
+    let result = spawn_codex_owned_obsolete_mcp(
+        &codex_fixture,
+        &runtime,
+        &db,
+        Some(&atlas_dir.join("config.toml")),
+        &identity_file,
+        None,
+        Some("timeout"),
+    );
+    let Err(error) = result else {
+        return Err(io::Error::other("owner fixture without publication was accepted").into());
+    };
+    let timeout_elapsed = timeout_started.elapsed();
+    let text = error.to_string();
+    if timeout_elapsed < CODEX_OWNER_READINESS_TIMEOUT
+        || !text.contains("did not publish its child PID within 30s")
+        || !text.contains("elapsed=")
+        || !text.contains(&format!("owner={}", codex_fixture.display()))
+        || !text.contains(&format!("identity_file={}", identity_file.display()))
+        || !text.contains(&format!("expected_runtime={}", runtime.display()))
+        || text.contains("fixture cleanup also failed")
+    {
+        return Err(io::Error::other(format!(
+            "true owner fixture timeout was not bounded and diagnostic: elapsed={timeout_elapsed:?}\n{text}"
+        ))
+        .into());
+    }
+    Ok(())
 }
 
 #[cfg(windows)]

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -197,7 +197,7 @@ const CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE: Duration = Duration::from_secs(
 #[cfg(windows)]
 const CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT: Duration = Duration::from_secs(1);
 #[cfg(windows)]
-const CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY: Duration = Duration::from_secs(4);
+const CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY: Duration = Duration::from_secs(2);
 #[cfg(windows)]
 // Delay the polling caller, not the child operation, so a completed helper is observed late.
 const CODEX_OWNER_LATE_COMPLETION_TEST_DELAY: Duration = Duration::from_secs(2);

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -11628,15 +11628,18 @@ public static class Program
         None,
     )?;
     let readiness_elapsed = readiness_started.elapsed();
+    let delayed_publication_max_elapsed = CODEX_OWNER_READINESS_TIMEOUT
+        + CODEX_OWNER_IDENTITY_CAPTURE_BUDGET
+        + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE;
     let delayed_publication_crossed_former_budget = readiness_elapsed > Duration::from_secs(5)
-        && readiness_elapsed < CODEX_OWNER_READINESS_TIMEOUT;
+        && readiness_elapsed < delayed_publication_max_elapsed;
     let mut second_codex_owner = None;
     let mut second_obsolete_mcp_pid = None;
     let mut non_codex_child = None;
     let test_result = (|| -> Result<(), Box<dyn Error>> {
         if !delayed_publication_crossed_former_budget {
             return Err(io::Error::other(format!(
-                "delayed Codex owner publication did not cross the former five-second boundary within the readiness budget: elapsed={readiness_elapsed:?} budget={CODEX_OWNER_READINESS_TIMEOUT:?}"
+                "delayed Codex owner publication did not cross the former five-second boundary within the bounded readiness/capture envelope: elapsed={readiness_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} identity_capture={CODEX_OWNER_IDENTITY_CAPTURE_BUDGET:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} max_elapsed={delayed_publication_max_elapsed:?}"
             ))
             .into());
         }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -36064,51 +36064,21 @@ fn codex_owner_retained_identity_path(child_identity_file: &Path) -> PathBuf {
 }
 
 #[cfg(windows)]
-fn stop_codex_owner_after_spawn_failure(
+fn cleanup_codex_owner_processes_after_spawn_failure(
     parent: &mut Child,
     child_identity_file: &Path,
     stable_runtime: &Path,
+    mut failures: Vec<String>,
 ) -> Result<(), Box<dyn Error>> {
-    let mut stop_file = child_identity_file.as_os_str().to_os_string();
-    stop_file.push(".stop");
-    let stop_result = fs::write(PathBuf::from(stop_file), b"stop");
-    let deadline = Instant::now() + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
-    if stop_result.is_ok() {
-        loop {
-            match parent.try_wait() {
-                Ok(Some(_)) => return Ok(()),
-                Ok(None) => {}
-                Err(error) => {
-                    drop(parent.kill());
-                    drop(parent.wait());
-                    return Err(io::Error::other(format!(
-                        "failed to observe Codex owner fixture cleanup: {error}"
-                    ))
-                    .into());
-                }
-            }
-            if Instant::now() >= deadline {
-                break;
-            }
-            thread::sleep(Duration::from_millis(25));
-        }
-    }
-
     let retained_identity_file = codex_owner_retained_identity_path(child_identity_file);
     let child_cleanup_result = read_codex_owner_child_identity(child_identity_file, stable_runtime)
         .or_else(|_| read_codex_owner_child_identity(&retained_identity_file, stable_runtime))
         .and_then(|identity| stop_windows_fixture_process(&identity));
-    let kill_result = parent.kill();
-    let wait_result = parent.wait();
-    let mut failures = Vec::new();
-    if let Err(error) = stop_result {
-        failures.push(format!("could not signal the owner fixture: {error}"));
-    } else {
-        failures.push("owner fixture did not stop within five seconds".to_string());
-    }
     if let Err(error) = child_cleanup_result {
         failures.push(format!("could not retire its owned child safely: {error}"));
     }
+    let kill_result = parent.kill();
+    let wait_result = parent.wait();
     if let Err(error) = kill_result
         && error.kind() != io::ErrorKind::InvalidInput
     {
@@ -36119,11 +36089,83 @@ fn stop_codex_owner_after_spawn_failure(
     if let Err(error) = wait_result {
         failures.push(format!("could not reap the held owner process: {error}"));
     }
-    Err(io::Error::other(format!(
-        "Codex owner fixture cleanup failed: {}",
-        failures.join("; ")
-    ))
-    .into())
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "Codex owner fixture cleanup failed: {}",
+            failures.join("; ")
+        ))
+        .into())
+    }
+}
+
+#[cfg(windows)]
+fn codex_owner_observation_failure(
+    parent: &mut Child,
+    child_identity_file: &Path,
+    stable_runtime: &Path,
+    error: impl std::fmt::Display,
+) -> Result<(), Box<dyn Error>> {
+    match cleanup_codex_owner_processes_after_spawn_failure(
+        parent,
+        child_identity_file,
+        stable_runtime,
+        Vec::new(),
+    ) {
+        Ok(()) => Ok(()),
+        Err(cleanup_error) => Err(io::Error::other(format!(
+            "failed to preserve child-first cleanup after owner observation error ({error}): {cleanup_error}"
+        ))
+        .into()),
+    }
+}
+
+#[cfg(windows)]
+fn stop_codex_owner_after_spawn_failure(
+    parent: &mut Child,
+    child_identity_file: &Path,
+    stable_runtime: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let mut stop_file = child_identity_file.as_os_str().to_os_string();
+    stop_file.push(".stop");
+    let stop_result = fs::write(PathBuf::from(stop_file), b"stop");
+    let deadline = Instant::now() + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
+    let mut observation_error = None;
+    if stop_result.is_ok() {
+        loop {
+            match parent.try_wait() {
+                Ok(Some(_)) => return Ok(()),
+                Ok(None) => {}
+                Err(error) => {
+                    observation_error = Some(error);
+                    break;
+                }
+            }
+            if Instant::now() >= deadline {
+                break;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    if let Some(error) = observation_error {
+        codex_owner_observation_failure(parent, child_identity_file, stable_runtime, error)?;
+        return Ok(());
+    }
+
+    let mut failures = Vec::new();
+    if let Err(error) = stop_result {
+        failures.push(format!("could not signal the owner fixture: {error}"));
+    } else {
+        failures.push("owner fixture did not stop within five seconds".to_string());
+    }
+    cleanup_codex_owner_processes_after_spawn_failure(
+        parent,
+        child_identity_file,
+        stable_runtime,
+        failures,
+    )
 }
 
 #[cfg(windows)]
@@ -36476,6 +36518,34 @@ public static class Program
     {
         return Err(io::Error::other(format!(
             "unexpectedly accepted negative owner fixture did not clean up its owned processes: {unexpected_error}"
+        ))
+        .into());
+    }
+
+    let observation_identity_file = temp.path().join("observation-failure.pid");
+    let (mut observation_parent, observation_identity) = spawn_codex_owned_obsolete_mcp(
+        &codex_fixture,
+        &runtime,
+        &db,
+        Some(&atlas_dir.join("config.toml")),
+        &observation_identity_file,
+        None,
+        None,
+    )?;
+    // Inject only the observation decision while exercising the same child-first cleanup path;
+    // the production caller retains the actual observation error in its spawn diagnostic.
+    let observation_cleanup_result = codex_owner_observation_failure(
+        &mut observation_parent,
+        &observation_identity_file,
+        &runtime,
+        "synthetic parent observation failure",
+    );
+    if observation_parent.try_wait()?.is_none()
+        || windows_process_is_alive(&observation_identity)?
+        || observation_cleanup_result.is_err()
+    {
+        return Err(io::Error::other(format!(
+            "parent observation failure did not preserve exact child-first cleanup: {observation_cleanup_result:?}"
         ))
         .into());
     }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -183,8 +183,14 @@ const CODEX_OWNER_READINESS_TIMEOUT: Duration = Duration::from_secs(30);
 // The failure path gives the owner this bounded window to observe the stop marker and exit.
 const CODEX_OWNER_FAILURE_CLEANUP_BUDGET: Duration = Duration::from_secs(5);
 #[cfg(windows)]
+// Retained identity capture runs after owner observation and before exact child stop.
+const CODEX_OWNER_IDENTITY_CAPTURE_BUDGET: Duration = Duration::from_secs(5);
+#[cfg(windows)]
 // The exact child-stop helper allows its owned process up to this wait budget to exit.
 const CODEX_OWNER_CHILD_STOP_BUDGET: Duration = Duration::from_secs(5);
+#[cfg(windows)]
+// Keep the complete cleanup envelope truthful when one bounded phase is delayed by suite load.
+const CODEX_OWNER_CLEANUP_SCHEDULER_TOLERANCE: Duration = Duration::from_secs(2);
 #[cfg(windows)]
 // Allow normal scheduling variance without allowing a late readiness retry to hide.
 const CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE: Duration = Duration::from_secs(2);
@@ -192,6 +198,8 @@ const CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE: Duration = Duration::from_secs(
 const CODEX_OWNER_IDENTITY_CAPTURE_TEST_TIMEOUT: Duration = Duration::from_secs(1);
 #[cfg(windows)]
 const CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY: Duration = Duration::from_secs(4);
+#[cfg(windows)]
+const CODEX_OWNER_COMPOSED_STOP_DELAY: Duration = Duration::from_secs(3);
 #[cfg(windows)]
 const CODEX_OWNER_STOP_HELPER_TEST_DELAY: Duration = Duration::from_secs(6);
 #[cfg(windows)]
@@ -36128,7 +36136,21 @@ fn codex_owner_retained_identity_path(child_identity_file: &Path) -> PathBuf {
 
 #[cfg(windows)]
 fn codex_owner_cleanup_deadline(started: Instant) -> Instant {
-    started + CODEX_OWNER_FAILURE_CLEANUP_BUDGET + CODEX_OWNER_CHILD_STOP_BUDGET
+    started
+        + CODEX_OWNER_FAILURE_CLEANUP_BUDGET
+        + CODEX_OWNER_IDENTITY_CAPTURE_BUDGET
+        + CODEX_OWNER_CHILD_STOP_BUDGET
+        + CODEX_OWNER_CLEANUP_SCHEDULER_TOLERANCE
+}
+
+#[cfg(windows)]
+fn codex_owner_identity_capture_deadline(cleanup_deadline: Instant) -> Instant {
+    let now = Instant::now();
+    let capture_budget = cleanup_deadline
+        .saturating_duration_since(now)
+        .saturating_sub(CODEX_OWNER_CHILD_STOP_BUDGET)
+        .min(CODEX_OWNER_IDENTITY_CAPTURE_BUDGET);
+    now + capture_budget
 }
 
 #[cfg(windows)]
@@ -36138,21 +36160,51 @@ fn cleanup_codex_owner_processes_after_spawn_failure(
     stable_runtime: &Path,
     mut failures: Vec<String>,
     cleanup_deadline: Instant,
+    identity_capture_delay: Option<Duration>,
+    child_stop_delay: Option<Duration>,
 ) -> Result<(), Box<dyn Error>> {
     let retained_identity_file = codex_owner_retained_identity_path(child_identity_file);
-    let child_cleanup_result = read_codex_owner_child_identity(
+    let capture_deadline = codex_owner_identity_capture_deadline(cleanup_deadline);
+    let mut capture_failures = Vec::new();
+    let child_identity = match read_codex_owner_child_identity_with_test_delay(
         child_identity_file,
         stable_runtime,
-        cleanup_deadline.saturating_duration_since(Instant::now()),
-    )
-    .or_else(|_| {
-        read_codex_owner_child_identity(
-            &retained_identity_file,
-            stable_runtime,
-            cleanup_deadline.saturating_duration_since(Instant::now()),
-        )
-    })
-    .and_then(|identity| stop_windows_fixture_process_until(&identity, cleanup_deadline, None));
+        capture_deadline.saturating_duration_since(Instant::now()),
+        identity_capture_delay,
+    ) {
+        Ok(identity) => Some(identity),
+        Err(error) => {
+            capture_failures.push(format!("normal child identity capture failed: {error}"));
+            match read_codex_owner_child_identity_with_test_delay(
+                &retained_identity_file,
+                stable_runtime,
+                capture_deadline.saturating_duration_since(Instant::now()),
+                identity_capture_delay,
+            ) {
+                Ok(identity) => Some(identity),
+                Err(error) => {
+                    capture_failures
+                        .push(format!("retained child identity capture failed: {error}"));
+                    None
+                }
+            }
+        }
+    };
+    let child_cleanup_result = match child_identity {
+        Some(identity) => {
+            stop_windows_fixture_process_until(&identity, cleanup_deadline, child_stop_delay)
+        }
+        None => match read_codex_owner_identity_record(&retained_identity_file) {
+            Ok(identity) => {
+                stop_windows_fixture_process_until(&identity, cleanup_deadline, child_stop_delay)
+            }
+            Err(error) => Err(io::Error::other(format!(
+                "no retained child identity was available after capture failure ({}): {error}",
+                capture_failures.join("; ")
+            ))
+            .into()),
+        },
+    };
     if let Err(error) = child_cleanup_result {
         failures.push(format!("could not retire its owned child safely: {error}"));
     }
@@ -36193,6 +36245,8 @@ fn codex_owner_observation_failure(
         stable_runtime,
         Vec::new(),
         cleanup_deadline,
+        None,
+        None,
     ) {
         Ok(()) => Ok(()),
         Err(cleanup_error) => Err(io::Error::other(format!(
@@ -36207,6 +36261,23 @@ fn stop_codex_owner_after_spawn_failure(
     parent: &mut Child,
     child_identity_file: &Path,
     stable_runtime: &Path,
+) -> Result<(), Box<dyn Error>> {
+    stop_codex_owner_after_spawn_failure_with_test_delays(
+        parent,
+        child_identity_file,
+        stable_runtime,
+        None,
+        None,
+    )
+}
+
+#[cfg(windows)]
+fn stop_codex_owner_after_spawn_failure_with_test_delays(
+    parent: &mut Child,
+    child_identity_file: &Path,
+    stable_runtime: &Path,
+    identity_capture_delay: Option<Duration>,
+    child_stop_delay: Option<Duration>,
 ) -> Result<(), Box<dyn Error>> {
     let mut stop_file = child_identity_file.as_os_str().to_os_string();
     stop_file.push(".stop");
@@ -36256,6 +36327,8 @@ fn stop_codex_owner_after_spawn_failure(
         stable_runtime,
         failures,
         cleanup_deadline,
+        identity_capture_delay,
+        child_stop_delay,
     )
 }
 
@@ -36315,9 +36388,27 @@ fn read_codex_owner_child_identity(
     stable_runtime: &Path,
     capture_timeout: Duration,
 ) -> Result<WindowsProcessIdentity, Box<dyn Error>> {
+    read_codex_owner_child_identity_with_test_delay(
+        child_identity_file,
+        stable_runtime,
+        capture_timeout,
+        None,
+    )
+}
+
+#[cfg(windows)]
+fn read_codex_owner_child_identity_with_test_delay(
+    child_identity_file: &Path,
+    stable_runtime: &Path,
+    capture_timeout: Duration,
+    test_delay: Option<Duration>,
+) -> Result<WindowsProcessIdentity, Box<dyn Error>> {
     let published = read_codex_owner_identity_record(child_identity_file)?;
-    let captured =
-        capture_windows_process_identity_with_timeout(published.process_id, capture_timeout, None)?;
+    let captured = capture_windows_process_identity_with_timeout(
+        published.process_id,
+        capture_timeout,
+        test_delay,
+    )?;
     if captured.process_id != published.process_id
         || captured.creation_file_time_utc != published.creation_file_time_utc
     {
@@ -36474,8 +36565,34 @@ fn spawn_codex_owned_obsolete_mcp(
                 ),
             ));
         }
+        if Instant::now() >= deadline {
+            let elapsed = started.elapsed();
+            return Err(codex_owner_spawn_error(
+                &mut parent,
+                codex_fixture,
+                child_pid_file,
+                stable_runtime,
+                format!(
+                    "Codex MCP owner fixture readiness deadline expired before identity validation (readiness_elapsed_ms={})",
+                    elapsed.as_millis()
+                ),
+            ));
+        }
         if child_pid_file.is_file() {
             let capture_timeout = deadline.saturating_duration_since(Instant::now());
+            if capture_timeout.is_zero() {
+                let elapsed = started.elapsed();
+                return Err(codex_owner_spawn_error(
+                    &mut parent,
+                    codex_fixture,
+                    child_pid_file,
+                    stable_runtime,
+                    format!(
+                        "Codex MCP owner fixture published its child PID after the readiness deadline (readiness_elapsed_ms={})",
+                        elapsed.as_millis()
+                    ),
+                ));
+            }
             match read_codex_owner_child_identity(child_pid_file, stable_runtime, capture_timeout) {
                 Ok(captured) if Instant::now() < deadline => return Ok((parent, captured)),
                 Ok(_) => {
@@ -36643,6 +36760,64 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
         .into());
     }
 
+    // Exercise the complete bounded cleanup sequence: owner observation, retained identity
+    // capture, and exact child stop each consume real scheduler-visible time.
+    let composed_identity_file = temp.path().join("composed-timeout.pid");
+    let mut composed_command = StdCommand::new(&codex_fixture);
+    composed_command
+        .arg(&composed_identity_file)
+        .arg(&runtime)
+        .arg(&db)
+        .env(CODEX_OWNER_PUBLICATION_MODE_ENV, "timeout-ignore-stop")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut composed_parent = composed_command.spawn()?;
+    let composed_retained_identity_file =
+        codex_owner_retained_identity_path(&composed_identity_file);
+    let retained_deadline = Instant::now() + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
+    while !composed_retained_identity_file.is_file() && Instant::now() < retained_deadline {
+        if let Some(status) = composed_parent.try_wait()? {
+            return Err(io::Error::other(format!(
+                "composed timeout owner exited before retaining child identity: {status}"
+            ))
+            .into());
+        }
+        let remaining = retained_deadline.saturating_duration_since(Instant::now());
+        thread::sleep(remaining.min(Duration::from_millis(25)));
+    }
+    if !composed_retained_identity_file.is_file() {
+        drop(composed_parent.kill());
+        drop(composed_parent.wait());
+        return Err(io::Error::other(
+            "composed timeout owner did not publish retained child identity",
+        )
+        .into());
+    }
+    let composed_result = stop_codex_owner_after_spawn_failure_with_test_delays(
+        &mut composed_parent,
+        &composed_identity_file,
+        &runtime,
+        Some(CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY),
+        Some(CODEX_OWNER_COMPOSED_STOP_DELAY),
+    );
+    let composed_text = composed_result
+        .as_ref()
+        .err()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let composed_identity = read_codex_owner_identity_record(&composed_retained_identity_file)?;
+    if composed_result.is_ok()
+        || composed_text.contains("could not retire its owned child safely")
+        || composed_parent.try_wait()?.is_none()
+        || windows_process_is_alive(&composed_identity)?
+    {
+        return Err(io::Error::other(format!(
+            "composed owner cleanup did not reserve bounded capture and exact child-stop time: {composed_text}"
+        ))
+        .into());
+    }
+
     let identity_file = temp.path().join("timeout.pid");
     let timeout_started = Instant::now();
     let result = spawn_codex_owned_obsolete_mcp(
@@ -36667,7 +36842,9 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
     let timeout_elapsed = timeout_started.elapsed();
     let timeout_upper_bound = CODEX_OWNER_READINESS_TIMEOUT
         + CODEX_OWNER_FAILURE_CLEANUP_BUDGET
+        + CODEX_OWNER_IDENTITY_CAPTURE_BUDGET
         + CODEX_OWNER_CHILD_STOP_BUDGET
+        + CODEX_OWNER_CLEANUP_SCHEDULER_TOLERANCE
         + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE;
     let text = error.to_string();
     let timeout_readiness_elapsed = text
@@ -36699,7 +36876,7 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
         || windows_process_is_alive(&timeout_child_identity)?
     {
         return Err(io::Error::other(format!(
-            "true owner fixture timeout was not bounded and diagnostic: total_elapsed={timeout_elapsed:?} readiness_elapsed={timeout_readiness_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} owner_observation_budget={CODEX_OWNER_FAILURE_CLEANUP_BUDGET:?} child_stop_budget={CODEX_OWNER_CHILD_STOP_BUDGET:?} total_upper_bound={timeout_upper_bound:?} readiness_upper_bound={timeout_readiness_upper_bound:?}\n{text}"
+            "true owner fixture timeout was not bounded and diagnostic: total_elapsed={timeout_elapsed:?} readiness_elapsed={timeout_readiness_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} owner_observation_budget={CODEX_OWNER_FAILURE_CLEANUP_BUDGET:?} identity_capture_budget={CODEX_OWNER_IDENTITY_CAPTURE_BUDGET:?} child_stop_budget={CODEX_OWNER_CHILD_STOP_BUDGET:?} cleanup_scheduler_tolerance={CODEX_OWNER_CLEANUP_SCHEDULER_TOLERANCE:?} total_upper_bound={timeout_upper_bound:?} readiness_upper_bound={timeout_readiness_upper_bound:?}\n{text}"
         ))
         .into());
     }
@@ -37043,102 +37220,66 @@ fn windows_fixture_late_publication_is_atomic_but_past_readiness() -> Result<(),
     compile_obsolete_projectatlas_fixture(&runtime)?;
     compile_codex_mcp_owner_fixture(&codex_fixture)?;
 
-    let mut command = StdCommand::new(&codex_fixture);
-    command
-        .arg(&identity_file)
-        .arg(&runtime)
-        .arg(&db)
-        .env(
-            CODEX_OWNER_PUBLICATION_DELAY_ENV,
-            (CODEX_OWNER_READINESS_TIMEOUT + Duration::from_secs(1))
-                .as_millis()
-                .to_string(),
-        )
-        .env(CODEX_OWNER_PUBLICATION_MODE_ENV, "late-publication")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-    let mut parent = command.spawn()?;
     let started = Instant::now();
-    let result = (|| -> Result<(Duration, WindowsProcessIdentity), Box<dyn Error>> {
-        let readiness_deadline = started + CODEX_OWNER_READINESS_TIMEOUT;
-        while Instant::now() < readiness_deadline {
-            if identity_file.is_file() {
-                return Err(io::Error::other(
-                    "late owner fixture published its identity before the readiness deadline",
-                )
-                .into());
-            }
-            if let Some(status) = parent.try_wait()? {
-                return Err(io::Error::other(format!(
-                    "late owner fixture exited before its delayed publication: {status}"
-                ))
-                .into());
-            }
-            thread::sleep(Duration::from_millis(25));
+    let result = spawn_codex_owned_obsolete_mcp(
+        &codex_fixture,
+        &runtime,
+        &db,
+        None,
+        &identity_file,
+        Some(CODEX_OWNER_READINESS_TIMEOUT + Duration::from_secs(1)),
+        Some("late-publication"),
+    );
+    let elapsed = started.elapsed();
+    let error = match result {
+        Ok((parent, child_identity)) => {
+            return Err(codex_owner_unexpected_acceptance_error(
+                "late-publication",
+                parent,
+                &child_identity,
+            ));
         }
-        if identity_file.is_file() {
-            return Err(io::Error::other(
-                "late owner fixture publication raced into the readiness deadline",
-            )
-            .into());
-        }
-
-        let publication_deadline = readiness_deadline + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
-        while !identity_file.is_file() && Instant::now() < publication_deadline {
-            if let Some(status) = parent.try_wait()? {
-                return Err(io::Error::other(format!(
-                    "late owner fixture exited before its delayed publication: {status}"
-                ))
-                .into());
-            }
-            let remaining = publication_deadline.saturating_duration_since(Instant::now());
-            thread::sleep(remaining.min(Duration::from_millis(25)));
-        }
-        if !identity_file.is_file() {
-            return Err(io::Error::other(format!(
-                "late owner fixture did not publish atomically after the readiness deadline: elapsed={:?}",
-                started.elapsed()
+        Err(error) => error,
+    };
+    let text = error.to_string();
+    let retained_identity =
+        read_codex_owner_identity_record(&codex_owner_retained_identity_path(&identity_file))?;
+    let total_upper_bound = CODEX_OWNER_READINESS_TIMEOUT
+        + CODEX_OWNER_FAILURE_CLEANUP_BUDGET
+        + CODEX_OWNER_IDENTITY_CAPTURE_BUDGET
+        + CODEX_OWNER_CHILD_STOP_BUDGET
+        + CODEX_OWNER_CLEANUP_SCHEDULER_TOLERANCE
+        + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE;
+    let readiness_elapsed = text
+        .split("readiness_elapsed_ms=")
+        .nth(1)
+        .and_then(|value| value.split(')').next())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .ok_or_else(|| {
+            io::Error::other(format!(
+                "late publication timeout omitted its readiness elapsed diagnostic: {text}"
             ))
-            .into());
-        }
-        let publication_elapsed = started.elapsed();
-        let captured = read_codex_owner_child_identity(
-            &identity_file,
-            &runtime,
-            CODEX_OWNER_FAILURE_CLEANUP_BUDGET,
-        )?;
-        Ok((publication_elapsed, captured))
-    })();
-
-    match result {
-        Ok((publication_elapsed, identity)) => {
-            cleanup_codex_owner_processes(parent, &identity)?;
-            if publication_elapsed <= CODEX_OWNER_READINESS_TIMEOUT {
-                return Err(io::Error::other(format!(
-                    "late owner fixture publication was not past readiness: elapsed={publication_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?}"
-                ))
-                .into());
-            }
-            Ok(())
-        }
-        Err(error) => {
-            let cleanup_result = cleanup_codex_owner_processes_after_spawn_failure(
-                &mut parent,
-                &identity_file,
-                &runtime,
-                Vec::new(),
-                codex_owner_cleanup_deadline(Instant::now()),
-            );
-            if let Err(cleanup_error) = cleanup_result {
-                return Err(io::Error::other(format!(
-                    "late publication regression failed and fixture cleanup also failed: {error}; {cleanup_error}"
-                ))
-                .into());
-            }
-            Err(error)
-        }
+        })?;
+    if !identity_file.is_file()
+        || elapsed < CODEX_OWNER_READINESS_TIMEOUT
+        || elapsed > total_upper_bound
+        || readiness_elapsed < CODEX_OWNER_READINESS_TIMEOUT
+        || readiness_elapsed
+            > CODEX_OWNER_READINESS_TIMEOUT + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE
+        || (!text.contains("did not publish its child PID within 30s")
+            && !text.contains("readiness deadline"))
+        || !text.contains(&format!("owner={}", codex_fixture.display()))
+        || !text.contains(&format!("identity_file={}", identity_file.display()))
+        || !text.contains(&format!("expected_runtime={}", runtime.display()))
+        || windows_process_is_alive(&retained_identity)?
+    {
+        return Err(io::Error::other(format!(
+            "late publication was accepted or not bounded: elapsed={elapsed:?} readiness_elapsed={readiness_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} readiness_scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} cleanup_deadline={total_upper_bound:?}\n{text}"
+        ))
+        .into());
     }
+    Ok(())
 }
 
 #[test]

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -36396,20 +36396,6 @@ fn codex_owner_unexpected_acceptance_error(
 }
 
 #[cfg(windows)]
-fn read_codex_owner_child_identity(
-    child_identity_file: &Path,
-    stable_runtime: &Path,
-    capture_timeout: Duration,
-) -> Result<WindowsProcessIdentity, Box<dyn Error>> {
-    read_codex_owner_child_identity_with_test_delay(
-        child_identity_file,
-        stable_runtime,
-        capture_timeout,
-        None,
-    )
-}
-
-#[cfg(windows)]
 fn read_codex_owner_child_identity_with_test_delay(
     child_identity_file: &Path,
     stable_runtime: &Path,
@@ -36516,6 +36502,29 @@ fn spawn_codex_owned_obsolete_mcp(
     publication_delay: Option<Duration>,
     publication_mode: Option<&str>,
 ) -> Result<(Child, WindowsProcessIdentity), Box<dyn Error>> {
+    spawn_codex_owned_obsolete_mcp_with_identity_capture_delay(
+        codex_fixture,
+        stable_runtime,
+        db,
+        config,
+        child_pid_file,
+        publication_delay,
+        publication_mode,
+        None,
+    )
+}
+
+#[cfg(windows)]
+fn spawn_codex_owned_obsolete_mcp_with_identity_capture_delay(
+    codex_fixture: &Path,
+    stable_runtime: &Path,
+    db: &Path,
+    config: Option<&Path>,
+    child_pid_file: &Path,
+    publication_delay: Option<Duration>,
+    publication_mode: Option<&str>,
+    identity_capture_delay: Option<Duration>,
+) -> Result<(Child, WindowsProcessIdentity), Box<dyn Error>> {
     let mut command = StdCommand::new(codex_fixture);
     command
         .arg(child_pid_file)
@@ -36566,31 +36575,17 @@ fn spawn_codex_owned_obsolete_mcp(
             }
         }
         if child_pid_file.is_file() {
-            let capture_timeout = deadline.saturating_duration_since(Instant::now());
-            if capture_timeout.is_zero() {
-                let elapsed = started.elapsed();
-                return Err(codex_owner_spawn_error(
-                    &mut parent,
-                    codex_fixture,
-                    child_pid_file,
-                    stable_runtime,
-                    format!(
-                        "Codex MCP owner fixture published its child PID after the readiness deadline (readiness_elapsed_ms={})",
-                        elapsed.as_millis()
-                    ),
-                ));
-            }
-            match read_codex_owner_child_identity(child_pid_file, stable_runtime, capture_timeout) {
-                Ok(captured) if Instant::now() < deadline => return Ok((parent, captured)),
-                Ok(_) => {
-                    return Err(codex_owner_spawn_error(
-                        &mut parent,
-                        codex_fixture,
-                        child_pid_file,
-                        stable_runtime,
-                        "published child identity validation completed after the readiness deadline",
-                    ));
-                }
+            // Once publication is observed, give exact identity validation its own bounded
+            // allowance.  The file may have been published before this poll crossed the
+            // readiness deadline, so classifying it as missing before validation would reject
+            // a valid owner under ordinary scheduler contention.
+            match read_codex_owner_child_identity_with_test_delay(
+                child_pid_file,
+                stable_runtime,
+                CODEX_OWNER_IDENTITY_CAPTURE_BUDGET,
+                identity_capture_delay,
+            ) {
+                Ok(captured) => return Ok((parent, captured)),
                 Err(error) => {
                     return Err(codex_owner_spawn_error(
                         &mut parent,
@@ -36638,6 +36633,53 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
     compile_obsolete_projectatlas_fixture(&runtime)?;
     let codex_fixture = temp.path().join(CODEX_FIXTURE_EXECUTABLE_FILE_NAME);
     compile_codex_mcp_owner_fixture(&codex_fixture)?;
+
+    // Exercise the production readiness helper when publication is observed before the
+    // deadline but bounded identity validation finishes just after it.  The dedicated
+    // capture allowance must accept the valid identity; using the old remaining-time
+    // allowance rejects this same causal path.
+    let deadline_validation_identity_file = temp.path().join("deadline-validation.pid");
+    let deadline_validation_publication_delay = CODEX_OWNER_READINESS_TIMEOUT
+        .saturating_sub(CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY)
+        + Duration::from_secs(1);
+    let deadline_validation_started = Instant::now();
+    let (deadline_validation_parent, deadline_validation_identity) =
+        spawn_codex_owned_obsolete_mcp_with_identity_capture_delay(
+            &codex_fixture,
+            &runtime,
+            &db,
+            None,
+            &deadline_validation_identity_file,
+            Some(deadline_validation_publication_delay),
+            None,
+            Some(CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY),
+        )?;
+    let deadline_validation_elapsed = deadline_validation_started.elapsed();
+    if deadline_validation_elapsed < CODEX_OWNER_READINESS_TIMEOUT
+        || deadline_validation_elapsed
+            > CODEX_OWNER_READINESS_TIMEOUT
+                + CODEX_OWNER_IDENTITY_CAPTURE_BUDGET
+                + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE
+    {
+        let cleanup_result = cleanup_codex_owner_processes(
+            deadline_validation_parent,
+            &deadline_validation_identity,
+        );
+        return Err(io::Error::other(format!(
+            "deadline-observed publication did not use its bounded identity allowance: elapsed={deadline_validation_elapsed:?} publication_delay={deadline_validation_publication_delay:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} identity_capture_budget={CODEX_OWNER_IDENTITY_CAPTURE_BUDGET:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} cleanup={cleanup_result:?}"
+        ))
+        .into());
+    }
+    let deadline_validation_cleanup =
+        cleanup_codex_owner_processes(deadline_validation_parent, &deadline_validation_identity);
+    if deadline_validation_cleanup.is_err()
+        || windows_process_is_alive(&deadline_validation_identity)?
+    {
+        return Err(io::Error::other(format!(
+            "deadline-observed publication did not clean up its accepted child: {deadline_validation_cleanup:?}"
+        ))
+        .into());
+    }
 
     for (index, (mode, expected)) in [
         ("early-exit", "exited before publishing"),
@@ -36702,54 +36744,6 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
             ))
             .into());
         }
-    }
-
-    // Keep a valid atomic publication close to the readiness edge.  The helper must
-    // inspect that publication before classifying a missing-file timeout, then give
-    // identity capture only the remaining readiness budget.
-    let deadline_edge_identity_file = temp.path().join("deadline-edge.pid");
-    let deadline_edge_started = Instant::now();
-    let deadline_edge_delay =
-        CODEX_OWNER_READINESS_TIMEOUT.saturating_sub(CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE);
-    let deadline_edge_result = spawn_codex_owned_obsolete_mcp(
-        &codex_fixture,
-        &runtime,
-        &db,
-        Some(&atlas_dir.join("config.toml")),
-        &deadline_edge_identity_file,
-        Some(deadline_edge_delay),
-        None,
-    );
-    let deadline_edge_elapsed = deadline_edge_started.elapsed();
-    let (deadline_edge_parent, deadline_edge_identity) = match deadline_edge_result {
-        Ok((parent, identity)) => {
-            if deadline_edge_elapsed < deadline_edge_delay
-                || deadline_edge_elapsed >= CODEX_OWNER_READINESS_TIMEOUT
-            {
-                let cleanup_result = cleanup_codex_owner_processes(parent, &identity);
-                return Err(io::Error::other(format!(
-                    "deadline-edge publication was not accepted inside the readiness budget: elapsed={deadline_edge_elapsed:?} publication_delay={deadline_edge_delay:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} cleanup={cleanup_result:?}"
-                ))
-                .into());
-            }
-            (parent, identity)
-        }
-        Err(error) => {
-            return Err(io::Error::other(format!(
-                "deadline-edge publication was rejected before identity validation: elapsed={deadline_edge_elapsed:?} publication_delay={deadline_edge_delay:?} error={error}"
-            ))
-            .into());
-        }
-    };
-    let deadline_edge_cleanup =
-        cleanup_codex_owner_processes(deadline_edge_parent, &deadline_edge_identity);
-    if deadline_edge_cleanup.is_err() || windows_process_is_alive(&deadline_edge_identity)? {
-        return Err(io::Error::other(
-            format!(
-                "deadline-edge publication did not clean up its accepted child: {deadline_edge_cleanup:?}"
-            ),
-        )
-        .into());
     }
 
     // Exercise the same branch a negative fixture would take if validation regressed.

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -189,7 +189,11 @@ const CODEX_OWNER_CHILD_STOP_BUDGET: Duration = Duration::from_secs(5);
 // Allow normal scheduling variance without allowing a late readiness retry to hide.
 const CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE: Duration = Duration::from_secs(2);
 #[cfg(windows)]
-const CODEX_OWNER_EARLY_EXIT_MAX_ELAPSED: Duration = Duration::from_secs(10);
+// Early owner exit must be observed before readiness expires; this bound allows only
+// the same scheduler margin as the bounded publication contract.
+fn codex_owner_early_exit_max_elapsed() -> Duration {
+    CODEX_OWNER_READINESS_TIMEOUT + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE
+}
 #[cfg(windows)]
 const CODEX_OWNER_DELAYED_PUBLICATION: Duration = Duration::from_secs(6);
 #[cfg(windows)]
@@ -36346,13 +36350,15 @@ fn spawn_codex_owned_obsolete_mcp(
     loop {
         match parent.try_wait() {
             Ok(Some(status)) => {
+                let observation_elapsed = started.elapsed();
                 return Err(codex_owner_spawn_error(
                     &mut parent,
                     codex_fixture,
                     child_pid_file,
                     stable_runtime,
                     format!(
-                        "Codex MCP owner fixture exited before publishing its child PID: {status}"
+                        "Codex MCP owner fixture exited before publishing its child PID: {status} (owner_observation_elapsed_ms={})",
+                        observation_elapsed.as_millis()
                     ),
                 ));
             }
@@ -36486,15 +36492,35 @@ public static class Program
         };
         let elapsed = started.elapsed();
         let text = error.to_string();
+        let early_exit_observation_elapsed = if mode == "early-exit" {
+            Some(
+                text.split("owner_observation_elapsed_ms=")
+                    .nth(1)
+                    .and_then(|value| value.split(')').next())
+                    .and_then(|value| value.trim().parse::<u64>().ok())
+                    .map(Duration::from_millis)
+                    .ok_or_else(|| {
+                        io::Error::other(format!(
+                            "early-exit owner fixture omitted its observation elapsed diagnostic:\n{text}"
+                        ))
+                    })?,
+            )
+        } else {
+            None
+        };
         if !text.contains(expected)
             || !text.contains(&format!("owner={}", codex_fixture.display()))
             || !text.contains(&format!("identity_file={}", identity_file.display()))
             || !text.contains(&format!("expected_runtime={}", runtime.display()))
-            || (mode == "early-exit" && elapsed > CODEX_OWNER_EARLY_EXIT_MAX_ELAPSED)
+            || (mode == "early-exit" && elapsed > codex_owner_early_exit_max_elapsed())
+            || early_exit_observation_elapsed
+                .as_ref()
+                .is_some_and(|observed| *observed >= CODEX_OWNER_READINESS_TIMEOUT)
             || text.contains("fixture cleanup also failed")
         {
             return Err(io::Error::other(format!(
-                "{mode} owner fixture failure was not bounded and diagnostic: elapsed={elapsed:?} max_early_exit={CODEX_OWNER_EARLY_EXIT_MAX_ELAPSED:?}\n{text}"
+                "{mode} owner fixture failure was not bounded and diagnostic: elapsed={elapsed:?} observed={early_exit_observation_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} max_early_exit={:?}\n{text}",
+                codex_owner_early_exit_max_elapsed()
             ))
             .into());
         }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -202,6 +202,9 @@ const CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY: Duration = Duration::from_secs(4)
 // Delay the polling caller, not the child operation, so a completed helper is observed late.
 const CODEX_OWNER_LATE_COMPLETION_TEST_DELAY: Duration = Duration::from_secs(2);
 #[cfg(windows)]
+// Delay the outer owner observer past its deadline after the fixture has received stop.
+const CODEX_OWNER_LATE_OWNER_OBSERVATION_TEST_DELAY: Duration = Duration::from_secs(6);
+#[cfg(windows)]
 // Delay the readiness poll past the deadline after the fixture has published, without
 // changing process-global state, proving the admission guard through the real helper.
 const CODEX_OWNER_OBSERVATION_TEST_DELAY: Duration = Duration::from_secs(31);
@@ -36291,6 +36294,7 @@ fn stop_codex_owner_after_spawn_failure(
         stable_runtime,
         None,
         None,
+        None,
     )
 }
 
@@ -36301,6 +36305,7 @@ fn stop_codex_owner_after_spawn_failure_with_test_delays(
     stable_runtime: &Path,
     identity_capture_delay: Option<Duration>,
     child_stop_delay: Option<Duration>,
+    owner_observation_delay: Option<Duration>,
 ) -> Result<(), Box<dyn Error>> {
     let mut stop_file = child_identity_file.as_os_str().to_os_string();
     stop_file.push(".stop");
@@ -36309,10 +36314,23 @@ fn stop_codex_owner_after_spawn_failure_with_test_delays(
     let cleanup_deadline = codex_owner_cleanup_deadline(cleanup_started);
     let observation_deadline = cleanup_started + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
     let mut observation_error = None;
+    let mut failures = Vec::new();
     if stop_result.is_ok() {
+        if let Some(delay) = owner_observation_delay {
+            thread::sleep(delay);
+        }
         loop {
             match parent.try_wait() {
-                Ok(Some(_)) => return Ok(()),
+                Ok(Some(status)) => {
+                    if Instant::now() >= observation_deadline {
+                        failures.push(format!(
+                            "owner fixture exited after observation deadline: {status} (owner_observation_elapsed_ms={})",
+                            cleanup_started.elapsed().as_millis()
+                        ));
+                        break;
+                    }
+                    return Ok(());
+                }
                 Ok(None) => {}
                 Err(error) => {
                     observation_error = Some(error);
@@ -36338,7 +36356,6 @@ fn stop_codex_owner_after_spawn_failure_with_test_delays(
         return Ok(());
     }
 
-    let mut failures = Vec::new();
     if let Err(error) = stop_result {
         failures.push(format!("could not signal the owner fixture: {error}"));
     } else {
@@ -36833,6 +36850,62 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
         .into());
     }
 
+    // A promptly stopped owner can be observed after the five-second owner-observation
+    // deadline when the polling caller is descheduled.  The late completion is a failure
+    // classification, but it must still use the retained-identity child-first cleanup path.
+    let late_observation_identity_file = temp.path().join("late-owner-observation.pid");
+    let (mut late_observation_parent, late_observation_identity) = spawn_codex_owned_obsolete_mcp(
+        &codex_fixture,
+        &runtime,
+        &db,
+        Some(&atlas_dir.join("config.toml")),
+        &late_observation_identity_file,
+        None,
+        None,
+    )?;
+    // Remove normal publication so cleanup must use the fixture-retained identity record.
+    fs::remove_file(&late_observation_identity_file)?;
+    let late_observation_result = stop_codex_owner_after_spawn_failure_with_test_delays(
+        &mut late_observation_parent,
+        &late_observation_identity_file,
+        &runtime,
+        None,
+        None,
+        Some(CODEX_OWNER_LATE_OWNER_OBSERVATION_TEST_DELAY),
+    );
+    let late_observation_text = late_observation_result
+        .as_ref()
+        .err()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let late_observation_elapsed = late_observation_text
+        .split("owner_observation_elapsed_ms=")
+        .nth(1)
+        .and_then(|value| value.split(')').next())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .ok_or_else(|| {
+            io::Error::other(format!(
+                "late owner observation omitted its elapsed diagnostic: {late_observation_text}"
+            ))
+        })?;
+    if late_observation_result.is_ok()
+        || !late_observation_text.contains("owner fixture exited after observation deadline")
+        || late_observation_elapsed < CODEX_OWNER_LATE_OWNER_OBSERVATION_TEST_DELAY
+        || late_observation_elapsed
+            > CODEX_OWNER_LATE_OWNER_OBSERVATION_TEST_DELAY
+                + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE
+        || late_observation_parent.try_wait()?.is_none()
+        || windows_process_is_alive(&late_observation_identity)?
+        || late_observation_text.contains("could not retire its owned child safely")
+    {
+        return Err(io::Error::other(format!(
+            "late owner observation did not fail closed through exact child-first cleanup: result={late_observation_result:?} child_alive={}\n{late_observation_text}",
+            windows_process_is_alive(&late_observation_identity)?
+        ))
+        .into());
+    }
+
     // Exercise the complete bounded cleanup sequence: owner observation, retained identity
     // capture, and exact child stop each consume real scheduler-visible time.
     let composed_identity_file = temp.path().join("composed-timeout.pid");
@@ -36898,6 +36971,7 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
         &runtime,
         Some(CODEX_OWNER_IDENTITY_CAPTURE_TEST_DELAY),
         Some(CODEX_OWNER_COMPOSED_STOP_DELAY),
+        None,
     );
     let composed_text = composed_result
         .as_ref()

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -36565,32 +36565,6 @@ fn spawn_codex_owned_obsolete_mcp(
                 ));
             }
         }
-        if Instant::now() >= deadline {
-            let elapsed = started.elapsed();
-            return Err(codex_owner_spawn_error(
-                &mut parent,
-                codex_fixture,
-                child_pid_file,
-                stable_runtime,
-                format!(
-                    "Codex MCP owner fixture did not publish its child PID within {CODEX_OWNER_READINESS_TIMEOUT:?} (elapsed={elapsed:?} readiness_elapsed_ms={})",
-                    elapsed.as_millis()
-                ),
-            ));
-        }
-        if Instant::now() >= deadline {
-            let elapsed = started.elapsed();
-            return Err(codex_owner_spawn_error(
-                &mut parent,
-                codex_fixture,
-                child_pid_file,
-                stable_runtime,
-                format!(
-                    "Codex MCP owner fixture readiness deadline expired before identity validation (readiness_elapsed_ms={})",
-                    elapsed.as_millis()
-                ),
-            ));
-        }
         if child_pid_file.is_file() {
             let capture_timeout = deadline.saturating_duration_since(Instant::now());
             if capture_timeout.is_zero() {
@@ -36627,6 +36601,19 @@ fn spawn_codex_owned_obsolete_mcp(
                     ));
                 }
             }
+        }
+        if Instant::now() >= deadline {
+            let elapsed = started.elapsed();
+            return Err(codex_owner_spawn_error(
+                &mut parent,
+                codex_fixture,
+                child_pid_file,
+                stable_runtime,
+                format!(
+                    "Codex MCP owner fixture did not publish its child PID within {CODEX_OWNER_READINESS_TIMEOUT:?} (elapsed={elapsed:?} readiness_elapsed_ms={})",
+                    elapsed.as_millis()
+                ),
+            ));
         }
         thread::sleep(Duration::from_millis(25));
     }
@@ -36715,6 +36702,54 @@ fn windows_codex_owner_fixture_readiness_is_bounded_and_identity_safe() -> Resul
             ))
             .into());
         }
+    }
+
+    // Keep a valid atomic publication close to the readiness edge.  The helper must
+    // inspect that publication before classifying a missing-file timeout, then give
+    // identity capture only the remaining readiness budget.
+    let deadline_edge_identity_file = temp.path().join("deadline-edge.pid");
+    let deadline_edge_started = Instant::now();
+    let deadline_edge_delay =
+        CODEX_OWNER_READINESS_TIMEOUT.saturating_sub(CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE);
+    let deadline_edge_result = spawn_codex_owned_obsolete_mcp(
+        &codex_fixture,
+        &runtime,
+        &db,
+        Some(&atlas_dir.join("config.toml")),
+        &deadline_edge_identity_file,
+        Some(deadline_edge_delay),
+        None,
+    );
+    let deadline_edge_elapsed = deadline_edge_started.elapsed();
+    let (deadline_edge_parent, deadline_edge_identity) = match deadline_edge_result {
+        Ok((parent, identity)) => {
+            if deadline_edge_elapsed < deadline_edge_delay
+                || deadline_edge_elapsed >= CODEX_OWNER_READINESS_TIMEOUT
+            {
+                let cleanup_result = cleanup_codex_owner_processes(parent, &identity);
+                return Err(io::Error::other(format!(
+                    "deadline-edge publication was not accepted inside the readiness budget: elapsed={deadline_edge_elapsed:?} publication_delay={deadline_edge_delay:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} cleanup={cleanup_result:?}"
+                ))
+                .into());
+            }
+            (parent, identity)
+        }
+        Err(error) => {
+            return Err(io::Error::other(format!(
+                "deadline-edge publication was rejected before identity validation: elapsed={deadline_edge_elapsed:?} publication_delay={deadline_edge_delay:?} error={error}"
+            ))
+            .into());
+        }
+    };
+    let deadline_edge_cleanup =
+        cleanup_codex_owner_processes(deadline_edge_parent, &deadline_edge_identity);
+    if deadline_edge_cleanup.is_err() || windows_process_is_alive(&deadline_edge_identity)? {
+        return Err(io::Error::other(
+            format!(
+                "deadline-edge publication did not clean up its accepted child: {deadline_edge_cleanup:?}"
+            ),
+        )
+        .into());
     }
 
     // Exercise the same branch a negative fixture would take if validation regressed.
@@ -37299,8 +37334,7 @@ fn windows_fixture_late_publication_is_atomic_but_past_readiness() -> Result<(),
                 "late publication timeout omitted its readiness elapsed diagnostic: {text}"
             ))
         })?;
-    if !identity_file.is_file()
-        || elapsed < CODEX_OWNER_READINESS_TIMEOUT
+    if elapsed < CODEX_OWNER_READINESS_TIMEOUT
         || elapsed > total_upper_bound
         || readiness_elapsed < CODEX_OWNER_READINESS_TIMEOUT
         || readiness_elapsed

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -183,6 +183,9 @@ const CODEX_OWNER_READINESS_TIMEOUT: Duration = Duration::from_secs(30);
 // The failure path gives the owner this bounded window to observe the stop marker and exit.
 const CODEX_OWNER_FAILURE_CLEANUP_BUDGET: Duration = Duration::from_secs(5);
 #[cfg(windows)]
+// The exact child-stop helper allows its owned process up to this wait budget to exit.
+const CODEX_OWNER_CHILD_STOP_BUDGET: Duration = Duration::from_secs(5);
+#[cfg(windows)]
 // Allow normal scheduling variance without allowing a late readiness retry to hide.
 const CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE: Duration = Duration::from_secs(2);
 #[cfg(windows)]
@@ -36574,6 +36577,7 @@ public static class Program
     let timeout_elapsed = timeout_started.elapsed();
     let timeout_upper_bound = CODEX_OWNER_READINESS_TIMEOUT
         + CODEX_OWNER_FAILURE_CLEANUP_BUDGET
+        + CODEX_OWNER_CHILD_STOP_BUDGET
         + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE;
     let text = error.to_string();
     let timeout_readiness_elapsed = text
@@ -36605,7 +36609,7 @@ public static class Program
         || windows_process_is_alive(&timeout_child_identity)?
     {
         return Err(io::Error::other(format!(
-            "true owner fixture timeout was not bounded and diagnostic: total_elapsed={timeout_elapsed:?} readiness_elapsed={timeout_readiness_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} cleanup_budget={CODEX_OWNER_FAILURE_CLEANUP_BUDGET:?} total_upper_bound={timeout_upper_bound:?} readiness_upper_bound={timeout_readiness_upper_bound:?}\n{text}"
+            "true owner fixture timeout was not bounded and diagnostic: total_elapsed={timeout_elapsed:?} readiness_elapsed={timeout_readiness_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} owner_observation_budget={CODEX_OWNER_FAILURE_CLEANUP_BUDGET:?} child_stop_budget={CODEX_OWNER_CHILD_STOP_BUDGET:?} total_upper_bound={timeout_upper_bound:?} readiness_upper_bound={timeout_readiness_upper_bound:?}\n{text}"
         ))
         .into());
     }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -180,6 +180,11 @@ static WINDOWS_RELEASE_ASSET_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex:
 #[cfg(windows)]
 const CODEX_OWNER_READINESS_TIMEOUT: Duration = Duration::from_secs(30);
 #[cfg(windows)]
+// The failure path gives the owner this bounded window to observe the stop marker and exit.
+const CODEX_OWNER_FAILURE_CLEANUP_BUDGET: Duration = Duration::from_secs(5);
+#[cfg(windows)]
+const CODEX_OWNER_EARLY_EXIT_MAX_ELAPSED: Duration = Duration::from_secs(5);
+#[cfg(windows)]
 const CODEX_OWNER_DELAYED_PUBLICATION: Duration = Duration::from_secs(6);
 #[cfg(windows)]
 const CODEX_OWNER_PUBLICATION_DELAY_ENV: &str =
@@ -36044,7 +36049,7 @@ fn stop_codex_owner_after_spawn_failure(
     let mut stop_file = child_identity_file.as_os_str().to_os_string();
     stop_file.push(".stop");
     let stop_result = fs::write(PathBuf::from(stop_file), b"stop");
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let deadline = Instant::now() + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
     if stop_result.is_ok() {
         loop {
             match parent.try_wait() {
@@ -36327,6 +36332,7 @@ public static class Program
     .enumerate()
     {
         let identity_file = temp.path().join(format!("{mode}-{index}.pid"));
+        let started = Instant::now();
         let result = spawn_codex_owned_obsolete_mcp(
             &codex_fixture,
             &runtime,
@@ -36341,15 +36347,17 @@ public static class Program
                 io::Error::other(format!("{mode} owner fixture publication was accepted")).into(),
             );
         };
+        let elapsed = started.elapsed();
         let text = error.to_string();
         if !text.contains(expected)
             || !text.contains(&format!("owner={}", codex_fixture.display()))
             || !text.contains(&format!("identity_file={}", identity_file.display()))
             || !text.contains(&format!("expected_runtime={}", runtime.display()))
+            || (mode == "early-exit" && elapsed > CODEX_OWNER_EARLY_EXIT_MAX_ELAPSED)
             || text.contains("fixture cleanup also failed")
         {
             return Err(io::Error::other(format!(
-                "{mode} owner fixture failure was not bounded and diagnostic:\n{text}"
+                "{mode} owner fixture failure was not bounded and diagnostic: elapsed={elapsed:?} max_early_exit={CODEX_OWNER_EARLY_EXIT_MAX_ELAPSED:?}\n{text}"
             ))
             .into());
         }
@@ -36370,8 +36378,10 @@ public static class Program
         return Err(io::Error::other("owner fixture without publication was accepted").into());
     };
     let timeout_elapsed = timeout_started.elapsed();
+    let timeout_upper_bound = CODEX_OWNER_READINESS_TIMEOUT + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
     let text = error.to_string();
     if timeout_elapsed < CODEX_OWNER_READINESS_TIMEOUT
+        || timeout_elapsed > timeout_upper_bound
         || !text.contains("did not publish its child PID within 30s")
         || !text.contains("elapsed=")
         || !text.contains(&format!("owner={}", codex_fixture.display()))
@@ -36380,7 +36390,7 @@ public static class Program
         || text.contains("fixture cleanup also failed")
     {
         return Err(io::Error::other(format!(
-            "true owner fixture timeout was not bounded and diagnostic: elapsed={timeout_elapsed:?}\n{text}"
+            "true owner fixture timeout was not bounded and diagnostic: elapsed={timeout_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} cleanup_budget={CODEX_OWNER_FAILURE_CLEANUP_BUDGET:?} upper_bound={timeout_upper_bound:?}\n{text}"
         ))
         .into());
     }

--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -232,6 +232,19 @@ public static class Program
             {
                 string identityPath = arguments[0];
                 string temporaryIdentityPath = identityPath + ".tmp";
+                string retainedIdentityPath = identityPath + ".owner";
+                string retainedIdentityTemporaryPath = retainedIdentityPath + ".tmp";
+                // Retain exact fixture ownership even when normal publication is withheld.
+                string creationTime = child.StartTime.ToUniversalTime()
+                    .ToFileTimeUtc()
+                    .ToString();
+                File.WriteAllLines(retainedIdentityTemporaryPath, new[]
+                {
+                    child.Id.ToString(),
+                    creationTime,
+                    childPath
+                });
+                File.Move(retainedIdentityTemporaryPath, retainedIdentityPath);
                 string publicationMode = Environment.GetEnvironmentVariable(
                     "PROJECTATLAS_TEST_CODEX_OWNER_PUBLICATION_MODE"
                 );
@@ -247,11 +260,9 @@ public static class Program
                 {
                     Thread.Sleep(delayMilliseconds);
                 }
-                if (publicationMode != "timeout")
+                if (publicationMode != "timeout"
+                    && publicationMode != "timeout-ignore-stop")
                 {
-                    string creationTime = child.StartTime.ToUniversalTime()
-                        .ToFileTimeUtc()
-                        .ToString();
                     if (publicationMode == "malformed")
                     {
                         File.WriteAllText(temporaryIdentityPath, "not-an-identity");
@@ -271,7 +282,8 @@ public static class Program
                 }
                 while (!child.WaitForExit(25))
                 {
-                    if (File.Exists(identityPath + ".stop"))
+                    if (publicationMode != "timeout-ignore-stop"
+                        && File.Exists(identityPath + ".stop"))
                     {
                         child.Kill();
                         child.WaitForExit();
@@ -36044,6 +36056,14 @@ fn windows_test_process_id_allowlist(process_ids: &[u32]) -> io::Result<String> 
 }
 
 #[cfg(windows)]
+/// Derive the fixture-private identity record used when normal publication is absent.
+fn codex_owner_retained_identity_path(child_identity_file: &Path) -> PathBuf {
+    let mut retained_identity = child_identity_file.as_os_str().to_os_string();
+    retained_identity.push(".owner");
+    PathBuf::from(retained_identity)
+}
+
+#[cfg(windows)]
 fn stop_codex_owner_after_spawn_failure(
     parent: &mut Child,
     child_identity_file: &Path,
@@ -36074,7 +36094,9 @@ fn stop_codex_owner_after_spawn_failure(
         }
     }
 
+    let retained_identity_file = codex_owner_retained_identity_path(child_identity_file);
     let child_cleanup_result = read_codex_owner_child_identity(child_identity_file, stable_runtime)
+        .or_else(|_| read_codex_owner_child_identity(&retained_identity_file, stable_runtime))
         .and_then(|identity| stop_windows_fixture_process(&identity));
     let kill_result = parent.kill();
     let wait_result = parent.wait();
@@ -36085,9 +36107,7 @@ fn stop_codex_owner_after_spawn_failure(
         failures.push("owner fixture did not stop within five seconds".to_string());
     }
     if let Err(error) = child_cleanup_result {
-        failures.push(format!(
-            "could not retire its published child safely: {error}"
-        ));
+        failures.push(format!("could not retire its owned child safely: {error}"));
     }
     if let Err(error) = kill_result
         && error.kind() != io::ErrorKind::InvalidInput
@@ -36159,6 +36179,43 @@ fn read_codex_owner_child_identity(
     child_identity_file: &Path,
     stable_runtime: &Path,
 ) -> Result<WindowsProcessIdentity, Box<dyn Error>> {
+    let published = read_codex_owner_identity_record(child_identity_file)?;
+    let captured = capture_windows_process_identity(published.process_id)?;
+    if captured.process_id != published.process_id
+        || captured.creation_file_time_utc != published.creation_file_time_utc
+    {
+        return Err(io::Error::other(format!(
+            "owner-published child identity differed: published_pid={} captured_pid={} published_creation={} captured_creation={}",
+            published.process_id,
+            captured.process_id,
+            published.creation_file_time_utc,
+            captured.creation_file_time_utc
+        ))
+        .into());
+    }
+    let owner_canonical =
+        normalize_native_path_display(fs::canonicalize(&published.executable_path)?);
+    let captured_canonical =
+        normalize_native_path_display(fs::canonicalize(&captured.executable_path)?);
+    let expected_canonical = normalize_native_path_display(fs::canonicalize(stable_runtime)?);
+    if !captured_canonical.eq_ignore_ascii_case(&owner_canonical)
+        || !captured_canonical.eq_ignore_ascii_case(&expected_canonical)
+    {
+        return Err(io::Error::other(format!(
+            "owner-published child path differed: published_raw={} captured_raw={} expected_raw={} published_canonical={owner_canonical} captured_canonical={captured_canonical} expected_canonical={expected_canonical}",
+            published.executable_path.display(),
+            captured.executable_path.display(),
+            stable_runtime.display()
+        ))
+        .into());
+    }
+    Ok(captured)
+}
+
+#[cfg(windows)]
+fn read_codex_owner_identity_record(
+    child_identity_file: &Path,
+) -> Result<WindowsProcessIdentity, Box<dyn Error>> {
     let identity_text = fs::read_to_string(child_identity_file)?;
     let mut identity_lines = identity_text.lines();
     let process_id = identity_lines
@@ -36175,33 +36232,11 @@ fn read_codex_owner_child_identity(
             .filter(|path| !path.is_empty())
             .ok_or_else(|| io::Error::other("owner fixture omitted child executable path"))?,
     );
-    let captured = capture_windows_process_identity(process_id)?;
-    if captured.process_id != process_id
-        || captured.creation_file_time_utc != owner_creation_file_time_utc
-    {
-        return Err(io::Error::other(format!(
-            "owner-published child identity differed: published_pid={process_id} captured_pid={} published_creation={owner_creation_file_time_utc} captured_creation={}",
-            captured.process_id,
-            captured.creation_file_time_utc
-        ))
-        .into());
-    }
-    let owner_canonical = normalize_native_path_display(fs::canonicalize(&owner_executable_path)?);
-    let captured_canonical =
-        normalize_native_path_display(fs::canonicalize(&captured.executable_path)?);
-    let expected_canonical = normalize_native_path_display(fs::canonicalize(stable_runtime)?);
-    if !captured_canonical.eq_ignore_ascii_case(&owner_canonical)
-        || !captured_canonical.eq_ignore_ascii_case(&expected_canonical)
-    {
-        return Err(io::Error::other(format!(
-            "owner-published child path differed: published_raw={} captured_raw={} expected_raw={} published_canonical={owner_canonical} captured_canonical={captured_canonical} expected_canonical={expected_canonical}",
-            owner_executable_path.display(),
-            captured.executable_path.display(),
-            stable_runtime.display()
-        ))
-        .into());
-    }
-    Ok(captured)
+    Ok(WindowsProcessIdentity {
+        process_id,
+        creation_file_time_utc: owner_creation_file_time_utc,
+        executable_path: owner_executable_path,
+    })
 }
 
 #[cfg(windows)]
@@ -36454,7 +36489,7 @@ public static class Program
         Some(&atlas_dir.join("config.toml")),
         &identity_file,
         None,
-        Some("timeout"),
+        Some("timeout-ignore-stop"),
     );
     let error = match result {
         Ok((parent, child_identity)) => {
@@ -36467,7 +36502,9 @@ public static class Program
         Err(error) => error,
     };
     let timeout_elapsed = timeout_started.elapsed();
-    let timeout_upper_bound = CODEX_OWNER_READINESS_TIMEOUT + CODEX_OWNER_FAILURE_CLEANUP_BUDGET;
+    let timeout_upper_bound = CODEX_OWNER_READINESS_TIMEOUT
+        + CODEX_OWNER_FAILURE_CLEANUP_BUDGET
+        + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE;
     let text = error.to_string();
     let timeout_readiness_elapsed = text
         .split("readiness_elapsed_ms=")
@@ -36482,6 +36519,8 @@ public static class Program
         })?;
     let timeout_readiness_upper_bound =
         CODEX_OWNER_READINESS_TIMEOUT + CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE;
+    let timeout_child_identity =
+        read_codex_owner_identity_record(&codex_owner_retained_identity_path(&identity_file))?;
     if timeout_elapsed < CODEX_OWNER_READINESS_TIMEOUT
         || timeout_elapsed > timeout_upper_bound
         || timeout_readiness_elapsed < CODEX_OWNER_READINESS_TIMEOUT
@@ -36491,7 +36530,9 @@ public static class Program
         || !text.contains(&format!("owner={}", codex_fixture.display()))
         || !text.contains(&format!("identity_file={}", identity_file.display()))
         || !text.contains(&format!("expected_runtime={}", runtime.display()))
-        || text.contains("fixture cleanup also failed")
+        || !text.contains("owner fixture did not stop within five seconds")
+        || !text.contains("fixture cleanup also failed")
+        || windows_process_is_alive(&timeout_child_identity)?
     {
         return Err(io::Error::other(format!(
             "true owner fixture timeout was not bounded and diagnostic: total_elapsed={timeout_elapsed:?} readiness_elapsed={timeout_readiness_elapsed:?} readiness={CODEX_OWNER_READINESS_TIMEOUT:?} scheduler_tolerance={CODEX_OWNER_READINESS_SCHEDULER_TOLERANCE:?} cleanup_budget={CODEX_OWNER_FAILURE_CLEANUP_BUDGET:?} total_upper_bound={timeout_upper_bound:?} readiness_upper_bound={timeout_readiness_upper_bound:?}\n{text}"

--- a/docs/v050-release-architecture.md
+++ b/docs/v050-release-architecture.md
@@ -343,6 +343,24 @@ flowchart TB
     ci --> maintenance
 ```
 
+## Codex MCP owner fixture readiness
+
+```mermaid
+flowchart TB
+    suite[Parallel Windows E2E] --> owner[Spawn compiled Codex owner]
+    owner --> child[Start obsolete MCP child]
+    child --> publish[Atomically publish PID, start time, and path]
+    owner --> poll{Readiness state within named 30 s bound}
+    publish --> poll
+    poll -->|exit or deadline| fail[Typed failure and owned cleanup]
+    poll -->|not ready| pause[Wait 25 ms]
+    pause --> poll
+    poll -->|ready| validate{Exact identity valid?}
+    validate -->|no| fail
+    validate -->|yes| installer[Run existing installer handoff assertions]
+    installer --> cleanup[Owned parent and child cleanup]
+```
+
 ## Production module ownership decision
 
 ```mermaid

--- a/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/.openspec.yaml
+++ b/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/design.md
+++ b/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The Windows installer E2E compiles a small Codex-owner fixture, starts an obsolete ProjectAtlas MCP child, and waits for the owner to atomically publish the child's PID, start time, and executable path. `spawn_codex_owned_obsolete_mcp` currently gives that publication five seconds. During the required parallel workspace gate, the owner/child pair exceeded that startup window and the gate failed after 145 other E2E tests passed; the exact test then passed in isolation. The product installer and MCP runtime were not the failing boundary.
+
+The repair must keep the test fail-closed. A larger wait is acceptable only when it remains named and bounded, preserves parent early-exit and exact identity validation, produces actionable failure diagnostics, and has deterministic proof beyond the former ceiling. #487 moves this owner from the monolithic E2E file into the delivery suite, so the accepted fix must land before that branch is refreshed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make valid Codex-owner child identity publication reliable under the supported parallel Windows workspace load.
+- Keep one named, bounded readiness budget and the existing 25 ms polling cadence.
+- Preserve atomic publication, exact PID/start-time/executable-path validation, early parent-exit detection, and owned-process cleanup.
+- Prove delayed success beyond five seconds and real bounded failure deterministically.
+- Preserve one final helper owner when #487 refreshes onto the accepted fix.
+
+**Non-Goals:**
+
+- Change production installer, MCP, process-retirement, or timeout behavior.
+- Retry a failed release gate until it happens to pass.
+- Serialize unrelated tests or the complete workspace suite.
+- Add a dependency, generic fixture framework, product setting, schema, or cross-platform abstraction.
+
+## Dependencies / Cross-Issue Impact
+
+#518 has no implementation prerequisite and is a direct child and blocker of release owner #492. It must land before #476 is republished and before #487 is accepted because both required Windows gates exercise this fixture owner. The change introduces no product, schema, crate, package, or public compatibility dependency; after it is accepted on `main`, #476 and #487 refresh onto that baseline and rerun their affected proof.
+
+## Decisions
+
+### Use one 30-second test-fixture readiness budget
+
+The owning helper will replace the inline five-second expression with a named 30-second readiness constant. Thirty seconds is bounded, remains small beside the owning installer E2E and workflow limits, and gives process creation enough headroom under parallel Windows CI contention without converting a hung fixture into an unbounded wait.
+
+Alternatives rejected:
+
+- Retrying the test or push would make acceptance nondeterministic.
+- A workspace-global lock would hide contention and serialize unrelated tests.
+- Keeping five seconds and adding sleeps before the broad suite would move the race rather than fix its owner.
+
+### Inject publication delay only into the fixture child process
+
+The compiled owner fixture will accept an optional test-only delay through its own child-process environment. The Rust helper will set that value on the spawned fixture command, never through process-global environment mutation. Existing production-like callers use no delay; a focused regression requests a delay longer than five seconds but shorter than the 30-second budget.
+
+This is the smallest causal seam: it exercises the real executable, child start, atomic identity file, polling loop, identity parser, and cleanup. A mocked clock/file-loop abstraction would add more code while proving less of the Windows process boundary.
+
+### Preserve failure classification before checking readiness
+
+Each poll continues to inspect whether the owner exited before accepting an identity file. A present identity file is parsed through the existing exact PID/start-time/executable-path validation. Timeout diagnostics include the elapsed budget and relevant owner, identity-file, and expected-runtime facts, while cleanup stays in the existing owned-process error path.
+
+The delay seam must not relax malformed/mismatched identity rejection or allow unrelated-process termination. Existing negative paths are reused where they already prove those contracts; only missing causal coverage is added.
+
+### Land before refreshing dependent delivery branches
+
+#518 lands on `main` first. #476 and #487 then refresh onto that exact accepted head; #487 preserves one delivery-suite helper and updates its frozen source/support inventory only as required by the real change. This avoids implementing the same repair in two divergent test layouts.
+
+## Risks / Trade-offs
+
+- [Risk] A true fixture hang takes longer to fail. -> Keep the 30-second constant test-only, preserve early owner-exit detection, and assert a real timeout remains bounded and diagnostic.
+- [Risk] The delay seam leaks into unrelated tests. -> Set it only on the spawned fixture `Command`; never mutate process-global environment.
+- [Risk] #487 loses or duplicates the repair during its split refresh. -> Make #518 a native blocker of #487 and verify one final helper owner after rebase.
+- [Risk] Identity validation is weakened while changing startup timing. -> Reuse the existing identity reader and negative tests without repair, fallback, or guessed process matching.
+
+## Migration Plan
+
+1. Land the accepted test-only helper, deterministic delayed-publication proof, diagram, and gates on `main` through #518.
+2. Refresh #476 and #487 onto the accepted #518 head; preserve one final helper owner and rerun their affected proof.
+3. Roll back #518 as one test-only commit series if the causal regression or broad workspace gate fails; no product or persistent-data migration exists.
+
+## Open Questions
+
+None.

--- a/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/proposal.md
+++ b/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The required Windows workspace gate can reject an otherwise accepted head when the Codex-owned obsolete-MCP fixture does not publish its child PID within a hard-coded five-second startup window under parallel suite contention. The exact test passes in isolation, so retry-only acceptance would hide a release-gate race rather than prove that the broad run is reliable for v0.5.0.
+
+## What Changes
+
+- Define one named, bounded readiness contract for the Codex MCP owner fixture that remains reliable under supported parallel workspace test load.
+- Preserve early parent-exit detection, atomic PID publication, exact PID/start-time/executable-path validation, bounded failure, and complete owned-process cleanup.
+- Add deterministic delayed-publication and true-failure proof so the repair cannot become an unbounded wait or a weakened process-identity assertion.
+- Reconcile the current monolithic test owner with the accepted #487 delivery-test split without duplicating the helper or changing product behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `windows-mcp-owner-fixture-readiness`: Deterministic, bounded Codex-owner/ProjectAtlas-child fixture startup, identity validation, diagnostics, and cleanup under full-suite contention.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects only the Windows CLI integration-test fixture owner and its focused architecture/test proof.
+- Unblocks the strict pre-push workspace gate for #476 and the final delivery-test owner in #487.
+- Adds no dependency, product configuration, public payload, installer/MCP behavior, schema, database path, or production timeout change.
+- Ready for implementation in v0.5.0 after the specification and architecture view are accepted.
+
+## Non-Goals
+
+- Masking product deadlocks or process leaks with an unbounded wait or repeated retry policy.
+- Serializing the complete workspace suite or weakening exact process identity and ownership checks.
+- Changing installer handoff semantics, MCP runtime behavior, or production timeout policy.
+- Adding a general test framework, dependency, product setting, or cross-platform abstraction.

--- a/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/specs/windows-mcp-owner-fixture-readiness/spec.md
+++ b/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/specs/windows-mcp-owner-fixture-readiness/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Fixture readiness is bounded and contention tolerant
+
+The Windows Codex MCP owner integration fixture SHALL use one named readiness budget that admits valid atomic child-identity publication beyond the former five-second ceiling under supported parallel workspace load and SHALL still terminate a missing publication within a finite bound.
+
+#### Scenario: Valid delayed publication exceeds the former ceiling
+
+- **WHEN** the real compiled owner fixture starts its ProjectAtlas MCP child and deliberately delays atomic identity publication for more than five seconds but less than the named readiness budget
+- **THEN** the owning helper accepts the exact published child identity without retrying the test or serializing unrelated workspace tests
+
+#### Scenario: Publication never arrives
+
+- **WHEN** the owner remains alive but does not publish a child identity before the named readiness budget expires
+- **THEN** the helper fails within that bound with elapsed-budget, owner, identity-file, and expected-runtime diagnostics and cleans up only its owned processes
+
+#### Scenario: Owner exits before publication
+
+- **WHEN** the owner fixture exits before publishing the child identity
+- **THEN** the helper reports the exit immediately instead of waiting for the readiness deadline or guessing a child process
+
+### Requirement: Exact process identity and cleanup remain fail closed
+
+The readiness repair SHALL retain atomic publication plus exact child PID, start-time, and executable-path validation, and SHALL NOT terminate or adopt a process whose identity or ownership is unproven.
+
+#### Scenario: Exact identity is published
+
+- **WHEN** the fixture atomically publishes a PID, matching start time, and canonical expected runtime path
+- **THEN** the helper returns that exact typed process identity and the owning installer E2E preserves its existing positive behavior assertions
+
+#### Scenario: Published identity is malformed or mismatched
+
+- **WHEN** the identity file is incomplete, malformed, refers to a reused PID/start time, or names a different executable path
+- **THEN** the helper fails closed with a typed diagnostic and performs no guessed or unrelated process termination
+
+#### Scenario: Failure cleanup runs
+
+- **WHEN** publication, identity validation, or the later installer assertion fails
+- **THEN** the test cleanup stops and waits only for the fixture-owned parent and child processes and leaves unrelated processes untouched
+
+### Requirement: Release and split ownership retain causal proof
+
+The accepted change SHALL pass the focused Windows fixture/installer E2E and the required parallel workspace gate without retry-only acceptance, and #487 SHALL retain exactly one final helper owner after refreshing onto the accepted change.
+
+#### Scenario: Required workspace gate runs under parallel load
+
+- **WHEN** the unchanged required Windows workspace test command executes the owning fixture alongside the broader suite
+- **THEN** valid delayed startup does not fail at the former five-second boundary and all true failure paths remain bounded
+
+#### Scenario: Delivery suite is refreshed
+
+- **WHEN** #487 refreshes its split delivery-test owner onto the accepted #518 main revision
+- **THEN** the readiness helper, delay seam, diagnostics, and causal tests exist exactly once in the final delivery owner and its frozen inventory reflects the real source
+
+#### Scenario: Product surfaces remain unchanged
+
+- **WHEN** the test-only change is built and exercised
+- **THEN** CLI/MCP payloads, installer handoff behavior, project-root selection, generated configuration, schemas, persistent state, and supported non-Windows behavior remain unchanged

--- a/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/tasks.md
+++ b/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/tasks.md
@@ -1,0 +1,14 @@
+## 1. Specification and Architecture
+
+- [x] 1.1 Finalize and map the sanitized Windows fixture-readiness contract, accepted complexity, v0.5 release relationships, non-goals, failure modes, and exact implementation/test ownership before implementation.
+- [x] 1.2 Add a focused Codex MCP owner fixture readiness/cleanup architecture view to the existing v0.5 release architecture document; render it with the locked Mermaid toolchain and inspect visual communication plus semantic truth.
+
+## 2. Bounded Fixture Readiness
+
+- [ ] 2.1 Replace the hard-coded five-second child-PID publication assumption at the smallest owning Windows delivery-test helper with one named bounded readiness contract; preserve 25 ms polling or an equally bounded existing mechanism, parent early-exit detection, atomic identity publication, exact PID/start-time/executable-path validation, actionable timeout diagnostics, and complete owned-process cleanup.
+- [ ] 2.2 Add deterministic regression proof whose valid publication exceeds the former five-second ceiling plus negative coverage for true timeout, early parent exit, malformed or mismatched identity, and cleanup; do not weaken or duplicate the existing production-installer behavior assertions.
+
+## 3. Integration and Acceptance
+
+- [ ] 3.1 Run the focused fixture and installer E2E, repeated required parallel workspace gate, strict Rust/workspace/OpenSpec/IssueOps checks, and exact-head hosted Windows proof; refresh dependent #476 and #487 only after the accepted fix is on `main`, and confirm #487 retains one final helper owner.
+- [ ] 3.2 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/tasks.md
+++ b/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/tasks.md
@@ -5,8 +5,8 @@
 
 ## 2. Bounded Fixture Readiness
 
-- [ ] 2.1 Replace the hard-coded five-second child-PID publication assumption at the smallest owning Windows delivery-test helper with one named bounded readiness contract; preserve 25 ms polling or an equally bounded existing mechanism, parent early-exit detection, atomic identity publication, exact PID/start-time/executable-path validation, actionable timeout diagnostics, and complete owned-process cleanup.
-- [ ] 2.2 Add deterministic regression proof whose valid publication exceeds the former five-second ceiling plus negative coverage for true timeout, early parent exit, malformed or mismatched identity, and cleanup; do not weaken or duplicate the existing production-installer behavior assertions.
+- [x] 2.1 Replace the hard-coded five-second child-PID publication assumption at the smallest owning Windows delivery-test helper with one named bounded readiness contract; preserve 25 ms polling or an equally bounded existing mechanism, parent early-exit detection, atomic identity publication, exact PID/start-time/executable-path validation, actionable timeout diagnostics, and complete owned-process cleanup.
+- [x] 2.2 Add deterministic regression proof whose valid publication exceeds the former five-second ceiling plus negative coverage for true timeout, early parent exit, malformed or mismatched identity, and cleanup; do not weaken or duplicate the existing production-installer behavior assertions.
 
 ## 3. Integration and Acceptance
 

--- a/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/tasks.md
+++ b/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/tasks.md
@@ -5,8 +5,8 @@
 
 ## 2. Bounded Fixture Readiness
 
-- [x] 2.1 Replace the hard-coded five-second child-PID publication assumption at the smallest owning Windows delivery-test helper with one named bounded readiness contract; preserve 25 ms polling or an equally bounded existing mechanism, parent early-exit detection, atomic identity publication, exact PID/start-time/executable-path validation, actionable timeout diagnostics, and complete owned-process cleanup.
-- [x] 2.2 Add deterministic regression proof whose valid publication exceeds the former five-second ceiling plus negative coverage for true timeout, early parent exit, malformed or mismatched identity, and cleanup; do not weaken or duplicate the existing production-installer behavior assertions.
+- [ ] 2.1 Replace the hard-coded five-second child-PID publication assumption at the smallest owning Windows delivery-test helper with one named bounded readiness contract; preserve 25 ms polling or an equally bounded existing mechanism, parent early-exit detection, atomic identity publication, exact PID/start-time/executable-path validation, actionable timeout diagnostics, and complete owned-process cleanup.
+- [ ] 2.2 Add deterministic regression proof whose valid publication exceeds the former five-second ceiling plus negative coverage for true timeout, early parent exit, malformed or mismatched identity, and cleanup; do not weaken or duplicate the existing production-installer behavior assertions.
 
 ## 3. Integration and Acceptance
 

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -14,7 +14,7 @@
         "456": { "blocked_by": [358, 465, 477, 484] },
         "464": { "blocked_by": [] },
         "465": { "blocked_by": [476, 480, 488] },
-        "476": { "blocked_by": [481] },
+        "476": { "blocked_by": [481, 518] },
         "477": { "blocked_by": [] },
         "480": { "blocked_by": [482] },
         "481": { "blocked_by": [482] },
@@ -23,14 +23,15 @@
         "484": { "blocked_by": [476, 481] },
         "485": { "blocked_by": [484, 486] },
         "486": { "blocked_by": [482, 483] },
-        "487": { "blocked_by": [] },
+        "487": { "blocked_by": [518] },
         "488": { "blocked_by": [] },
         "489": { "blocked_by": [] },
         "490": { "blocked_by": [339, 342, 358, 384, 464, 465, 489] },
         "491": { "blocked_by": [] },
-        "492": { "blocked_by": [339, 342, 358, 372, 384, 388, 390, 456, 464, 465, 476, 477, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 495, 517] },
+        "492": { "blocked_by": [339, 342, 358, 372, 384, 388, 390, 456, 464, 465, 476, 477, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 495, 517, 518] },
         "495": { "blocked_by": [] },
-        "517": { "blocked_by": [] }
+        "517": { "blocked_by": [] },
+        "518": { "blocked_by": [] }
       }
     },
     "v0.6.0-00": {
@@ -185,6 +186,7 @@
     "serialize-lint-reports": 472,
     "simplify-token-tui-dashboard": 296,
     "stabilize-hostile-parser-fixture-admission": 397,
+    "stabilize-windows-mcp-owner-fixture-readiness": 518,
     "stabilize-parser-recovery-harness": 391
   }
 }


### PR DESCRIPTION
## Summary

- Replace the fixture's five-second child identity publication assumption with one bounded 30-second readiness contract.
- Preserve early parent-exit handling, atomic identity publication, exact PID/start-time/canonical executable-path checks, actionable timeout diagnostics, and owned-process cleanup.
- Add deterministic delayed-publication and causal negative-boundary coverage without changing product installer or MCP behavior.

## Validation

- Focused Windows fixture readiness, delayed publication, timeout, early-exit, identity, and cleanup proof passed repeatedly.
- The exact owning installer E2E selector and required Rust quality gates passed on the accepted head.
- IssueOps checklist parity: local 6 / remote 6 / checked 4.

Refs #518
