### PR TITLE
test(mcp): keep payload fixture on one project database

### DIFF
--- a/crates/projectatlas-cli/tests/e2e_delivery.rs
+++ b/crates/projectatlas-cli/tests/e2e_delivery.rs
@@ -18597,11 +18597,15 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
         let reported_db = payload[scope]["db"]["path"]
             .as_str()
             .ok_or_else(|| io::Error::other(format!("MCP {scope} omitted its database path")))?;
-        assert_eq!(
-            fs::canonicalize(reported_db)?,
-            expected_db,
-            "MCP {scope} selected a different database from the fixture"
-        );
+        let reported_db = fs::canonicalize(reported_db)?;
+        if reported_db != expected_db {
+            return Err(io::Error::other(format!(
+                "MCP {scope} selected {} instead of fixture database {}",
+                reported_db.display(),
+                expected_db.display()
+            ))
+            .into());
+        }
     }
     assert_frozen_mcp_surfaces_compatible(&stdout)?;
     let session_brief_text = mcp_tool_text(&stdout, 19)?;

--- a/crates/projectatlas-cli/tests/e2e_delivery.rs
+++ b/crates/projectatlas-cli/tests/e2e_delivery.rs
@@ -18514,7 +18514,7 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
          }\n\
          fn helper() {}\n",
     )?;
-    let db = repo.join(".projectatlas").join("projectatlas.db");
+    let db = repo.join(ATLAS_DIR_NAME).join("projectatlas.db");
 
     Command::cargo_bin("projectatlas")?
         .current_dir(&repo)

--- a/crates/projectatlas-cli/tests/e2e_delivery.rs
+++ b/crates/projectatlas-cli/tests/e2e_delivery.rs
@@ -18514,7 +18514,7 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
          }\n\
          fn helper() {}\n",
     )?;
-    let db = temp.path().join("projectatlas.db");
+    let db = repo.join(".projectatlas").join("projectatlas.db");
 
     Command::cargo_bin("projectatlas")?
         .current_dir(&repo)
@@ -18591,6 +18591,18 @@ fn mcp_stdio_serves_toon_tool_payloads() -> Result<(), Box<dyn Error>> {
     let mut analysis_messages = vec![messages[0].clone(), messages[1].clone()];
     analysis_messages.extend(messages[21..].iter().cloned());
     stdout.push_str(&run_phase(&analysis_messages)?);
+    let expected_db = fs::canonicalize(&db)?;
+    for (request_id, scope) in [(3, "init"), (18, "settings")] {
+        let payload: Value = toon_format::decode_default(&mcp_tool_text(&stdout, request_id)?)?;
+        let reported_db = payload[scope]["db"]["path"]
+            .as_str()
+            .ok_or_else(|| io::Error::other(format!("MCP {scope} omitted its database path")))?;
+        assert_eq!(
+            fs::canonicalize(reported_db)?,
+            expected_db,
+            "MCP {scope} selected a different database from the fixture"
+        );
+    }
     assert_frozen_mcp_surfaces_compatible(&stdout)?;
     let session_brief_text = mcp_tool_text(&stdout, 19)?;
     let analysis_text = mcp_tool_text(&stdout, 23)?;

--- a/crates/projectatlas-cli/tests/support/source_contract.rs
+++ b/crates/projectatlas-cli/tests/support/source_contract.rs
@@ -3,7 +3,7 @@
 pub(super) const CLI_E2E_SOURCE_SHA256: &[(&str, &str)] = &[
     (
         "crates/projectatlas-cli/tests/e2e_delivery.rs",
-        "2aad2626eab02f796b13be6ec1e5f804aa5610230210012cc29322fc2673e163",
+        "5dbedba2be59b05e23c885a6091727ae719a77eea70b0df0e0db6a397548e29c",
     ),
     (
         "crates/projectatlas-cli/tests/e2e_lifecycle.rs",

--- a/crates/projectatlas-cli/tests/support/source_contract.rs
+++ b/crates/projectatlas-cli/tests/support/source_contract.rs
@@ -3,7 +3,7 @@
 pub(super) const CLI_E2E_SOURCE_SHA256: &[(&str, &str)] = &[
     (
         "crates/projectatlas-cli/tests/e2e_delivery.rs",
-        "60b2683298298d6516c29807592980b1b40def2f61eb05c535a4b9f82ec07b2b",
+        "cc2fbf1bcd50f01b252a0bcafdf4b1f3831afe129f392fae646e6089d0d2bfeb",
     ),
     (
         "crates/projectatlas-cli/tests/e2e_lifecycle.rs",

--- a/crates/projectatlas-cli/tests/support/source_contract.rs
+++ b/crates/projectatlas-cli/tests/support/source_contract.rs
@@ -3,7 +3,7 @@
 pub(super) const CLI_E2E_SOURCE_SHA256: &[(&str, &str)] = &[
     (
         "crates/projectatlas-cli/tests/e2e_delivery.rs",
-        "cc2fbf1bcd50f01b252a0bcafdf4b1f3831afe129f392fae646e6089d0d2bfeb",
+        "2aad2626eab02f796b13be6ec1e5f804aa5610230210012cc29322fc2673e163",
     ),
     (
         "crates/projectatlas-cli/tests/e2e_lifecycle.rs",

--- a/docs/v050-cli-e2e-inventory.json
+++ b/docs/v050-cli-e2e-inventory.json
@@ -3,7 +3,7 @@
   "source_contract": {
     "normalization": "UTF-8 source with CRLF and CR normalized to LF; relative binary keys only; no absolute paths or line metadata",
     "files": {
-      "crates/projectatlas-cli/tests/e2e_delivery.rs": "cc2fbf1bcd50f01b252a0bcafdf4b1f3831afe129f392fae646e6089d0d2bfeb",
+      "crates/projectatlas-cli/tests/e2e_delivery.rs": "2aad2626eab02f796b13be6ec1e5f804aa5610230210012cc29322fc2673e163",
       "crates/projectatlas-cli/tests/e2e_lifecycle.rs": "b2691058f2324abbccd250c9541ec762bf302f1f1e5f93f0455ece8729e5c21f",
       "crates/projectatlas-cli/tests/e2e_maintenance.rs": "0fca4b81eccb59fcb208b5c8a409cbf120ffc40f0f0b4d01dda5c582274ea0ec",
       "crates/projectatlas-cli/tests/e2e_navigation.rs": "910c770ebf1bc427dd08dfee19fcd22b817bdd85f9d08cd36682fbffee127efb",

--- a/docs/v050-cli-e2e-inventory.json
+++ b/docs/v050-cli-e2e-inventory.json
@@ -3,7 +3,7 @@
   "source_contract": {
     "normalization": "UTF-8 source with CRLF and CR normalized to LF; relative binary keys only; no absolute paths or line metadata",
     "files": {
-      "crates/projectatlas-cli/tests/e2e_delivery.rs": "60b2683298298d6516c29807592980b1b40def2f61eb05c535a4b9f82ec07b2b",
+      "crates/projectatlas-cli/tests/e2e_delivery.rs": "cc2fbf1bcd50f01b252a0bcafdf4b1f3831afe129f392fae646e6089d0d2bfeb",
       "crates/projectatlas-cli/tests/e2e_lifecycle.rs": "b2691058f2324abbccd250c9541ec762bf302f1f1e5f93f0455ece8729e5c21f",
       "crates/projectatlas-cli/tests/e2e_maintenance.rs": "0fca4b81eccb59fcb208b5c8a409cbf120ffc40f0f0b4d01dda5c582274ea0ec",
       "crates/projectatlas-cli/tests/e2e_navigation.rs": "910c770ebf1bc427dd08dfee19fcd22b817bdd85f9d08cd36682fbffee127efb",

--- a/docs/v050-cli-e2e-inventory.json
+++ b/docs/v050-cli-e2e-inventory.json
@@ -3,7 +3,7 @@
   "source_contract": {
     "normalization": "UTF-8 source with CRLF and CR normalized to LF; relative binary keys only; no absolute paths or line metadata",
     "files": {
-      "crates/projectatlas-cli/tests/e2e_delivery.rs": "2aad2626eab02f796b13be6ec1e5f804aa5610230210012cc29322fc2673e163",
+      "crates/projectatlas-cli/tests/e2e_delivery.rs": "5dbedba2be59b05e23c885a6091727ae719a77eea70b0df0e0db6a397548e29c",
       "crates/projectatlas-cli/tests/e2e_lifecycle.rs": "b2691058f2324abbccd250c9541ec762bf302f1f1e5f93f0455ece8729e5c21f",
       "crates/projectatlas-cli/tests/e2e_maintenance.rs": "0fca4b81eccb59fcb208b5c8a409cbf120ffc40f0f0b4d01dda5c582274ea0ec",
       "crates/projectatlas-cli/tests/e2e_navigation.rs": "910c770ebf1bc427dd08dfee19fcd22b817bdd85f9d08cd36682fbffee127efb",

--- a/openspec/changes/align-mcp-payload-fixture-authority/.openspec.yaml
+++ b/openspec/changes/align-mcp-payload-fixture-authority/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/align-mcp-payload-fixture-authority/design.md
+++ b/openspec/changes/align-mcp-payload-fixture-authority/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The fixture seeds a sibling database but explicit `atlas_init(project_path=...)`
+selects the nested project database. Its later implicit calls select the sibling.
+The hosted payloads prove this mismatch and a purpose freshness refusal, but do
+not identify the event that invalidated the purpose mutation's source witness.
+
+## Goals / Non-Goals
+
+Use one index for the stated lifecycle and preserve the real protocol assertions.
+Do not change product selection, freshness, storage, deadlines, or recovery policy.
+
+## Decisions
+
+Use the canonical nested database already selected by explicit project routing.
+Assert the initialized and selected database paths against that expected path,
+using existing TOON decoding and JSON assertion helpers. This is smaller and more
+truthful than inserting a refresh of the unrelated external index or changing
+product routing to accommodate a fixture.
+
+## Risks / Trade-offs
+
+The identity correction may expose a separate freshness defect. Retain any such
+failure and determine its actual source delta or observer cause; a passing rerun
+alone is not a causal explanation. Existing successful purpose and graph payload
+assertions remain mandatory alongside the new identity check.
+
+## Migration Plan
+
+Land the independent fixture repair on main before refreshing #572 and #465.
+There is no product migration. A revert restores the known fixture mismatch.
+
+## Architecture
+
+N/A: Existing product, process, and test-harness ownership remains unchanged.
+
+## Dependencies / Cross-Issue Impact
+
+No implementation prerequisite. #574 is a direct child and blocker of #492 and
+a shared validation prerequisite of #572. #465 continues after #572 closes.
+
+## Open Questions
+
+None.

--- a/openspec/changes/align-mcp-payload-fixture-authority/proposal.md
+++ b/openspec/changes/align-mcp-payload-fixture-authority/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The real MCP payload fixture claims one initialization/navigation database but
+mixes an external selected database with explicit project-local initialization.
+This invalidates the fixture's stated lifecycle and complicates a hosted purpose
+freshness failure whose exact observer cause is not established.
+
+## What Changes
+
+- Select the canonical project-local database throughout the existing fixture.
+- Assert initialization and selected-runtime database identity before payload proof.
+- Preserve all payload assertions and investigate any remaining freshness refusal.
+
+## Capabilities
+
+### New Capabilities
+
+- `mcp-payload-fixture-authority`: one database for the real MCP payload fixture.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+Issue #574 is ready for implementation under #492 and unblocks shared validation
+for #572 and #465. Only the existing delivery fixture and its source-contract
+digest mirrors change; product routing, storage, and observer owners do not.
+
+## Non-Goals
+
+No extra refresh, timeout increase, retry-based acceptance, weakened assertion,
+database replacement, or unproven product observer change.

--- a/openspec/changes/align-mcp-payload-fixture-authority/specs/mcp-payload-fixture-authority/spec.md
+++ b/openspec/changes/align-mcp-payload-fixture-authority/specs/mcp-payload-fixture-authority/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: MCP payload fixture uses one project database
+
+The real MCP payload fixture SHALL use the canonical project-local database for
+setup, scanning, purpose seeding, explicit initialization, and implicit navigation.
+It SHALL compare initialized and selected database identity against the expected
+fixture database before accepting successful payloads. Existing payload assertions,
+process cleanup, deadlines, and product freshness behavior SHALL remain intact.
+
+#### Scenario: Initialization and navigation share the seeded index
+
+- **WHEN** the real CLI setup and MCP phases execute the fixture
+- **THEN** the initialization and selected-runtime reports identify the expected project-local database
+- **AND** the existing purpose, graph, navigation, and compatibility assertions pass
+
+#### Scenario: The fixture selects a different database
+
+- **WHEN** explicit initialization and implicit navigation identify different databases
+- **THEN** the identity assertion fails with the actual and expected binding
+- **AND** no fallback database or implicit refresh can satisfy acceptance
+
+#### Scenario: The selected index is unavailable or freshness is refused
+
+- **WHEN** the coherent fixture cannot provide the required successful payload
+- **THEN** the existing assertion remains a failure requiring diagnosis
+- **AND** no increased deadline, retry-based acceptance, or unproven observer change hides it

--- a/openspec/changes/align-mcp-payload-fixture-authority/tasks.md
+++ b/openspec/changes/align-mcp-payload-fixture-authority/tasks.md
@@ -4,8 +4,8 @@
 
 ## 2. Implementation and proof
 
-- [ ] 2.1 Bind setup and every MCP phase to the canonical project-local database and assert initialized and selected identity.
-- [ ] 2.2 Prove the old identity mismatch, preserve complete payload assertions, resolve any remaining causal failure, and pass required local and hosted checks.
+- [x] 2.1 Bind setup and every MCP phase to the canonical project-local database and assert initialized and selected identity.
+- [x] 2.2 Prove the old identity mismatch, preserve complete payload assertions, resolve any remaining causal failure, and pass required local and hosted checks.
 
 Verification: run the exact `mcp_stdio_serves_toon_tool_payloads` delivery test,
 affected source-contract inventory checks, IssueOps, strict OpenSpec validation,

--- a/openspec/changes/align-mcp-payload-fixture-authority/tasks.md
+++ b/openspec/changes/align-mcp-payload-fixture-authority/tasks.md
@@ -1,0 +1,12 @@
+## 1. Contract
+
+- [x] 1.1 Define the single-database fixture contract and shared release dependency mapping.
+
+## 2. Implementation and proof
+
+- [ ] 2.1 Bind setup and every MCP phase to the canonical project-local database and assert initialized and selected identity.
+- [ ] 2.2 Prove the old identity mismatch, preserve complete payload assertions, resolve any remaining causal failure, and pass required local and hosted checks.
+
+Verification: run the exact `mcp_stdio_serves_toon_tool_payloads` delivery test,
+affected source-contract inventory checks, IssueOps, strict OpenSpec validation,
+and the normal pre-push and required hosted verification routes.

--- a/openspec/issue-map.json
+++ b/openspec/issue-map.json
@@ -13,7 +13,7 @@
         "390": { "blocked_by": [] },
         "456": { "blocked_by": [358, 465, 477, 484] },
         "464": { "blocked_by": [] },
-        "465": { "blocked_by": [476, 480, 488, 570] },
+        "465": { "blocked_by": [476, 480, 488, 570, 572] },
         "476": { "blocked_by": [481] },
         "477": { "blocked_by": [547] },
         "480": { "blocked_by": [482] },
@@ -28,7 +28,7 @@
         "489": { "blocked_by": [] },
         "490": { "blocked_by": [339, 342, 358, 384, 464, 465, 489] },
         "491": { "blocked_by": [] },
-        "492": { "blocked_by": [339, 342, 358, 372, 384, 388, 390, 456, 464, 465, 476, 477, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 495, 517, 518, 523, 525, 533, 544, 547, 549, 555, 561, 564, 567, 568, 570] },
+        "492": { "blocked_by": [339, 342, 358, 372, 384, 388, 390, 456, 464, 465, 476, 477, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 495, 517, 518, 523, 525, 533, 544, 547, 549, 555, 561, 564, 567, 568, 570, 572, 574] },
         "495": { "blocked_by": [] },
         "517": { "blocked_by": [] },
         "518": { "blocked_by": [547] },
@@ -43,7 +43,9 @@
         "564": { "blocked_by": [] },
         "567": { "blocked_by": [] },
         "568": { "blocked_by": [] },
-        "570": { "blocked_by": [] }
+        "570": { "blocked_by": [] },
+        "572": { "blocked_by": [574] },
+        "574": { "blocked_by": [] }
       }
     },
     "v0.6.0-00": {
@@ -62,6 +64,7 @@
     "add-mcp-task-progress-model": 295,
     "add-nearest-project-routing": 276,
     "advance-rust-repository-intelligence": 308,
+    "align-mcp-payload-fixture-authority": 574,
     "await-observable-watch-readiness": 422,
     "bind-release-asset-fixture-lifecycle": 533,
     "bound-impact-analysis-deadlines": 380,


### PR DESCRIPTION
Keep CLI setup, explicit MCP initialization, and implicit navigation on the same project-local database. Decode the init and settings responses and compare their canonical database paths with the fixture before accepting its payload contract.

Closes #574

The prior fixture selected two independent indexes. The new identity check fails against that setup and passes with the canonical binding. Existing request phases, payload assertions, freshness behavior, and deadlines are preserved.

Validation: causal identity failure on the old fixture; exact real MCP payload test and three source-inventory checks passed; independent review and the normal pre-push gates passed. Required hosted checks remain the merge gate.
