### PR TITLE
test(windows): prove completed-parent pipe cleanup

### DIFF
--- a/crates/projectatlas-cli/tests/e2e_delivery.rs
+++ b/crates/projectatlas-cli/tests/e2e_delivery.rs
@@ -21454,10 +21454,12 @@ fn release_asset_server_lifecycle_is_causal_and_bounded() -> Result<(), Box<dyn 
 
     #[cfg(windows)]
     let completed_parent_with_descendant = || {
-        let mut command = StdCommand::new("powershell");
-        command.arg("-NoProfile").arg("-Command").arg(
-            r#"$script = '$child = [Diagnostics.ProcessStartInfo]::new(); $child.FileName = ''ping.exe''; $child.Arguments = ''-n 16 127.0.0.1''; $child.UseShellExecute = $false; $child.CreateNoWindow = $true; [void][Diagnostics.Process]::Start($child)'; $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($script)); $middle = [Diagnostics.ProcessStartInfo]::new(); $middle.FileName = 'powershell.exe'; $middle.Arguments = "-NoProfile -EncodedCommand $encoded"; $middle.UseShellExecute = $false; $middle.CreateNoWindow = $true; $middleProcess = [Diagnostics.Process]::Start($middle); $middleProcess.WaitForExit(); if ($middleProcess.ExitCode -ne 0) { exit $middleProcess.ExitCode }"#,
-        );
+        let mut command = StdCommand::new("cmd.exe");
+        command.args([
+            "/D",
+            "/C",
+            "cmd.exe /D /C start /B ping.exe -n 16 127.0.0.1",
+        ]);
         command
     };
     #[cfg(unix)]
@@ -21466,6 +21468,47 @@ fn release_asset_server_lifecycle_is_causal_and_bounded() -> Result<(), Box<dyn 
         command.arg("-c").arg("sleep 15 &");
         command
     };
+
+    // Withhold cleanup once to prove the same fixture actually leaves a pipe
+    // holder after successful parent exit, rather than passing with an empty tree.
+    let mut retained_pipe_command = completed_parent_with_descendant();
+    retained_pipe_command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut parent_observed_at = None;
+    let retained_pipe_output =
+        wait_for_plugin_installer_output_with_test_delay_and_kill_and_handoff(
+            spawn_plugin_installer_process(&mut retained_pipe_command)?,
+            "fixture-completed-parent-pipe-control",
+            Duration::from_secs(10),
+            None,
+            None,
+            None,
+            &mut |child| {
+                if !child.try_wait()?.is_some_and(|status| status.success()) {
+                    return Err(io::Error::other(
+                        "pipe control did not establish successful parent exit before cleanup",
+                    ));
+                }
+                parent_observed_at = Some(Instant::now());
+                Ok(())
+            },
+            None,
+        )?;
+    let retained_pipe_duration = parent_observed_at
+        .ok_or_else(|| io::Error::other("pipe control did not observe parent completion"))?
+        .elapsed();
+    require(
+        retained_pipe_output.status.success(),
+        "pipe control did not preserve successful parent status",
+    )?;
+    if retained_pipe_duration <= Duration::from_secs(10) {
+        return Err(io::Error::other(format!(
+            "completed parent fixture did not retain a descendant pipe beyond the cleanup bound: {retained_pipe_duration:?}",
+        ))
+        .into());
+    }
 
     let server = new_server()?;
     let mut completed_parent_command = completed_parent_with_descendant();

--- a/crates/projectatlas-cli/tests/support/source_contract.rs
+++ b/crates/projectatlas-cli/tests/support/source_contract.rs
@@ -3,7 +3,7 @@
 pub(super) const CLI_E2E_SOURCE_SHA256: &[(&str, &str)] = &[
     (
         "crates/projectatlas-cli/tests/e2e_delivery.rs",
-        "3ee3ab5250d3fa4be0f6d7a9d26f55629cccaf6d53d6828e8e5bbc9dac8eef2c",
+        "909e25795c7970a2bd7519e4da3fb69ce8ca9fdc2eaa2637b0f52e105245e2fc",
     ),
     (
         "crates/projectatlas-cli/tests/e2e_lifecycle.rs",

--- a/docs/v050-cli-e2e-inventory.json
+++ b/docs/v050-cli-e2e-inventory.json
@@ -3,7 +3,7 @@
   "source_contract": {
     "normalization": "UTF-8 source with CRLF and CR normalized to LF; relative binary keys only; no absolute paths or line metadata",
     "files": {
-      "crates/projectatlas-cli/tests/e2e_delivery.rs": "3ee3ab5250d3fa4be0f6d7a9d26f55629cccaf6d53d6828e8e5bbc9dac8eef2c",
+      "crates/projectatlas-cli/tests/e2e_delivery.rs": "909e25795c7970a2bd7519e4da3fb69ce8ca9fdc2eaa2637b0f52e105245e2fc",
       "crates/projectatlas-cli/tests/e2e_lifecycle.rs": "b2691058f2324abbccd250c9541ec762bf302f1f1e5f93f0455ece8729e5c21f",
       "crates/projectatlas-cli/tests/e2e_maintenance.rs": "35c4cf8a4e3e69ffd4fb3ca18b191d5c79ea27646ba9fd7d3d21f5c0788aab32",
       "crates/projectatlas-cli/tests/e2e_navigation.rs": "72b95317626c27cbe036b8fc02d2749a302347c4fb1f3fb961f1e86d9bcee397",

--- a/openspec/changes/prove-completed-parent-pipe-cleanup/.openspec.yaml
+++ b/openspec/changes/prove-completed-parent-pipe-cleanup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/prove-completed-parent-pipe-cleanup/design.md
+++ b/openspec/changes/prove-completed-parent-pipe-cleanup/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The existing installer observer owns a Windows job or Unix process group, drains stdout and stderr concurrently, and retires descendants after observing parent exit. Its lifecycle test currently launches two PowerShell interpreters before a finite pipe-holding descendant. Two hosted Windows runs failed before observing the intended successful parent exit; local runs pass. A standalone local probe establishes parent success in 0.391 seconds with output retained until 15.578 seconds, but does not reproduce the hosted cause.
+
+## Goals / Non-Goals
+
+**Goals:** Establish the intended completed-parent state causally and prove prompt owned-descendant cleanup, successful status preservation, and strict late-observation behavior through the existing lifecycle test.
+
+**Non-Goals:** Product, database, protocol, dependency, CI routing, timeout-policy, or process-framework changes; retry-only acceptance; new serialization or global locks.
+
+## Decisions
+
+- Keep the existing `PluginInstallerProcess`, job/process-group ownership, concurrent output readers, and observer. The defect is isolated at the fixture boundary; a replacement process framework would duplicate proven ownership and failure handling.
+- Replace the two PowerShell launches with `cmd.exe /D /C` running `cmd.exe /D /C start /B ping.exe -n 16 127.0.0.1`. The unquoted executable needs no empty `start` title or nested quote escaping. Independent probes establish prompt parent success and approximately 15 seconds of inherited-pipe retention, including with `CREATE_NO_WINDOW`. The hosted logs establish failure to reach the intended parent-exited state, but do not identify the operating-system scheduling cause; hosted verification remains required.
+- Add one no-cleanup control through the existing injected termination closure. Require successful parent exit at that checkpoint and measure subsequent pipe drainage against the existing ten-second cleanup bound. Then execute the same fixture with real job/process-group cleanup and require prompt completion. This directly distinguishes an absent or prematurely exited pipe holder from effective cleanup, without marker files, reader-scheduling assumptions, or another process API.
+- Exercise both ordinary successful completion and deliberately late observation with the same fixture. Reuse the existing bounded exit synchronization when separating fixture readiness from observation is necessary. Keep cleanup failure diagnostics and existing deadline values intact.
+- Use a fixed small process tree and bounded output. No persistent state, data migration, pool, new synchronization service, or cross-crate abstraction is required. Retaining nested PowerShell adds interpreter startup without contributing to the state under test; a recursive Rust fixture or native process-query API adds unnecessary machinery when the existing shell and injection boundary suffice.
+
+## Risks / Trade-offs
+
+- A fixture may pass without creating the intended descendant -> establish successful parent exit with a still-retained output pipe before cleanup.
+- Shell quoting or interpreter startup may test the wrong state -> inspect native command arguments and isolate startup from descendant retirement.
+- A readiness adjustment may weaken timeout semantics -> retain the strict late-observation case and existing live-parent timeout and failure-cleanup cases.
+- Local success may conceal the hosted failure -> require the affected hosted Windows gate on the accepted fix, plus existing selected platform compatibility checks.
+- The no-cleanup control adds approximately 15 seconds -> retain the finite descendant lifetime and existing outer test deadline; this cost proves the missing causal condition and does not extend an installer deadline.
+
+## Migration Plan
+
+Update only the owning test fixture and any required frozen test-source identity. Run focused causal checks, required local gates, independent review, and affected hosted checks. Merge the shared baseline before refreshing the preserved PHP branch. No runtime or database migration is involved.
+
+## Dependencies / Cross-Issue Impact
+
+#561 belongs to release owner #492 and follows the already completed lifecycle work in #533. It has no open implementation prerequisite. Its shared gate currently prevents #477 acceptance; the PHP source remains separately owned and preserved. #560 owns the separate metadata-event routing defect.
+
+## Open Questions
+
+None.

--- a/openspec/changes/prove-completed-parent-pipe-cleanup/proposal.md
+++ b/openspec/changes/prove-completed-parent-pipe-cleanup/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The hosted Windows lifecycle gate repeatedly times out before its completed-parent fixture reaches the intended state, although the unchanged test passes locally. The proof must distinguish fixture startup from cleanup of a completed parent's pipe-inheriting descendant so a shared release gate tests the intended behavior causally.
+
+## What Changes
+
+- Reproduce the fixture's parent, intermediate child, descendant, and inherited-output lifecycle at the existing delivery-test boundary.
+- Use the smallest existing platform mechanism that establishes the intended completed-parent state and proves prompt retirement of the exact owned descendant.
+- Preserve successful parent status, strict late-observation classification, inherited-output cleanup, and all existing operation and workflow deadlines.
+
+## Capabilities
+
+### New Capabilities
+
+- `completed-parent-fixture-proof`: causal proof of successful parent exit and cleanup of pipe-inheriting descendants in the installer test harness.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+Owning issue #561. Implementation is confined to CLI delivery-test infrastructure and its existing verification contracts. The PHP work in #477 remains separate and preserved. This proposal is ready for bounded investigation; implementation follows the observed process-state cause.
+
+## Non-Goals
+
+No timeout inflation, retry-only acceptance, suite serialization, new process/server framework, product changes, or unrelated CI routing changes.

--- a/openspec/changes/prove-completed-parent-pipe-cleanup/specs/completed-parent-fixture-proof/spec.md
+++ b/openspec/changes/prove-completed-parent-pipe-cleanup/specs/completed-parent-fixture-proof/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Completed-parent cleanup proof establishes its process state
+
+The installer lifecycle fixture SHALL establish a successful parent exit while an owned descendant still holds an inherited output pipe. The proof SHALL distinguish failure to reach that state from failure to retire the descendant and drain output. The fixture MUST use the existing process ownership and cleanup boundary and retain finite startup and cleanup bounds.
+
+#### Scenario: Successful parent leaves an owned pipe holder
+- **WHEN** the fixture parent exits successfully with a descendant retaining its output pipe
+- **THEN** the observer retires that owned descendant, drains the pipe promptly, and preserves the successful parent exit status
+- **AND** the proof establishes that the descendant retained the pipe before cleanup, so an empty process tree cannot pass as cleanup proof
+
+#### Scenario: Fixture does not reach the completed-parent state
+- **WHEN** the fixture fails to establish successful parent exit within its existing bounded startup allowance
+- **THEN** the test fails with a diagnostic identifying the missing fixture state and cleans up only its owned process tree
+- **AND** it does not claim completed-parent cleanup was exercised
+
+### Requirement: Lifecycle fixture retains strict observer and containment contracts
+
+The fixture correction MUST preserve strict observation deadlines, successful and late-completion classification, output draining, and Windows job or Unix process-group containment. It MUST NOT increase operation or workflow deadlines, suppress an existing route, or accept repeated retries as proof.
+
+#### Scenario: Successful exit is first observed after the deadline
+- **WHEN** a completed parent with an owned pipe-inheriting descendant is deliberately observed after its deadline
+- **THEN** the observer reports completion after the deadline and retires the owned descendant without waiting for its natural lifetime
+
+#### Scenario: Shared lifecycle gate runs on supported platforms
+- **WHEN** the existing release asset lifecycle gate runs locally and in the affected hosted platform jobs
+- **THEN** completed-parent cleanup and the existing live-parent timeout, late-observation, output-drain, and failure-cleanup cases pass under their unchanged contracts

--- a/openspec/changes/prove-completed-parent-pipe-cleanup/tasks.md
+++ b/openspec/changes/prove-completed-parent-pipe-cleanup/tasks.md
@@ -1,0 +1,22 @@
+## 1. Contract and specification
+
+- [x] 1.1 Reconcile the observed parent, descendant, and inherited-output lifecycle; select the smallest causal fixture correction and complete the issue, specification, and release dependency mapping.
+
+## 2. Fixture and verification
+
+- [ ] 2.1 Correct the completed-parent fixture in the existing delivery-test owner, proving successful parent exit with a retained descendant pipe and prompt owned cleanup without changing operation or workflow deadlines.
+- [ ] 2.2 Preserve and verify successful status, late-observation classification, live-parent timeout, output draining, cleanup failure, and supported-platform behavior through the existing lifecycle and observer tests; update only required frozen source identities and pass required local and hosted gates.
+
+## Verification
+
+Use the existing bounded command runner or normal pre-push gate for long checks:
+
+- `cargo test --locked -p projectatlas-cli --test e2e_delivery release_asset_server_lifecycle_is_causal_and_bounded -- --exact --nocapture`
+- `cargo test --locked -p projectatlas-cli --test e2e_delivery e2e_process_observers_ -- --nocapture`
+- `cargo fmt --check`
+- `cargo check --workspace --all-targets --all-features`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features` and `cargo test --doc --all-features`
+- `cargo doc --workspace --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
+- `python .github/scripts/issue-checklists.py --repo styler-ai/ProjectAtlas --planned-issue 561`
+- The affected hosted lifecycle and installer jobs selected by the current CI planner.

--- a/openspec/changes/prove-completed-parent-pipe-cleanup/tasks.md
+++ b/openspec/changes/prove-completed-parent-pipe-cleanup/tasks.md
@@ -4,8 +4,8 @@
 
 ## 2. Fixture and verification
 
-- [ ] 2.1 Correct the completed-parent fixture in the existing delivery-test owner, proving successful parent exit with a retained descendant pipe and prompt owned cleanup without changing operation or workflow deadlines.
-- [ ] 2.2 Preserve and verify successful status, late-observation classification, live-parent timeout, output draining, cleanup failure, and supported-platform behavior through the existing lifecycle and observer tests; update only required frozen source identities and pass required local and hosted gates.
+- [x] 2.1 Correct the completed-parent fixture in the existing delivery-test owner, proving successful parent exit with a retained descendant pipe and prompt owned cleanup without changing operation or workflow deadlines.
+- [x] 2.2 Preserve and verify successful status, late-observation classification, live-parent timeout, output draining, cleanup failure, and supported-platform behavior through the existing lifecycle and observer tests; update only required frozen source identities and pass required local and hosted gates.
 
 ## Verification
 

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -28,7 +28,7 @@
         "489": { "blocked_by": [] },
         "490": { "blocked_by": [339, 342, 358, 384, 464, 465, 489] },
         "491": { "blocked_by": [] },
-        "492": { "blocked_by": [339, 342, 358, 372, 384, 388, 390, 456, 464, 465, 476, 477, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 495, 517, 518, 523, 525, 533, 544, 547, 549, 555] },
+        "492": { "blocked_by": [339, 342, 358, 372, 384, 388, 390, 456, 464, 465, 476, 477, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 495, 517, 518, 523, 525, 533, 544, 547, 549, 555, 561] },
         "495": { "blocked_by": [] },
         "517": { "blocked_by": [] },
         "518": { "blocked_by": [547] },
@@ -38,7 +38,8 @@
         "544": { "blocked_by": [] },
         "547": { "blocked_by": [] },
         "549": { "blocked_by": [] },
-        "555": { "blocked_by": [487] }
+        "555": { "blocked_by": [487] },
+        "561": { "blocked_by": [] }
       }
     },
     "v0.6.0-00": {
@@ -170,6 +171,7 @@
     "persist-graph-coverage-limits": 471,
     "prefer-worktree-guidance-before-database-preflight": 412,
     "preserve-indexing-across-invalid-symbol-identities": 467,
+    "prove-completed-parent-pipe-cleanup": 561,
     "publish-rustdoc-readme-links": 300,
     "rationalize-agent-tool-surface": {
       "contract": "checklist-v1",


### PR DESCRIPTION
The Windows completed-parent lifecycle fixture repeatedly timed out before reaching the state needed to test descendant cleanup. Replace its two PowerShell launches with a native command-interpreter fixture and add a no-cleanup control that proves pipe retention after successful parent exit. The same fixture must then drain promptly through the existing Windows job or Unix process-group cleanup; deadline values and late-observation behavior remain unchanged.

Validation: focused Windows lifecycle passed, existing observer failure cases and frozen-inventory checks passed, and an empty-tree mutation failed the new retention assertion. Full local and hosted gates remain required before closure.

Fixes #561
