### PR TITLE
docs(openspec): specify Windows output-bound proof (#525)

### DIFF
--- a/openspec/changes/stabilize-windows-runtime-output-bound-proof/.openspec.yaml
+++ b/openspec/changes/stabilize-windows-runtime-output-bound-proof/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/stabilize-windows-runtime-output-bound-proof/design.md
+++ b/openspec/changes/stabilize-windows-runtime-output-bound-proof/design.md
@@ -1,0 +1,40 @@
+## Context
+
+`windows_installer_fresh_path_probe_respects_machine_precedence` currently calls the private PowerShell runtime validator and infers that the one-MiB live output limit fired when the whole call returns in less than four seconds. The owned `.cmd` fixture first launches another PowerShell process, so hosted-runner startup delay can consume that assertion budget before output begins. The production helper already has separate output-limit and five-second-timeout branches, but its nullable payload result does not expose which rejection branch the test exercised.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the Windows E2E assert the actual output-limit disposition instead of an arbitrary pre-launch wall-clock proxy.
+- Preserve the same five-second timeout, one-MiB ceiling, exact owned-process stop/reap behavior, cleanup, and nullable production result.
+- Causally cover output-limit and true-timeout branches under ordinary parallel execution.
+
+**Non-Goals:**
+
+- New process infrastructure, dependencies, retries, suite serialization, or larger resource bounds.
+- Installer, PATH, MCP, database, CLI, or public payload behavior changes.
+- Cross-platform abstraction for one Windows-only fixture.
+
+## Decisions
+
+### Expose one optional private probe disposition for tests
+
+Extend the existing private `Invoke-ProjectAtlasBoundedJsonCommand` helper with one optional test-observation sink, omitted by every production caller. Set it immediately at the existing output-limit or timeout decision before the same owned-process stop path runs. The normal nullable payload and all production calls remain unchanged.
+
+This is smaller and more causal than adding scheduler slack, inferring the branch from total elapsed time, preserving random temporary probe files, or introducing a process-test framework.
+
+### Make the fixture finite and branch-specific
+
+Use the existing owned Windows fixture to emit more than the existing output ceiling and then remain alive. Assert the explicit output-limit disposition, rejected payload, exact child cleanup, and probe-file cleanup. Keep a separate non-flooding owned process for the true timeout disposition. A test-owned startup delay may reproduce contention, but it is not itself the success criterion.
+
+### Preserve the existing ownership boundary
+
+The test remains in the current Windows delivery E2E owner and follows #487's accepted move when that branch lands. No product module, shared test framework, workflow, schema, or architecture diagram changes.
+
+## Risks / Trade-offs
+
+- [Risk] A test observation changes production control flow. -> Make it optional, assign only at existing branch points, and prove identical production-facing results with the sink omitted.
+- [Risk] The fixture still passes without exceeding the ceiling. -> Emit a finite payload strictly larger than the existing bound before blocking and assert the output-limit disposition.
+- [Risk] The fix races ongoing E2E ownership changes. -> Start implementation only from the accepted shared baseline and preserve the final single #487 owner.
+- [Risk] A disposition string becomes a new public contract. -> Keep it private to the installer script/test boundary and do not serialize or document it as product output.

--- a/openspec/changes/stabilize-windows-runtime-output-bound-proof/design.md
+++ b/openspec/changes/stabilize-windows-runtime-output-bound-proof/design.md
@@ -38,3 +38,15 @@ The test remains in the current Windows delivery E2E owner and follows #487's ac
 - [Risk] The fixture still passes without exceeding the ceiling. -> Emit a finite payload strictly larger than the existing bound before blocking and assert the output-limit disposition.
 - [Risk] The fix races ongoing E2E ownership changes. -> Start implementation only from the accepted shared baseline and preserve the final single #487 owner.
 - [Risk] A disposition string becomes a new public contract. -> Keep it private to the installer script/test boundary and do not serialize or document it as product output.
+
+## Migration Plan
+
+No data or schema migration. Land the private observation and causal Windows fixtures together; rollback is a direct revert of that script/test change.
+
+## Dependencies / Cross-Issue Impact
+
+No prerequisite issue. If #487 lands first, refresh onto its accepted test-ownership move; #518 and #523 remain separate E2E boundaries.
+
+## Open Questions
+
+None.

--- a/openspec/changes/stabilize-windows-runtime-output-bound-proof/proposal.md
+++ b/openspec/changes/stabilize-windows-runtime-output-bound-proof/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The Windows installer E2E currently measures its output-flooding probe from before the nested writer process starts. Under ordinary hosted-runner contention, process startup can consume the test's four-second assertion budget even when the one-MiB live output bound stops the probe correctly, making a required release gate flaky and non-causal.
+
+## What Changes
+
+- Measure output-bound enforcement from one test-owned writer-readiness observation instead of charging nested-process startup delay to the byte-limit assertion.
+- Distinguish delayed startup, live output-limit termination, and the existing true five-second timeout while preserving exact owned-process cleanup and fail-closed runtime validation.
+- Keep installer/runtime behavior, the five-second product timeout, the one-MiB output ceiling, public contracts, dependencies, and suite parallelism unchanged unless the causal fixture proves a separate product defect.
+- Treat this as backlog specification work until the packet and issue mirror are published on `main`; only then may #525 enter `v0.5.0-00` and implementation routing.
+
+Non-goals:
+
+- Increasing timeout or output limits, retrying, or serializing the Windows suite.
+- Adding a process-test framework, dependency, persistent state, or cross-platform abstraction.
+- Changing installer, PATH, runtime, MCP, database, or public CLI behavior without a separately reproduced defect.
+
+## Capabilities
+
+### New Capabilities
+
+- `windows-runtime-output-bound-proof`: deterministic causal Windows proof that installer-owned runtime probes enforce their live output ceiling independently of nested-process startup delay.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Windows-only CLI E2E fixture code in the existing delivery-test owner.
+- Existing `Invoke-ProjectAtlasBoundedJsonCommand` behavior is observed but is not expected to change.
+- OpenSpec/IssueOps mapping and the v0.5 release graph after published readiness.
+- No Rust product source, SQLite schema, dependency, workflow, installer contract, or public payload change is expected.

--- a/openspec/changes/stabilize-windows-runtime-output-bound-proof/proposal.md
+++ b/openspec/changes/stabilize-windows-runtime-output-bound-proof/proposal.md
@@ -4,7 +4,7 @@ The Windows installer E2E currently measures its output-flooding probe from befo
 
 ## What Changes
 
-- Measure output-bound enforcement from one test-owned writer-readiness observation instead of charging nested-process startup delay to the byte-limit assertion.
+- Assert output-bound enforcement from one optional private output-limit/timeout disposition at the existing decision points; writer readiness may coordinate the fixture but is not the branch oracle.
 - Distinguish delayed startup, live output-limit termination, and the existing true five-second timeout while preserving exact owned-process cleanup and fail-closed runtime validation.
 - Keep installer/runtime behavior, the five-second product timeout, the one-MiB output ceiling, public contracts, dependencies, and suite parallelism unchanged unless the causal fixture proves a separate product defect.
 - Treat this as backlog specification work until the packet and issue mirror are published on `main`; only then may #525 enter `v0.5.0-00` and implementation routing.

--- a/openspec/changes/stabilize-windows-runtime-output-bound-proof/specs/windows-runtime-output-bound-proof/spec.md
+++ b/openspec/changes/stabilize-windows-runtime-output-bound-proof/specs/windows-runtime-output-bound-proof/spec.md
@@ -20,7 +20,7 @@ Production installer callers SHALL continue to receive the existing nullable val
 
 #### Scenario: Invalid, flooding, hanging, or cleanup-failing runtime
 - **WHEN** runtime execution violates validation, resource, exit, or cleanup requirements
-- **THEN** the same null/fail-closed production result is returned and only the exact installer-owned process and temporary probe files are cleaned
+- **THEN** the same null/fail-closed production result is returned, bounded cleanup is attempted only for the exact installer-owned process and temporary probe files, and deletion failure is not reported as successful cleanup or validation
 
 ### Requirement: The release gate is reliable under ordinary parallel load
 The focused Windows fixture and the ordinary parallel locked workspace gate SHALL pass without retries, suite serialization, timeout inflation, global locks, or test-only acceptance of a true timeout.

--- a/openspec/changes/stabilize-windows-runtime-output-bound-proof/specs/windows-runtime-output-bound-proof/spec.md
+++ b/openspec/changes/stabilize-windows-runtime-output-bound-proof/specs/windows-runtime-output-bound-proof/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Windows runtime-probe output limits have causal test proof
+The existing private Windows installer runtime probe SHALL expose enough optional test-only observation to distinguish live output-limit termination from true timeout without changing its production payload, timeout, output ceiling, or process lifecycle.
+
+#### Scenario: Delayed writer exceeds the live ceiling
+- **WHEN** an owned runtime writer starts after an injected fixture delay, emits more than the existing one-MiB ceiling, and remains alive
+- **THEN** the test observes output-limit termination, a rejected payload, exact owned-process reaping, and complete probe-file cleanup without using total pre-launch elapsed time as the branch oracle
+
+#### Scenario: Writer never exceeds the ceiling
+- **WHEN** an owned runtime remains alive without producing a valid payload or exceeding the byte ceiling
+- **THEN** the test observes the existing five-second timeout disposition and the same exact cleanup instead of accepting output-limit success
+
+### Requirement: Production runtime validation remains unchanged
+Production installer callers SHALL continue to receive the existing nullable validated JSON result and SHALL retain the five-second timeout, one-MiB per-probe-file ceiling, strict UTF-8/JSON validation, fail-closed errors, and exact owned-process cleanup. No test observation SHALL be emitted through CLI, installer, MCP, or machine-readable product output.
+
+#### Scenario: Valid bounded runtime
+- **WHEN** a runtime exits successfully inside the existing limits with valid strict JSON
+- **THEN** the same validated payload is returned with no additional output or persistent state
+
+#### Scenario: Invalid, flooding, hanging, or cleanup-failing runtime
+- **WHEN** runtime execution violates validation, resource, exit, or cleanup requirements
+- **THEN** the same null/fail-closed production result is returned and only the exact installer-owned process and temporary probe files are cleaned
+
+### Requirement: The release gate is reliable under ordinary parallel load
+The focused Windows fixture and the ordinary parallel locked workspace gate SHALL pass without retries, suite serialization, timeout inflation, global locks, or test-only acceptance of a true timeout.
+
+#### Scenario: Hosted runner contention
+- **WHEN** nested-process startup is delayed by ordinary scheduler contention
+- **THEN** the test decides from the actual probe disposition and cleanup outcome rather than an arbitrary shorter wall-clock threshold

--- a/openspec/changes/stabilize-windows-runtime-output-bound-proof/tasks.md
+++ b/openspec/changes/stabilize-windows-runtime-output-bound-proof/tasks.md
@@ -1,0 +1,14 @@
+## 1. Contract And Issue Alignment
+
+- [x] 1.1 Map `stabilize-windows-runtime-output-bound-proof` to GitHub issue #525, synchronize the exact issue/OpenSpec packet and `complexity:medium` classification, and keep milestone, hierarchy, dependency, and `status:ready` mutations deferred until the packet is published on `main`.
+- [x] 1.2 Reconcile the issue and design with the existing CLI E2E contract-ownership diagram and retain that durable view unchanged only if its Windows delivery-test and shared-process ownership remains accurate.
+
+## 2. Causal Output-Bound Proof
+
+- [ ] 2.1 Add one optional private test-observation sink at the existing Windows bounded-runtime-probe helper so output-limit and timeout decisions are distinguishable while every production caller retains the same nullable payload, five-second timeout, one-MiB ceiling, strict validation, and exact cleanup.
+- [ ] 2.2 Replace the pre-launch four-second proxy with causal owned fixtures for delayed startup plus finite over-ceiling output and for true timeout; prove explicit disposition, rejected payload, exact process-tree reaping, probe-file cleanup, and normal valid-runtime compatibility without retry, serialization, global locks, or resource-bound changes.
+
+## 3. Verification And Delivery
+
+- [ ] 3.1 Run PowerShell syntax/static checks, the focused Windows installer E2E, repeated ordinary parallel locked workspace proof with explicit timeouts, formatting/diff checks, and all affected Rust/workspace gates; preserve bounded CPU, memory, output, process, and wall-time behavior.
+- [ ] 3.2 Refresh onto the accepted shared E2E baseline, pass strict OpenSpec and live IssueOps, resolve every exact-head review finding, pass hosted Windows and required cross-platform checks, and reconcile the final source, test owner, issue tasks, architecture link, and #492 release graph.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -28,11 +28,12 @@
         "489": { "blocked_by": [] },
         "490": { "blocked_by": [339, 342, 358, 384, 464, 465, 489] },
         "491": { "blocked_by": [] },
-        "492": { "blocked_by": [339, 342, 358, 372, 384, 388, 390, 456, 464, 465, 476, 477, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 495, 517, 518, 523] },
+        "492": { "blocked_by": [339, 342, 358, 372, 384, 388, 390, 456, 464, 465, 476, 477, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 495, 517, 518, 523, 525] },
         "495": { "blocked_by": [] },
         "517": { "blocked_by": [] },
         "518": { "blocked_by": [] },
-        "523": { "blocked_by": [] }
+        "523": { "blocked_by": [] },
+        "525": { "blocked_by": [] }
       }
     },
     "v0.6.0-00": {
@@ -189,6 +190,7 @@
     "simplify-token-tui-dashboard": 296,
     "stabilize-hostile-parser-fixture-admission": 397,
     "stabilize-windows-mcp-owner-fixture-readiness": 518,
+    "stabilize-windows-runtime-output-bound-proof": 525,
     "stabilize-parser-recovery-harness": 391
   }
 }


### PR DESCRIPTION
Relates to #525

Defines the minimal implementation and proof boundary for separating the Windows runtime output-limit assertion from host startup delay. This planning PR intentionally does not close the issue.