### PR TITLE
docs(openspec): specify E2E observer deadlines

### DIFF
--- a/openspec/changes/enforce-e2e-process-observer-deadlines/.openspec.yaml
+++ b/openspec/changes/enforce-e2e-process-observer-deadlines/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/enforce-e2e-process-observer-deadlines/design.md
+++ b/openspec/changes/enforce-e2e-process-observer-deadlines/design.md
@@ -1,0 +1,54 @@
+## Context
+
+`McpContractSession::shutdown`, `run_mcp_stdio_with_env`, and `wait_for_plugin_installer_output` each poll a child under an explicit deadline. Their current loops accept `try_wait` completion before testing the deadline, so a descheduled observer can wake after the deadline and report success for a completion it did not establish in time. The helpers already own the necessary child, clock, cleanup, status, and output behavior; this is an ordering defect, not a missing process framework.
+
+The existing [CLI E2E contract ownership split](../../../docs/v050-release-architecture.md#cli-e2e-contract-ownership-split) remains accurate: these are shared test-process helpers consumed by MCP, installer, and release contracts. No architecture diagram changes are required.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make an observation at or after the absolute deadline a timeout before completion can be accepted.
+- Preserve child termination/reaping, captured output, exit-status validation, diagnostics, and in-time success.
+- Prove the ordering causally by delaying the observer independently from child completion.
+
+**Non-Goals:**
+
+- New retry, locking, serialization, timeout configuration, dependency, or shared process abstraction.
+- Product runtime, CLI/MCP protocol, installer behavior, or database changes.
+- Changes to #518's Windows Codex-owner readiness and cleanup helpers.
+
+## Decisions
+
+### Check the deadline before the acceptance poll
+
+Each owning loop will derive one absolute deadline and classify `Instant::now() >= deadline` before a completed status can enter its success path. An expired branch may still use `try_wait` to decide whether termination is necessary, but it must always reap the exact child and return the existing timeout class with the available diagnostics.
+
+Checking only the elapsed time after `try_wait`, or adding scheduler slack, was rejected because either keeps completion authoritative after the contract expired or merely makes the race less frequent.
+
+### Keep the correction local to the three concrete owners
+
+The helpers have different return values and cleanup/output obligations, so each receives the same small ordering correction at its existing ownership boundary. A generic polling framework or trait would add indirection without reducing the three distinct state transitions.
+
+### Add test-only causal observation delays
+
+Narrow test-only seams will delay the first completion observation while fixtures complete promptly. Regressions will assert timeout classification plus exact child reaping, alongside compatible in-deadline success. Ordinary sleeping children alone were rejected because they do not distinguish child lateness from observer lateness.
+
+## Risks / Trade-offs
+
+- **Exact deadline-edge behavior becomes stricter** → Specify and test `>=` so equality cannot depend on loop ordering.
+- **A timed-out child may already be complete** → Probe only for cleanup disposition, never acceptance, then reap it and retain timeout classification.
+- **Test seams could leak into production behavior** → Keep them private to the E2E test module and reuse the normal helper paths.
+- **Shared-file conflict with #518** → Start implementation only after the #518 amendment no longer owns a mutable `e2e.rs` boundary; rebase onto accepted `main` before proof.
+
+## Migration Plan
+
+No state migration is required. Land the three local corrections and causal regressions together; rollback is the ordinary commit revert if the exact release proof exposes a compatibility regression.
+
+## Dependencies / Cross-Issue Impact
+
+#518's accepted shared `e2e.rs` baseline is already on `main`, so #523 has no remaining native blocker. #523 owns only the three named generic observers and their causal regressions. If #487's accepted test split lands afterward, it must refresh onto #523 and retain exactly one final helper owner without weakening these assertions. #523 remains one direct child and blocker of release owner #492; no product, schema, installer, or MCP dependency is introduced.
+
+## Open Questions
+
+None.

--- a/openspec/changes/enforce-e2e-process-observer-deadlines/proposal.md
+++ b/openspec/changes/enforce-e2e-process-observer-deadlines/proposal.md
@@ -22,7 +22,7 @@ None.
 
 - Affects only generic process-observer helpers and their tests in `crates/projectatlas-cli/tests/e2e.rs`.
 - Adds no product CLI/MCP behavior, public schema, crate, dependency, workflow, database, migration, or persistent state.
-- The change is ready for implementation after its issue/OpenSpec packet is accepted, but its shared-file implementation lane must not overlap the active #518 amendment.
+- The #518 shared-file baseline is accepted on `main`, so this change has no remaining implementation prerequisite.
 
 ## Non-Goals
 

--- a/openspec/changes/enforce-e2e-process-observer-deadlines/proposal.md
+++ b/openspec/changes/enforce-e2e-process-observer-deadlines/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Three generic E2E subprocess observers can accept a child that completed before polling resumed even when the observation occurs after the caller's explicit deadline. This can turn a late, invalid test observation into apparent success and weaken v0.5.0-rc1 release proof under ordinary scheduler contention.
+
+## What Changes
+
+- Classify deadline expiry before accepting child completion in the shared MCP-session, MCP-process, and installer-output E2E observers.
+- Preserve bounded output collection, status validation, child termination/reaping, diagnostics, and all existing successful in-deadline behavior.
+- Add causal delayed-observer regressions that distinguish completion time from observation time without retries, global locks, suite serialization, or extra scheduler slack.
+
+## Capabilities
+
+### New Capabilities
+
+- `e2e-process-observer-deadlines`: Require generic subprocess test observers to reject completion first observed at or after their deadline while preserving exact cleanup and compatible in-time success.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects only generic process-observer helpers and their tests in `crates/projectatlas-cli/tests/e2e.rs`.
+- Adds no product CLI/MCP behavior, public schema, crate, dependency, workflow, database, migration, or persistent state.
+- The change is ready for implementation after its issue/OpenSpec packet is accepted, but its shared-file implementation lane must not overlap the active #518 amendment.
+
+## Non-Goals
+
+- Changing subprocess timeout durations, adding retries, or serializing the E2E suite.
+- Refactoring all process helpers into a new framework or abstraction.
+- Expanding #518's Windows Codex-owner fixture boundary into this issue.
+- Claiming that a process completed within its deadline when the observer did not establish that fact in time.

--- a/openspec/changes/enforce-e2e-process-observer-deadlines/specs/e2e-process-observer-deadlines/spec.md
+++ b/openspec/changes/enforce-e2e-process-observer-deadlines/specs/e2e-process-observer-deadlines/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Generic subprocess observers classify deadline expiry before completion
+
+Every generic E2E child-process observer covered by this change MUST classify an observation made at or after its absolute deadline as timed out before accepting child completion. The timeout path MUST terminate the exact child only when still running, reap it in all cases, preserve available output and diagnostics, and MUST NOT report successful completion.
+
+#### Scenario: Completed child is first observed after the deadline
+
+- **WHEN** a child completes promptly but the owning observer first resumes at or after its absolute deadline
+- **THEN** the observer SHALL return its timeout classification, SHALL reap the exact child, and SHALL NOT accept the completed status or output as an in-time success
+
+#### Scenario: Running child reaches the deadline
+
+- **WHEN** the observer reaches its absolute deadline while the exact child remains running
+- **THEN** the observer SHALL terminate and reap that child and return the existing bounded timeout diagnostic with all safely available output
+
+#### Scenario: Child completion is observed before the deadline
+
+- **WHEN** the observer establishes child completion before its absolute deadline
+- **THEN** it SHALL retain the existing output collection, exit-status validation, diagnostics, and success or failure behavior
+
+### Requirement: Deadline-ordering proof is causal and scheduler independent
+
+Owning regressions MUST control observer delay independently from prompt child completion for `McpContractSession::shutdown`, `run_mcp_stdio_with_env`, and `wait_for_plugin_installer_output`. Proof MUST cover late observation and compatible in-time completion without retries, suite serialization, global locks, or enlarged timeout slack.
+
+#### Scenario: Observer delay crosses the deadline after prompt completion
+
+- **WHEN** a test fixture completes within its allowance and a test-only seam delays the observer until the deadline has expired
+- **THEN** the regression SHALL causally exercise the timeout-before-completion branch and verify exact child cleanup
+
+#### Scenario: Normal observer scheduling remains compatible
+
+- **WHEN** the same helpers observe valid completion within their existing deadlines under the normal parallel test schedule
+- **THEN** focused and workspace proof SHALL retain their prior successful behavior and bounded resource cleanup

--- a/openspec/changes/enforce-e2e-process-observer-deadlines/tasks.md
+++ b/openspec/changes/enforce-e2e-process-observer-deadlines/tasks.md
@@ -1,0 +1,14 @@
+## 1. Contract And Issue Alignment
+
+- [x] 1.1 Map `enforce-e2e-process-observer-deadlines` to GitHub issue #523, keep it a direct child and blocker of release owner #492 with no fabricated prerequisite, synchronize the exact issue/OpenSpec packet and `v0.5.0-00` milestone, and pass strict OpenSpec validation.
+- [x] 1.2 Reconcile the issue and design against the existing CLI E2E contract-ownership diagram, update that durable view if its shared-process ownership is inaccurate, or retain it unchanged with a reasoned semantic review.
+
+## 2. Deadline Classification And Cleanup
+
+- [ ] 2.1 Make `McpContractSession::shutdown`, `run_mcp_stdio_with_env`, and `wait_for_plugin_installer_output` classify `Instant::now() >= deadline` before accepting completion while preserving exact-child termination/reaping, output, status, diagnostics, and in-deadline compatibility without a new process framework.
+- [ ] 2.2 Add narrow test-only observer-delay seams and causal late-observation regressions for all three helpers, including prompt child completion, timeout classification, exact cleanup, normal in-time success, and no retries, locks, serialization, or scheduler slack.
+
+## 3. Verification And Delivery
+
+- [ ] 3.1 Run the owning causal regressions, affected MCP/installer E2E, formatting and diff checks, and the normal parallel locked workspace suite with explicit timeouts; retain failure/status/output compatibility and bounded CPU, memory, process, and wall-time behavior.
+- [ ] 3.2 Rebase onto the accepted shared `e2e.rs` baseline after #518, pass strict OpenSpec and live IssueOps, resolve every exact-head review finding, pass hosted checks, and reconcile the final implementation, specification, architecture link, issue tasks, and release graph without weakening #492's holistic release proof.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -14,7 +14,7 @@
         "456": { "blocked_by": [358, 465, 477, 484] },
         "464": { "blocked_by": [] },
         "465": { "blocked_by": [476, 480, 488] },
-        "476": { "blocked_by": [481, 518] },
+        "476": { "blocked_by": [481] },
         "477": { "blocked_by": [] },
         "480": { "blocked_by": [482] },
         "481": { "blocked_by": [482] },
@@ -23,15 +23,16 @@
         "484": { "blocked_by": [476, 481] },
         "485": { "blocked_by": [484, 486] },
         "486": { "blocked_by": [482, 483] },
-        "487": { "blocked_by": [518] },
+        "487": { "blocked_by": [] },
         "488": { "blocked_by": [] },
         "489": { "blocked_by": [] },
         "490": { "blocked_by": [339, 342, 358, 384, 464, 465, 489] },
         "491": { "blocked_by": [] },
-        "492": { "blocked_by": [339, 342, 358, 372, 384, 388, 390, 456, 464, 465, 476, 477, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 495, 517, 518] },
+        "492": { "blocked_by": [339, 342, 358, 372, 384, 388, 390, 456, 464, 465, 476, 477, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 495, 517, 518, 523] },
         "495": { "blocked_by": [] },
         "517": { "blocked_by": [] },
-        "518": { "blocked_by": [] }
+        "518": { "blocked_by": [] },
+        "523": { "blocked_by": [] }
       }
     },
     "v0.6.0-00": {
@@ -130,6 +131,7 @@
     "connect-classified-documentation-graph": 440,
     "delegate-bulk-purpose-curation": 301,
     "drain-mcp-test-responses-before-eof": 416,
+    "enforce-e2e-process-observer-deadlines": 523,
     "enforce-issue-acceptance-review-tasks": 517,
     "enforce-rust-test-quality-gates": 309,
     "expose-concrete-codex-tool-schemas": 386,


### PR DESCRIPTION
## Summary
- specify fail-closed absolute-deadline handling for the three existing E2E process observers
- map #523 into the v0.5 release graph and reconcile obsolete dependency edges with live GitHub state
- keep implementation and behavior proof explicitly pending

## Validation
- `openspec validate enforce-e2e-process-observer-deadlines --strict`
- `python .github/scripts/issue-checklists.py --self-test`
- `python .github/scripts/issue-checklists.py --repo styler-ai/ProjectAtlas --root . --planned-issue 523`
- `git diff --check`

Relates to #523