### PR TITLE
fix(test): keep observer probes causally live

### DIFF
--- a/crates/projectatlas-cli/tests/e2e.rs
+++ b/crates/projectatlas-cli/tests/e2e.rs
@@ -34875,7 +34875,6 @@ impl McpContractSession {
                 },
             );
             if let Err(error) = synchronization {
-                self.stdin.take();
                 let stdout_reader = self.stdout_reader.take();
                 let stderr_reader = self.stderr_reader.take();
                 let mut child = self
@@ -34883,6 +34882,7 @@ impl McpContractSession {
                     .take()
                     .ok_or_else(|| io::Error::other("MCP contract child was consumed"))?;
                 let kill_result = kill_child(&mut child);
+                self.stdin.take();
                 let status_after_kill = child.try_wait();
                 if kill_result.is_err() && !matches!(&status_after_kill, Ok(Some(_))) {
                     let packet = McpContractCleanupPacket {
@@ -35483,8 +35483,8 @@ fn run_mcp_stdio_with_env_and_test_delay_and_kill_and_handoff(
             exit_probe_error.take(),
         )
     {
-        stdin.take();
         let kill_result = kill_child(&mut child);
+        stdin.take();
         let status_after_kill = child.try_wait();
         if kill_result.is_err() && !matches!(&status_after_kill, Ok(Some(_))) {
             if let Some(handoff) = handoff_live_child {
@@ -39527,8 +39527,8 @@ fn wait_for_plugin_installer_output_with_test_delay_and_kill_and_handoff(
             exit_probe_error.take(),
         )
     {
-        child.stdin.take();
         let kill_result = kill_child(&mut child);
+        child.stdin.take();
         let status_after_kill = child.try_wait();
         if kill_result.is_err() && !matches!(&status_after_kill, Ok(Some(_))) {
             if let Some(handoff) = handoff_live_child {

--- a/openspec/changes/enforce-e2e-process-observer-deadlines/tasks.md
+++ b/openspec/changes/enforce-e2e-process-observer-deadlines/tasks.md
@@ -11,4 +11,4 @@
 ## 3. Verification And Delivery
 
 - [x] 3.1 Run the owning causal regressions, affected MCP/installer E2E, formatting and diff checks, and the normal parallel locked workspace suite with explicit timeouts; retain failure/status/output compatibility and bounded CPU, memory, process, and wall-time behavior.
-- [x] 3.2 Rebase onto the accepted shared `e2e.rs` baseline after #518, pass strict OpenSpec and live IssueOps, resolve every exact-head review finding, pass hosted checks, and reconcile the final implementation, specification, architecture link, issue tasks, and release graph without weakening #492's holistic release proof.
+- [ ] 3.2 Rebase onto the accepted shared `e2e.rs` baseline after #518, pass strict OpenSpec and live IssueOps, resolve every exact-head review finding, pass hosted checks, and reconcile the final implementation, specification, architecture link, issue tasks, and release graph without weakening #492's holistic release proof.

--- a/openspec/changes/enforce-e2e-process-observer-deadlines/tasks.md
+++ b/openspec/changes/enforce-e2e-process-observer-deadlines/tasks.md
@@ -11,4 +11,4 @@
 ## 3. Verification And Delivery
 
 - [x] 3.1 Run the owning causal regressions, affected MCP/installer E2E, formatting and diff checks, and the normal parallel locked workspace suite with explicit timeouts; retain failure/status/output compatibility and bounded CPU, memory, process, and wall-time behavior.
-- [ ] 3.2 Rebase onto the accepted shared `e2e.rs` baseline after #518, pass strict OpenSpec and live IssueOps, resolve every exact-head review finding, pass hosted checks, and reconcile the final implementation, specification, architecture link, issue tasks, and release graph without weakening #492's holistic release proof.
+- [x] 3.2 Rebase onto the accepted shared `e2e.rs` baseline after #518, pass strict OpenSpec and live IssueOps, resolve every exact-head review finding, pass hosted checks, and reconcile the final implementation, specification, architecture link, issue tasks, and release graph without weakening #492's holistic release proof.


### PR DESCRIPTION
Closes #523

## Summary
- keep owned stdin alive through each exact-child termination probe
- preserve causal timeout cleanup for MCP session, stdio, and installer observers

## Validation
- cargo test --locked --workspace --all-features
- strict OpenSpec and targeted IssueOps
- strict pre-push hook