### PR TITLE
fix(runtime): finish native source-observer teardown (#570)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -793,6 +793,16 @@ jobs:
         timeout-minutes: 5
         run: cargo test --locked -p projectatlas-cli mcp_server_stays_bound_to_one_project_database --test e2e_lifecycle
 
+      - name: Native source-observer teardown and MCP identity
+        if: contains(matrix.contracts, 'mcp')
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo test --locked -p projectatlas-cli --bin projectatlas --all-features runtime::source_observation::tests::native_observer_teardown_releases_root_and_external_config -- --exact --nocapture
+          cargo test --locked -p projectatlas-cli --bin projectatlas --all-features runtime::source_observation::tests::native_observer_failed_registration_releases_admitted_root -- --exact --nocapture
+          cargo test --locked -p projectatlas-cli --bin projectatlas --all-features mcp::tests::mcp_calls_share_server_identity_and_new_server_uses_another -- --exact --nocapture
+
       - name: Persistent MCP Git config stdin E2E
         if: contains(matrix.contracts, 'mcp')
         timeout-minutes: 5

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -11062,7 +11062,12 @@ mod tests {
         require(
             instances == 2 && events == 3,
             "MCP calls did not reuse one identity per server construction",
-        )
+        )?;
+        drop(connection);
+        drop(restarted);
+        drop(first);
+        fs::remove_dir_all(&repo)?;
+        require(!repo.exists(), "MCP teardown left its repository in use")
     }
 
     #[test]

--- a/crates/projectatlas-cli/src/runtime/source_observation.rs
+++ b/crates/projectatlas-cli/src/runtime/source_observation.rs
@@ -266,6 +266,14 @@ impl Hash for SourceBinding {
 }
 
 impl SourceBinding {
+    /// Configuration directory observed separately when it lies outside the source root.
+    fn external_config_parent(&self) -> Option<&Path> {
+        self.config
+            .as_deref()
+            .filter(|config| !config.starts_with(&self.root))
+            .and_then(Path::parent)
+    }
+
     /// Resolve one root, database, and optional configuration into a stable binding.
     fn new(database: &Path, root: &Path, config: Option<&Path>) -> Result<Self, CliError> {
         let root = root.canonicalize().map_err(|source| CliError::Io {
@@ -309,7 +317,7 @@ struct SourceObservationEntry {
     /// Exact source, database, and configuration identity.
     binding: SourceBinding,
     /// Native watcher kept alive for the entry lifetime.
-    _watcher: RecommendedWatcher,
+    watcher: RecommendedWatcher,
     /// Bounded receiver whose lock serializes callback publication with drain acknowledgment.
     receiver: Arc<Mutex<Receiver<Event>>>,
     /// Monotonic count of relevant events accepted by the callback.
@@ -329,6 +337,20 @@ struct SourceObservationEntry {
     #[cfg(test)]
     /// Continuity loss injected between the drain fast check and lock for owning race tests.
     drain_continuity_invalidations: AtomicU64,
+}
+
+#[cfg(windows)]
+impl Drop for SourceObservationEntry {
+    fn drop(&mut self) {
+        let _ = self.watcher.unwatch(&self.binding.root);
+        if let Some(parent) = self.binding.external_config_parent() {
+            let _ = self.watcher.unwatch(parent);
+        }
+        // notify's Windows Unwatch and Drop only enqueue actions. Configure waits
+        // for an acknowledgement after preceding cancellation/completion work,
+        // so directory cleanup cannot race an outstanding native notification.
+        let _ = self.watcher.configure(notify::Config::default());
+    }
 }
 
 impl fmt::Debug for SourceObservationEntry {
@@ -357,27 +379,16 @@ impl SourceObservationEntry {
         let test_sender = sender.clone();
         let ingress_sequence = Arc::new(AtomicU64::new(0));
         let continuity_lost = Arc::new(AtomicBool::new(false));
-        let mut watcher = notify::recommended_watcher(watcher_callback(
+        let watcher = notify::recommended_watcher(watcher_callback(
             sender,
             Arc::clone(&receiver),
             Arc::clone(&ingress_sequence),
             Arc::clone(&continuity_lost),
         ))
         .map_err(|source| observer_error(&binding.root, &source))?;
-        watcher
-            .watch(&binding.root, RecursiveMode::Recursive)
-            .map_err(|source| observer_error(&binding.root, &source))?;
-        if let Some(config) = binding.config.as_deref()
-            && !config.starts_with(&binding.root)
-            && let Some(parent) = config.parent()
-        {
-            watcher
-                .watch(parent, RecursiveMode::NonRecursive)
-                .map_err(|source| observer_error(&binding.root, &source))?;
-        }
-        Ok(Self {
+        let mut entry = Self {
             binding,
-            _watcher: watcher,
+            watcher,
             receiver,
             ingress_sequence,
             continuity_lost,
@@ -389,7 +400,18 @@ impl SourceObservationEntry {
             acceptance_event: Mutex::new(None),
             #[cfg(test)]
             drain_continuity_invalidations: AtomicU64::new(0),
-        })
+        };
+        entry
+            .watcher
+            .watch(&entry.binding.root, RecursiveMode::Recursive)
+            .map_err(|source| observer_error(&entry.binding.root, &source))?;
+        if let Some(parent) = entry.binding.external_config_parent() {
+            entry
+                .watcher
+                .watch(parent, RecursiveMode::NonRecursive)
+                .map_err(|source| observer_error(&entry.binding.root, &source))?;
+        }
+        Ok(entry)
     }
 
     /// Publish one deterministic test event through the production handshake.
@@ -1404,6 +1426,51 @@ mod tests {
         } else {
             Err(std::io::Error::other(message).into())
         }
+    }
+
+    #[test]
+    fn native_observer_teardown_releases_root_and_external_config() -> Result<(), Box<dyn Error>> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("repo");
+        let external = temp.path().join("settings");
+        fs::create_dir_all(&root)?;
+        fs::create_dir_all(&external)?;
+        let config = external.join("config.toml");
+        fs::write(&config, "")?;
+        let database = root.join("atlas.db");
+        let entry =
+            SourceObservationEntry::start(SourceBinding::new(&database, &root, Some(&config))?)?;
+        fs::write(root.join("source.rs"), "fn observed() {}")?;
+        drop(entry);
+        require(!database.exists(), "observer cleanup created an index")?;
+        fs::remove_dir_all(&root)?;
+        fs::remove_dir_all(&external)?;
+        require(
+            !root.exists() && !external.exists(),
+            "watch directories remain",
+        )
+    }
+
+    #[test]
+    fn native_observer_failed_registration_releases_admitted_root() -> Result<(), Box<dyn Error>> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("repo");
+        fs::create_dir_all(&root)?;
+        let database = root.join("atlas.db");
+        let config = temp.path().join("missing-parent").join("config.toml");
+        let binding = SourceBinding::new(&database, &root, Some(&config))?;
+        let result = SourceObservationEntry::start(binding.clone());
+        require(result.is_err(), "missing configuration parent was accepted")?;
+        require(
+            !database.exists(),
+            "failed observer startup created an index",
+        )?;
+        fs::remove_dir_all(&root)?;
+        require(!root.exists(), "failed startup retained its root")?;
+        require(
+            SourceObservationEntry::start(binding).is_err(),
+            "missing root was accepted",
+        )
     }
 
     #[test]

--- a/crates/projectatlas-cli/src/runtime/source_observation.rs
+++ b/crates/projectatlas-cli/src/runtime/source_observation.rs
@@ -342,14 +342,14 @@ struct SourceObservationEntry {
 #[cfg(windows)]
 impl Drop for SourceObservationEntry {
     fn drop(&mut self) {
-        let _ = self.watcher.unwatch(&self.binding.root);
+        drop(self.watcher.unwatch(&self.binding.root));
         if let Some(parent) = self.binding.external_config_parent() {
-            let _ = self.watcher.unwatch(parent);
+            drop(self.watcher.unwatch(parent));
         }
         // notify's Windows Unwatch and Drop only enqueue actions. Configure waits
         // for an acknowledgement after preceding cancellation/completion work,
         // so directory cleanup cannot race an outstanding native notification.
-        let _ = self.watcher.configure(notify::Config::default());
+        drop(self.watcher.configure(notify::Config::default()));
     }
 }
 

--- a/openspec/changes/finish-native-source-observer-teardown/.openspec.yaml
+++ b/openspec/changes/finish-native-source-observer-teardown/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/finish-native-source-observer-teardown/design.md
+++ b/openspec/changes/finish-native-source-observer-teardown/design.md
@@ -1,0 +1,31 @@
+## Context
+
+Each MCP server owns a source-observation registry. Entries own notify watchers for a repository root and, when outside that root, the configuration parent. Pinned notify 8.2.0 on Windows queues Unwatch and Stop asynchronously. Temporary-directory cleanup can overlap an outstanding ReadDirectoryChangesW request.
+
+## Goals / Non-Goals
+
+Complete owned Windows cancellation before entry drop returns, including partially failed startup. Preserve existing identity, observation, root isolation, errors, and non-Windows behavior. No new watcher wrapper, dependency, retries, timeout policy, database changes, or thread pool.
+
+## Decisions
+
+Use the existing entry as a Rust RAII owner before either watch registration. Derive both registration and teardown paths from its binding. On Windows, enqueue unwatch for those paths, then call the existing synchronous configure acknowledgement. The backend processes these actions in order: unwatch cancels and closes the directory request and waits for completion before configure acknowledges. Unwatch alone is insufficient; a new worker/join framework would duplicate the dependency's existing mechanism.
+
+Teardown is constant work for at most two watches and performs no source traversal, publication, or database access. Drop remains non-panicking; disconnected backend errors mean the worker cannot process further requests. The Windows acknowledgement result does not indicate a configuration change and is not used as one.
+
+## Risks / Trade-offs
+
+- Backend ordering is dependency-specific: document the pinned behavior beside the barrier and protect real native directory cleanup in tests.
+- A second registration can fail: construct the entry first so its Drop owns the successfully registered root.
+- Completion waits for the native backend: preserve its cancellation mechanism rather than adding retries or accepting early cleanup.
+
+## Migration Plan
+
+No data migration. Merge the shared runtime fix, refresh dependent worktrees, and rerun affected proof. Reverting source restores the old lifecycle without changing stored data.
+
+## Dependencies / Cross-Issue Impact
+
+#570 has no implementation prerequisite. It belongs to #492 and blocks #465 validation. Merge the shared baseline repair before refreshing #465; #358 remains queued after document closure.
+
+## Open Questions
+
+None.

--- a/openspec/changes/finish-native-source-observer-teardown/proposal.md
+++ b/openspec/changes/finish-native-source-observer-teardown/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Windows MCP server teardown can leave native directory notifications active while temporary repositories are removed, hanging otherwise completed tests. This shared runtime defect blocks normal release validation.
+
+## What Changes
+
+- Complete Windows unwatch operations within the source-observer entry lifetime.
+- Preserve cleanup ownership when watch registration fails partway through startup.
+- Prove directory cleanup after server teardown and failed registration.
+
+## Capabilities
+
+### New Capabilities
+
+- `native-source-observer-teardown`: Complete owned Windows directory-watch cancellation before releasing the observer.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The existing CLI source-observation entry and MCP identity regression test. No public API, dependency, database, or non-Windows observation change. Issue #570 is ready for implementation and blocks #465 validation under release owner #492.
+
+## Non-Goals
+
+No timeouts, retries, watcher framework, test suppression, or CI redesign.

--- a/openspec/changes/finish-native-source-observer-teardown/specs/native-source-observer-teardown/spec.md
+++ b/openspec/changes/finish-native-source-observer-teardown/specs/native-source-observer-teardown/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Complete owned Windows watcher cancellation
+
+A source-observation entry SHALL finish native Windows cancellation of its root and applicable external configuration-parent watch before its lifetime ends. Teardown SHALL preserve the existing owner and root binding and SHALL NOT mutate source or indexed data.
+
+#### Scenario: MCP server teardown permits repository cleanup
+- **WHEN** MCP overview calls establish observations in two server instances and those instances are dropped
+- **THEN** their native directory watches finish cancellation before subsequent repository removal
+- **AND** existing server identity and usage assertions remain valid.
+
+#### Scenario: External configuration parent is watched
+- **WHEN** an entry watches a configuration parent outside its repository root and is dropped
+- **THEN** cancellation completes for both owned directory watches.
+
+### Requirement: Partial startup retains cleanup ownership
+
+An entry SHALL own watcher cleanup before registering paths and SHALL retain existing typed startup errors.
+
+#### Scenario: External parent registration fails after root admission
+- **WHEN** root registration succeeds but the external configuration-parent registration fails
+- **THEN** startup returns its existing observer error after cleaning up the admitted root watch
+- **AND** subsequent repository removal does not overlap that watch.
+
+#### Scenario: Root registration fails
+- **WHEN** the repository root cannot be watched
+- **THEN** startup returns the existing observer error without leaving owned native watches.
+
+### Requirement: Preserve observation compatibility
+
+The repair SHALL preserve normal observation, per-project isolation, and non-Windows watcher behavior. It SHALL NOT initialize a missing index or select another root during cleanup.
+
+#### Scenario: Unrelated root remains active
+- **WHEN** one source-observation entry is dropped while another bound root remains observed
+- **THEN** only the dropped entry's watches are removed and the other observation remains usable.
+
+#### Scenario: Cleanup performs no implicit index mutation
+- **WHEN** an entry is dropped with an absent or existing index
+- **THEN** cleanup neither creates nor modifies that index and does not retarget any other project.

--- a/openspec/changes/finish-native-source-observer-teardown/tasks.md
+++ b/openspec/changes/finish-native-source-observer-teardown/tasks.md
@@ -1,0 +1,12 @@
+## 1. Contract
+
+- [x] 1.1 Define the native source-observer teardown and partial-start cleanup contract with its release dependency mapping.
+
+## 2. Implementation and proof
+
+- [ ] 2.1 Complete Windows source-observer unwatch operations before releasing the owning entry, including partial registration failure.
+- [ ] 2.2 Prove native directory cleanup after MCP server teardown and partial watcher startup, preserve observation behavior on supported platforms, and pass required local and hosted gates.
+
+## Verification
+
+Run focused source-observation and MCP identity tests with their actual nonzero counts, then the normal pre-push gates: cargo fmt --check; cargo check --workspace --all-targets --all-features; cargo clippy --workspace --all-targets --all-features -- -D warnings; cargo test --workspace --all-features; cargo test --doc --all-features; strict rustdoc. Run OpenSpec validation and scoped IssueOps before transitions. Required hosted proof follows affected-ci-proof.py.

--- a/openspec/changes/finish-native-source-observer-teardown/tasks.md
+++ b/openspec/changes/finish-native-source-observer-teardown/tasks.md
@@ -4,8 +4,8 @@
 
 ## 2. Implementation and proof
 
-- [ ] 2.1 Complete Windows source-observer unwatch operations before releasing the owning entry, including partial registration failure.
-- [ ] 2.2 Prove native directory cleanup after MCP server teardown and partial watcher startup, preserve observation behavior on supported platforms, and pass required local and hosted gates.
+- [x] 2.1 Complete Windows source-observer unwatch operations before releasing the owning entry, including partial registration failure.
+- [x] 2.2 Prove native directory cleanup after MCP server teardown and partial watcher startup, preserve observation behavior on supported platforms, and pass required local and hosted gates.
 
 ## Verification
 

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -13,7 +13,7 @@
         "390": { "blocked_by": [] },
         "456": { "blocked_by": [358, 465, 477, 484] },
         "464": { "blocked_by": [] },
-        "465": { "blocked_by": [476, 480, 488] },
+        "465": { "blocked_by": [476, 480, 488, 570] },
         "476": { "blocked_by": [481] },
         "477": { "blocked_by": [547] },
         "480": { "blocked_by": [482] },
@@ -28,7 +28,7 @@
         "489": { "blocked_by": [] },
         "490": { "blocked_by": [339, 342, 358, 384, 464, 465, 489] },
         "491": { "blocked_by": [] },
-        "492": { "blocked_by": [339, 342, 358, 372, 384, 388, 390, 456, 464, 465, 476, 477, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 495, 517, 518, 523, 525, 533, 544, 547, 549, 555, 561, 564, 567, 568] },
+        "492": { "blocked_by": [339, 342, 358, 372, 384, 388, 390, 456, 464, 465, 476, 477, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 495, 517, 518, 523, 525, 533, 544, 547, 549, 555, 561, 564, 567, 568, 570] },
         "495": { "blocked_by": [] },
         "517": { "blocked_by": [] },
         "518": { "blocked_by": [547] },
@@ -42,7 +42,8 @@
         "561": { "blocked_by": [] },
         "564": { "blocked_by": [] },
         "567": { "blocked_by": [] },
-        "568": { "blocked_by": [] }
+        "568": { "blocked_by": [] },
+        "570": { "blocked_by": [] }
       }
     },
     "v0.6.0-00": {
@@ -177,6 +178,7 @@
     "prefer-worktree-guidance-before-database-preflight": 412,
     "preserve-indexing-across-invalid-symbol-identities": 467,
     "enforce-release-asset-completion-deadline": 564,
+    "finish-native-source-observer-teardown": 570,
     "prove-completed-parent-pipe-cleanup": 561,
     "publish-rustdoc-readme-links": 300,
     "rationalize-agent-tool-surface": {


### PR DESCRIPTION
## Summary

Windows source-observer shutdown could return while notify still held an outstanding directory-change request, allowing later repository cleanup to hang after MCP assertions completed. The existing entry now owns partial startup and waits for queued Windows unwatch operations to finish through the backend acknowledgement. Regression tests exercise MCP server cleanup, external configuration watches, and failed registration.

## Issue

Closes #570

## Validation

The exact MCP identity test and all 21 source-observation tests pass on native Windows. Full normal repository gates and independent review pass. Hosted Rust and all four platform jobs pass; Windows, Linux, and macOS ARM logs each confirm the three exact teardown regressions executed successfully. OpenSpec and issue implementation and acceptance checklists are synchronized.
