### PR TITLE
chore(issueops): reopen incomplete #518 cleanup tasks

### DIFF
--- a/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/tasks.md
+++ b/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/tasks.md
@@ -11,4 +11,4 @@
 ## 3. Integration and Acceptance
 
 - [ ] 3.1 Run the focused fixture and installer E2E, repeated required parallel workspace gate, strict Rust/workspace/OpenSpec/IssueOps checks, and exact-head hosted Windows proof; refresh dependent #476 and #487 only after the accepted fix is on `main`, and confirm #487 retains one final helper owner.
-- [x] 3.2 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
+- [ ] 3.2 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.

--- a/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/tasks.md
+++ b/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/tasks.md
@@ -5,8 +5,8 @@
 
 ## 2. Bounded Fixture Readiness
 
-- [x] 2.1 Replace the hard-coded five-second child-PID publication assumption at the smallest owning Windows delivery-test helper with one named bounded readiness contract; preserve 25 ms polling or an equally bounded existing mechanism, parent early-exit detection, atomic identity publication, exact PID/start-time/executable-path validation, actionable timeout diagnostics, and complete owned-process cleanup.
-- [x] 2.2 Add deterministic regression proof whose valid publication exceeds the former five-second ceiling plus negative coverage for true timeout, early parent exit, malformed or mismatched identity, and cleanup; do not weaken or duplicate the existing production-installer behavior assertions.
+- [ ] 2.1 Replace the hard-coded five-second child-PID publication assumption at the smallest owning Windows delivery-test helper with one named bounded readiness contract; preserve 25 ms polling or an equally bounded existing mechanism, parent early-exit detection, atomic identity publication, exact PID/start-time/executable-path validation, actionable timeout diagnostics, and complete owned-process cleanup.
+- [ ] 2.2 Add deterministic regression proof whose valid publication exceeds the former five-second ceiling plus negative coverage for true timeout, early parent exit, malformed or mismatched identity, and cleanup; do not weaken or duplicate the existing production-installer behavior assertions.
 
 ## 3. Integration and Acceptance
 


### PR DESCRIPTION
Relates to #518

Reopens OpenSpec implementation tasks 2.1 and 2.2 after the immutable-boundary review found the Windows cleanup deadline behavior incomplete. This mirrors the already-correct live issue checklist and changes no product source.

Validation: the complete strict pre-push gate passed, including workspace tests, CLI E2E, docs, live IssueOps, scan, and lint.