### PR TITLE
fix(ci): preserve source verification across PR metadata edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 # Purpose: Verify ProjectAtlas Rust quality gates and multi-OS behavior tests.
 
 name: 01-CI
+run-name: ${{ github.event_name == 'pull_request' && format('{0}-pr-{1}-base-{2}-head-{3}', (github.event.action != 'edited' || github.event.changes.base != null) && 'source' || 'metadata', github.event.pull_request.number, github.event.pull_request.base.sha, github.event.pull_request.head.sha) || format('ci-{0}-{1}', github.event_name, github.sha) }}
 
 # /**
 #  * Purpose: Run Rust source, test, and build checks.
@@ -880,18 +881,46 @@ jobs:
         run: cargo test --locked -p projectatlas-cli generated_mcp_config_preserves_explicit_conventional_database_authority --test e2e_lifecycle -- --exact --nocapture
 
   verify:
-    name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.base == null && 'metadata-edit' || 'verify' }}
-    if: always() && (github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null)
+    name: verify
+    # Every native CI suite supplies verify; metadata must validate real source proof.
+    if: always()
     needs: [plan, repository, rust, e2e-smoke]
     runs-on: ubuntu-latest
+    timeout-minutes: 125
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     steps:
+      - name: Verify existing source proof for metadata
+        if: github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.base == null
+        timeout-minutes: 121
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_BASE: ${{ github.event.pull_request.base.sha }}
+          EVENT_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          helper="$RUNNER_TEMP/affected-ci-proof.py"
+          gh api -H 'Accept: application/vnd.github.raw+json' \
+            "repos/$GITHUB_REPOSITORY/contents/.github/scripts/affected-ci-proof.py?ref=$EVENT_BASE" > "$helper"
+          python3 "$helper" verify-metadata \
+            --repo "$GITHUB_REPOSITORY" \
+            --pull-request "$PR_NUMBER" \
+            --run-id "$GITHUB_RUN_ID" \
+            --base "$EVENT_BASE" \
+            --head "$EVENT_HEAD"
+
       - name: Checkout exact source
+        if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.plan.outputs.head || github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
           fetch-depth: 2
 
       - name: Aggregate selected proof
+        if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
         env:
           PLAN_RESULT: ${{ needs.plan.result }}
           PLAN: ${{ needs.plan.outputs.plan }}

--- a/crates/projectatlas-cli/tests/e2e_delivery.rs
+++ b/crates/projectatlas-cli/tests/e2e_delivery.rs
@@ -3728,12 +3728,57 @@ fn issueops_and_workflows_use_behavior_focused_quality_gates() -> Result<(), Box
     }
     let verify_job = workflow_job_block(&ci, "verify")?;
     for required in [
-        "name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.base == null && 'metadata-edit' || 'verify' }}",
-        &format!("if: always() && ({source_event})"),
+        "    name: verify\n",
+        "    if: always()\n",
+        "      actions: read\n",
     ] {
         if !verify_job.contains(required) {
             return Err(io::Error::other(format!(
-                "metadata-only edits must not emit or satisfy source aggregate {required:?}"
+                "native verification must revalidate source proof on metadata: {required:?}"
+            ))
+            .into());
+        }
+    }
+    let metadata_event = "github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.base == null";
+    let metadata_step =
+        workflow_job_step(&ci, "verify", "Verify existing source proof for metadata")?;
+    if metadata_step["if"].as_str() != Some(metadata_event) {
+        return Err(
+            io::Error::other("metadata proof lookup must not run for source events").into(),
+        );
+    }
+    let metadata_run = metadata_step["run"]
+        .as_str()
+        .ok_or_else(|| io::Error::other("metadata verification omitted its execution step"))?;
+    if metadata_step["env"]["EVENT_BASE"].as_str()
+        != Some("${{ github.event.pull_request.base.sha }}")
+        || !metadata_run.contains("affected-ci-proof.py?ref=$EVENT_BASE")
+        || metadata_run.contains("affected-ci-proof.py?ref=$EVENT_HEAD")
+    {
+        return Err(io::Error::other(
+            "metadata verification must execute only the captured accepted-base helper",
+        )
+        .into());
+    }
+    for required in [
+        "format('{0}-pr-{1}-base-{2}-head-{3}'",
+        "&& 'source' || 'metadata'",
+        "github.event.pull_request.number, github.event.pull_request.base.sha, github.event.pull_request.head.sha",
+        "verify-metadata",
+        "--run-id \"$GITHUB_RUN_ID\"",
+    ] {
+        if !ci.contains(required) {
+            return Err(io::Error::other(format!(
+                "metadata proof omitted native event binding {required:?}"
+            ))
+            .into());
+        }
+    }
+    for name in ["Checkout exact source", "Aggregate selected proof"] {
+        let step = workflow_job_step(&ci, "verify", name)?;
+        if step["if"].as_str() != Some(source_event) {
+            return Err(io::Error::other(format!(
+                "metadata-only edits must not execute source step {name:?}"
             ))
             .into());
         }

--- a/crates/projectatlas-cli/tests/support/source_contract.rs
+++ b/crates/projectatlas-cli/tests/support/source_contract.rs
@@ -3,7 +3,7 @@
 pub(super) const CLI_E2E_SOURCE_SHA256: &[(&str, &str)] = &[
     (
         "crates/projectatlas-cli/tests/e2e_delivery.rs",
-        "c88722b6f7cb8ffc7f9cbcffb81789b35aeae76b8ae744b6922b145eae7e2990",
+        "964b2fa019a509442bf512dae3422a113c5a2a8fd0dbc334d885919246d5d9ba",
     ),
     (
         "crates/projectatlas-cli/tests/e2e_lifecycle.rs",

--- a/docs/v050-cli-e2e-inventory.json
+++ b/docs/v050-cli-e2e-inventory.json
@@ -3,7 +3,7 @@
   "source_contract": {
     "normalization": "UTF-8 source with CRLF and CR normalized to LF; relative binary keys only; no absolute paths or line metadata",
     "files": {
-      "crates/projectatlas-cli/tests/e2e_delivery.rs": "c88722b6f7cb8ffc7f9cbcffb81789b35aeae76b8ae744b6922b145eae7e2990",
+      "crates/projectatlas-cli/tests/e2e_delivery.rs": "964b2fa019a509442bf512dae3422a113c5a2a8fd0dbc334d885919246d5d9ba",
       "crates/projectatlas-cli/tests/e2e_lifecycle.rs": "b2691058f2324abbccd250c9541ec762bf302f1f1e5f93f0455ece8729e5c21f",
       "crates/projectatlas-cli/tests/e2e_maintenance.rs": "0fca4b81eccb59fcb208b5c8a409cbf120ffc40f0f0b4d01dda5c582274ea0ec",
       "crates/projectatlas-cli/tests/e2e_navigation.rs": "0430e0340a7cb9e047806030f664ce0619c90ca39f938bc92c3128fc664b0026",

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -146,8 +146,17 @@ Commit identity is provenance, not a general test invalidation key. After a comm
   Unknown paths and shared workflow, planner, toolchain, lockfile, manifest,
   schema, or test-support authorities select complete normal-PR proof. A base
   retarget replans against the new base even when the head is unchanged; a title
-  or body edit runs no source job, emits no `verify` context, and cannot cancel
-  in-flight source proof.
+  or body edit runs no source job and cannot cancel or rerun source proof. Its required `verify` job
+  reads the existing source run instead: the latest source run for this PR/head
+  must match the event's captured base and have successful native `plan` and
+  `verify` jobs. Source run names capture PR/base/head at event creation; an old
+  run's mutable PR association is not historical proof. Metadata fetches only
+  the verification helper at the captured accepted base, without checkout, planning, builds,
+  tests, or source aggregation. It rechecks the live PR before passing and waits
+  up to 120 minutes for pending source work. Missing, failed, stale, inaccessible,
+  or incomplete proof fails closed, including discovery beyond 100 head-matching
+  runs. Missing accepted-base verification support fails closed; the submitted
+  head is never a fallback authority. This keeps native protected readiness truthful after metadata edits.
 - The lightweight required `pr-state` workflow owns exactly-one-open-issue
   reference validation and requires the PR milestone to match that issue's
   milestone. GitHub native required conversation resolution owns all

--- a/openspec/changes/preserve-ci-proof-across-pr-metadata/tasks.md
+++ b/openspec/changes/preserve-ci-proof-across-pr-metadata/tasks.md
@@ -5,8 +5,8 @@
 ## 2. Implementation and proof
 
 - [x] 2.1 Establish the bounded native source-run verifier and its failure-path tests on the accepted base through normal protected source checks.
-- [ ] 2.2 Activate metadata verification using only the captured accepted-base verifier without rebuilding source, and update causal routing checks and guidance.
-- [ ] 2.3 Prove metadata edits preserve source-check identity and readiness, base retargets execute exact comparison proof, and incomplete retarget proof cannot be accepted by later metadata; pass required local and hosted gates.
+- [x] 2.2 Activate metadata verification using only the captured accepted-base verifier without rebuilding source, and update causal routing checks and guidance.
+- [x] 2.3 Prove metadata edits preserve source-check identity and readiness, base retargets execute exact comparison proof, and incomplete retarget proof cannot be accepted by later metadata; pass required local and hosted gates.
 
 Verification: `cargo test --locked -p projectatlas-cli --test e2e_delivery issueops_and_workflows_use_behavior_focused_quality_gates -- --exact --nocapture`;
 `python .github/scripts/affected-ci-proof.py --self-test`;

--- a/openspec/changes/preserve-ci-proof-across-pr-metadata/tasks.md
+++ b/openspec/changes/preserve-ci-proof-across-pr-metadata/tasks.md
@@ -4,7 +4,7 @@
 
 ## 2. Implementation and proof
 
-- [ ] 2.1 Establish the bounded native source-run verifier and its failure-path tests on the accepted base through normal protected source checks.
+- [x] 2.1 Establish the bounded native source-run verifier and its failure-path tests on the accepted base through normal protected source checks.
 - [ ] 2.2 Activate metadata verification using only the captured accepted-base verifier without rebuilding source, and update causal routing checks and guidance.
 - [ ] 2.3 Prove metadata edits preserve source-check identity and readiness, base retargets execute exact comparison proof, and incomplete retarget proof cannot be accepted by later metadata; pass required local and hosted gates.
 


### PR DESCRIPTION
## Summary

Title and body edits now use the existing required `verify` job to validate successful native source CI for the same PR, captured base, and head without running source checks again. Metadata fetches the verifier only from the captured accepted base; source and base-retarget events retain the existing planner and aggregate. Missing or unsuccessful source proof fails closed. Pending source work is observed with a bounded wait.

The trusted verifier prerequisite is already on main. This activation also adds causal workflow checks for base-only verifier execution and updates the workflow guide.

## Issue

Closes #560

## Validation

- Focused workflow regression passes; unsafe head-fetch and base-binding mutations fail the owning assertion.
- Formatting, strict OpenSpec validation, and candidate IssueOps pass.
- Independent implementation and acceptance review found no outstanding findings.
- Normal implementation pre-push checks, Atlas scan, and low-purpose lint passed; initial and retarget source CI passed on Linux, Windows, macOS x64, and macOS ARM64.
- Hosted title/body edits preserved native readiness without source execution. Overlapping metadata waited for the latest source run, rejected cancellation despite older success, and recovered after the same source event was rerun successfully.
- Issue edits refreshed PR-state without launching source CI. Final readiness remains subject to required checks on the published closeout head.
