### PR TITLE
docs(openspec): close #518 readiness proof

### DIFF
--- a/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/tasks.md
+++ b/openspec/changes/stabilize-windows-mcp-owner-fixture-readiness/tasks.md
@@ -10,5 +10,5 @@
 
 ## 3. Integration and Acceptance
 
-- [ ] 3.1 Run the focused fixture and installer E2E, repeated required parallel workspace gate, strict Rust/workspace/OpenSpec/IssueOps checks, and exact-head hosted Windows proof; refresh dependent #487 only after the accepted fix is on `main`, and confirm it retains one final helper owner.
+- [x] 3.1 Run the focused fixture and installer E2E, repeated required parallel workspace gate, strict Rust/workspace/OpenSpec/IssueOps checks, and exact-head hosted Windows proof; refresh dependent #487 only after the accepted fix is on `main`, and confirm it retains one final helper owner.
 - [x] 3.2 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.


### PR DESCRIPTION
Closes #518

Marks the final integration task complete after the accepted implementation landed on main, both hosted matrices passed, and Terra confirmed the refreshed dependent split retains exactly one Windows fixture helper owner.