### PR TITLE
feat(analysis): add entrypoint-aware repository dead-code profiles

### DIFF
--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -124,6 +124,8 @@ const DEFAULT_CALLER_LABEL: &str = "default";
 const DEFAULT_FILE_SUMMARY_LIMIT: usize = 25;
 /// CLI top-level field for detailed and analysis relation responses.
 const CLI_PAYLOAD_SYMBOL_RELATIONS: &str = "symbol_relations";
+/// Federated analysis does not support single-root entrypoint profiling.
+const CLI_ERROR_ENTRYPOINT_FEDERATED: &str = "entrypoint profiles require one project root";
 /// One-shot watcher refresh mode.
 const WATCH_MODE_ONCE: &str = "single-refresh";
 /// Event-backed watcher mode.
@@ -2259,6 +2261,14 @@ fn run(cli: &mut Cli) -> Result<(), CliError> {
                             .to_string(),
                     )));
                 }
+                let mode = analysis_mode
+                    .unwrap_or(RelationAnalysisModeArg::Architecture)
+                    .into();
+                if mode == RelationAnalysisMode::Entrypoint && !roots.is_empty() {
+                    return Err(CliError::Service(ServiceError::InvalidInput(
+                        CLI_ERROR_ENTRYPOINT_FEDERATED.to_string(),
+                    )));
+                }
                 let federation_control = (!roots.is_empty()).then(|| {
                     standalone_index_work_control()
                         .with_timeout_ceiling(Duration::from_millis(10_000))
@@ -2318,9 +2328,6 @@ fn run(cli: &mut Cli) -> Result<(), CliError> {
                                 .to_string(),
                         )));
                     }
-                    let mode: RelationAnalysisMode = analysis_mode
-                        .unwrap_or(RelationAnalysisModeArg::Architecture)
-                        .into();
                     let parsed_entrypoints = if mode == RelationAnalysisMode::Entrypoint {
                         entrypoints
                             .iter()
@@ -6568,6 +6575,39 @@ mod tests {
                 && toon.contains("not-installed")
                 && toon.contains("compatible semantic"),
             "CLI TOON lost typed semantic capability state",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn cli_rejects_federated_entrypoint_analysis_before_opening_roots() -> Result<(), Box<dyn Error>>
+    {
+        let mut cli = Cli::try_parse_from([
+            "projectatlas",
+            "symbols",
+            "relations",
+            "--view",
+            "analysis",
+            "--root",
+            "missing-a",
+            "--root",
+            "missing-b",
+            "--analysis-mode",
+            "entrypoint",
+            "--file",
+            "src/a.rs",
+        ])?;
+        let error = match super::run(&mut cli) {
+            Ok(()) => {
+                return Err(io::Error::other("federated entrypoint analysis was accepted").into());
+            }
+            Err(error) => error,
+        };
+        require_condition(
+            error
+                .to_string()
+                .contains(super::CLI_ERROR_ENTRYPOINT_FEDERATED),
+            "federated entrypoint rejection did not preserve its typed boundary",
         )?;
         Ok(())
     }

--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -48,10 +48,10 @@ use projectatlas_fs::worktree::{
 };
 use projectatlas_service::{
     COVERAGE_PAGE_MAX_LIMIT, CodeSlice, CodeSliceBudget, CodeSliceDraft, CoverageDiscoveryReport,
-    DetailedRelationBudget, DetailedRelationQuery, FederatedStore, FileSummaryReport,
-    GitImpactSelection, RelationAnalysisMode, RelationAnalysisQuery, RelationAnchor,
-    RelationDirection, RelationResolutionFilter, SearchQuery, SearchReport, SearchRetrievalMode,
-    ServiceError, SymbolSliceSelector, TokenReport, TokenReportRequest,
+    DetailedRelationBudget, DetailedRelationQuery, EntrypointProfile, FederatedStore,
+    FileSummaryReport, GitImpactSelection, RelationAnalysisMode, RelationAnalysisQuery,
+    RelationAnchor, RelationDirection, RelationResolutionFilter, SearchQuery, SearchReport,
+    SearchRetrievalMode, ServiceError, SymbolSliceSelector, TokenReport, TokenReportRequest,
     build_file_summary_from_source_with_selection, load_coverage_discovery,
     load_detailed_relation_page, load_federated_detailed_relations,
     load_federated_relation_analysis, load_relation_analysis, load_token_report,
@@ -491,6 +491,8 @@ enum RelationAnalysisModeArg {
     Impact,
     /// One node-simple static relationship path.
     Trace,
+    /// Bounded reachability from an explicit entrypoint profile.
+    Entrypoint,
 }
 
 impl From<RelationAnalysisModeArg> for RelationAnalysisMode {
@@ -499,6 +501,7 @@ impl From<RelationAnalysisModeArg> for RelationAnalysisMode {
             RelationAnalysisModeArg::Architecture => Self::Architecture,
             RelationAnalysisModeArg::Impact => Self::Impact,
             RelationAnalysisModeArg::Trace => Self::Trace,
+            RelationAnalysisModeArg::Entrypoint => Self::Entrypoint,
         }
     }
 }
@@ -601,6 +604,15 @@ struct RelationAnalysisArgs {
     /// Closed analysis projection computed over the bounded relation traversal.
     #[arg(long, value_enum)]
     analysis_mode: Option<RelationAnalysisModeArg>,
+    /// Stable name for an explicit entrypoint profile.
+    #[arg(long)]
+    profile_name: Option<String>,
+    /// JSON `RelationAnchor` value; repeat for multiple entrypoints.
+    #[arg(long = "entrypoint")]
+    entrypoints: Vec<String>,
+    /// Relation family admitted by an entrypoint profile; repeat to add families.
+    #[arg(long = "profile-relation")]
+    profile_relations: Vec<String>,
     /// Exact JSON `RelationAnchor` (`file` or fully disambiguated `symbol`) for trace mode.
     #[arg(long)]
     trace_target: Option<String>,
@@ -2213,6 +2225,9 @@ fn run(cli: &mut Cli) -> Result<(), CliError> {
                 } = detailed.as_ref();
                 let RelationAnalysisArgs {
                     analysis_mode,
+                    profile_name,
+                    entrypoints,
+                    profile_relations,
                     trace_target,
                     vcs,
                     include_communities,
@@ -2220,6 +2235,9 @@ fn run(cli: &mut Cli) -> Result<(), CliError> {
                     include_dead_code,
                 } = analysis.as_ref();
                 let analysis_controls_explicit = analysis_mode.is_some()
+                    || profile_name.is_some()
+                    || !entrypoints.is_empty()
+                    || !profile_relations.is_empty()
                     || trace_target.is_some()
                     || vcs.is_some()
                     || *include_communities
@@ -2300,16 +2318,61 @@ fn run(cli: &mut Cli) -> Result<(), CliError> {
                                 .to_string(),
                         )));
                     }
-                    let file = file.as_deref().ok_or_else(|| {
-                        CliError::Service(ServiceError::InvalidInput(
-                            "detailed symbol relations require --file".to_string(),
-                        ))
-                    })?;
-                    let file = validated_indexed_file_key(store, Path::new(file))?;
+                    let mode: RelationAnalysisMode = analysis_mode
+                        .unwrap_or(RelationAnalysisModeArg::Architecture)
+                        .into();
+                    let parsed_entrypoints = if mode == RelationAnalysisMode::Entrypoint {
+                        entrypoints
+                            .iter()
+                            .map(|value| serde_json::from_str::<RelationAnchor>(value))
+                            .collect::<Result<Vec<_>, _>>()
+                            .map_err(|error| {
+                                CliError::Service(ServiceError::InvalidInput(format!(
+                                    "--entrypoint must be an exact RelationAnchor JSON object: {error}"
+                                )))
+                            })?
+                    } else {
+                        Vec::new()
+                    };
+                    if mode == RelationAnalysisMode::Entrypoint
+                        && !parsed_entrypoints.is_empty()
+                        && (symbol.is_some()
+                            || symbol_parent.is_some()
+                            || symbol_kind.is_some()
+                            || symbol_signature.is_some())
+                    {
+                        return Err(CliError::Service(ServiceError::InvalidInput(
+                            "--entrypoint anchors cannot be combined with detailed symbol selectors"
+                                .to_string(),
+                        )));
+                    }
+                    let file = match file.as_deref() {
+                        Some(file) => file.to_string(),
+                        None if mode == RelationAnalysisMode::Entrypoint => parsed_entrypoints
+                            .first()
+                            .map(|anchor| match anchor {
+                                RelationAnchor::File { file }
+                                | RelationAnchor::Symbol { file, .. } => file.as_str().to_string(),
+                            })
+                            .ok_or_else(|| {
+                                CliError::Service(ServiceError::InvalidInput(
+                                    "entrypoint analysis requires --entrypoint or --file"
+                                        .to_string(),
+                                ))
+                            })?,
+                        None => {
+                            return Err(CliError::Service(ServiceError::InvalidInput(
+                                "detailed symbol relations require --file".to_string(),
+                            )));
+                        }
+                    };
+                    let file = validated_indexed_file_key(store, Path::new(&file))?;
                     let file = RepositoryFilePath::new(Path::new(&file)).map_err(|error| {
                         CliError::Service(ServiceError::InvalidInput(error.to_string()))
                     })?;
-                    let anchor = if let Some(symbol) = symbol {
+                    let anchor = if let Some(anchor) = parsed_entrypoints.first() {
+                        anchor.clone()
+                    } else if let Some(symbol) = symbol {
                         if symbol.is_empty() {
                             return Err(CliError::Service(ServiceError::InvalidInput(
                                 "detailed relation symbol must not be empty".to_string(),
@@ -2420,9 +2483,6 @@ fn run(cli: &mut Cli) -> Result<(), CliError> {
                                 }
                             }
                         };
-                        let mode: RelationAnalysisMode = analysis_mode
-                            .unwrap_or(RelationAnalysisModeArg::Architecture)
-                            .into();
                         let trace_target = trace_target
                             .as_deref()
                             .map(serde_json::from_str::<RelationAnchor>)
@@ -2432,6 +2492,39 @@ fn run(cli: &mut Cli) -> Result<(), CliError> {
                                     "--trace-target must be an exact RelationAnchor JSON object: {error}"
                                 )))
                             })?;
+                        let entrypoint_profile = if mode == RelationAnalysisMode::Entrypoint {
+                            let anchors = if parsed_entrypoints.is_empty() {
+                                vec![relations.anchor.clone()]
+                            } else {
+                                parsed_entrypoints.clone()
+                            };
+                            let relation_families = if profile_relations.is_empty() {
+                                GraphRelationKind::ALL.to_vec()
+                            } else {
+                                profile_relations
+                                    .iter()
+                                    .map(|value| parse_coverage_relation(value))
+                                    .collect::<Result<Vec<_>, _>>()?
+                            };
+                            Some(EntrypointProfile {
+                                name: profile_name
+                                    .clone()
+                                    .unwrap_or_else(|| "entrypoint-profile".to_string()),
+                                anchors,
+                                relations: relation_families,
+                            })
+                        } else {
+                            if profile_name.is_some()
+                                || !entrypoints.is_empty()
+                                || !profile_relations.is_empty()
+                            {
+                                return Err(CliError::Service(ServiceError::InvalidInput(
+                                    "entrypoint profile controls require --analysis-mode entrypoint"
+                                        .to_string(),
+                                )));
+                            }
+                            None
+                        };
                         let query = RelationAnalysisQuery {
                             relations,
                             mode,
@@ -2441,6 +2534,7 @@ fn run(cli: &mut Cli) -> Result<(), CliError> {
                             include_communities: *include_communities,
                             include_cycles: *include_cycles,
                             include_dead_code: *include_dead_code,
+                            entrypoint_profile,
                         };
                         if let Some(stores) = federated_stores.take() {
                             let control = federation_control.as_ref().ok_or_else(|| {

--- a/crates/projectatlas-cli/src/main.rs
+++ b/crates/projectatlas-cli/src/main.rs
@@ -2496,7 +2496,7 @@ fn run(cli: &mut Cli) -> Result<(), CliError> {
                             let anchors = if parsed_entrypoints.is_empty() {
                                 vec![relations.anchor.clone()]
                             } else {
-                                parsed_entrypoints.clone()
+                                parsed_entrypoints
                             };
                             let relation_families = if profile_relations.is_empty() {
                                 GraphRelationKind::ALL.to_vec()

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -105,7 +105,7 @@ use projectatlas_service::build_file_summary_from_source;
 use projectatlas_service::{
     COVERAGE_PAGE_MAX_LIMIT, CodeSliceBudget, CoverageDigest, CoverageTrustState,
     DetailedRelationBudget, DetailedRelationNode, DetailedRelationQuery, DetailedRelationReport,
-    DetailedRelationRow, DetailedRelationWork, FederatedDetailedRelationReport,
+    DetailedRelationRow, DetailedRelationWork, EntrypointProfile, FederatedDetailedRelationReport,
     FederatedParticipant, FederatedRelationWork, FederatedRendezvous, FederatedStore,
     FileCallSummary, FileSummaryReport, FileSymbolSummary, GitImpactSelection,
     RelationAnalysisMode, RelationAnalysisQuery, RelationAnchor, RelationDirection,
@@ -464,6 +464,8 @@ const MCP_RELATION_ANALYSIS_MODE_ARCHITECTURE: &str = "architecture";
 const MCP_RELATION_ANALYSIS_MODE_IMPACT: &str = "impact";
 /// Static trace relation-analysis mode.
 const MCP_RELATION_ANALYSIS_MODE_TRACE: &str = "trace";
+/// Explicit entrypoint-profile reachability mode.
+const MCP_RELATION_ANALYSIS_MODE_ENTRYPOINT: &str = "entrypoint";
 /// Default working-tree VCS impact selection.
 const MCP_RELATION_ANALYSIS_VCS_WORKING_TREE: &str = "working_tree";
 /// Staged-index VCS impact selection.
@@ -1213,8 +1215,14 @@ struct AtlasSymbolRelationsParams {
     deadline_ms: Option<u64>,
     /// Maximum encoded bytes admitted to the detailed response.
     output_bytes: Option<u32>,
-    /// Closed analysis mode: `architecture`, `impact`, or `trace`.
+    /// Closed analysis mode: `architecture`, `impact`, `trace`, or `entrypoint`.
     analysis_mode: Option<String>,
+    /// Stable name for an explicit entrypoint profile.
+    profile_name: Option<String>,
+    /// JSON `RelationAnchor` values; repeat for multiple entrypoints.
+    entrypoints: Option<Vec<String>>,
+    /// Relation families admitted by an entrypoint profile.
+    profile_relations: Option<Vec<String>>,
     /// Exact target symbol name for trace mode.
     trace_target: Option<String>,
     /// Exact target file for trace mode; alone selects a file target.
@@ -1244,6 +1252,15 @@ struct AtlasSymbolRelationsParams {
 /// Return whether any closed analysis-only control was supplied.
 fn relation_analysis_controls_present(params: &AtlasSymbolRelationsParams) -> bool {
     params.analysis_mode.is_some()
+        || params.profile_name.is_some()
+        || params
+            .entrypoints
+            .as_ref()
+            .is_some_and(|items| !items.is_empty())
+        || params
+            .profile_relations
+            .as_ref()
+            .is_some_and(|items| !items.is_empty())
         || params.trace_target.is_some()
         || params.trace_target_file.is_some()
         || params.trace_target_parent.is_some()
@@ -9153,6 +9170,7 @@ impl ProjectAtlasMcpServer {
                 MCP_RELATION_ANALYSIS_MODE_ARCHITECTURE => RelationAnalysisMode::Architecture,
                 MCP_RELATION_ANALYSIS_MODE_IMPACT => RelationAnalysisMode::Impact,
                 MCP_RELATION_ANALYSIS_MODE_TRACE => RelationAnalysisMode::Trace,
+                MCP_RELATION_ANALYSIS_MODE_ENTRYPOINT => RelationAnalysisMode::Entrypoint,
                 _unsupported => {
                     return Err(CliError::Service(ServiceError::InvalidInput(
                         MCP_ERROR_UNSUPPORTED_ANALYSIS_MODE.to_string(),
@@ -9163,6 +9181,58 @@ impl ProjectAtlasMcpServer {
             let vcs_explicit =
                 params.vcs.is_some() || params.vcs_base.is_some() || params.vcs_head.is_some();
             let vcs = relation_analysis_vcs(params)?;
+            if mode == RelationAnalysisMode::Entrypoint
+                && matches!(&stores, SymbolRelationStores::Federated(_))
+            {
+                return Err(CliError::Service(ServiceError::InvalidInput(
+                    "entrypoint profiles require one project root".to_string(),
+                )));
+            }
+            let entrypoint_profile = if mode == RelationAnalysisMode::Entrypoint {
+                let anchors = match params.entrypoints.as_ref() {
+                    Some(values) if !values.is_empty() => values
+                        .iter()
+                        .map(|value| serde_json::from_str::<RelationAnchor>(value))
+                        .collect::<Result<Vec<_>, _>>()
+                        .map_err(|error| {
+                            CliError::Service(ServiceError::InvalidInput(format!(
+                                "entrypoints must contain exact RelationAnchor JSON objects: {error}"
+                            )))
+                        })?,
+                    _ => vec![relations.anchor.clone()],
+                };
+                let relation_families = match params.profile_relations.as_ref() {
+                    Some(values) if !values.is_empty() => values
+                        .iter()
+                        .map(|value| parse_coverage_relation(value))
+                        .collect::<Result<Vec<_>, _>>()?,
+                    _ => GraphRelationKind::ALL.to_vec(),
+                };
+                Some(EntrypointProfile {
+                    name: params
+                        .profile_name
+                        .clone()
+                        .unwrap_or_else(|| "entrypoint-profile".to_string()),
+                    anchors,
+                    relations: relation_families,
+                })
+            } else {
+                if params.profile_name.is_some()
+                    || params
+                        .entrypoints
+                        .as_ref()
+                        .is_some_and(|items| !items.is_empty())
+                    || params
+                        .profile_relations
+                        .as_ref()
+                        .is_some_and(|items| !items.is_empty())
+                {
+                    return Err(CliError::Service(ServiceError::InvalidInput(
+                        "entrypoint profile controls require analysis_mode=entrypoint".to_string(),
+                    )));
+                }
+                None
+            };
             let query = RelationAnalysisQuery {
                 relations,
                 mode,
@@ -9171,6 +9241,7 @@ impl ProjectAtlasMcpServer {
                 include_communities: params.include_communities.unwrap_or(false),
                 include_cycles: params.include_cycles.unwrap_or(false),
                 include_dead_code: params.include_dead_code.unwrap_or(false),
+                entrypoint_profile,
             };
             let toon = match stores {
                 SymbolRelationStores::Single(store) => {
@@ -9317,10 +9388,32 @@ impl ProjectAtlasMcpServer {
                 .and_then(|worktrees| worktrees.first())
                 .map(String::as_str)
                 .or(params.worktree.as_deref());
+            let profile_file = if analysis
+                && params.analysis_mode.as_deref() == Some(MCP_RELATION_ANALYSIS_MODE_ENTRYPOINT)
+            {
+                params
+                    .entrypoints
+                    .as_ref()
+                    .and_then(|values| values.first())
+                    .map(|value| serde_json::from_str::<RelationAnchor>(value))
+                    .transpose()
+                    .map_err(|error| {
+                        CliError::Service(ServiceError::InvalidInput(format!(
+                            "entrypoints must contain exact RelationAnchor JSON objects: {error}"
+                        )))
+                    })?
+                    .map(|anchor| match anchor {
+                        RelationAnchor::File { file } | RelationAnchor::Symbol { file, .. } => {
+                            file.as_str().to_string()
+                        }
+                    })
+            } else {
+                None
+            };
             let (state, file, routed_project) = self.state_and_optional_file_key(
                 params.project_path.as_deref(),
                 selected_worktree,
-                params.file.as_deref(),
+                params.file.as_deref().or(profile_file.as_deref()),
                 nearest_project,
             )?;
             if params.roots.is_some() || federated_worktrees.is_some() {
@@ -12032,6 +12125,35 @@ mod tests {
                 && analysis.contains("next_call:")
                 && analysis.contains("work:"),
             "MCP relation analysis omitted its closed mode, findings, work, or reusable next call",
+        )?;
+        let entrypoint_anchor = serde_json::to_string(&RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/lib.rs"))?,
+        })?;
+        let entrypoint = server.atlas_symbol_relations_response(
+            &AtlasSymbolRelationsParams {
+                project_path: Some(project_path.to_string()),
+                file: None,
+                nearest_project: Some(false),
+                view: Some("analysis".to_string()),
+                direction: Some("outbound".to_string()),
+                resolution: Some("any".to_string()),
+                depth: Some(2),
+                limit: Some(50),
+                output_bytes: Some(64 * 1024),
+                analysis_mode: Some("entrypoint".to_string()),
+                profile_name: Some("mcp-entrypoint".to_string()),
+                entrypoints: Some(vec![entrypoint_anchor]),
+                profile_relations: Some(vec!["calls".to_string()]),
+                ..AtlasSymbolRelationsParams::default()
+            },
+            None,
+        );
+        require(
+            entrypoint.contains("symbol_relations:")
+                && entrypoint.contains("mode: entrypoint")
+                && entrypoint.contains("entrypoint_profile:")
+                && entrypoint.contains("coverage:"),
+            "MCP entrypoint analysis did not serialize the shared profile contract",
         )?;
 
         let state = ProjectAtlasMcpServer::project_state_from_root(Path::new(project_path))?;

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -476,6 +476,9 @@ const MCP_ERROR_ENTRYPOINT_ANCHORS_PREFIX: &str =
 /// MCP validation error for entrypoint controls on another analysis mode.
 const MCP_ERROR_ENTRYPOINT_CONTROLS_MODE: &str =
     "entrypoint profile controls require analysis_mode=entrypoint";
+/// MCP validation error for contradictory entrypoint and symbol selectors.
+const MCP_ERROR_ENTRYPOINT_SYMBOL_SELECTOR: &str =
+    "entrypoint anchors cannot be combined with detailed symbol selectors";
 /// Default working-tree VCS impact selection.
 const MCP_RELATION_ANALYSIS_VCS_WORKING_TREE: &str = "working_tree";
 /// Staged-index VCS impact selection.
@@ -9198,6 +9201,20 @@ impl ProjectAtlasMcpServer {
                     MCP_ERROR_ENTRYPOINT_FEDERATED.to_string(),
                 )));
             }
+            if mode == RelationAnalysisMode::Entrypoint
+                && params
+                    .entrypoints
+                    .as_ref()
+                    .is_some_and(|items| !items.is_empty())
+                && (params.symbol.is_some()
+                    || params.symbol_parent.is_some()
+                    || params.symbol_kind.is_some()
+                    || params.symbol_signature.is_some())
+            {
+                return Err(CliError::Service(ServiceError::InvalidInput(
+                    MCP_ERROR_ENTRYPOINT_SYMBOL_SELECTOR.to_string(),
+                )));
+            }
             let entrypoint_profile = if mode == RelationAnalysisMode::Entrypoint {
                 let anchors = match params.entrypoints.as_ref() {
                     Some(values) if !values.is_empty() => values
@@ -12152,7 +12169,7 @@ mod tests {
                 output_bytes: Some(64 * 1024),
                 analysis_mode: Some("entrypoint".to_string()),
                 profile_name: Some("mcp-entrypoint".to_string()),
-                entrypoints: Some(vec![entrypoint_anchor]),
+                entrypoints: Some(vec![entrypoint_anchor.clone()]),
                 profile_relations: Some(vec!["calls".to_string()]),
                 ..AtlasSymbolRelationsParams::default()
             },
@@ -12164,6 +12181,29 @@ mod tests {
                 && entrypoint.contains("entrypoint_profile:")
                 && entrypoint.contains("coverage:"),
             "MCP entrypoint analysis did not serialize the shared profile contract",
+        )?;
+        let entrypoint_symbol_conflict = server.atlas_symbol_relations_response(
+            &AtlasSymbolRelationsParams {
+                project_path: Some(project_path.to_string()),
+                file: None,
+                nearest_project: Some(false),
+                view: Some("analysis".to_string()),
+                direction: Some("outbound".to_string()),
+                resolution: Some("any".to_string()),
+                depth: Some(2),
+                limit: Some(50),
+                output_bytes: Some(64 * 1024),
+                analysis_mode: Some("entrypoint".to_string()),
+                symbol: Some("first".to_string()),
+                entrypoints: Some(vec![entrypoint_anchor]),
+                profile_relations: Some(vec!["calls".to_string()]),
+                ..AtlasSymbolRelationsParams::default()
+            },
+            None,
+        );
+        require(
+            entrypoint_symbol_conflict.contains(MCP_ERROR_ENTRYPOINT_SYMBOL_SELECTOR),
+            "MCP silently ignored a symbol selector alongside explicit entrypoint anchors",
         )?;
 
         let state = ProjectAtlasMcpServer::project_state_from_root(Path::new(project_path))?;

--- a/crates/projectatlas-cli/src/mcp.rs
+++ b/crates/projectatlas-cli/src/mcp.rs
@@ -466,6 +466,16 @@ const MCP_RELATION_ANALYSIS_MODE_IMPACT: &str = "impact";
 const MCP_RELATION_ANALYSIS_MODE_TRACE: &str = "trace";
 /// Explicit entrypoint-profile reachability mode.
 const MCP_RELATION_ANALYSIS_MODE_ENTRYPOINT: &str = "entrypoint";
+/// Default entrypoint profile name.
+const MCP_ENTRYPOINT_PROFILE_DEFAULT_NAME: &str = "entrypoint-profile";
+/// MCP validation error when entrypoint analysis receives federated stores.
+const MCP_ERROR_ENTRYPOINT_FEDERATED: &str = "entrypoint profiles require one project root";
+/// Prefix for invalid entrypoint anchor JSON.
+const MCP_ERROR_ENTRYPOINT_ANCHORS_PREFIX: &str =
+    "entrypoints must contain exact RelationAnchor JSON objects: ";
+/// MCP validation error for entrypoint controls on another analysis mode.
+const MCP_ERROR_ENTRYPOINT_CONTROLS_MODE: &str =
+    "entrypoint profile controls require analysis_mode=entrypoint";
 /// Default working-tree VCS impact selection.
 const MCP_RELATION_ANALYSIS_VCS_WORKING_TREE: &str = "working_tree";
 /// Staged-index VCS impact selection.
@@ -9185,7 +9195,7 @@ impl ProjectAtlasMcpServer {
                 && matches!(&stores, SymbolRelationStores::Federated(_))
             {
                 return Err(CliError::Service(ServiceError::InvalidInput(
-                    "entrypoint profiles require one project root".to_string(),
+                    MCP_ERROR_ENTRYPOINT_FEDERATED.to_string(),
                 )));
             }
             let entrypoint_profile = if mode == RelationAnalysisMode::Entrypoint {
@@ -9195,9 +9205,9 @@ impl ProjectAtlasMcpServer {
                         .map(|value| serde_json::from_str::<RelationAnchor>(value))
                         .collect::<Result<Vec<_>, _>>()
                         .map_err(|error| {
-                            CliError::Service(ServiceError::InvalidInput(format!(
-                                "entrypoints must contain exact RelationAnchor JSON objects: {error}"
-                            )))
+                            let mut message = MCP_ERROR_ENTRYPOINT_ANCHORS_PREFIX.to_string();
+                            message.push_str(&error.to_string());
+                            CliError::Service(ServiceError::InvalidInput(message))
                         })?,
                     _ => vec![relations.anchor.clone()],
                 };
@@ -9212,7 +9222,7 @@ impl ProjectAtlasMcpServer {
                     name: params
                         .profile_name
                         .clone()
-                        .unwrap_or_else(|| "entrypoint-profile".to_string()),
+                        .unwrap_or_else(|| MCP_ENTRYPOINT_PROFILE_DEFAULT_NAME.to_string()),
                     anchors,
                     relations: relation_families,
                 })
@@ -9228,7 +9238,7 @@ impl ProjectAtlasMcpServer {
                         .is_some_and(|items| !items.is_empty())
                 {
                     return Err(CliError::Service(ServiceError::InvalidInput(
-                        "entrypoint profile controls require analysis_mode=entrypoint".to_string(),
+                        MCP_ERROR_ENTRYPOINT_CONTROLS_MODE.to_string(),
                     )));
                 }
                 None
@@ -9398,9 +9408,9 @@ impl ProjectAtlasMcpServer {
                     .map(|value| serde_json::from_str::<RelationAnchor>(value))
                     .transpose()
                     .map_err(|error| {
-                        CliError::Service(ServiceError::InvalidInput(format!(
-                            "entrypoints must contain exact RelationAnchor JSON objects: {error}"
-                        )))
+                        let mut message = MCP_ERROR_ENTRYPOINT_ANCHORS_PREFIX.to_string();
+                        message.push_str(&error.to_string());
+                        CliError::Service(ServiceError::InvalidInput(message))
                     })?
                     .map(|anchor| match anchor {
                         RelationAnchor::File { file } | RelationAnchor::Symbol { file, .. } => {

--- a/crates/projectatlas-cli/tests/e2e_delivery.rs
+++ b/crates/projectatlas-cli/tests/e2e_delivery.rs
@@ -23075,9 +23075,20 @@ fn assert_frozen_mcp_surfaces_compatible(stdout: &str) -> Result<(), Box<dyn Err
             .get(name.as_str())
             .and_then(|tool| tool.get("inputSchema"))
             .ok_or_else(|| io::Error::other(format!("current MCP tool {name} is missing")))?;
+        let normalized_baseline = if name == "atlas_symbol_relations" {
+            let mut schema = baseline_schema.clone();
+            if let Some(description) = schema.pointer_mut("/properties/analysis_mode/description") {
+                *description = json!(
+                    "Closed analysis mode: `architecture`, `impact`, `trace`, or `entrypoint`."
+                );
+            }
+            schema
+        } else {
+            baseline_schema.clone()
+        };
         assert_json_contract_subset(
             &format!("{name}.inputSchema"),
-            baseline_schema,
+            &normalized_baseline,
             current_schema,
         )?;
     }

--- a/crates/projectatlas-cli/tests/e2e_delivery.rs
+++ b/crates/projectatlas-cli/tests/e2e_delivery.rs
@@ -456,7 +456,7 @@ const LANGUAGE_SUPPORT_FILE_NAME: &str = "language-support.md";
 
 const MCP_CONTRACT_PLUGIN_ROOT_ENV: &str = "PROJECTATLAS_MCP_CONTRACT_PLUGIN_ROOT";
 
-const MCP_TOOLS_SHA256: &str = "c364a97710088181c61ebf3ba57573fae5cf26b0eb21fe12f49d956a18ad6fcd";
+const MCP_TOOLS_SHA256: &str = "9a01e84163fd5a60cd850a6ccb2edb0c4cdb60bc3bd9c7cec9a61541c980b4c5";
 
 const WRONG_PROJECT_OWNER_DIR_NAME: &str = "wrong-owner";
 

--- a/crates/projectatlas-cli/tests/e2e_delivery.rs
+++ b/crates/projectatlas-cli/tests/e2e_delivery.rs
@@ -30715,6 +30715,10 @@ fn plugin_installer_manages_atlas_forwarder_lifecycle_and_argv() -> Result<(), B
             String::from_utf8_lossy(&committed_cleanup.stdout),
             String::from_utf8_lossy(&committed_cleanup.stderr)
         );
+        let cleanup_normalized = cleanup_text
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
         let retained = fs::read_dir(runtime_directory)?
             .collect::<Result<Vec<_>, io::Error>>()?
             .into_iter()
@@ -30727,7 +30731,7 @@ fn plugin_installer_manages_atlas_forwarder_lifecycle_and_argv() -> Result<(), B
             .collect::<Vec<_>>();
         require(
             committed_cleanup.status.success()
-                && cleanup_text.contains("retirement committed; quarantine cleanup remains")
+                && cleanup_normalized.contains("retirement committed; quarantine cleanup remains")
                 && !forwarder.exists()
                 && !provenance.exists()
                 && !installer_state.exists()

--- a/crates/projectatlas-cli/tests/e2e_navigation.rs
+++ b/crates/projectatlas-cli/tests/e2e_navigation.rs
@@ -734,8 +734,18 @@ fn entrypoint_analysis_cli_and_mcp_share_profile_result_and_rejections()
         repo.join(SRC_DIR_NAME).join(LIB_RS_FILE_NAME),
         "pub fn root() { child(); }\nfn child() {}\nfn isolated() {}\n",
     )?;
+    fs::write(
+        repo.join("composer.json"),
+        r#"{"autoload":{"psr-4":{"Parity\\":"src/"}}}"#,
+    )?;
+    fs::write(
+        repo.join(SRC_DIR_NAME).join("Parity.php"),
+        "<?php\nnamespace Parity;\nfunction helper(): void {}\n",
+    )?;
     let database = repo.join(ATLAS_DIR_NAME).join("projectatlas.db");
     run_scan(&repo, &database)?;
+    let php_summary = json_summary_command(&repo, &database, "src/Parity.php")?;
+    require_json_string(&php_summary, &["language"], "php")?;
 
     let anchor = serde_json::json!({
         "kind": "file",
@@ -767,6 +777,18 @@ fn entrypoint_analysis_cli_and_mcp_share_profile_result_and_rejections()
         .get("symbol_relations")
         .ok_or("CLI omitted symbol_relations")?;
     require_json_string(cli_report, &["mode"], "entrypoint")?;
+    if cli_report["entrypoint_profile"]["coverage"] != "partial"
+        || cli_report["findings"].as_array().is_none_or(|findings| {
+            findings
+                .iter()
+                .any(|finding| finding["status"] == "candidate")
+        })
+    {
+        return Err(io::Error::other(
+            "representative PHP graph uncertainty was exposed as a deletion candidate",
+        )
+        .into());
+    }
 
     let executable = mcp_contract_executable();
     let mut session = McpContractSession::spawn(&executable, &repo, &database)?;

--- a/crates/projectatlas-cli/tests/e2e_navigation.rs
+++ b/crates/projectatlas-cli/tests/e2e_navigation.rs
@@ -8843,9 +8843,20 @@ fn assert_frozen_mcp_surfaces_compatible(stdout: &str) -> Result<(), Box<dyn Err
             .get(name.as_str())
             .and_then(|tool| tool.get("inputSchema"))
             .ok_or_else(|| io::Error::other(format!("current MCP tool {name} is missing")))?;
+        let normalized_baseline = if name == "atlas_symbol_relations" {
+            let mut schema = baseline_schema.clone();
+            if let Some(description) = schema.pointer_mut("/properties/analysis_mode/description") {
+                *description = json!(
+                    "Closed analysis mode: `architecture`, `impact`, `trace`, or `entrypoint`."
+                );
+            }
+            schema
+        } else {
+            baseline_schema.clone()
+        };
         assert_json_contract_subset(
             &format!("{name}.inputSchema"),
-            baseline_schema,
+            &normalized_baseline,
             current_schema,
         )?;
     }

--- a/crates/projectatlas-cli/tests/e2e_navigation.rs
+++ b/crates/projectatlas-cli/tests/e2e_navigation.rs
@@ -725,6 +725,133 @@ fn detailed_relation_cli_bounds_the_exact_json_envelope() -> Result<(), Box<dyn 
 }
 
 #[test]
+fn entrypoint_analysis_cli_and_mcp_share_profile_result_and_rejections()
+-> Result<(), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let repo = temp.path().join("entrypoint-parity");
+    fs::create_dir_all(repo.join(SRC_DIR_NAME))?;
+    fs::write(
+        repo.join(SRC_DIR_NAME).join(LIB_RS_FILE_NAME),
+        "pub fn root() { child(); }\nfn child() {}\nfn isolated() {}\n",
+    )?;
+    let database = repo.join(ATLAS_DIR_NAME).join("projectatlas.db");
+    run_scan(&repo, &database)?;
+
+    let anchor = serde_json::json!({
+        "kind": "file",
+        "file": "src/lib.rs"
+    })
+    .to_string();
+    let cli_args = vec![
+        "--db".to_string(),
+        database.display().to_string(),
+        "symbols".to_string(),
+        "relations".to_string(),
+        "--view".to_string(),
+        "analysis".to_string(),
+        "--analysis-mode".to_string(),
+        "entrypoint".to_string(),
+        "--entrypoint".to_string(),
+        anchor.clone(),
+        "--profile-name".to_string(),
+        "parity".to_string(),
+        "--profile-relation".to_string(),
+        "calls".to_string(),
+        "--profile-relation".to_string(),
+        "contains".to_string(),
+        "--limit".to_string(),
+        "50".to_string(),
+    ];
+    let cli = run_mcp_contract_json(&mcp_contract_executable(), &repo, &cli_args)?;
+    let cli_report = cli
+        .get("symbol_relations")
+        .ok_or("CLI omitted symbol_relations")?;
+    require_json_string(cli_report, &["mode"], "entrypoint")?;
+
+    let executable = mcp_contract_executable();
+    let mut session = McpContractSession::spawn(&executable, &repo, &database)?;
+    let operation_result = (|| -> Result<(), Box<dyn Error>> {
+        let mcp: Value = toon_format::decode_default(&session.call_tool(
+            "atlas_symbol_relations",
+            &serde_json::json!({
+                "project_path": repo,
+                "view": "analysis",
+                "analysis_mode": "entrypoint",
+                "entrypoints": [anchor],
+                "profile_name": "parity",
+                "profile_relations": ["calls", "contains"],
+                "limit": 50
+            }),
+        )?)?;
+        let mcp_report = mcp
+            .get("symbol_relations")
+            .ok_or("MCP omitted symbol_relations")?;
+        require_json_string(mcp_report, &["mode"], "entrypoint")?;
+        for field in [
+            "entrypoint_profile",
+            "truncated",
+            "returned",
+            "total",
+            "findings",
+        ] {
+            if cli_report.get(field) != mcp_report.get(field) {
+                return Err(
+                    io::Error::other(format!("CLI and MCP entrypoint {field} diverged")).into(),
+                );
+            }
+        }
+        let invalid_cli = StdCommand::new(&executable)
+            .current_dir(&repo)
+            .env("PROJECTATLAS_NO_TELEMETRY", "1")
+            .arg("--format")
+            .arg("json")
+            .args([
+                "--db",
+                database.to_str().ok_or("database path is not UTF-8")?,
+                "symbols",
+                "relations",
+                "--view",
+                "analysis",
+                "--analysis-mode",
+                "architecture",
+                "--file",
+                "src/lib.rs",
+                "--profile-relation",
+                "calls",
+            ])
+            .output()?;
+        if invalid_cli.status.success()
+            || !String::from_utf8_lossy(&invalid_cli.stderr).contains("entrypoint profile controls")
+        {
+            return Err(io::Error::other(format!(
+                "CLI accepted entrypoint controls outside entrypoint mode: status={}, stderr={}",
+                invalid_cli.status,
+                String::from_utf8_lossy(&invalid_cli.stderr)
+            ))
+            .into());
+        }
+        let invalid_mcp = session.call_tool(
+            "atlas_symbol_relations",
+            &serde_json::json!({
+                "project_path": repo,
+                "view": "analysis",
+                "analysis_mode": "architecture",
+                "file": "src/lib.rs",
+                "profile_relations": ["calls"]
+            }),
+        )?;
+        if !invalid_mcp.contains("entrypoint profile controls") {
+            return Err(io::Error::other(
+                "MCP accepted entrypoint controls outside entrypoint mode",
+            )
+            .into());
+        }
+        Ok(())
+    })();
+    complete_mcp_test_after_shutdown(operation_result, || session.shutdown())
+}
+
+#[test]
 fn impact_analysis_deadline_and_mcp_cancellation_release_resources() -> Result<(), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let repo = temp.path().join("bounded-impact-adapters");

--- a/crates/projectatlas-cli/tests/e2e_navigation.rs
+++ b/crates/projectatlas-cli/tests/e2e_navigation.rs
@@ -98,6 +98,8 @@ const INSTALLER_RS_FILE_NAME: &str = "installer.rs";
 
 const LIB_RS_FILE_NAME: &str = "lib.rs";
 
+const COMPOSER_JSON_FILE_NAME: &str = "composer.json";
+
 const GIT_DIR_NAME: &str = ".git";
 
 const ATLAS_DIR_NAME: &str = ".projectatlas";
@@ -735,7 +737,7 @@ fn entrypoint_analysis_cli_and_mcp_share_profile_result_and_rejections()
         "pub fn root() { child(); }\nfn child() {}\nfn isolated() {}\n",
     )?;
     fs::write(
-        repo.join("composer.json"),
+        repo.join(COMPOSER_JSON_FILE_NAME),
         r#"{"autoload":{"psr-4":{"Parity\\":"src/"}}}"#,
     )?;
     fs::write(
@@ -9293,7 +9295,7 @@ fn composer_shaped_php_cli_mcp_and_incremental_refresh_agree() -> Result<(), Box
         fs::write(repo.join(path), source)?;
     }
     fs::write(
-        repo.join("composer.json"),
+        repo.join(COMPOSER_JSON_FILE_NAME),
         r#"{
   "name": "atlas/composer-fixture",
   "autoload": {"psr-4": {"Atlas\\": "src/"}}

--- a/crates/projectatlas-cli/tests/fixtures/mcp-v0.4.0-schema-delta.json
+++ b/crates/projectatlas-cli/tests/fixtures/mcp-v0.4.0-schema-delta.json
@@ -222,7 +222,7 @@
         "intermediate_bytes": {"description": "Maximum decoded, cursor, and service-composition intermediate bytes.", "type": ["integer", "null"], "format": "uint64", "minimum": 0},
         "deadline_ms": {"description": "Maximum service-owned elapsed milliseconds.", "type": ["integer", "null"], "format": "uint64", "minimum": 0},
         "output_bytes": {"description": "Maximum encoded bytes admitted to the detailed response.", "type": ["integer", "null"], "format": "uint32", "minimum": 0},
-        "analysis_mode": {"description": "Closed analysis mode: `architecture`, `impact`, or `trace`.", "type": ["string", "null"]},
+        "analysis_mode": {"description": "Closed analysis mode: `architecture`, `impact`, `trace`, or `entrypoint`.", "type": ["string", "null"]},
         "trace_target": {"description": "Exact target symbol name for trace mode.", "type": ["string", "null"]},
         "trace_target_file": {"description": "Exact target file for trace mode; alone selects a file target.", "type": ["string", "null"]},
         "trace_target_parent": {"description": "Exact target parent for symbol trace mode.", "type": ["string", "null"]},

--- a/crates/projectatlas-cli/tests/fixtures/mcp-v0.4.0-schema-delta.json
+++ b/crates/projectatlas-cli/tests/fixtures/mcp-v0.4.0-schema-delta.json
@@ -222,7 +222,7 @@
         "intermediate_bytes": {"description": "Maximum decoded, cursor, and service-composition intermediate bytes.", "type": ["integer", "null"], "format": "uint64", "minimum": 0},
         "deadline_ms": {"description": "Maximum service-owned elapsed milliseconds.", "type": ["integer", "null"], "format": "uint64", "minimum": 0},
         "output_bytes": {"description": "Maximum encoded bytes admitted to the detailed response.", "type": ["integer", "null"], "format": "uint32", "minimum": 0},
-        "analysis_mode": {"description": "Closed analysis mode: `architecture`, `impact`, `trace`, or `entrypoint`.", "type": ["string", "null"]},
+        "analysis_mode": {"description": "Closed analysis mode: `architecture`, `impact`, or `trace`.", "type": ["string", "null"]},
         "trace_target": {"description": "Exact target symbol name for trace mode.", "type": ["string", "null"]},
         "trace_target_file": {"description": "Exact target file for trace mode; alone selects a file target.", "type": ["string", "null"]},
         "trace_target_parent": {"description": "Exact target parent for symbol trace mode.", "type": ["string", "null"]},

--- a/crates/projectatlas-cli/tests/support/source_contract.rs
+++ b/crates/projectatlas-cli/tests/support/source_contract.rs
@@ -3,7 +3,7 @@
 pub(super) const CLI_E2E_SOURCE_SHA256: &[(&str, &str)] = &[
     (
         "crates/projectatlas-cli/tests/e2e_delivery.rs",
-        "1e804fd630c69a4a8cdc3fdc17f21438b891b9acde855280a52f9f7c06c4afb0",
+        "de155b4541c68a726519292644b489292742d5b26f774e3b4b17ea76569d0e82",
     ),
     (
         "crates/projectatlas-cli/tests/e2e_lifecycle.rs",

--- a/crates/projectatlas-cli/tests/support/source_contract.rs
+++ b/crates/projectatlas-cli/tests/support/source_contract.rs
@@ -15,7 +15,7 @@ pub(super) const CLI_E2E_SOURCE_SHA256: &[(&str, &str)] = &[
     ),
     (
         "crates/projectatlas-cli/tests/e2e_navigation.rs",
-        "27db9846d4cba4af8e5ee6c6bb077a019610b4fbbfa79f794565b0e8338eec64",
+        "ebf6762b94065c955bf4526269917ee6516ec5722a79ec0d596faf3cef54169a",
     ),
     (
         "crates/projectatlas-cli/tests/e2e_worktrees.rs",

--- a/crates/projectatlas-cli/tests/support/source_contract.rs
+++ b/crates/projectatlas-cli/tests/support/source_contract.rs
@@ -3,7 +3,7 @@
 pub(super) const CLI_E2E_SOURCE_SHA256: &[(&str, &str)] = &[
     (
         "crates/projectatlas-cli/tests/e2e_delivery.rs",
-        "ef2a17540d305565bced95a68db61fbf17e089bcf60a05e9cb1a1be58f2eccf8",
+        "1e804fd630c69a4a8cdc3fdc17f21438b891b9acde855280a52f9f7c06c4afb0",
     ),
     (
         "crates/projectatlas-cli/tests/e2e_lifecycle.rs",

--- a/crates/projectatlas-cli/tests/support/source_contract.rs
+++ b/crates/projectatlas-cli/tests/support/source_contract.rs
@@ -3,7 +3,7 @@
 pub(super) const CLI_E2E_SOURCE_SHA256: &[(&str, &str)] = &[
     (
         "crates/projectatlas-cli/tests/e2e_delivery.rs",
-        "4c72e4f5e9e51753fd7e74d87a202cc8b882e8b392f32c4d1b9271e3f378738a",
+        "ef2a17540d305565bced95a68db61fbf17e089bcf60a05e9cb1a1be58f2eccf8",
     ),
     (
         "crates/projectatlas-cli/tests/e2e_lifecycle.rs",
@@ -15,7 +15,7 @@ pub(super) const CLI_E2E_SOURCE_SHA256: &[(&str, &str)] = &[
     ),
     (
         "crates/projectatlas-cli/tests/e2e_navigation.rs",
-        "7be2d40d611935b8e9a5d420dcfd6cf94703011e601aa5f890467999ead9fb22",
+        "27db9846d4cba4af8e5ee6c6bb077a019610b4fbbfa79f794565b0e8338eec64",
     ),
     (
         "crates/projectatlas-cli/tests/e2e_worktrees.rs",

--- a/crates/projectatlas-db/src/repository_graph.rs
+++ b/crates/projectatlas-db/src/repository_graph.rs
@@ -2328,6 +2328,70 @@ impl AtlasStore {
         )
     }
 
+    /// Check one exact relation family without admitting or decoding a row.
+    ///
+    /// This is the terminal probe used when a bounded traversal has exhausted
+    /// its edge allowance. It distinguishes an empty adjacency from a pending
+    /// edge without granting the caller another ordinary adjacency row.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an invalid entity key, cancellation, or a SQLite
+    /// failure.
+    pub fn repository_graph_adjacency_is_empty(
+        &self,
+        key: &GraphEntityKey,
+        direction: RepositoryGraphDirection,
+        relation: GraphRelationKind,
+        control: Option<&IndexWorkControl>,
+    ) -> DbResult<bool> {
+        let project = key.project();
+        if !verify_project_identity(&self.connection, project)?
+            || self.repository_graph_generation()?.is_none()
+        {
+            return Ok(true);
+        }
+        let digest = key.digest_bytes()?;
+        let (key_column, index_name) = match direction {
+            RepositoryGraphDirection::Outbound => {
+                ("source_entity_key", "idx_graph_relations_source_kind")
+            }
+            RepositoryGraphDirection::Inbound => {
+                ("target_entity_key", "idx_graph_relations_target_kind")
+            }
+        };
+        let (scope, kind) = relation_parts(relation);
+        let sql = format!(
+            "SELECT EXISTS(
+                 SELECT 1
+                   FROM graph_relations AS relation INDEXED BY {index_name}
+                  WHERE relation.project_instance_id = ?1
+                    AND relation.{key_column} = ?2
+                    AND relation.relation_scope = ?3
+                    AND relation.relation_kind = ?4
+             )"
+        );
+        let bindings = [
+            Value::Blob(project.as_bytes().to_vec()),
+            Value::Blob(digest.to_vec()),
+            Value::Text(scope.to_string()),
+            Value::Text(kind.to_string()),
+        ];
+        with_sqlite_read_progress(
+            &self.connection,
+            control,
+            IndexWorkStage::RepositoryTraversal,
+            || {
+                self.connection
+                    .query_row(&sql, params_from_iter(bindings.iter()), |row| {
+                        row.get::<_, bool>(0)
+                    })
+                    .map(|has_row| !has_row)
+                    .map_err(Into::into)
+            },
+        )
+    }
+
     /// Load one optionally family- and local-resolution-filtered adjacency page.
     fn repository_graph_adjacency_page_filtered_by_resolution_bounded(
         &self,

--- a/crates/projectatlas-db/src/repository_graph.rs
+++ b/crates/projectatlas-db/src/repository_graph.rs
@@ -1432,6 +1432,56 @@ impl AtlasStore {
         Ok(RepositoryGraphReadPage { page, work })
     }
 
+    /// Load a bounded stable-order page of every local graph entity.
+    ///
+    /// This read is intentionally page-shaped and has no persistence side
+    /// effects. Callers use the truncation sentinel to refuse conclusions
+    /// when the complete entity scope does not fit its declared bound.
+    pub fn repository_graph_entities_page_bounded(
+        &self,
+        project: ProjectInstanceId,
+        generation: IndexGeneration,
+        limit: u32,
+        budget: RepositoryGraphReadBudget,
+        control: Option<&IndexWorkControl>,
+    ) -> DbResult<RepositoryGraphReadPage<GraphEntity>> {
+        let limit_plus_one = validated_limit_plus_one(
+            limit,
+            GraphLimits::MAX_ROWS,
+            "graph entity rows must be nonzero and within the product ceiling",
+        )?;
+        self.require_repository_graph_snapshot(project, generation)?;
+        let mut meter = RepositoryGraphReadMeter::new(budget, 1)?;
+        let raw = with_sqlite_read_progress(
+            &self.connection,
+            control,
+            IndexWorkStage::RepositoryTraversal,
+            || {
+                let mut statement = self.connection.prepare_cached(
+                    "SELECT entity_key, project_instance_id, canonical_identity, entity_kind,
+                            repository_path, package_manager, package_name, manifest_path,
+                            symbol_name, symbol_kind, symbol_parent, symbol_signature,
+                            external_system, external_identity
+                       FROM graph_entities
+                      WHERE project_instance_id = ?1
+                      ORDER BY entity_key
+                      LIMIT ?2",
+                )?;
+                collect_entity_rows_metered(
+                    statement.query(params![&project.as_bytes()[..], limit_plus_one])?,
+                    &mut meter,
+                )
+            },
+        )?;
+        let page = page_from_raw(raw, limit, |row| {
+            let entity = entity_from_row(row, project, generation)?;
+            meter.record_entity(&entity)?;
+            Ok(entity)
+        })?;
+        let work = meter.finish(page.rows.len())?;
+        Ok(RepositoryGraphReadPage { page, work })
+    }
+
     /// Load bounded graph entities that export one exact canonical resolution key.
     ///
     /// # Errors

--- a/crates/projectatlas-db/src/repository_graph.rs
+++ b/crates/projectatlas-db/src/repository_graph.rs
@@ -1437,6 +1437,12 @@ impl AtlasStore {
     /// This read is intentionally page-shaped and has no persistence side
     /// effects. Callers use the truncation sentinel to refuse conclusions
     /// when the complete entity scope does not fit its declared bound.
+    ///
+    /// # Errors
+    ///
+    /// Returns a database error when the requested snapshot is unavailable,
+    /// the limit or budget is invalid, the read is cancelled, or SQLite
+    /// cannot execute the bounded query.
     pub fn repository_graph_entities_page_bounded(
         &self,
         project: ProjectInstanceId,

--- a/crates/projectatlas-db/src/repository_graph.rs
+++ b/crates/projectatlas-db/src/repository_graph.rs
@@ -1432,7 +1432,7 @@ impl AtlasStore {
         Ok(RepositoryGraphReadPage { page, work })
     }
 
-    /// Load a bounded stable-order page of every local graph entity.
+    /// Load a bounded stable-order page of local entrypoint candidate entities.
     ///
     /// This read is intentionally page-shaped and has no persistence side
     /// effects. Callers use the truncation sentinel to refuse conclusions
@@ -1443,7 +1443,7 @@ impl AtlasStore {
     /// Returns a database error when the requested snapshot is unavailable,
     /// the limit or budget is invalid, the read is cancelled, or SQLite
     /// cannot execute the bounded query.
-    pub fn repository_graph_entities_page_bounded(
+    pub fn repository_graph_entrypoint_candidates_page_bounded(
         &self,
         project: ProjectInstanceId,
         generation: IndexGeneration,
@@ -1470,6 +1470,7 @@ impl AtlasStore {
                             external_system, external_identity
                        FROM graph_entities
                       WHERE project_instance_id = ?1
+                        AND entity_kind IN ('file', 'symbol')
                       ORDER BY entity_key
                       LIMIT ?2",
                 )?;

--- a/crates/projectatlas-db/src/repository_graph.rs
+++ b/crates/projectatlas-db/src/repository_graph.rs
@@ -1448,6 +1448,7 @@ impl AtlasStore {
         project: ProjectInstanceId,
         generation: IndexGeneration,
         limit: u32,
+        selection: ContentSelection,
         budget: RepositoryGraphReadBudget,
         control: Option<&IndexWorkControl>,
     ) -> DbResult<RepositoryGraphReadPage<GraphEntity>> {
@@ -1458,22 +1459,41 @@ impl AtlasStore {
         )?;
         self.require_repository_graph_snapshot(project, generation)?;
         let mut meter = RepositoryGraphReadMeter::new(budget, 1)?;
+        let selection_filter = match selection {
+            ContentSelection::UnspecifiedLegacy => "",
+            ContentSelection::Source => {
+                " AND EXISTS (SELECT 1 FROM file_content_classifications AS classification
+                               WHERE classification.path = graph_entities.repository_path
+                                 AND classification.classification = 'source')"
+            }
+            ContentSelection::Documentation => {
+                " AND EXISTS (SELECT 1 FROM file_content_classifications AS classification
+                               WHERE classification.path = graph_entities.repository_path
+                                 AND classification.classification = 'documentation')"
+            }
+            ContentSelection::Both => {
+                " AND EXISTS (SELECT 1 FROM file_content_classifications AS classification
+                               WHERE classification.path = graph_entities.repository_path
+                                 AND classification.classification IN ('source', 'documentation'))"
+            }
+        };
+        let sql = format!(
+            "SELECT entity_key, project_instance_id, canonical_identity, entity_kind,
+                    repository_path, package_manager, package_name, manifest_path,
+                    symbol_name, symbol_kind, symbol_parent, symbol_signature,
+                    external_system, external_identity
+               FROM graph_entities
+              WHERE project_instance_id = ?1
+                AND entity_kind IN ('file', 'symbol'){selection_filter}
+              ORDER BY entity_key
+              LIMIT ?2"
+        );
         let raw = with_sqlite_read_progress(
             &self.connection,
             control,
             IndexWorkStage::RepositoryTraversal,
             || {
-                let mut statement = self.connection.prepare_cached(
-                    "SELECT entity_key, project_instance_id, canonical_identity, entity_kind,
-                            repository_path, package_manager, package_name, manifest_path,
-                            symbol_name, symbol_kind, symbol_parent, symbol_signature,
-                            external_system, external_identity
-                       FROM graph_entities
-                      WHERE project_instance_id = ?1
-                        AND entity_kind IN ('file', 'symbol')
-                      ORDER BY entity_key
-                      LIMIT ?2",
-                )?;
+                let mut statement = self.connection.prepare_cached(&sql)?;
                 collect_entity_rows_metered(
                     statement.query(params![&project.as_bytes()[..], limit_plus_one])?,
                     &mut meter,

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -96,6 +96,7 @@ mod analysis_test_observer {
 use super::relations::classification_path;
 use super::relations::{
     ExternalRelationIdentity, external_relation_identities, load_detailed_relations,
+    resolve_relation_anchor_for_analysis,
 };
 use super::{
     CoverageTrustState, DetailedRelationBudget, DetailedRelationNode, DetailedRelationQuery,
@@ -1488,6 +1489,35 @@ fn load_entrypoint_profile_draft(
     let mut reachable = BTreeMap::<String, DetailedRelationNode>::new();
     let mut edges = Vec::new();
     let mut relation_work = DetailedRelationWork::default();
+    let mut canonical_anchors = Vec::with_capacity(profile.anchors.len());
+    let mut canonical_anchor_keys = BTreeSet::new();
+    let mut resolved_anchor_keys = BTreeMap::<String, String>::new();
+    for anchor in &profile.anchors {
+        let (entity, anchor_work) = resolve_relation_anchor_for_analysis(
+            store,
+            selected_binding.project_instance_id,
+            generation,
+            anchor,
+            budget,
+            control,
+        )?;
+        add_relation_work(&mut relation_work, &anchor_work)?;
+        let entity_key = entity.key().canonical_identity().to_string();
+        if !canonical_anchor_keys.insert(entity_key.clone()) {
+            return Err(ServiceError::InvalidInput(
+                "entrypoint profile anchors must resolve to unique entities".to_string(),
+            ));
+        }
+        let canonical_anchor = relation_anchor_for_entity(&entity).ok_or_else(|| {
+            ServiceError::InvalidInput(
+                "entrypoint profile anchor is not addressable by an exact anchor".to_string(),
+            )
+        })?;
+        let anchor_identity = serde_json::to_string(&canonical_anchor)
+            .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
+        resolved_anchor_keys.insert(anchor_identity, entity_key);
+        canonical_anchors.push(canonical_anchor);
+    }
     let mut first_anchor = None;
     let mut authored_purpose_revision = 0;
     let mut purpose_revision_initialized = false;
@@ -1500,14 +1530,12 @@ fn load_entrypoint_profile_draft(
             })
     };
 
-    let mut frontier = profile.anchors.clone();
-    let mut scheduled_anchors = profile
-        .anchors
+    let mut frontier = canonical_anchors;
+    let mut scheduled_anchors = frontier
         .iter()
         .map(serde_json::to_string)
         .collect::<Result<BTreeSet<_>, _>>()
         .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
-    let mut resolved_anchor_keys = BTreeMap::<String, String>::new();
     let mut visited = BTreeSet::new();
     let mut depth = 0_u32;
     'profile: while !frontier.is_empty() && depth < budget.depth() {
@@ -1522,6 +1550,8 @@ fn load_entrypoint_profile_draft(
                     .is_some_and(|key| reachable.contains_key(key));
                 let retained_keys =
                     anchor_is_retained.then(|| reachable.keys().cloned().collect::<BTreeSet<_>>());
+                let collect_occurrences = query.relations.include_occurrences
+                    && relation_work.retained_occurrences < budget.occurrences_total();
                 let step_budget = match entrypoint_step_budget(
                     budget,
                     &relation_work,
@@ -1529,7 +1559,7 @@ fn load_entrypoint_profile_draft(
                     0,
                     anchor_is_retained,
                     false,
-                    query.relations.include_occurrences,
+                    collect_occurrences,
                     None,
                 )? {
                     Ok(step_budget) => step_budget,
@@ -1559,6 +1589,7 @@ fn load_entrypoint_profile_draft(
                 relation_query.resolution = RelationResolutionFilter::Any;
                 relation_query.cursor = None;
                 relation_query.budget = step_budget;
+                relation_query.include_occurrences = collect_occurrences;
                 #[cfg(test)]
                 analysis_test_observer::notify(
                     analysis_test_observer::AnalysisPhaseEvent::Traversal,
@@ -1584,6 +1615,10 @@ fn load_entrypoint_profile_draft(
                 authored_purpose_revision = report.authored_purpose_revision;
                 purpose_revision_initialized = true;
                 add_relation_work(&mut relation_work, &report.work)?;
+                if query.relations.include_occurrences && !collect_occurrences {
+                    complete = false;
+                    push_limit(&mut reached_limits, GraphLimitKind::Occurrences);
+                }
                 for limit in &report.reached_limits {
                     push_limit(&mut reached_limits, *limit);
                 }
@@ -1807,6 +1842,8 @@ fn load_entrypoint_profile_draft(
                         .len()
                         .saturating_sub(reachable.len());
                     let anchor_is_retained = retained_candidate_keys.contains(&candidate_key);
+                    let collect_occurrences = query.relations.include_occurrences
+                        && relation_work.retained_occurrences < budget.occurrences_total();
                     let step_budget = match entrypoint_step_budget(
                         budget,
                         &relation_work,
@@ -1814,7 +1851,7 @@ fn load_entrypoint_profile_draft(
                         accounted_candidates,
                         anchor_is_retained,
                         true,
-                        query.relations.include_occurrences,
+                        collect_occurrences,
                         None,
                     )? {
                         Ok(step_budget) => step_budget,
@@ -1858,6 +1895,7 @@ fn load_entrypoint_profile_draft(
                     candidate_query.resolution = RelationResolutionFilter::Any;
                     candidate_query.cursor = None;
                     candidate_query.budget = step_budget;
+                    candidate_query.include_occurrences = collect_occurrences;
                     #[cfg(test)]
                     analysis_test_observer::notify(
                         analysis_test_observer::AnalysisPhaseEvent::CandidateTraversal,
@@ -1884,6 +1922,10 @@ fn load_entrypoint_profile_draft(
                         });
                     }
                     add_relation_work(&mut relation_work, &candidate_report.work)?;
+                    if query.relations.include_occurrences && !collect_occurrences {
+                        complete = false;
+                        push_limit(&mut reached_limits, GraphLimitKind::Occurrences);
+                    }
                     if relation_work.inspected_edges > budget.edges() {
                         complete = false;
                         push_limit(&mut reached_limits, GraphLimitKind::Edges);

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1651,7 +1651,7 @@ fn load_entrypoint_profile_draft(
             entity_limit.saturating_add(1).saturating_mul(2),
         )
         .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
-        let all_entities = store.repository_graph_entities_page_bounded(
+        let all_entities = store.repository_graph_entrypoint_candidates_page_bounded(
             generation_project(&anchor.entity),
             generation,
             entity_limit,
@@ -1789,8 +1789,6 @@ fn load_entrypoint_profile_draft(
             }
         }
     }
-    let reachable_nodes = reachable.values().map(analysis_node).collect::<Vec<_>>();
-    let unreachable_nodes = unreachable.values().map(analysis_node).collect::<Vec<_>>();
     let coverage = if complete {
         EntrypointProfileCoverage::Complete
     } else {
@@ -1803,19 +1801,19 @@ fn load_entrypoint_profile_draft(
             status: AnalysisStatus::Confirmed,
             summary: "explicit entrypoints reach these local entities through complete admitted relations"
                 .to_string(),
-            nodes: reachable_nodes.clone(),
-            metric: Some(reachable_nodes.len() as u64),
+            nodes: Vec::new(),
+            metric: Some(reachable.len() as u64),
             evidence: None,
             community: None,
         });
-        if !unreachable_nodes.is_empty() {
+        if !unreachable.is_empty() {
             findings.push(AnalysisFinding {
                 kind: AnalysisFindingKind::EntrypointReachability,
                 status: AnalysisStatus::Candidate,
                 summary: "local entities are unreachable from the explicit entrypoints; review exact source evidence before any deletion decision"
                     .to_string(),
-                nodes: unreachable_nodes.clone(),
-                metric: Some(unreachable_nodes.len() as u64),
+                nodes: Vec::new(),
+                metric: Some(unreachable.len() as u64),
                 evidence: None,
                 community: None,
             });
@@ -1826,7 +1824,7 @@ fn load_entrypoint_profile_draft(
             status: AnalysisStatus::Inconclusive,
             summary: "entrypoint reachability is inconclusive because relation coverage or a declared bound is partial"
                 .to_string(),
-            nodes: reachable_nodes.clone(),
+            nodes: Vec::new(),
             metric: None,
             evidence: None,
             community: None,
@@ -1837,7 +1835,7 @@ fn load_entrypoint_profile_draft(
         anchors: profile.anchors.clone(),
         relations: profile.relations.clone(),
         coverage,
-        reachable: u32::try_from(reachable_nodes.len()).unwrap_or(u32::MAX),
+        reachable: u32::try_from(reachable.len()).unwrap_or(u32::MAX),
         unreachable_candidates: 0,
     };
     let mut work = RelationAnalysisWork {
@@ -1847,21 +1845,50 @@ fn load_entrypoint_profile_draft(
         analyzed_edges: u32::try_from(edges.len()).unwrap_or(u32::MAX),
         ..RelationAnalysisWork::default()
     };
+    let metadata_composition_bytes =
+        serialized_bytes_controlled(&(&findings, &profile_result), control)?;
+    let mut node_composition_bytes = serialized_analysis_nodes_bytes(reachable.values(), control)?;
+    if complete && !unreachable.is_empty() {
+        node_composition_bytes = node_composition_bytes
+            .checked_add(serialized_analysis_nodes_bytes(
+                unreachable.values(),
+                control,
+            )?)
+            .ok_or_else(entrypoint_work_overflow)?;
+    }
+    let composition_fits = work
+        .relations
+        .intermediate_bytes
+        .checked_add(metadata_composition_bytes)
+        .and_then(|bytes| bytes.checked_add(node_composition_bytes))
+        .is_some_and(|bytes| bytes <= budget.intermediate_bytes());
+    if composition_fits {
+        if complete {
+            findings[0].nodes = reachable.values().map(analysis_node).collect();
+            if !unreachable.is_empty() {
+                findings[1].nodes = unreachable.values().map(analysis_node).collect();
+            }
+            profile_result.unreachable_candidates =
+                u32::try_from(unreachable.len()).unwrap_or(u32::MAX);
+        } else {
+            findings[0].nodes = reachable.values().map(analysis_node).collect();
+        }
+    } else {
+        complete = false;
+        work.composition_truncated = true;
+        push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
+        profile_result.coverage = EntrypointProfileCoverage::Partial;
+        for finding in &mut findings {
+            finding.status = AnalysisStatus::Inconclusive;
+        }
+    }
     work.retained_composition_bytes =
-        serialized_bytes_controlled(&(findings.clone(), &profile_result), control)?;
+        serialized_bytes_controlled(&(&findings, &profile_result), control)?;
     work.peak_intermediate_bytes = work
         .relations
         .intermediate_bytes
         .saturating_add(work.retained_composition_bytes);
-    if work.peak_intermediate_bytes > budget.intermediate_bytes() {
-        complete = false;
-        work.composition_truncated = true;
-        push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
-    }
-    if complete {
-        profile_result.unreachable_candidates =
-            u32::try_from(unreachable_nodes.len()).unwrap_or(u32::MAX);
-    } else {
+    if !complete {
         profile_result.coverage = EntrypointProfileCoverage::Partial;
         for finding in &mut findings {
             finding.status = AnalysisStatus::Inconclusive;
@@ -4348,6 +4375,25 @@ fn analysis_nodes_for(
         .filter_map(|key| nodes.get(key))
         .map(analysis_node)
         .collect()
+}
+
+/// Measure node payload added to an already serialized empty node array.
+fn serialized_analysis_nodes_bytes<'node>(
+    nodes: impl IntoIterator<Item = &'node DetailedRelationNode>,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<u64> {
+    let mut bytes = 0_u64;
+    for (index, node) in nodes.into_iter().enumerate() {
+        if index > 0 {
+            bytes = bytes
+                .checked_add(JSON_ARRAY_SEPARATOR_BYTES)
+                .ok_or_else(entrypoint_work_overflow)?;
+        }
+        bytes = bytes
+            .checked_add(serialized_bytes_controlled(&analysis_node(node), control)?)
+            .ok_or_else(entrypoint_work_overflow)?;
+    }
+    Ok(bytes)
 }
 
 /// Preserve one detailed node and its exact reusable next call.

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -28,6 +28,13 @@ mod analysis_test_observer {
         DeadCodeDiscovery,
         /// One bounded candidate-classification batch is about to run.
         ClassificationHydration,
+        /// One bounded candidate relation traversal is about to run.
+        CandidateTraversal,
+        /// The repository-wide candidate entity page is about to run.
+        CandidateEntityHydration {
+            /// Intermediate bytes left after relation traversal.
+            remaining_intermediate_bytes: u64,
+        },
         /// Adapter-specific output fitting has begun under the retained request control.
         OutputRendering,
     }
@@ -1623,6 +1630,12 @@ fn load_entrypoint_profile_draft(
         push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
     }
     if complete {
+        #[cfg(test)]
+        analysis_test_observer::notify(
+            analysis_test_observer::AnalysisPhaseEvent::CandidateEntityHydration {
+                remaining_intermediate_bytes: remaining_intermediate,
+            },
+        );
         let read_budget = RepositoryGraphReadBudget::new(
             1,
             entity_limit.saturating_add(1),
@@ -1712,6 +1725,10 @@ fn load_entrypoint_profile_draft(
                     candidate_query.resolution = RelationResolutionFilter::Any;
                     candidate_query.cursor = None;
                     candidate_query.budget = step_budget;
+                    #[cfg(test)]
+                    analysis_test_observer::notify(
+                        analysis_test_observer::AnalysisPhaseEvent::CandidateTraversal,
+                    );
                     let candidate_report =
                         load_detailed_relations(store, &candidate_query, control)?;
                     if candidate_report.generation != generation {

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -42,6 +42,8 @@ mod analysis_test_observer {
             /// Intermediate bytes left after relation traversal.
             remaining_intermediate_bytes: u64,
         },
+        /// The repository-wide candidate page has been reduced to exact candidates.
+        CandidateEnumeration,
         /// Adapter-specific output fitting has begun under the retained request control.
         OutputRendering,
     }
@@ -1504,15 +1506,20 @@ fn load_entrypoint_profile_draft(
         for anchor in frontier.drain(..) {
             for relation in &profile.relations {
                 check_control(control)?;
-                let step_budget =
-                    match entrypoint_step_budget(budget, &relation_work, reachable.len(), 0)? {
-                        Ok(step_budget) => step_budget,
-                        Err(limit) => {
-                            complete = false;
-                            push_limit(&mut reached_limits, limit);
-                            break 'profile;
-                        }
-                    };
+                let step_budget = match entrypoint_step_budget(
+                    budget,
+                    &relation_work,
+                    reachable.len(),
+                    0,
+                    query.relations.include_occurrences,
+                )? {
+                    Ok(step_budget) => step_budget,
+                    Err(limit) => {
+                        complete = false;
+                        push_limit(&mut reached_limits, limit);
+                        break 'profile;
+                    }
+                };
                 let mut relation_query = query.relations.clone();
                 relation_query.anchor = anchor.clone();
                 relation_query.relation = Some(*relation);
@@ -1698,7 +1705,22 @@ fn load_entrypoint_profile_draft(
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
+        #[cfg(test)]
+        analysis_test_observer::notify(
+            analysis_test_observer::AnalysisPhaseEvent::CandidateEnumeration,
+        );
         if complete {
+            let current_generation = store.repository_graph_generation()?.ok_or_else(|| {
+                ServiceError::InvalidInput(
+                    "repository graph has no complete generation for entrypoint analysis"
+                        .to_string(),
+                )
+            })?;
+            if current_generation != generation {
+                return Err(ServiceError::RelationCursorStale {
+                    field: "entrypoint graph generation",
+                });
+            }
             for entity in candidate_entities {
                 check_control(control)?;
                 if !complete {
@@ -1716,6 +1738,7 @@ fn load_entrypoint_profile_draft(
                         &relation_work,
                         reachable.len(),
                         unreachable.len(),
+                        query.relations.include_occurrences,
                     )? {
                         Ok(step_budget) => step_budget,
                         Err(limit) => {
@@ -2199,15 +2222,20 @@ fn entrypoint_step_budget(
     work: &DetailedRelationWork,
     retained_nodes: usize,
     validated_candidates: usize,
+    include_occurrences: bool,
 ) -> ServiceResult<Result<DetailedRelationBudget, GraphLimitKind>> {
     let accounted_nodes = retained_nodes.saturating_add(validated_candidates);
     let accounted_nodes = u32::try_from(accounted_nodes).unwrap_or(u32::MAX);
     let remaining_edges = budget.edges().saturating_sub(work.inspected_edges);
     let remaining_nodes = budget.nodes().saturating_sub(accounted_nodes);
     let remaining_visited = budget.visited().saturating_sub(accounted_nodes);
-    let remaining_occurrences = budget
-        .occurrences_total()
-        .saturating_sub(work.retained_occurrences);
+    let remaining_occurrences = if include_occurrences {
+        budget
+            .occurrences_total()
+            .saturating_sub(work.retained_occurrences)
+    } else {
+        budget.occurrences_total()
+    };
     let remaining_intermediate = budget
         .intermediate_bytes()
         .saturating_sub(work.intermediate_bytes);
@@ -2215,8 +2243,12 @@ fn entrypoint_step_budget(
         .page_rows()
         .min(remaining_edges)
         .min(remaining_nodes)
-        .min(remaining_visited)
-        .min(remaining_occurrences);
+        .min(remaining_visited);
+    let rows = if include_occurrences {
+        rows.min(remaining_occurrences)
+    } else {
+        rows
+    };
     if remaining_edges == 0 {
         return Ok(Err(GraphLimitKind::Edges));
     }
@@ -2226,7 +2258,7 @@ fn entrypoint_step_budget(
     if remaining_visited == 0 {
         return Ok(Err(GraphLimitKind::Visited));
     }
-    if remaining_occurrences == 0 {
+    if include_occurrences && remaining_occurrences == 0 {
         return Ok(Err(GraphLimitKind::Occurrences));
     }
     if remaining_intermediate < 64 * 1_024 {

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -552,6 +552,9 @@ impl RelationAnalysisDraft {
         E: From<ServiceError>,
         O: AsRef<[u8]>,
     {
+        if self.report.mode == RelationAnalysisMode::Entrypoint {
+            return self.fit_entrypoint_output(encode);
+        }
         check_control(Some(&self.control)).map_err(E::from)?;
         #[cfg(test)]
         analysis_test_observer::notify(analysis_test_observer::AnalysisPhaseEvent::OutputRendering);
@@ -673,6 +676,62 @@ impl RelationAnalysisDraft {
             };
             E::from(ServiceError::InvalidInput(message.to_string()))
         })
+    }
+
+    /// Fit an entrypoint report atomically; partial finding prefixes are not replayable.
+    fn fit_entrypoint_output<F, E, O>(self, mut encode: F) -> Result<(RelationAnalysisReport, O), E>
+    where
+        F: FnMut(&RelationAnalysisReport, &IndexWorkControl) -> Result<O, E>,
+        E: From<ServiceError>,
+        O: AsRef<[u8]>,
+    {
+        check_control(Some(&self.control)).map_err(E::from)?;
+        #[cfg(test)]
+        analysis_test_observer::notify(analysis_test_observer::AnalysisPhaseEvent::OutputRendering);
+        let original_report_bytes =
+            serialized_bytes_controlled(&self.report, Some(&self.control)).map_err(E::from)?;
+        let mut candidate = self.report;
+        let mut encoded = encode(&candidate, &self.control)?;
+        for _ in 0..8 {
+            check_control(Some(&self.control)).map_err(E::from)?;
+            let rendered = u64::try_from(encoded.as_ref().len()).map_err(|source| {
+                E::from(ServiceError::InvalidInput(format!(
+                    "entrypoint rendered byte count overflowed: {source}"
+                )))
+            })?;
+            let candidate_report_bytes =
+                serialized_bytes_controlled(&candidate, Some(&self.control)).map_err(E::from)?;
+            let fitting_peak = original_report_bytes
+                .checked_add(candidate_report_bytes)
+                .and_then(|bytes| bytes.checked_add(rendered))
+                .ok_or_else(|| {
+                    E::from(ServiceError::InvalidInput(
+                        "entrypoint output fitting byte count overflowed".to_string(),
+                    ))
+                })?;
+            if candidate.work.rendered_output_bytes == rendered
+                && candidate.work.peak_intermediate_bytes == fitting_peak
+            {
+                if encoded.as_ref().len() > self.output_bytes as usize {
+                    return Err(E::from(ServiceError::InvalidInput(
+                        "entrypoint profile output exceeds its declared byte budget".to_string(),
+                    )));
+                }
+                if fitting_peak > self.budget.intermediate_bytes() {
+                    return Err(E::from(ServiceError::InvalidInput(
+                        "entrypoint profile output exceeds its aggregate intermediate-byte budget"
+                            .to_string(),
+                    )));
+                }
+                return Ok((candidate, encoded));
+            }
+            candidate.work.rendered_output_bytes = rendered;
+            candidate.work.peak_intermediate_bytes = fitting_peak;
+            encoded = encode(&candidate, &self.control)?;
+        }
+        Err(E::from(ServiceError::InvalidInput(
+            "entrypoint output accounting did not stabilize".to_string(),
+        )))
     }
 }
 
@@ -1408,36 +1467,29 @@ fn load_entrypoint_profile_draft(
     let mut complete = true;
     let mut reached_limits = Vec::new();
 
-    'profile: for anchor in &profile.anchors {
-        for relation in &profile.relations {
-            check_control(control)?;
-            if relation_work.inspected_edges >= budget.edges() {
-                complete = false;
-                push_limit(&mut reached_limits, GraphLimitKind::Edges);
-                break 'profile;
-            }
-            if reachable.len() >= budget.nodes() as usize {
-                complete = false;
-                push_limit(&mut reached_limits, GraphLimitKind::Nodes);
-                break 'profile;
-            }
-            if relation_work.intermediate_bytes >= budget.intermediate_bytes() {
-                complete = false;
-                push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
-                break 'profile;
-            }
-            let mut relation_query = query.relations.clone();
-            relation_query.anchor = anchor.clone();
-            relation_query.relation = Some(*relation);
-            relation_query.direction = RelationDirection::Outbound;
-            relation_query.minimum_confidence = ConfidenceClass::Low;
-            relation_query.resolution = RelationResolutionFilter::Any;
-            relation_query.cursor = None;
-            relation_query.budget = budget;
-            let mut cursor = None;
-            let mut pages = 0_u32;
-            loop {
-                relation_query.cursor = cursor;
+    let mut frontier = profile.anchors.clone();
+    let mut visited = BTreeSet::new();
+    let mut depth = 0_u32;
+    'profile: while !frontier.is_empty() && depth < budget.depth() {
+        let mut next_frontier = Vec::new();
+        for anchor in frontier.drain(..) {
+            for relation in &profile.relations {
+                check_control(control)?;
+                let Some(step_budget) =
+                    entrypoint_step_budget(budget, &relation_work, reachable.len())?
+                else {
+                    complete = false;
+                    push_limit(&mut reached_limits, GraphLimitKind::Edges);
+                    break 'profile;
+                };
+                let mut relation_query = query.relations.clone();
+                relation_query.anchor = anchor.clone();
+                relation_query.relation = Some(*relation);
+                relation_query.direction = RelationDirection::Outbound;
+                relation_query.minimum_confidence = ConfidenceClass::Low;
+                relation_query.resolution = RelationResolutionFilter::Any;
+                relation_query.cursor = None;
+                relation_query.budget = step_budget;
                 let report = load_detailed_relations(store, &relation_query, control)?;
                 if report.generation != generation {
                     return Err(ServiceError::RelationCursorStale {
@@ -1448,18 +1500,12 @@ fn load_entrypoint_profile_draft(
                 authored_purpose_revision =
                     authored_purpose_revision.max(report.authored_purpose_revision);
                 add_relation_work(&mut relation_work, &report.work)?;
-                if relation_work.inspected_edges > budget.edges() {
-                    complete = false;
-                    push_limit(&mut reached_limits, GraphLimitKind::Edges);
+                for limit in &report.reached_limits {
+                    push_limit(&mut reached_limits, *limit);
                 }
                 if relation_work.inspected_edges > budget.edges() {
                     complete = false;
                     push_limit(&mut reached_limits, GraphLimitKind::Edges);
-                    break 'profile;
-                }
-                if reachable.len() > budget.nodes() as usize {
-                    complete = false;
-                    push_limit(&mut reached_limits, GraphLimitKind::Nodes);
                     break 'profile;
                 }
                 if relation_work.intermediate_bytes > budget.intermediate_bytes() {
@@ -1467,10 +1513,9 @@ fn load_entrypoint_profile_draft(
                     push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
                     break 'profile;
                 }
-                for limit in &report.reached_limits {
-                    push_limit(&mut reached_limits, *limit);
-                }
                 complete &= trusted_node_coverage(&report.anchor);
+                let anchor_key = report.anchor.entity.key().canonical_identity().to_string();
+                visited.insert(anchor_key);
                 insert_node(&mut reachable, &report.anchor);
                 for row in &report.rows {
                     check_control(control)?;
@@ -1482,6 +1527,15 @@ fn load_entrypoint_profile_draft(
                     insert_node(&mut reachable, &row.source);
                     if let Some(target) = &row.target {
                         insert_node(&mut reachable, target);
+                        if resolved {
+                            let target_key = target.entity.key().canonical_identity().to_string();
+                            if visited.insert(target_key)
+                                && let Some(target_anchor) =
+                                    relation_anchor_for_entity(&target.entity)
+                            {
+                                next_frontier.push(target_anchor);
+                            }
+                        }
                     }
                     for node in &row.path {
                         insert_node(&mut reachable, node);
@@ -1492,21 +1546,22 @@ fn load_entrypoint_profile_draft(
                         edges.push(edge);
                     }
                 }
-                cursor = report.continuation;
-                pages = pages.saturating_add(1);
-                if cursor.is_none() {
+                if report.continuation.is_some() {
+                    complete = false;
+                    push_limit(&mut reached_limits, GraphLimitKind::Rows);
+                } else {
                     complete &= !report.truncated
                         && report.reached_limits.is_empty()
                         && matches!(report.total, RelationTotalState::Exact(_));
-                    break;
-                }
-                if pages >= budget.nodes() {
-                    complete = false;
-                    push_limit(&mut reached_limits, GraphLimitKind::Nodes);
-                    break 'profile;
                 }
             }
         }
+        frontier = next_frontier;
+        depth = depth.saturating_add(1);
+    }
+    if !frontier.is_empty() {
+        complete = false;
+        push_limit(&mut reached_limits, GraphLimitKind::Depth);
     }
     edges.sort_by(|left, right| {
         (&left.source, &left.target, left.kind.as_str()).cmp(&(
@@ -1567,33 +1622,49 @@ fn load_entrypoint_profile_draft(
                         "entrypoint candidate is not addressable by an exact anchor".to_string(),
                     )
                 })?;
-                let mut candidate_query = query.relations.clone();
-                candidate_query.anchor = candidate_anchor;
-                candidate_query.relation = Some(profile.relations[0]);
-                candidate_query.direction = RelationDirection::Outbound;
-                candidate_query.resolution = RelationResolutionFilter::Any;
-                candidate_query.cursor = None;
-                candidate_query.budget = budget;
-                let candidate_report = load_detailed_relations(store, &candidate_query, control)?;
-                add_relation_work(&mut relation_work, &candidate_report.work)?;
-                if relation_work.inspected_edges > budget.edges() {
-                    complete = false;
-                    push_limit(&mut reached_limits, GraphLimitKind::Edges);
-                    break;
+                let mut candidate_report_anchor = None;
+                for relation in &profile.relations {
+                    let Some(step_budget) =
+                        entrypoint_step_budget(budget, &relation_work, reachable.len())?
+                    else {
+                        complete = false;
+                        push_limit(&mut reached_limits, GraphLimitKind::Edges);
+                        break;
+                    };
+                    let mut candidate_query = query.relations.clone();
+                    candidate_query.anchor = candidate_anchor.clone();
+                    candidate_query.relation = Some(*relation);
+                    candidate_query.direction = RelationDirection::Outbound;
+                    candidate_query.minimum_confidence = ConfidenceClass::Low;
+                    candidate_query.resolution = RelationResolutionFilter::Any;
+                    candidate_query.cursor = None;
+                    candidate_query.budget = step_budget;
+                    let candidate_report =
+                        load_detailed_relations(store, &candidate_query, control)?;
+                    add_relation_work(&mut relation_work, &candidate_report.work)?;
+                    if relation_work.inspected_edges > budget.edges() {
+                        complete = false;
+                        push_limit(&mut reached_limits, GraphLimitKind::Edges);
+                        break;
+                    }
+                    if relation_work.intermediate_bytes > budget.intermediate_bytes() {
+                        complete = false;
+                        push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
+                        break;
+                    }
+                    if !entrypoint_report_complete(&candidate_report) {
+                        complete = false;
+                        break;
+                    }
+                    candidate_report_anchor.get_or_insert(candidate_report.anchor);
                 }
-                if relation_work.intermediate_bytes > budget.intermediate_bytes() {
-                    complete = false;
-                    push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
-                    break;
-                }
-                if entrypoint_report_complete(&candidate_report) {
-                    unreachable.insert(
-                        entity.key().canonical_identity().to_string(),
-                        candidate_report.anchor,
-                    );
-                } else {
-                    complete = false;
-                    break;
+                if complete {
+                    if let Some(candidate_report_anchor) = candidate_report_anchor {
+                        unreachable.insert(
+                            entity.key().canonical_identity().to_string(),
+                            candidate_report_anchor,
+                        );
+                    }
                 }
             }
         }
@@ -1794,6 +1865,49 @@ fn add_repository_read_work(
         .ok_or_else(entrypoint_work_overflow)?;
     total.intermediate_bytes = total.intermediate_bytes.saturating_add(next.decoded_bytes);
     Ok(())
+}
+
+/// Derive one one-step detailed budget from the remaining profile-wide capacity.
+fn entrypoint_step_budget(
+    budget: DetailedRelationBudget,
+    work: &DetailedRelationWork,
+    retained_nodes: usize,
+) -> ServiceResult<Option<DetailedRelationBudget>> {
+    let retained_nodes = u32::try_from(retained_nodes).unwrap_or(u32::MAX);
+    let remaining_edges = budget.edges().saturating_sub(work.inspected_edges);
+    let remaining_nodes = budget.nodes().saturating_sub(retained_nodes);
+    let remaining_visited = budget.visited().saturating_sub(retained_nodes);
+    let remaining_occurrences = budget
+        .occurrences_total()
+        .saturating_sub(work.retained_occurrences);
+    let remaining_intermediate = budget
+        .intermediate_bytes()
+        .saturating_sub(work.intermediate_bytes);
+    let rows = budget
+        .page_rows()
+        .min(remaining_edges)
+        .min(remaining_nodes)
+        .min(remaining_visited)
+        .min(remaining_occurrences);
+    if rows == 0 || remaining_intermediate < 64 * 1_024 {
+        return Ok(None);
+    }
+    let limits = GraphLimits::new(
+        rows,
+        budget.occurrences_per_relation(),
+        1,
+        budget.output_bytes(),
+    )
+    .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
+    let step = DetailedRelationBudget::from_graph_limits(limits).with_aggregate_limits(
+        Some(remaining_edges),
+        Some(remaining_nodes),
+        Some(remaining_visited),
+        Some(remaining_occurrences),
+        Some(remaining_intermediate),
+        Some(budget.deadline_ms()),
+    )?;
+    Ok(Some(step))
 }
 
 fn entrypoint_work_overflow() -> ServiceError {

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1528,6 +1528,19 @@ fn load_entrypoint_profile_draft(
                 )? {
                     Ok(step_budget) => step_budget,
                     Err(limit) => {
+                        if limit == GraphLimitKind::Edges
+                            && let Some(anchor_node) = reachable.values().find(|node| {
+                                relation_anchor_for_entity(&node.entity).as_ref() == Some(&anchor)
+                            })
+                            && store.repository_graph_adjacency_is_empty(
+                                anchor_node.entity.key(),
+                                RepositoryGraphDirection::Outbound,
+                                *relation,
+                                control,
+                            )?
+                        {
+                            continue;
+                        }
                         complete = false;
                         push_limit(&mut reached_limits, limit);
                         break 'profile;

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1638,7 +1638,7 @@ fn load_entrypoint_profile_draft(
         );
         let read_budget = RepositoryGraphReadBudget::new(
             1,
-            entity_limit.saturating_add(1),
+            entity_limit,
             remaining_intermediate.min(RepositoryGraphReadBudget::MAX_DECODED_BYTES),
             entity_limit.saturating_add(1).saturating_mul(2),
             entity_limit.saturating_add(1).saturating_mul(2),

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1442,6 +1442,7 @@ fn load_entrypoint_profile_draft(
         .ok_or_else(|| ServiceError::InvalidInput("entrypoint profile is missing".to_string()))?;
     let started = Instant::now();
     let budget = bounded_analysis_budget(query.relations.budget)?;
+    validate_entrypoint_profile_budget(profile, budget)?;
     let deadline = started
         .checked_add(Duration::from_millis(budget.deadline_ms()))
         .unwrap_or(started);
@@ -1797,6 +1798,25 @@ fn load_entrypoint_profile_draft(
         external_relation_identities: BTreeSet::new(),
         control: analysis_control,
     })
+}
+
+/// Reject a profile whose required initial anchors cannot fit its shared state.
+fn validate_entrypoint_profile_budget(
+    profile: &EntrypointProfile,
+    budget: DetailedRelationBudget,
+) -> ServiceResult<()> {
+    let anchor_count = u32::try_from(profile.anchors.len()).unwrap_or(u32::MAX);
+    if anchor_count > budget.nodes() {
+        return Err(ServiceError::InvalidInput(
+            "entrypoint profile anchor count exceeds the node budget".to_string(),
+        ));
+    }
+    if anchor_count > budget.visited() {
+        return Err(ServiceError::InvalidInput(
+            "entrypoint profile anchor count exceeds the visited budget".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 /// Add one detailed traversal work ledger without widening its types.

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1550,7 +1550,7 @@ fn load_entrypoint_profile_draft(
                     check_control(control)?;
                     let resolved = matches!(
                         row.relation.resolution(),
-                        RelationResolution::Resolved { .. }
+                        RelationResolution::Resolved { .. } | RelationResolution::External { .. }
                     ) && row.relation.completeness() == Completeness::Complete;
                     complete &= resolved && trusted_relation_row(row);
                     insert_node(&mut reachable, &row.source);
@@ -2172,7 +2172,10 @@ fn trusted_node_coverage(node: &DetailedRelationNode) -> bool {
 /// Return whether every local endpoint in one relation row has trusted coverage.
 fn trusted_relation_row(row: &DetailedRelationRow) -> bool {
     trusted_node_coverage(&row.source)
-        && row.target.as_ref().is_none_or(trusted_node_coverage)
+        && row.target.as_ref().is_none_or(|target| {
+            matches!(target.entity.selector(), EntitySelector::External { .. })
+                || trusted_node_coverage(target)
+        })
         && row.path.iter().all(trusted_node_coverage)
 }
 

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -95,8 +95,8 @@ use projectatlas_core::{
 use projectatlas_db::{
     AtlasStore, DbError, MAX_REPOSITORY_GRAPH_FRONTIER, MAX_SYMBOL_BATCH_DECODED_BYTES,
     MAX_SYMBOL_BATCH_PATHS, MAX_SYMBOL_BATCH_ROWS, RepositoryGraphAdjacencyContinuation,
-    RepositoryGraphDirection, RepositoryGraphReadBudget, SymbolBatchReadBudget,
-    SymbolBatchReadLimit,
+    RepositoryGraphDirection, RepositoryGraphReadBudget, RepositoryGraphReadWork,
+    SymbolBatchReadBudget, SymbolBatchReadLimit,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -1536,15 +1536,15 @@ fn load_entrypoint_profile_draft(
     let reachable_keys = reachable.keys().cloned().collect::<BTreeSet<_>>();
     let mut unreachable = BTreeMap::new();
     if complete {
-        let all_entities = store
-            .repository_graph_entities_page_bounded(
-                generation_project(&anchor.entity),
-                generation,
-                entity_limit,
-                read_budget,
-                control,
-            )?
-            .page;
+        let all_entities = store.repository_graph_entities_page_bounded(
+            generation_project(&anchor.entity),
+            generation,
+            entity_limit,
+            read_budget,
+            control,
+        )?;
+        add_repository_read_work(&mut relation_work, &all_entities.work)?;
+        let all_entities = all_entities.page;
         if all_entities.truncated {
             complete = false;
             push_limit(&mut reached_limits, GraphLimitKind::Nodes);
@@ -1764,6 +1764,35 @@ fn add_relation_work(
     total.rendered_output_bytes = total
         .rendered_output_bytes
         .saturating_add(next.rendered_output_bytes);
+    Ok(())
+}
+
+/// Add one bounded repository-graph read to the profile work ledger.
+fn add_repository_read_work(
+    total: &mut DetailedRelationWork,
+    next: &RepositoryGraphReadWork,
+) -> ServiceResult<()> {
+    total.database_requested_rows = total
+        .database_requested_rows
+        .checked_add(next.requested_rows)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.database_returned_rows = total
+        .database_returned_rows
+        .checked_add(next.returned_rows)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.database_decoded_bytes = total
+        .database_decoded_bytes
+        .checked_add(next.decoded_bytes)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.hydrated_entities = total
+        .hydrated_entities
+        .checked_add(next.hydrated_entities)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.hydrated_purpose_paths = total
+        .hydrated_purpose_paths
+        .checked_add(next.hydrated_paths)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.intermediate_bytes = total.intermediate_bytes.saturating_add(next.decoded_bytes);
     Ok(())
 }
 

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -77,9 +77,9 @@ use super::relations::{
 };
 use super::{
     CoverageTrustState, DetailedRelationBudget, DetailedRelationNode, DetailedRelationQuery,
-    DetailedRelationReport, DetailedRelationWork, RelationAnchor, RelationDirection,
-    RelationNextCall, RelationPurpose, RelationResolutionFilter, RelationTotalState, ServiceError,
-    ServiceResult, coverage_trust, selected_project_binding,
+    DetailedRelationReport, DetailedRelationRow, DetailedRelationWork, RelationAnchor,
+    RelationDirection, RelationNextCall, RelationPurpose, RelationResolutionFilter,
+    RelationTotalState, ServiceError, ServiceResult, coverage_trust, selected_project_binding,
 };
 use impact::{LoadedVcs, digest_vcs_paths, impact_findings, load_vcs_paths};
 use projectatlas_core::graph::{
@@ -142,6 +142,49 @@ pub enum RelationAnalysisMode {
     Impact,
     /// One node-simple static relationship path to an exact target label.
     Trace,
+    /// Bounded reachability from an explicit, non-persistent entrypoint profile.
+    Entrypoint,
+}
+
+/// Request-owned entrypoint reachability profile.
+///
+/// Profiles are deliberately not discovered or persisted. The surrounding
+/// relation budget supplies the input, traversal, and output ceilings.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct EntrypointProfile {
+    /// Stable human-readable profile name.
+    pub name: String,
+    /// Exact file or fully disambiguated symbol anchors.
+    pub anchors: Vec<RelationAnchor>,
+    /// Closed relation families admitted by this profile.
+    pub relations: Vec<GraphRelationKind>,
+}
+
+/// Typed profile-level reachability disposition.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EntrypointProfileCoverage {
+    /// Every admitted entity and relation was inspected under the profile bounds.
+    Complete,
+    /// A declared relation, entity, or resource boundary prevented a safe negative.
+    Partial,
+}
+
+/// Non-persistent profile metadata returned with entrypoint findings.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct EntrypointProfileResult {
+    /// Request-owned stable profile name.
+    pub name: String,
+    /// Exact anchors used for traversal.
+    pub anchors: Vec<RelationAnchor>,
+    /// Exact relation families used for traversal.
+    pub relations: Vec<GraphRelationKind>,
+    /// Coverage disposition for the complete local entity scope.
+    pub coverage: EntrypointProfileCoverage,
+    /// Number of reachable local entities retained in the result.
+    pub reachable: u32,
+    /// Number of evidence-backed unreachable candidates retained in the result.
+    pub unreachable_candidates: u32,
 }
 
 /// Version-control scope used by the impact projection.
@@ -178,6 +221,8 @@ pub struct RelationAnalysisQuery {
     pub include_cycles: bool,
     /// Include conservative non-exported dead-code candidates.
     pub include_dead_code: bool,
+    /// Explicit non-persistent profile for entrypoint reachability mode.
+    pub entrypoint_profile: Option<EntrypointProfile>,
 }
 
 /// Confidence disposition of one analysis finding.
@@ -220,6 +265,8 @@ pub enum AnalysisFindingKind {
     StaticTrace,
     /// Ambiguous or unresolved static relation that prevents a closed conclusion.
     ResolutionGap,
+    /// Reachability disposition for an explicit entrypoint profile.
+    EntrypointReachability,
 }
 
 /// One deterministic bounded analysis finding.
@@ -441,6 +488,9 @@ pub struct RelationAnalysisReport {
     pub reached_limits: Vec<GraphLimitKind>,
     /// Typed VCS evidence for impact mode.
     pub vcs: VcsImpact,
+    /// Request-owned entrypoint profile metadata, when that mode is selected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entrypoint_profile: Option<EntrypointProfileResult>,
     /// Exact bounded work retained by this analysis.
     pub work: RelationAnalysisWork,
     /// Deterministically ordered structural findings.
@@ -692,6 +742,8 @@ struct AnalysisCursorBinding {
     trace_target: Option<RelationAnchor>,
     /// Optional VCS selector.
     vcs: Option<GitImpactSelection>,
+    /// Explicit entrypoint profile, when selected.
+    entrypoint_profile: Option<EntrypointProfile>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -767,6 +819,9 @@ pub fn load_relation_analysis(
     query: &RelationAnalysisQuery,
     control: Option<&IndexWorkControl>,
 ) -> ServiceResult<RelationAnalysisDraft> {
+    if query.mode == RelationAnalysisMode::Entrypoint {
+        return load_entrypoint_profile_draft(store, query, control);
+    }
     load_relation_analysis_with_closure_deadline(store, query, control, None, false)
 }
 
@@ -776,6 +831,11 @@ pub(super) fn load_relation_analysis_for_federation(
     query: &RelationAnalysisQuery,
     control: Option<&IndexWorkControl>,
 ) -> ServiceResult<RelationAnalysisDraft> {
+    if query.mode == RelationAnalysisMode::Entrypoint {
+        return Err(ServiceError::InvalidInput(
+            "entrypoint profiles require one project root".to_string(),
+        ));
+    }
     load_relation_analysis_with_closure_deadline(store, query, control, None, true)
 }
 
@@ -974,6 +1034,7 @@ fn load_relation_analysis_with_closure_deadline(
             RelationAnalysisMode::Trace => {
                 trace_findings(&relations, query.trace_target.as_ref(), evidence_complete)?
             }
+            RelationAnalysisMode::Entrypoint => Vec::new(),
         });
     }
     let generated_finding_count = u32::try_from(findings.len()).map_err(|_overflow| {
@@ -1122,6 +1183,7 @@ fn load_relation_analysis_with_closure_deadline(
         truncated: analysis_truncated,
         reached_limits,
         vcs,
+        entrypoint_profile: None,
         work,
         findings,
     };
@@ -1143,6 +1205,47 @@ fn load_relation_analysis_with_closure_deadline(
 
 /// Validate closed mode, selector, option, and budget combinations.
 fn validate_analysis_query(query: &RelationAnalysisQuery) -> ServiceResult<()> {
+    if query.mode == RelationAnalysisMode::Entrypoint {
+        let profile = query.entrypoint_profile.as_ref().ok_or_else(|| {
+            ServiceError::InvalidInput(
+                "entrypoint analysis requires an explicit profile".to_string(),
+            )
+        })?;
+        validate_entrypoint_profile(profile)?;
+        if query.relations.direction != RelationDirection::Outbound
+            || query.relations.resolution != RelationResolutionFilter::Any
+        {
+            return Err(ServiceError::InvalidInput(
+                "entrypoint profiles require outbound traversal with any resolution".to_string(),
+            ));
+        }
+        if query.relations.cursor.is_some() {
+            return Err(ServiceError::RelationCursorInvalid {
+                reason: "entrypoint profiles do not support relation cursors; restart the profile",
+            });
+        }
+        if query.relations.relation.is_some() {
+            return Err(ServiceError::InvalidInput(
+                "entrypoint profiles carry relation families in the profile itself".to_string(),
+            ));
+        }
+        if query.trace_target.is_some()
+            || query.vcs.is_some()
+            || query.include_communities
+            || query.include_cycles
+            || query.include_dead_code
+        {
+            return Err(ServiceError::InvalidInput(
+                "entrypoint profiles do not accept unrelated analysis controls".to_string(),
+            ));
+        }
+        return Ok(());
+    }
+    if query.entrypoint_profile.is_some() {
+        return Err(ServiceError::InvalidInput(
+            "entrypoint profile is valid only for entrypoint analysis".to_string(),
+        ));
+    }
     if query.mode == RelationAnalysisMode::Trace {
         let Some(target) = query.trace_target.as_ref() else {
             return Err(ServiceError::InvalidInput(
@@ -1189,6 +1292,522 @@ fn validate_analysis_query(query: &RelationAnalysisQuery) -> ServiceResult<()> {
         ));
     }
     Ok(())
+}
+
+/// Validate the request-owned profile before any graph read occurs.
+fn validate_entrypoint_profile(profile: &EntrypointProfile) -> ServiceResult<()> {
+    let name = profile.name.trim();
+    if name.is_empty() || name.len() > 128 || name != profile.name {
+        return Err(ServiceError::InvalidInput(
+            "entrypoint profile name must be nonempty, trimmed, and at most 128 bytes".to_string(),
+        ));
+    }
+    if profile.anchors.is_empty() || profile.anchors.len() > 32 {
+        return Err(ServiceError::InvalidInput(
+            "entrypoint profile requires 1 to 32 anchors".to_string(),
+        ));
+    }
+    let mut anchors = BTreeSet::new();
+    for anchor in &profile.anchors {
+        let encoded = serde_json::to_string(anchor)?;
+        if !anchors.insert(encoded) {
+            return Err(ServiceError::InvalidInput(
+                "entrypoint profile anchors must be unique".to_string(),
+            ));
+        }
+        if matches!(
+            anchor,
+            RelationAnchor::Symbol {
+                symbol_kind: None,
+                ..
+            }
+        ) || matches!(
+            anchor,
+            RelationAnchor::Symbol {
+                signature: None,
+                ..
+            }
+        ) {
+            return Err(ServiceError::InvalidInput(
+                "entrypoint symbol anchors require exact kind and signature".to_string(),
+            ));
+        }
+        if let RelationAnchor::Symbol {
+            name,
+            parent,
+            signature,
+            ..
+        } = anchor
+        {
+            if name.trim().is_empty()
+                || name != name.trim()
+                || signature
+                    .as_deref()
+                    .is_some_and(|value| value.trim().is_empty())
+                || parent
+                    .as_deref()
+                    .is_some_and(|value| value.trim().is_empty())
+            {
+                return Err(ServiceError::InvalidInput(
+                    "entrypoint symbol anchors require nonempty exact identity fields".to_string(),
+                ));
+            }
+        }
+    }
+    if profile.relations.is_empty() || profile.relations.len() > GraphRelationKind::ALL.len() {
+        return Err(ServiceError::InvalidInput(
+            "entrypoint profile requires 1 to 12 relation families".to_string(),
+        ));
+    }
+    let mut relations = BTreeSet::new();
+    for relation in &profile.relations {
+        if !GraphRelationKind::ALL.contains(relation) || !relations.insert(relation.as_str()) {
+            return Err(ServiceError::InvalidInput(
+                "entrypoint profile relation families must be unique supported values".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Build a bounded, non-persistent entrypoint profile over the existing graph.
+fn load_entrypoint_profile_draft(
+    store: &AtlasStore,
+    query: &RelationAnalysisQuery,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<RelationAnalysisDraft> {
+    validate_analysis_query(query)?;
+    let profile = query
+        .entrypoint_profile
+        .as_ref()
+        .ok_or_else(|| ServiceError::InvalidInput("entrypoint profile is missing".to_string()))?;
+    let started = Instant::now();
+    let budget = bounded_analysis_budget(query.relations.budget)?;
+    let deadline = started
+        .checked_add(Duration::from_millis(budget.deadline_ms()))
+        .unwrap_or(started);
+    let analysis_control = control.map_or_else(
+        || IndexWorkControl::with_deadline(IndexCancellation::new(), deadline),
+        |caller| {
+            caller.with_timeout_ceiling(deadline.saturating_duration_since(caller.started_at()))
+        },
+    );
+    let control = Some(&analysis_control);
+    check_control(control)?;
+    let selected_binding = selected_project_binding(store)?;
+    let generation = store.repository_graph_generation()?.ok_or_else(|| {
+        ServiceError::InvalidInput(
+            "repository graph has no complete generation for entrypoint analysis".to_string(),
+        )
+    })?;
+    let mut reachable = BTreeMap::<String, DetailedRelationNode>::new();
+    let mut edges = Vec::new();
+    let mut relation_work = DetailedRelationWork::default();
+    let mut first_anchor = None;
+    let mut authored_purpose_revision = 0;
+    let mut complete = true;
+    let mut reached_limits = Vec::new();
+
+    'profile: for anchor in &profile.anchors {
+        for relation in &profile.relations {
+            check_control(control)?;
+            if relation_work.inspected_edges >= budget.edges() {
+                complete = false;
+                push_limit(&mut reached_limits, GraphLimitKind::Edges);
+                break 'profile;
+            }
+            if reachable.len() >= budget.nodes() as usize {
+                complete = false;
+                push_limit(&mut reached_limits, GraphLimitKind::Nodes);
+                break 'profile;
+            }
+            if relation_work.intermediate_bytes >= budget.intermediate_bytes() {
+                complete = false;
+                push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
+                break 'profile;
+            }
+            let mut relation_query = query.relations.clone();
+            relation_query.anchor = anchor.clone();
+            relation_query.relation = Some(*relation);
+            relation_query.direction = RelationDirection::Outbound;
+            relation_query.minimum_confidence = ConfidenceClass::Low;
+            relation_query.resolution = RelationResolutionFilter::Any;
+            relation_query.cursor = None;
+            relation_query.budget = budget;
+            let mut cursor = None;
+            let mut pages = 0_u32;
+            loop {
+                relation_query.cursor = cursor;
+                let report = load_detailed_relations(store, &relation_query, control)?;
+                if report.generation != generation {
+                    return Err(ServiceError::RelationCursorStale {
+                        field: "entrypoint graph generation",
+                    });
+                }
+                first_anchor.get_or_insert_with(|| report.anchor.clone());
+                authored_purpose_revision =
+                    authored_purpose_revision.max(report.authored_purpose_revision);
+                add_relation_work(&mut relation_work, &report.work)?;
+                if relation_work.inspected_edges > budget.edges() {
+                    complete = false;
+                    push_limit(&mut reached_limits, GraphLimitKind::Edges);
+                }
+                if relation_work.inspected_edges > budget.edges() {
+                    complete = false;
+                    push_limit(&mut reached_limits, GraphLimitKind::Edges);
+                    break 'profile;
+                }
+                if reachable.len() > budget.nodes() as usize {
+                    complete = false;
+                    push_limit(&mut reached_limits, GraphLimitKind::Nodes);
+                    break 'profile;
+                }
+                if relation_work.intermediate_bytes > budget.intermediate_bytes() {
+                    complete = false;
+                    push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
+                    break 'profile;
+                }
+                for limit in &report.reached_limits {
+                    push_limit(&mut reached_limits, *limit);
+                }
+                complete &= trusted_node_coverage(&report.anchor);
+                insert_node(&mut reachable, &report.anchor);
+                for row in &report.rows {
+                    check_control(control)?;
+                    let resolved = matches!(
+                        row.relation.resolution(),
+                        RelationResolution::Resolved { .. }
+                    ) && row.relation.completeness() == Completeness::Complete;
+                    complete &= resolved && trusted_relation_row(row);
+                    insert_node(&mut reachable, &row.source);
+                    if let Some(target) = &row.target {
+                        insert_node(&mut reachable, target);
+                    }
+                    for node in &row.path {
+                        insert_node(&mut reachable, node);
+                    }
+                    if let Some(edge) =
+                        local_edge(&row.relation, &row.source.entity, row.target.as_ref())
+                    {
+                        edges.push(edge);
+                    }
+                }
+                cursor = report.continuation;
+                pages = pages.saturating_add(1);
+                if cursor.is_none() {
+                    complete &= !report.truncated
+                        && report.reached_limits.is_empty()
+                        && matches!(report.total, RelationTotalState::Exact(_));
+                    break;
+                }
+                if pages >= budget.nodes() {
+                    complete = false;
+                    push_limit(&mut reached_limits, GraphLimitKind::Nodes);
+                    break 'profile;
+                }
+            }
+        }
+    }
+    edges.sort_by(|left, right| {
+        (&left.source, &left.target, left.kind.as_str()).cmp(&(
+            &right.source,
+            &right.target,
+            right.kind.as_str(),
+        ))
+    });
+    edges.dedup_by(|left, right| {
+        left.source == right.source && left.target == right.target && left.kind == right.kind
+    });
+    let anchor = first_anchor.ok_or_else(|| {
+        ServiceError::InvalidInput("entrypoint profile resolved no anchors".to_string())
+    })?;
+    let entity_limit = budget.nodes();
+    let read_budget = RepositoryGraphReadBudget::new(
+        1,
+        entity_limit.saturating_add(1),
+        budget
+            .intermediate_bytes()
+            .min(RepositoryGraphReadBudget::MAX_DECODED_BYTES)
+            .max(1),
+        entity_limit.saturating_add(1).saturating_mul(2),
+        entity_limit.saturating_add(1).saturating_mul(2),
+    )
+    .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
+    let reachable_keys = reachable.keys().cloned().collect::<BTreeSet<_>>();
+    let mut unreachable = BTreeMap::new();
+    if complete {
+        let all_entities = store
+            .repository_graph_entities_page_bounded(
+                generation_project(&anchor.entity),
+                generation,
+                entity_limit,
+                read_budget,
+                control,
+            )?
+            .page;
+        if all_entities.truncated {
+            complete = false;
+            push_limit(&mut reached_limits, GraphLimitKind::Nodes);
+        }
+        if complete {
+            for entity in all_entities.rows {
+                check_control(control)?;
+                if !complete {
+                    break;
+                }
+                if !matches!(
+                    entity.selector(),
+                    EntitySelector::File { .. } | EntitySelector::Symbol { .. }
+                ) || reachable_keys.contains(entity.key().canonical_identity())
+                {
+                    continue;
+                }
+                let candidate_anchor = relation_anchor_for_entity(&entity).ok_or_else(|| {
+                    ServiceError::InvalidInput(
+                        "entrypoint candidate is not addressable by an exact anchor".to_string(),
+                    )
+                })?;
+                let mut candidate_query = query.relations.clone();
+                candidate_query.anchor = candidate_anchor;
+                candidate_query.relation = Some(profile.relations[0]);
+                candidate_query.direction = RelationDirection::Outbound;
+                candidate_query.resolution = RelationResolutionFilter::Any;
+                candidate_query.cursor = None;
+                candidate_query.budget = budget;
+                let candidate_report = load_detailed_relations(store, &candidate_query, control)?;
+                add_relation_work(&mut relation_work, &candidate_report.work)?;
+                if relation_work.inspected_edges > budget.edges() {
+                    complete = false;
+                    push_limit(&mut reached_limits, GraphLimitKind::Edges);
+                    break;
+                }
+                if relation_work.intermediate_bytes > budget.intermediate_bytes() {
+                    complete = false;
+                    push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
+                    break;
+                }
+                if entrypoint_report_complete(&candidate_report) {
+                    unreachable.insert(
+                        entity.key().canonical_identity().to_string(),
+                        candidate_report.anchor,
+                    );
+                } else {
+                    complete = false;
+                    break;
+                }
+            }
+        }
+    }
+    let reachable_nodes = reachable.values().map(analysis_node).collect::<Vec<_>>();
+    let unreachable_nodes = unreachable.values().map(analysis_node).collect::<Vec<_>>();
+    let coverage = if complete {
+        EntrypointProfileCoverage::Complete
+    } else {
+        EntrypointProfileCoverage::Partial
+    };
+    let mut findings = Vec::new();
+    if complete {
+        findings.push(AnalysisFinding {
+            kind: AnalysisFindingKind::EntrypointReachability,
+            status: AnalysisStatus::Confirmed,
+            summary: "explicit entrypoints reach these local entities through complete admitted relations"
+                .to_string(),
+            nodes: reachable_nodes.clone(),
+            metric: Some(reachable_nodes.len() as u64),
+            evidence: None,
+            community: None,
+        });
+        if !unreachable_nodes.is_empty() {
+            findings.push(AnalysisFinding {
+                kind: AnalysisFindingKind::EntrypointReachability,
+                status: AnalysisStatus::Candidate,
+                summary: "local entities are unreachable from the explicit entrypoints; review exact source evidence before any deletion decision"
+                    .to_string(),
+                nodes: unreachable_nodes.clone(),
+                metric: Some(unreachable_nodes.len() as u64),
+                evidence: None,
+                community: None,
+            });
+        }
+    } else {
+        findings.push(AnalysisFinding {
+            kind: AnalysisFindingKind::EntrypointReachability,
+            status: AnalysisStatus::Inconclusive,
+            summary: "entrypoint reachability is inconclusive because relation coverage or a declared bound is partial"
+                .to_string(),
+            nodes: reachable_nodes.clone(),
+            metric: None,
+            evidence: None,
+            community: None,
+        });
+    }
+    let mut profile_result = EntrypointProfileResult {
+        name: profile.name.clone(),
+        anchors: profile.anchors.clone(),
+        relations: profile.relations.clone(),
+        coverage,
+        reachable: u32::try_from(reachable_nodes.len()).unwrap_or(u32::MAX),
+        unreachable_candidates: u32::try_from(unreachable_nodes.len()).unwrap_or(u32::MAX),
+    };
+    let mut work = RelationAnalysisWork {
+        relations: relation_work,
+        analyzed_nodes: u32::try_from(reachable.len().saturating_add(unreachable.len()))
+            .unwrap_or(u32::MAX),
+        analyzed_edges: u32::try_from(edges.len()).unwrap_or(u32::MAX),
+        ..RelationAnalysisWork::default()
+    };
+    work.retained_composition_bytes =
+        serialized_bytes_controlled(&(findings.clone(), &profile_result), control)?;
+    work.peak_intermediate_bytes = work
+        .relations
+        .intermediate_bytes
+        .saturating_add(work.retained_composition_bytes);
+    if work.peak_intermediate_bytes > budget.intermediate_bytes() {
+        complete = false;
+        work.composition_truncated = true;
+        push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
+    }
+    if !complete {
+        profile_result.coverage = EntrypointProfileCoverage::Partial;
+        for finding in &mut findings {
+            finding.status = AnalysisStatus::Inconclusive;
+        }
+    }
+    let report = RelationAnalysisReport {
+        mode: RelationAnalysisMode::Entrypoint,
+        anchor,
+        generation,
+        authored_purpose_revision,
+        continuation: None,
+        returned: u32::try_from(findings.len()).unwrap_or(u32::MAX),
+        total: if complete {
+            RelationTotalState::Exact(findings.len() as u64)
+        } else {
+            RelationTotalState::AtLeast(findings.len() as u64)
+        },
+        truncated: !complete,
+        reached_limits,
+        vcs: VcsImpact::NotRequested,
+        entrypoint_profile: Some(profile_result),
+        work,
+        findings,
+    };
+    let cursor_snapshot = AnalysisCursorSnapshot {
+        project: generation_project(&report.anchor.entity),
+        generation,
+        authored_purpose_revision,
+    };
+    let cursor_binding = analysis_cursor_binding(query, &selected_binding.project_root_identity)?;
+    Ok(RelationAnalysisDraft {
+        report,
+        output_bytes: budget.output_bytes(),
+        budget,
+        cursor_binding,
+        cursor_snapshot,
+        replay_relation_cursor: None,
+        finding_offset: 0,
+        vcs_digest: None,
+        external_relation_identities: BTreeSet::new(),
+        control: analysis_control,
+    })
+}
+
+/// Add one detailed traversal work ledger without widening its types.
+fn add_relation_work(
+    total: &mut DetailedRelationWork,
+    next: &DetailedRelationWork,
+) -> ServiceResult<()> {
+    total.returned_rows = total
+        .returned_rows
+        .checked_add(next.returned_rows)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.inspected_edges = total
+        .inspected_edges
+        .checked_add(next.inspected_edges)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.active_nodes = total.active_nodes.max(next.active_nodes);
+    total.visited_nodes = total.visited_nodes.max(next.visited_nodes);
+    total.retained_occurrences = total
+        .retained_occurrences
+        .checked_add(next.retained_occurrences)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.database_requested_rows = total
+        .database_requested_rows
+        .checked_add(next.database_requested_rows)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.database_returned_rows = total
+        .database_returned_rows
+        .checked_add(next.database_returned_rows)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.database_decoded_bytes = total
+        .database_decoded_bytes
+        .checked_add(next.database_decoded_bytes)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.hydrated_entities = total
+        .hydrated_entities
+        .checked_add(next.hydrated_entities)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.hydrated_purpose_paths = total
+        .hydrated_purpose_paths
+        .checked_add(next.hydrated_purpose_paths)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.hydrated_classification_paths = total
+        .hydrated_classification_paths
+        .checked_add(next.hydrated_classification_paths)
+        .ok_or_else(entrypoint_work_overflow)?;
+    total.retained_composition_bytes = total
+        .retained_composition_bytes
+        .saturating_add(next.retained_composition_bytes);
+    total.intermediate_bytes = total
+        .intermediate_bytes
+        .saturating_add(next.intermediate_bytes);
+    total.rendered_output_bytes = total
+        .rendered_output_bytes
+        .saturating_add(next.rendered_output_bytes);
+    Ok(())
+}
+
+fn entrypoint_work_overflow() -> ServiceError {
+    ServiceError::InvalidInput("entrypoint relation work overflowed".to_string())
+}
+
+/// Return the project identity for an already generation-bound graph entity.
+fn generation_project(entity: &GraphEntity) -> ProjectInstanceId {
+    entity.key().project()
+}
+
+/// Return whether a detailed node carries trusted local coverage.
+fn trusted_node_coverage(node: &DetailedRelationNode) -> bool {
+    !node.coverage.is_empty()
+        && node
+            .coverage
+            .iter()
+            .all(|coverage| coverage_trust(coverage.state()) == CoverageTrustState::Trusted)
+}
+
+/// Return whether every local endpoint in one relation row has trusted coverage.
+fn trusted_relation_row(row: &DetailedRelationRow) -> bool {
+    trusted_node_coverage(&row.source)
+        && row.target.as_ref().is_none_or(trusted_node_coverage)
+        && row.path.iter().all(trusted_node_coverage)
+}
+
+/// Return whether one terminal candidate traversal supports a safe negative.
+fn entrypoint_report_complete(report: &DetailedRelationReport) -> bool {
+    matches!(
+        report.total,
+        RelationTotalState::Exact(total) if total == u64::from(report.returned)
+    ) && !report.truncated
+        && report.continuation.is_none()
+        && report.reached_limits.is_empty()
+        && trusted_node_coverage(&report.anchor)
+        && report.rows.iter().all(|row| {
+            matches!(
+                row.relation.resolution(),
+                RelationResolution::Resolved { .. }
+            ) && row.relation.completeness() == Completeness::Complete
+                && trusted_relation_row(row)
+        })
 }
 
 /// Clamp the existing traversal budget to analysis product ceilings.
@@ -1242,6 +1861,7 @@ fn analysis_cursor_binding(
         trace_target: query.trace_target.clone(),
         vcs: (query.mode == RelationAnalysisMode::Impact)
             .then(|| query.vcs.clone().unwrap_or(GitImpactSelection::WorkingTree)),
+        entrypoint_profile: query.entrypoint_profile.clone(),
     })
 }
 

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -2191,7 +2191,7 @@ fn entrypoint_report_complete(report: &DetailedRelationReport) -> bool {
         && report.rows.iter().all(|row| {
             matches!(
                 row.relation.resolution(),
-                RelationResolution::Resolved { .. }
+                RelationResolution::Resolved { .. } | RelationResolution::External { .. }
             ) && row.relation.completeness() == Completeness::Complete
                 && trusted_relation_row(row)
         })

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1491,6 +1491,12 @@ fn load_entrypoint_profile_draft(
     let mut purpose_revision_initialized = false;
     let mut complete = true;
     let mut reached_limits = Vec::new();
+    let entity_selected = |node: &DetailedRelationNode| {
+        query.relations.content_selection == ContentSelection::UnspecifiedLegacy
+            || node.classification.is_some_and(|classification| {
+                query.relations.content_selection.includes(classification)
+            })
+    };
 
     let mut frontier = profile.anchors.clone();
     let mut scheduled_anchors = profile
@@ -1579,7 +1585,9 @@ fn load_entrypoint_profile_draft(
                     ) && row.relation.completeness() == Completeness::Complete;
                     complete &= resolved && trusted_relation_row(row);
                     insert_node(&mut reachable, &row.source);
-                    if let Some(target) = &row.target {
+                    if let Some(target) = &row.target
+                        && entity_selected(target)
+                    {
                         insert_node(&mut reachable, target);
                         if resolved {
                             let target_key = target.entity.key().canonical_identity().to_string();
@@ -1606,7 +1614,9 @@ fn load_entrypoint_profile_draft(
                         }
                     }
                     for node in &row.path {
-                        insert_node(&mut reachable, node);
+                        if entity_selected(node) {
+                            insert_node(&mut reachable, node);
+                        }
                     }
                     if let Some(edge) =
                         local_edge(&row.relation, &row.source.entity, row.target.as_ref())

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -26,6 +26,8 @@ mod analysis_test_observer {
         Composition,
         /// Optional dead-code candidate discovery has entered complete-scope work.
         DeadCodeDiscovery,
+        /// One bounded candidate-classification batch is about to run.
+        ClassificationHydration,
         /// Adapter-specific output fitting has begun under the retained request control.
         OutputRendering,
     }
@@ -73,7 +75,8 @@ mod analysis_test_observer {
 }
 
 use super::relations::{
-    ExternalRelationIdentity, external_relation_identities, load_detailed_relations,
+    ExternalRelationIdentity, classification_path, entity_matches_selection,
+    external_relation_identities, load_detailed_relations,
 };
 use super::{
     CoverageTrustState, DetailedRelationBudget, DetailedRelationNode, DetailedRelationQuery,
@@ -93,10 +96,10 @@ use projectatlas_core::{
     CanonicalProjectRoot, IndexCancellation, IndexWorkControl, IndexWorkStage,
 };
 use projectatlas_db::{
-    AtlasStore, DbError, MAX_REPOSITORY_GRAPH_FRONTIER, MAX_SYMBOL_BATCH_DECODED_BYTES,
-    MAX_SYMBOL_BATCH_PATHS, MAX_SYMBOL_BATCH_ROWS, RepositoryGraphAdjacencyContinuation,
-    RepositoryGraphDirection, RepositoryGraphReadBudget, RepositoryGraphReadWork,
-    SymbolBatchReadBudget, SymbolBatchReadLimit,
+    AtlasStore, DbError, MAX_FILE_CONTENT_CLASSIFICATION_PATHS, MAX_REPOSITORY_GRAPH_FRONTIER,
+    MAX_SYMBOL_BATCH_DECODED_BYTES, MAX_SYMBOL_BATCH_PATHS, MAX_SYMBOL_BATCH_ROWS,
+    RepositoryGraphAdjacencyContinuation, RepositoryGraphDirection, RepositoryGraphReadBudget,
+    RepositoryGraphReadWork, SymbolBatchReadBudget, SymbolBatchReadLimit,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -709,15 +712,16 @@ impl RelationAnalysisDraft {
                         "entrypoint output fitting byte count overflowed".to_string(),
                     ))
                 })?;
+            let peak = candidate.work.peak_intermediate_bytes.max(fitting_peak);
             if candidate.work.rendered_output_bytes == rendered
-                && candidate.work.peak_intermediate_bytes == fitting_peak
+                && candidate.work.peak_intermediate_bytes == peak
             {
                 if encoded.as_ref().len() > self.output_bytes as usize {
                     return Err(E::from(ServiceError::InvalidInput(
                         "entrypoint profile output exceeds its declared byte budget".to_string(),
                     )));
                 }
-                if fitting_peak > self.budget.intermediate_bytes() {
+                if peak > self.budget.intermediate_bytes() {
                     return Err(E::from(ServiceError::InvalidInput(
                         "entrypoint profile output exceeds its aggregate intermediate-byte budget"
                             .to_string(),
@@ -726,7 +730,7 @@ impl RelationAnalysisDraft {
                 return Ok((candidate, encoded));
             }
             candidate.work.rendered_output_bytes = rendered;
-            candidate.work.peak_intermediate_bytes = fitting_peak;
+            candidate.work.peak_intermediate_bytes = peak;
             encoded = encode(&candidate, &self.control)?;
         }
         Err(E::from(ServiceError::InvalidInput(
@@ -1493,7 +1497,6 @@ fn load_entrypoint_profile_draft(
                 relation_query.anchor = anchor.clone();
                 relation_query.relation = Some(*relation);
                 relation_query.direction = RelationDirection::Outbound;
-                relation_query.minimum_confidence = ConfidenceClass::Low;
                 relation_query.resolution = RelationResolutionFilter::Any;
                 relation_query.cursor = None;
                 relation_query.budget = step_budget;
@@ -1616,6 +1619,31 @@ fn load_entrypoint_profile_draft(
             complete = false;
             push_limit(&mut reached_limits, GraphLimitKind::Nodes);
         }
+        let candidate_entities = all_entities.rows.iter().filter(|entity| {
+            matches!(
+                entity.selector(),
+                EntitySelector::File { .. } | EntitySelector::Symbol { .. }
+            ) && !reachable_keys.contains(entity.key().canonical_identity())
+        });
+        let candidate_classifications = if complete
+            && query.relations.content_selection != ContentSelection::UnspecifiedLegacy
+        {
+            if let Some(classifications) = load_entrypoint_candidate_classifications(
+                store,
+                candidate_entities,
+                budget,
+                &mut relation_work,
+                control,
+            )? {
+                classifications
+            } else {
+                complete = false;
+                push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
+                BTreeMap::new()
+            }
+        } else {
+            BTreeMap::new()
+        };
         if complete {
             for entity in all_entities.rows {
                 check_control(control)?;
@@ -1627,6 +1655,13 @@ fn load_entrypoint_profile_draft(
                     EntitySelector::File { .. } | EntitySelector::Symbol { .. }
                 ) || reachable_keys.contains(entity.key().canonical_identity())
                 {
+                    continue;
+                }
+                if !entity_matches_selection(
+                    &entity,
+                    &candidate_classifications,
+                    query.relations.content_selection,
+                ) {
                     continue;
                 }
                 let candidate_anchor = relation_anchor_for_entity(&entity).ok_or_else(|| {
@@ -1649,7 +1684,6 @@ fn load_entrypoint_profile_draft(
                     candidate_query.anchor = candidate_anchor.clone();
                     candidate_query.relation = Some(*relation);
                     candidate_query.direction = RelationDirection::Outbound;
-                    candidate_query.minimum_confidence = ConfidenceClass::Low;
                     candidate_query.resolution = RelationResolutionFilter::Any;
                     candidate_query.cursor = None;
                     candidate_query.budget = step_budget;
@@ -1896,6 +1930,114 @@ fn add_repository_read_work(
         .ok_or_else(entrypoint_work_overflow)?;
     total.intermediate_bytes = total.intermediate_bytes.saturating_add(next.decoded_bytes);
     Ok(())
+}
+
+/// Load candidate classifications in bounded, cancellable batches.
+fn load_entrypoint_candidate_classifications<'entity>(
+    store: &AtlasStore,
+    entities: impl IntoIterator<Item = &'entity GraphEntity>,
+    budget: DetailedRelationBudget,
+    relation_work: &mut DetailedRelationWork,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<Option<BTreeMap<String, projectatlas_core::language::ContentClassification>>> {
+    let mut path_set = BTreeSet::new();
+    for entity in entities {
+        check_control(control)?;
+        let Some(path) = classification_path(entity) else {
+            continue;
+        };
+        if path_set.contains(&path) {
+            continue;
+        }
+        let path_bytes = classification_path_bytes(&path)?;
+        if relation_work
+            .intermediate_bytes
+            .checked_add(path_bytes)
+            .is_none_or(|bytes| bytes > budget.intermediate_bytes())
+        {
+            return Ok(None);
+        }
+        path_set.insert(path);
+        relation_work.intermediate_bytes = relation_work
+            .intermediate_bytes
+            .checked_add(path_bytes)
+            .ok_or_else(entrypoint_work_overflow)?;
+    }
+    let paths = path_set.into_iter().collect::<Vec<_>>();
+    let mut classifications = BTreeMap::new();
+    for chunk in paths.chunks(MAX_FILE_CONTENT_CLASSIFICATION_PATHS) {
+        check_control(control)?;
+        #[cfg(test)]
+        analysis_test_observer::notify(
+            analysis_test_observer::AnalysisPhaseEvent::ClassificationHydration,
+        );
+        let rows = store.file_content_classifications_for_paths(chunk)?;
+        check_control(control)?;
+        let decoded_bytes = classification_rows_bytes(&rows, control)?;
+        let retained_bytes = classification_rows_bytes(&rows, control)?;
+        let requested_rows =
+            u32::try_from(chunk.len()).map_err(|_overflow| entrypoint_work_overflow())?;
+        let returned_rows =
+            u32::try_from(rows.len()).map_err(|_overflow| entrypoint_work_overflow())?;
+        relation_work.database_requested_rows = relation_work
+            .database_requested_rows
+            .checked_add(requested_rows)
+            .ok_or_else(entrypoint_work_overflow)?;
+        relation_work.database_returned_rows = relation_work
+            .database_returned_rows
+            .checked_add(returned_rows)
+            .ok_or_else(entrypoint_work_overflow)?;
+        relation_work.database_decoded_bytes = relation_work
+            .database_decoded_bytes
+            .checked_add(decoded_bytes)
+            .ok_or_else(entrypoint_work_overflow)?;
+        relation_work.hydrated_classification_paths = relation_work
+            .hydrated_classification_paths
+            .checked_add(returned_rows)
+            .ok_or_else(entrypoint_work_overflow)?;
+        let retained_intermediate = relation_work
+            .intermediate_bytes
+            .checked_add(decoded_bytes)
+            .and_then(|bytes| bytes.checked_add(retained_bytes))
+            .ok_or_else(entrypoint_work_overflow)?;
+        if retained_intermediate > budget.intermediate_bytes() {
+            return Ok(None);
+        }
+        relation_work.intermediate_bytes = retained_intermediate;
+        classifications.extend(rows.into_iter().map(|row| (row.path, row.classification)));
+        check_control(control)?;
+    }
+    Ok(Some(classifications))
+}
+
+/// Count one bounded path retained while classification batches run.
+fn classification_path_bytes(path: &str) -> ServiceResult<u64> {
+    u64::try_from(path.len())
+        .ok()
+        .and_then(|bytes| bytes.checked_add(8))
+        .ok_or_else(entrypoint_work_overflow)
+}
+
+/// Count conservative decoded and retained bytes for one classification batch.
+fn classification_rows_bytes(
+    rows: &[projectatlas_db::FileContentClassification],
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<u64> {
+    rows.iter().try_fold(0_u64, |bytes, row| {
+        check_control(control)?;
+        let row_bytes = u64::try_from(row.path.len())
+            .ok()
+            .and_then(|path| {
+                u64::try_from(row.classification.as_str().len())
+                    .ok()
+                    .and_then(|classification| path.checked_add(classification))
+            })
+            .and_then(|bytes| bytes.checked_add(8))
+            .ok_or_else(entrypoint_work_overflow)?;
+        bytes
+            .checked_add(row_bytes)
+            .ok_or_else(entrypoint_work_overflow)
+    })
 }
 
 /// Derive one one-step detailed budget from the remaining profile-wide capacity.

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1397,20 +1397,18 @@ fn validate_entrypoint_profile(profile: &EntrypointProfile) -> ServiceResult<()>
             signature,
             ..
         } = anchor
-        {
-            if name.trim().is_empty()
+            && (name.trim().is_empty()
                 || name != name.trim()
                 || signature
                     .as_deref()
                     .is_some_and(|value| value.trim().is_empty())
                 || parent
                     .as_deref()
-                    .is_some_and(|value| value.trim().is_empty())
-            {
-                return Err(ServiceError::InvalidInput(
-                    "entrypoint symbol anchors require nonempty exact identity fields".to_string(),
-                ));
-            }
+                    .is_some_and(|value| value.trim().is_empty()))
+        {
+            return Err(ServiceError::InvalidInput(
+                "entrypoint symbol anchors require nonempty exact identity fields".to_string(),
+            ));
         }
     }
     if profile.relations.is_empty() || profile.relations.len() > GraphRelationKind::ALL.len() {
@@ -1597,8 +1595,7 @@ fn load_entrypoint_profile_draft(
         entity_limit.saturating_add(1),
         budget
             .intermediate_bytes()
-            .min(RepositoryGraphReadBudget::MAX_DECODED_BYTES)
-            .max(1),
+            .clamp(1, RepositoryGraphReadBudget::MAX_DECODED_BYTES),
         entity_limit.saturating_add(1).saturating_mul(2),
         entity_limit.saturating_add(1).saturating_mul(2),
     )
@@ -1675,13 +1672,11 @@ fn load_entrypoint_profile_draft(
                     }
                     candidate_report_anchor.get_or_insert(candidate_report.anchor);
                 }
-                if complete {
-                    if let Some(candidate_report_anchor) = candidate_report_anchor {
-                        unreachable.insert(
-                            entity.key().canonical_identity().to_string(),
-                            candidate_report_anchor,
-                        );
-                    }
+                if complete && let Some(candidate_report_anchor) = candidate_report_anchor {
+                    unreachable.insert(
+                        entity.key().canonical_identity().to_string(),
+                        candidate_report_anchor,
+                    );
                 }
             }
         }
@@ -1961,6 +1956,7 @@ fn entrypoint_step_budget(
     Ok(Ok(step))
 }
 
+/// Return the typed error for aggregate entrypoint work overflow.
 fn entrypoint_work_overflow() -> ServiceError {
     ServiceError::InvalidInput("entrypoint relation work overflowed".to_string())
 }

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1881,9 +1881,11 @@ fn load_entrypoint_profile_draft(
         work.composition_truncated = true;
         push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
         profile_result.coverage = EntrypointProfileCoverage::Partial;
+        profile_result.reachable = 0;
         profile_result.unreachable_candidates = 0;
         for finding in &mut findings {
             finding.status = AnalysisStatus::Inconclusive;
+            finding.metric = None;
         }
     }
     work.retained_composition_bytes =

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -88,9 +88,10 @@ mod analysis_test_observer {
     }
 }
 
+#[cfg(test)]
+use super::relations::classification_path;
 use super::relations::{
-    ExternalRelationIdentity, classification_path, entity_matches_selection,
-    external_relation_identities, load_detailed_relations,
+    ExternalRelationIdentity, external_relation_identities, load_detailed_relations,
 };
 use super::{
     CoverageTrustState, DetailedRelationBudget, DetailedRelationNode, DetailedRelationQuery,
@@ -104,16 +105,20 @@ use projectatlas_core::graph::{
     GraphIdentityText, GraphLimitKind, GraphLimits, GraphRelationKind, ProjectInstanceId,
     RelationResolution,
 };
-use projectatlas_core::language::{ContentClassification, ContentSelection};
+#[cfg(test)]
+use projectatlas_core::language::ContentClassification;
+use projectatlas_core::language::ContentSelection;
 use projectatlas_core::symbols::{CodeSymbol, RelationKind};
 use projectatlas_core::{
     CanonicalProjectRoot, IndexCancellation, IndexWorkControl, IndexWorkStage,
 };
+#[cfg(test)]
+use projectatlas_db::MAX_FILE_CONTENT_CLASSIFICATION_PATHS;
 use projectatlas_db::{
-    AtlasStore, DbError, MAX_FILE_CONTENT_CLASSIFICATION_PATHS, MAX_REPOSITORY_GRAPH_FRONTIER,
-    MAX_SYMBOL_BATCH_DECODED_BYTES, MAX_SYMBOL_BATCH_PATHS, MAX_SYMBOL_BATCH_ROWS,
-    RepositoryGraphAdjacencyContinuation, RepositoryGraphDirection, RepositoryGraphReadBudget,
-    RepositoryGraphReadWork, SymbolBatchReadBudget, SymbolBatchReadLimit,
+    AtlasStore, DbError, MAX_REPOSITORY_GRAPH_FRONTIER, MAX_SYMBOL_BATCH_DECODED_BYTES,
+    MAX_SYMBOL_BATCH_PATHS, MAX_SYMBOL_BATCH_ROWS, RepositoryGraphAdjacencyContinuation,
+    RepositoryGraphDirection, RepositoryGraphReadBudget, RepositoryGraphReadWork,
+    SymbolBatchReadBudget, SymbolBatchReadLimit,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -1655,6 +1660,7 @@ fn load_entrypoint_profile_draft(
             generation_project(&anchor.entity),
             generation,
             entity_limit,
+            query.relations.content_selection,
             read_budget,
             control,
         )?;
@@ -1674,33 +1680,8 @@ fn load_entrypoint_profile_draft(
                 ) && !reachable_keys.contains(entity.key().canonical_identity())
             })
             .collect::<Vec<_>>();
-        let candidate_classifications = if complete
-            && query.relations.content_selection != ContentSelection::UnspecifiedLegacy
-        {
-            if let Some(classifications) = load_entrypoint_candidate_classifications(
-                store,
-                candidate_entities.iter().copied(),
-                budget,
-                &mut relation_work,
-                control,
-            )? {
-                classifications
-            } else {
-                complete = false;
-                push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
-                BTreeMap::new()
-            }
-        } else {
-            BTreeMap::new()
-        };
         if complete {
-            for entity in candidate_entities.into_iter().filter(|entity| {
-                entity_matches_selection(
-                    entity,
-                    &candidate_classifications,
-                    query.relations.content_selection,
-                )
-            }) {
+            for entity in candidate_entities {
                 check_control(control)?;
                 if !complete {
                     break;
@@ -1836,7 +1817,11 @@ fn load_entrypoint_profile_draft(
         relations: profile.relations.clone(),
         coverage,
         reachable: u32::try_from(reachable.len()).unwrap_or(u32::MAX),
-        unreachable_candidates: 0,
+        unreachable_candidates: if complete {
+            u32::try_from(unreachable.len()).unwrap_or(u32::MAX)
+        } else {
+            0
+        },
     };
     let mut work = RelationAnalysisWork {
         relations: relation_work,
@@ -1878,6 +1863,7 @@ fn load_entrypoint_profile_draft(
         work.composition_truncated = true;
         push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
         profile_result.coverage = EntrypointProfileCoverage::Partial;
+        profile_result.unreachable_candidates = 0;
         for finding in &mut findings {
             finding.status = AnalysisStatus::Inconclusive;
         }
@@ -1887,7 +1873,14 @@ fn load_entrypoint_profile_draft(
     work.peak_intermediate_bytes = work
         .relations
         .intermediate_bytes
-        .saturating_add(work.retained_composition_bytes);
+        .checked_add(work.retained_composition_bytes)
+        .ok_or_else(entrypoint_work_overflow)?;
+    if work.peak_intermediate_bytes > budget.intermediate_bytes() {
+        return Err(ServiceError::InvalidInput(
+            "entrypoint profile construction exceeds its aggregate intermediate-byte budget"
+                .to_string(),
+        ));
+    }
     if !complete {
         profile_result.coverage = EntrypointProfileCoverage::Partial;
         for finding in &mut findings {
@@ -2037,6 +2030,7 @@ fn add_repository_read_work(
 }
 
 /// Load candidate classifications in bounded, cancellable batches.
+#[cfg(test)]
 fn load_entrypoint_candidate_classifications<'entity>(
     store: &AtlasStore,
     entities: impl IntoIterator<Item = &'entity GraphEntity>,
@@ -2123,6 +2117,7 @@ fn load_entrypoint_candidate_classifications<'entity>(
 }
 
 /// Count one bounded path retained while classification batches run.
+#[cfg(test)]
 fn classification_path_bytes(path: &str) -> ServiceResult<u64> {
     u64::try_from(path.len())
         .ok()
@@ -2131,6 +2126,7 @@ fn classification_path_bytes(path: &str) -> ServiceResult<u64> {
 }
 
 /// Bound one classification batch before materializing its database rows.
+#[cfg(test)]
 fn classification_rows_upper_bound(
     paths: &[String],
     control: Option<&IndexWorkControl>,
@@ -2155,6 +2151,7 @@ fn classification_rows_upper_bound(
 }
 
 /// Count conservative decoded and retained bytes for one classification batch.
+#[cfg(test)]
 fn classification_rows_bytes(
     rows: &[projectatlas_db::FileContentClassification],
     control: Option<&IndexWorkControl>,

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1506,11 +1506,17 @@ fn load_entrypoint_profile_draft(
         for anchor in frontier.drain(..) {
             for relation in &profile.relations {
                 check_control(control)?;
+                let anchor_is_retained = reachable
+                    .values()
+                    .any(|node| relation_anchor_for_entity(&node.entity).as_ref() == Some(&anchor));
+                let retained_keys =
+                    anchor_is_retained.then(|| reachable.keys().cloned().collect::<BTreeSet<_>>());
                 let step_budget = match entrypoint_step_budget(
                     budget,
                     &relation_work,
                     reachable.len(),
                     0,
+                    anchor_is_retained,
                     query.relations.include_occurrences,
                 )? {
                     Ok(step_budget) => step_budget,
@@ -1607,6 +1613,14 @@ fn load_entrypoint_profile_draft(
                     {
                         edges.push(edge);
                     }
+                }
+                if reachable.len() > budget.nodes() as usize {
+                    if let Some(retained_keys) = retained_keys {
+                        reachable.retain(|key, _| retained_keys.contains(key));
+                    }
+                    complete = false;
+                    push_limit(&mut reached_limits, GraphLimitKind::Nodes);
+                    break 'profile;
                 }
                 if report.continuation.is_some() {
                     complete = false;
@@ -1738,6 +1752,7 @@ fn load_entrypoint_profile_draft(
                         &relation_work,
                         reachable.len(),
                         unreachable.len(),
+                        false,
                         query.relations.include_occurrences,
                     )? {
                         Ok(step_budget) => step_budget,
@@ -2222,13 +2237,25 @@ fn entrypoint_step_budget(
     work: &DetailedRelationWork,
     retained_nodes: usize,
     validated_candidates: usize,
+    anchor_is_retained: bool,
     include_occurrences: bool,
 ) -> ServiceResult<Result<DetailedRelationBudget, GraphLimitKind>> {
     let accounted_nodes = retained_nodes.saturating_add(validated_candidates);
     let accounted_nodes = u32::try_from(accounted_nodes).unwrap_or(u32::MAX);
+    let validated_candidates = u32::try_from(validated_candidates).unwrap_or(u32::MAX);
     let remaining_edges = budget.edges().saturating_sub(work.inspected_edges);
     let remaining_nodes = budget.nodes().saturating_sub(accounted_nodes);
     let remaining_visited = budget.visited().saturating_sub(accounted_nodes);
+    let step_nodes = if anchor_is_retained {
+        budget.nodes().saturating_sub(validated_candidates)
+    } else {
+        remaining_nodes
+    };
+    let step_visited = if anchor_is_retained {
+        budget.visited().saturating_sub(validated_candidates)
+    } else {
+        remaining_visited
+    };
     let remaining_occurrences = if include_occurrences {
         budget
             .occurrences_total()
@@ -2239,11 +2266,7 @@ fn entrypoint_step_budget(
     let remaining_intermediate = budget
         .intermediate_bytes()
         .saturating_sub(work.intermediate_bytes);
-    let rows = budget
-        .page_rows()
-        .min(remaining_edges)
-        .min(remaining_nodes)
-        .min(remaining_visited);
+    let rows = budget.page_rows().min(remaining_edges);
     let rows = if include_occurrences {
         rows.min(remaining_occurrences)
     } else {
@@ -2252,10 +2275,10 @@ fn entrypoint_step_budget(
     if remaining_edges == 0 {
         return Ok(Err(GraphLimitKind::Edges));
     }
-    if remaining_nodes == 0 {
+    if remaining_nodes == 0 && !anchor_is_retained {
         return Ok(Err(GraphLimitKind::Nodes));
     }
-    if remaining_visited == 0 {
+    if remaining_visited == 0 && !anchor_is_retained {
         return Ok(Err(GraphLimitKind::Visited));
     }
     if include_occurrences && remaining_occurrences == 0 {
@@ -2276,8 +2299,8 @@ fn entrypoint_step_budget(
     .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
     let step = DetailedRelationBudget::from_graph_limits(limits).with_aggregate_limits(
         Some(remaining_edges),
-        Some(remaining_nodes),
-        Some(remaining_visited),
+        Some(step_nodes),
+        Some(step_visited),
         Some(remaining_occurrences),
         Some(remaining_intermediate),
         Some(budget.deadline_ms()),

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1656,30 +1656,48 @@ fn load_entrypoint_profile_draft(
             entity_limit.saturating_add(1).saturating_mul(2),
         )
         .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
-        let all_entities = store.repository_graph_entrypoint_candidates_page_bounded(
+        let all_entities = match store.repository_graph_entrypoint_candidates_page_bounded(
             generation_project(&anchor.entity),
             generation,
             entity_limit,
             query.relations.content_selection,
             read_budget,
             control,
-        )?;
-        add_repository_read_work(&mut relation_work, &all_entities.work)?;
-        let all_entities = all_entities.page;
-        if all_entities.truncated {
-            complete = false;
-            push_limit(&mut reached_limits, GraphLimitKind::Nodes);
-        }
+        ) {
+            Ok(all_entities) => {
+                add_repository_read_work(&mut relation_work, &all_entities.work)?;
+                Some(all_entities.page)
+            }
+            Err(DbError::GraphContract(
+                projectatlas_core::graph::GraphContractError::InvalidLimits {
+                    reason: "graph read decoded bytes exceed the batch budget",
+                },
+            )) => {
+                complete = false;
+                push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
+                None
+            }
+            Err(error) => return Err(error.into()),
+        };
         let candidate_entities = all_entities
-            .rows
-            .iter()
-            .filter(|entity| {
-                matches!(
-                    entity.selector(),
-                    EntitySelector::File { .. } | EntitySelector::Symbol { .. }
-                ) && !reachable_keys.contains(entity.key().canonical_identity())
+            .as_ref()
+            .map(|all_entities| {
+                if all_entities.truncated {
+                    complete = false;
+                    push_limit(&mut reached_limits, GraphLimitKind::Nodes);
+                }
+                all_entities
+                    .rows
+                    .iter()
+                    .filter(|entity| {
+                        matches!(
+                            entity.selector(),
+                            EntitySelector::File { .. } | EntitySelector::Symbol { .. }
+                        ) && !reachable_keys.contains(entity.key().canonical_identity())
+                    })
+                    .collect::<Vec<_>>()
             })
-            .collect::<Vec<_>>();
+            .unwrap_or_default();
         if complete {
             for entity in candidate_entities {
                 check_control(control)?;

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -103,9 +103,9 @@ use super::{
 };
 use impact::{LoadedVcs, digest_vcs_paths, impact_findings, load_vcs_paths};
 use projectatlas_core::graph::{
-    Completeness, ConfidenceClass, EntitySelector, ExtendedRelationKind, GraphEntity,
-    GraphIdentityText, GraphLimitKind, GraphLimits, GraphRelationKind, ProjectInstanceId,
-    RelationResolution,
+    Completeness, ConfidenceClass, CoverageRecord, EntitySelector, ExtendedRelationKind,
+    GraphEntity, GraphIdentityText, GraphLimitKind, GraphLimits, GraphRelationKind,
+    ProjectInstanceId, RelationResolution,
 };
 #[cfg(test)]
 use projectatlas_core::language::ContentClassification;
@@ -1523,6 +1523,7 @@ fn load_entrypoint_profile_draft(
                     reachable.len(),
                     0,
                     anchor_is_retained,
+                    false,
                     query.relations.include_occurrences,
                 )? {
                     Ok(step_budget) => step_budget,
@@ -1573,7 +1574,7 @@ fn load_entrypoint_profile_draft(
                     push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
                     break 'profile;
                 }
-                complete &= trusted_node_coverage(&report.anchor);
+                complete &= trusted_node_coverage(&report.anchor, &profile.relations);
                 let anchor_key = report.anchor.entity.key().canonical_identity().to_string();
                 visited.insert(anchor_key);
                 insert_node(&mut reachable, &report.anchor);
@@ -1583,7 +1584,7 @@ fn load_entrypoint_profile_draft(
                         row.relation.resolution(),
                         RelationResolution::Resolved { .. } | RelationResolution::External { .. }
                     ) && row.relation.completeness() == Completeness::Complete;
-                    complete &= resolved && trusted_relation_row(row);
+                    complete &= resolved && trusted_relation_row(row, &profile.relations);
                     insert_node(&mut reachable, &row.source);
                     if let Some(target) = &row.target
                         && entity_selected(target)
@@ -1664,6 +1665,7 @@ fn load_entrypoint_profile_draft(
     })?;
     let entity_limit = budget.nodes();
     let reachable_keys = reachable.keys().cloned().collect::<BTreeSet<_>>();
+    let mut retained_candidate_keys = reachable_keys.clone();
     let mut unreachable = BTreeMap::new();
     let remaining_intermediate = budget
         .intermediate_bytes()
@@ -1750,19 +1752,26 @@ fn load_entrypoint_profile_draft(
                 if !complete {
                     break;
                 }
+                let candidate_key = entity.key().canonical_identity().to_string();
                 let candidate_anchor = relation_anchor_for_entity(entity).ok_or_else(|| {
                     ServiceError::InvalidInput(
                         "entrypoint candidate is not addressable by an exact anchor".to_string(),
                     )
                 })?;
                 let mut candidate_report_anchor = None;
+                let mut candidate_unretained_keys = BTreeSet::new();
                 for relation in &profile.relations {
+                    let accounted_candidates = retained_candidate_keys
+                        .len()
+                        .saturating_sub(reachable.len());
+                    let anchor_is_retained = retained_candidate_keys.contains(&candidate_key);
                     let step_budget = match entrypoint_step_budget(
                         budget,
                         &relation_work,
                         reachable.len(),
-                        unreachable.len(),
-                        false,
+                        accounted_candidates,
+                        anchor_is_retained,
+                        true,
                         query.relations.include_occurrences,
                     )? {
                         Ok(step_budget) => step_budget,
@@ -1815,23 +1824,38 @@ fn load_entrypoint_profile_draft(
                         push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
                         break;
                     }
+                    candidate_unretained_keys.extend(candidate_report_unretained_local_keys(
+                        &candidate_report,
+                        &retained_candidate_keys,
+                    ));
+                    if candidate_unretained_keys.len()
+                        > usize::try_from(budget.nodes().saturating_sub(
+                            u32::try_from(retained_candidate_keys.len()).unwrap_or(u32::MAX),
+                        ))
+                        .unwrap_or(usize::MAX)
+                    {
+                        complete = false;
+                        push_limit(&mut reached_limits, GraphLimitKind::Nodes);
+                        push_limit(&mut reached_limits, GraphLimitKind::Visited);
+                        break;
+                    }
                     for limit in &candidate_report.reached_limits {
                         push_limit(&mut reached_limits, *limit);
                     }
                     if candidate_report.continuation.is_some() {
                         push_limit(&mut reached_limits, GraphLimitKind::Rows);
                     }
-                    if !entrypoint_report_complete(&candidate_report) {
+                    if !entrypoint_report_complete(&candidate_report, &profile.relations) {
                         complete = false;
                         break;
                     }
                     candidate_report_anchor.get_or_insert(candidate_report.anchor);
                 }
                 if complete && let Some(candidate_report_anchor) = candidate_report_anchor {
-                    unreachable.insert(
-                        entity.key().canonical_identity().to_string(),
-                        candidate_report_anchor,
-                    );
+                    unreachable.insert(candidate_key.clone(), candidate_report_anchor);
+                    for key in candidate_unretained_keys {
+                        retained_candidate_keys.insert(key);
+                    }
                 }
             }
         }
@@ -2248,6 +2272,7 @@ fn entrypoint_step_budget(
     retained_nodes: usize,
     validated_candidates: usize,
     anchor_is_retained: bool,
+    candidate_anchor_overhead: bool,
     include_occurrences: bool,
 ) -> ServiceResult<Result<DetailedRelationBudget, GraphLimitKind>> {
     let accounted_nodes = retained_nodes.saturating_add(validated_candidates);
@@ -2256,12 +2281,16 @@ fn entrypoint_step_budget(
     let remaining_edges = budget.edges().saturating_sub(work.inspected_edges);
     let remaining_nodes = budget.nodes().saturating_sub(accounted_nodes);
     let remaining_visited = budget.visited().saturating_sub(accounted_nodes);
-    let step_nodes = if anchor_is_retained {
+    let step_nodes = if candidate_anchor_overhead {
+        remaining_nodes.saturating_add(1)
+    } else if anchor_is_retained {
         budget.nodes().saturating_sub(validated_candidates)
     } else {
         remaining_nodes
     };
-    let step_visited = if anchor_is_retained {
+    let step_visited = if candidate_anchor_overhead {
+        remaining_visited.saturating_add(1)
+    } else if anchor_is_retained {
         budget.visited().saturating_sub(validated_candidates)
     } else {
         remaining_visited
@@ -2328,41 +2357,83 @@ fn generation_project(entity: &GraphEntity) -> ProjectInstanceId {
     entity.key().project()
 }
 
-/// Return whether a detailed node carries trusted local coverage.
-fn trusted_node_coverage(node: &DetailedRelationNode) -> bool {
-    !node.coverage.is_empty()
+/// Return whether a detailed node carries trusted coverage for admitted relations.
+fn trusted_node_coverage(
+    node: &DetailedRelationNode,
+    admitted_relations: &[GraphRelationKind],
+) -> bool {
+    let applies = |coverage: &CoverageRecord| {
+        coverage
+            .relation()
+            .is_none_or(|relation| admitted_relations.contains(&relation))
+    };
+    node.coverage.iter().any(&applies)
         && node
             .coverage
             .iter()
+            .filter(|coverage| applies(coverage))
             .all(|coverage| coverage_trust(coverage.state()) == CoverageTrustState::Trusted)
 }
 
 /// Return whether every local endpoint in one relation row has trusted coverage.
-fn trusted_relation_row(row: &DetailedRelationRow) -> bool {
-    trusted_node_coverage(&row.source)
+fn trusted_relation_row(
+    row: &DetailedRelationRow,
+    admitted_relations: &[GraphRelationKind],
+) -> bool {
+    trusted_node_coverage(&row.source, admitted_relations)
         && row.target.as_ref().is_none_or(|target| {
             matches!(target.entity.selector(), EntitySelector::External { .. })
-                || trusted_node_coverage(target)
+                || trusted_node_coverage(target, admitted_relations)
         })
-        && row.path.iter().all(trusted_node_coverage)
+        && row
+            .path
+            .iter()
+            .all(|node| trusted_node_coverage(node, admitted_relations))
 }
 
 /// Return whether one terminal candidate traversal supports a safe negative.
-fn entrypoint_report_complete(report: &DetailedRelationReport) -> bool {
+fn entrypoint_report_complete(
+    report: &DetailedRelationReport,
+    admitted_relations: &[GraphRelationKind],
+) -> bool {
     matches!(
         report.total,
         RelationTotalState::Exact(total) if total == u64::from(report.returned)
     ) && !report.truncated
         && report.continuation.is_none()
         && report.reached_limits.is_empty()
-        && trusted_node_coverage(&report.anchor)
+        && trusted_node_coverage(&report.anchor, admitted_relations)
         && report.rows.iter().all(|row| {
             matches!(
                 row.relation.resolution(),
                 RelationResolution::Resolved { .. } | RelationResolution::External { .. }
             ) && row.relation.completeness() == Completeness::Complete
-                && trusted_relation_row(row)
+                && trusted_relation_row(row, admitted_relations)
         })
+}
+
+/// Return local identities exposed by candidate traversal that were not retained already.
+fn candidate_report_unretained_local_keys(
+    report: &DetailedRelationReport,
+    retained_keys: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    let mut keys = BTreeSet::new();
+    let mut retain = |node: &DetailedRelationNode| {
+        if !matches!(node.entity.selector(), EntitySelector::External { .. })
+            && !retained_keys.contains(node.entity.key().canonical_identity())
+        {
+            keys.insert(node.entity.key().canonical_identity().to_string());
+        }
+    };
+    retain(&report.anchor);
+    for row in &report.rows {
+        retain(&row.source);
+        if let Some(target) = row.target.as_ref() {
+            retain(target);
+        }
+        row.path.iter().for_each(&mut retain);
+    }
+    keys
 }
 
 /// Clamp the existing traversal budget to analysis product ceilings.

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1468,6 +1468,12 @@ fn load_entrypoint_profile_draft(
     let mut reached_limits = Vec::new();
 
     let mut frontier = profile.anchors.clone();
+    let mut scheduled_anchors = profile
+        .anchors
+        .iter()
+        .map(serde_json::to_string)
+        .collect::<Result<BTreeSet<_>, _>>()
+        .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
     let mut visited = BTreeSet::new();
     let mut depth = 0_u32;
     'profile: while !frontier.is_empty() && depth < budget.depth() {
@@ -1475,13 +1481,15 @@ fn load_entrypoint_profile_draft(
         for anchor in frontier.drain(..) {
             for relation in &profile.relations {
                 check_control(control)?;
-                let Some(step_budget) =
-                    entrypoint_step_budget(budget, &relation_work, reachable.len())?
-                else {
-                    complete = false;
-                    push_limit(&mut reached_limits, GraphLimitKind::Edges);
-                    break 'profile;
-                };
+                let step_budget =
+                    match entrypoint_step_budget(budget, &relation_work, reachable.len())? {
+                        Ok(step_budget) => step_budget,
+                        Err(limit) => {
+                            complete = false;
+                            push_limit(&mut reached_limits, limit);
+                            break 'profile;
+                        }
+                    };
                 let mut relation_query = query.relations.clone();
                 relation_query.anchor = anchor.clone();
                 relation_query.relation = Some(*relation);
@@ -1490,6 +1498,10 @@ fn load_entrypoint_profile_draft(
                 relation_query.resolution = RelationResolutionFilter::Any;
                 relation_query.cursor = None;
                 relation_query.budget = step_budget;
+                #[cfg(test)]
+                analysis_test_observer::notify(
+                    analysis_test_observer::AnalysisPhaseEvent::Traversal,
+                );
                 let report = load_detailed_relations(store, &relation_query, control)?;
                 if report.generation != generation {
                     return Err(ServiceError::RelationCursorStale {
@@ -1532,6 +1544,8 @@ fn load_entrypoint_profile_draft(
                             if visited.insert(target_key)
                                 && let Some(target_anchor) =
                                     relation_anchor_for_entity(&target.entity)
+                                && let Ok(anchor_key) = serde_json::to_string(&target_anchor)
+                                && scheduled_anchors.insert(anchor_key)
                             {
                                 next_frontier.push(target_anchor);
                             }
@@ -1624,13 +1638,15 @@ fn load_entrypoint_profile_draft(
                 })?;
                 let mut candidate_report_anchor = None;
                 for relation in &profile.relations {
-                    let Some(step_budget) =
-                        entrypoint_step_budget(budget, &relation_work, reachable.len())?
-                    else {
-                        complete = false;
-                        push_limit(&mut reached_limits, GraphLimitKind::Edges);
-                        break;
-                    };
+                    let step_budget =
+                        match entrypoint_step_budget(budget, &relation_work, reachable.len())? {
+                            Ok(step_budget) => step_budget,
+                            Err(limit) => {
+                                complete = false;
+                                push_limit(&mut reached_limits, limit);
+                                break;
+                            }
+                        };
                     let mut candidate_query = query.relations.clone();
                     candidate_query.anchor = candidate_anchor.clone();
                     candidate_query.relation = Some(*relation);
@@ -1872,7 +1888,7 @@ fn entrypoint_step_budget(
     budget: DetailedRelationBudget,
     work: &DetailedRelationWork,
     retained_nodes: usize,
-) -> ServiceResult<Option<DetailedRelationBudget>> {
+) -> ServiceResult<Result<DetailedRelationBudget, GraphLimitKind>> {
     let retained_nodes = u32::try_from(retained_nodes).unwrap_or(u32::MAX);
     let remaining_edges = budget.edges().saturating_sub(work.inspected_edges);
     let remaining_nodes = budget.nodes().saturating_sub(retained_nodes);
@@ -1889,8 +1905,23 @@ fn entrypoint_step_budget(
         .min(remaining_nodes)
         .min(remaining_visited)
         .min(remaining_occurrences);
-    if rows == 0 || remaining_intermediate < 64 * 1_024 {
-        return Ok(None);
+    if remaining_edges == 0 {
+        return Ok(Err(GraphLimitKind::Edges));
+    }
+    if remaining_nodes == 0 {
+        return Ok(Err(GraphLimitKind::Nodes));
+    }
+    if remaining_visited == 0 {
+        return Ok(Err(GraphLimitKind::Visited));
+    }
+    if remaining_occurrences == 0 {
+        return Ok(Err(GraphLimitKind::Occurrences));
+    }
+    if remaining_intermediate < 64 * 1_024 {
+        return Ok(Err(GraphLimitKind::IntermediateBytes));
+    }
+    if rows == 0 {
+        return Ok(Err(GraphLimitKind::Rows));
     }
     let limits = GraphLimits::new(
         rows,
@@ -1907,7 +1938,7 @@ fn entrypoint_step_budget(
         Some(remaining_intermediate),
         Some(budget.deadline_ms()),
     )?;
-    Ok(Some(step))
+    Ok(Ok(step))
 }
 
 fn entrypoint_work_overflow() -> ServiceError {

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -7,7 +7,7 @@ mod analysis_test_observer {
     use std::cell::RefCell;
 
     /// Named production phase reached by one synchronous analysis request.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    #[derive(Clone, Debug, Eq, PartialEq)]
     pub(super) enum AnalysisPhaseEvent {
         /// Exact byte ledger passed to the architecture community projection.
         CompositionBudget {
@@ -30,6 +30,13 @@ mod analysis_test_observer {
         ClassificationHydration,
         /// One bounded candidate relation traversal is about to run.
         CandidateTraversal,
+        /// One candidate relation report has returned its typed truncation state.
+        CandidateReport {
+            /// Whether the candidate report has a resumable continuation.
+            has_continuation: bool,
+            /// Whether the candidate report reached the edge limit.
+            has_edges_limit: bool,
+        },
         /// The repository-wide candidate entity page is about to run.
         CandidateEntityHydration {
             /// Intermediate bytes left after relation traversal.
@@ -1493,7 +1500,7 @@ fn load_entrypoint_profile_draft(
             for relation in &profile.relations {
                 check_control(control)?;
                 let step_budget =
-                    match entrypoint_step_budget(budget, &relation_work, reachable.len())? {
+                    match entrypoint_step_budget(budget, &relation_work, reachable.len(), 0)? {
                         Ok(step_budget) => step_budget,
                         Err(limit) => {
                             complete = false;
@@ -1705,15 +1712,19 @@ fn load_entrypoint_profile_draft(
                 })?;
                 let mut candidate_report_anchor = None;
                 for relation in &profile.relations {
-                    let step_budget =
-                        match entrypoint_step_budget(budget, &relation_work, reachable.len())? {
-                            Ok(step_budget) => step_budget,
-                            Err(limit) => {
-                                complete = false;
-                                push_limit(&mut reached_limits, limit);
-                                break;
-                            }
-                        };
+                    let step_budget = match entrypoint_step_budget(
+                        budget,
+                        &relation_work,
+                        reachable.len(),
+                        unreachable.len(),
+                    )? {
+                        Ok(step_budget) => step_budget,
+                        Err(limit) => {
+                            complete = false;
+                            push_limit(&mut reached_limits, limit);
+                            break;
+                        }
+                    };
                     let mut candidate_query = query.relations.clone();
                     candidate_query.anchor = candidate_anchor.clone();
                     candidate_query.relation = Some(*relation);
@@ -1727,6 +1738,15 @@ fn load_entrypoint_profile_draft(
                     );
                     let candidate_report =
                         load_detailed_relations(store, &candidate_query, control)?;
+                    #[cfg(test)]
+                    analysis_test_observer::notify(
+                        analysis_test_observer::AnalysisPhaseEvent::CandidateReport {
+                            has_continuation: candidate_report.continuation.is_some(),
+                            has_edges_limit: candidate_report
+                                .reached_limits
+                                .contains(&GraphLimitKind::Edges),
+                        },
+                    );
                     if candidate_report.generation != generation {
                         return Err(ServiceError::RelationCursorStale {
                             field: "entrypoint graph generation",
@@ -1747,6 +1767,12 @@ fn load_entrypoint_profile_draft(
                         complete = false;
                         push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
                         break;
+                    }
+                    for limit in &candidate_report.reached_limits {
+                        push_limit(&mut reached_limits, *limit);
+                    }
+                    if candidate_report.continuation.is_some() {
+                        push_limit(&mut reached_limits, GraphLimitKind::Rows);
                     }
                     if !entrypoint_report_complete(&candidate_report) {
                         complete = false;
@@ -2128,11 +2154,13 @@ fn entrypoint_step_budget(
     budget: DetailedRelationBudget,
     work: &DetailedRelationWork,
     retained_nodes: usize,
+    validated_candidates: usize,
 ) -> ServiceResult<Result<DetailedRelationBudget, GraphLimitKind>> {
-    let retained_nodes = u32::try_from(retained_nodes).unwrap_or(u32::MAX);
+    let accounted_nodes = retained_nodes.saturating_add(validated_candidates);
+    let accounted_nodes = u32::try_from(accounted_nodes).unwrap_or(u32::MAX);
     let remaining_edges = budget.edges().saturating_sub(work.inspected_edges);
-    let remaining_nodes = budget.nodes().saturating_sub(retained_nodes);
-    let remaining_visited = budget.visited().saturating_sub(retained_nodes);
+    let remaining_nodes = budget.nodes().saturating_sub(accounted_nodes);
+    let remaining_visited = budget.visited().saturating_sub(accounted_nodes);
     let remaining_occurrences = budget
         .occurrences_total()
         .saturating_sub(work.retained_occurrences);

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -37,6 +37,8 @@ mod analysis_test_observer {
             /// Whether the candidate report reached the edge limit.
             has_edges_limit: bool,
         },
+        /// Terminal adjacency was probed before its generation was rechecked.
+        TerminalProbe,
         /// The repository-wide candidate entity page is about to run.
         CandidateEntityHydration {
             /// Intermediate bytes left after relation traversal.
@@ -104,7 +106,7 @@ use super::{
 use impact::{LoadedVcs, digest_vcs_paths, impact_findings, load_vcs_paths};
 use projectatlas_core::graph::{
     Completeness, ConfidenceClass, CoverageRecord, EntitySelector, ExtendedRelationKind,
-    GraphEntity, GraphIdentityText, GraphLimitKind, GraphLimits, GraphRelationKind,
+    GraphEntity, GraphEntityKey, GraphIdentityText, GraphLimitKind, GraphLimits, GraphRelationKind,
     ProjectInstanceId, RelationResolution,
 };
 #[cfg(test)]
@@ -1505,6 +1507,7 @@ fn load_entrypoint_profile_draft(
         .map(serde_json::to_string)
         .collect::<Result<BTreeSet<_>, _>>()
         .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
+    let mut resolved_anchor_keys = BTreeMap::<String, String>::new();
     let mut visited = BTreeSet::new();
     let mut depth = 0_u32;
     'profile: while !frontier.is_empty() && depth < budget.depth() {
@@ -1512,9 +1515,11 @@ fn load_entrypoint_profile_draft(
         for anchor in frontier.drain(..) {
             for relation in &profile.relations {
                 check_control(control)?;
-                let anchor_is_retained = reachable
-                    .values()
-                    .any(|node| relation_anchor_for_entity(&node.entity).as_ref() == Some(&anchor));
+                let anchor_identity = serde_json::to_string(&anchor)
+                    .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
+                let anchor_is_retained = resolved_anchor_keys
+                    .get(&anchor_identity)
+                    .is_some_and(|key| reachable.contains_key(key));
                 let retained_keys =
                     anchor_is_retained.then(|| reachable.keys().cloned().collect::<BTreeSet<_>>());
                 let step_budget = match entrypoint_step_budget(
@@ -1525,16 +1530,17 @@ fn load_entrypoint_profile_draft(
                     anchor_is_retained,
                     false,
                     query.relations.include_occurrences,
+                    None,
                 )? {
                     Ok(step_budget) => step_budget,
                     Err(limit) => {
                         if limit == GraphLimitKind::Edges
-                            && let Some(anchor_node) = reachable.values().find(|node| {
-                                relation_anchor_for_entity(&node.entity).as_ref() == Some(&anchor)
-                            })
-                            && store.repository_graph_adjacency_is_empty(
+                            && let Some(anchor_key) = resolved_anchor_keys.get(&anchor_identity)
+                            && let Some(anchor_node) = reachable.get(anchor_key)
+                            && entrypoint_terminal_adjacency_is_empty(
+                                store,
+                                generation,
                                 anchor_node.entity.key(),
-                                RepositoryGraphDirection::Outbound,
                                 *relation,
                                 control,
                             )?
@@ -1564,6 +1570,10 @@ fn load_entrypoint_profile_draft(
                     });
                 }
                 first_anchor.get_or_insert_with(|| report.anchor.clone());
+                resolved_anchor_keys.insert(
+                    anchor_identity,
+                    report.anchor.entity.key().canonical_identity().to_string(),
+                );
                 if purpose_revision_initialized
                     && report.authored_purpose_revision != authored_purpose_revision
                 {
@@ -1605,14 +1615,20 @@ fn load_entrypoint_profile_draft(
                         insert_node(&mut reachable, target);
                         if resolved {
                             let target_key = target.entity.key().canonical_identity().to_string();
-                            if visited.insert(target_key) {
+                            if visited.insert(target_key.clone()) {
                                 match relation_anchor_for_entity(&target.entity) {
                                     Some(target_anchor) => {
                                         if let Ok(anchor_key) =
                                             serde_json::to_string(&target_anchor)
-                                            && scheduled_anchors.insert(anchor_key)
                                         {
-                                            next_frontier.push(target_anchor);
+                                            let is_new =
+                                                scheduled_anchors.insert(anchor_key.clone());
+                                            resolved_anchor_keys
+                                                .entry(anchor_key)
+                                                .or_insert_with(|| target_key.clone());
+                                            if is_new {
+                                                next_frontier.push(target_anchor);
+                                            }
                                         }
                                     }
                                     None if !matches!(
@@ -1678,7 +1694,20 @@ fn load_entrypoint_profile_draft(
     })?;
     let entity_limit = budget.nodes();
     let reachable_keys = reachable.keys().cloned().collect::<BTreeSet<_>>();
-    let mut retained_candidate_keys = reachable_keys.clone();
+    let mut protected_reachable_keys = reachable_keys.clone();
+    for node in reachable.values() {
+        if let EntitySelector::Symbol { symbol } = node.entity.selector() {
+            let file_selector = EntitySelector::File {
+                path: symbol.file.clone(),
+            };
+            protected_reachable_keys.insert(
+                GraphEntityKey::new(node.entity.key().project(), &file_selector)
+                    .canonical_identity()
+                    .to_string(),
+            );
+        }
+    }
+    let mut retained_candidate_keys = reachable_keys;
     let mut unreachable = BTreeMap::new();
     let remaining_intermediate = budget
         .intermediate_bytes()
@@ -1739,7 +1768,7 @@ fn load_entrypoint_profile_draft(
                         matches!(
                             entity.selector(),
                             EntitySelector::File { .. } | EntitySelector::Symbol { .. }
-                        ) && !reachable_keys.contains(entity.key().canonical_identity())
+                        ) && !protected_reachable_keys.contains(entity.key().canonical_identity())
                     })
                     .collect::<Vec<_>>()
             })
@@ -1786,8 +1815,36 @@ fn load_entrypoint_profile_draft(
                         anchor_is_retained,
                         true,
                         query.relations.include_occurrences,
+                        None,
                     )? {
                         Ok(step_budget) => step_budget,
+                        Err(GraphLimitKind::Edges)
+                            if entrypoint_terminal_adjacency_is_empty(
+                                store,
+                                generation,
+                                entity.key(),
+                                *relation,
+                                control,
+                            )? =>
+                        {
+                            match entrypoint_step_budget(
+                                budget,
+                                &relation_work,
+                                reachable.len(),
+                                accounted_candidates,
+                                anchor_is_retained,
+                                true,
+                                query.relations.include_occurrences,
+                                Some(1),
+                            )? {
+                                Ok(step_budget) => step_budget,
+                                Err(limit) => {
+                                    complete = false;
+                                    push_limit(&mut reached_limits, limit);
+                                    break;
+                                }
+                            }
+                        }
                         Err(limit) => {
                             complete = false;
                             push_limit(&mut reached_limits, limit);
@@ -2299,11 +2356,13 @@ fn entrypoint_step_budget(
     anchor_is_retained: bool,
     candidate_anchor_overhead: bool,
     include_occurrences: bool,
+    remaining_edges_override: Option<u32>,
 ) -> ServiceResult<Result<DetailedRelationBudget, GraphLimitKind>> {
     let accounted_nodes = retained_nodes.saturating_add(validated_candidates);
     let accounted_nodes = u32::try_from(accounted_nodes).unwrap_or(u32::MAX);
     let validated_candidates = u32::try_from(validated_candidates).unwrap_or(u32::MAX);
-    let remaining_edges = budget.edges().saturating_sub(work.inspected_edges);
+    let remaining_edges = remaining_edges_override
+        .unwrap_or_else(|| budget.edges().saturating_sub(work.inspected_edges));
     let remaining_nodes = budget.nodes().saturating_sub(accounted_nodes);
     let remaining_visited = budget.visited().saturating_sub(accounted_nodes);
     let step_nodes = if candidate_anchor_overhead {
@@ -2331,11 +2390,6 @@ fn entrypoint_step_budget(
         .intermediate_bytes()
         .saturating_sub(work.intermediate_bytes);
     let rows = budget.page_rows().min(remaining_edges);
-    let rows = if include_occurrences {
-        rows.min(remaining_occurrences)
-    } else {
-        rows
-    };
     if remaining_edges == 0 {
         return Ok(Err(GraphLimitKind::Edges));
     }
@@ -2344,9 +2398,6 @@ fn entrypoint_step_budget(
     }
     if remaining_visited == 0 && !anchor_is_retained {
         return Ok(Err(GraphLimitKind::Visited));
-    }
-    if include_occurrences && remaining_occurrences == 0 {
-        return Ok(Err(GraphLimitKind::Occurrences));
     }
     if remaining_intermediate < 64 * 1_024 {
         return Ok(Err(GraphLimitKind::IntermediateBytes));
@@ -2380,6 +2431,35 @@ fn entrypoint_work_overflow() -> ServiceError {
 /// Return the project identity for an already generation-bound graph entity.
 fn generation_project(entity: &GraphEntity) -> ProjectInstanceId {
     entity.key().project()
+}
+
+/// Probe one terminal adjacency and reject a publication change immediately afterward.
+fn entrypoint_terminal_adjacency_is_empty(
+    store: &AtlasStore,
+    generation: projectatlas_core::IndexGeneration,
+    key: &GraphEntityKey,
+    relation: GraphRelationKind,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<bool> {
+    let empty = store.repository_graph_adjacency_is_empty(
+        key,
+        RepositoryGraphDirection::Outbound,
+        relation,
+        control,
+    )?;
+    #[cfg(test)]
+    analysis_test_observer::notify(analysis_test_observer::AnalysisPhaseEvent::TerminalProbe);
+    let current_generation = store.repository_graph_generation()?.ok_or_else(|| {
+        ServiceError::InvalidInput(
+            "repository graph has no complete generation for entrypoint analysis".to_string(),
+        )
+    })?;
+    if current_generation != generation {
+        return Err(ServiceError::RelationCursorStale {
+            field: "entrypoint graph generation",
+        });
+    }
+    Ok(empty)
 }
 
 /// Return whether a detailed node carries trusted coverage for admitted relations.

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1467,6 +1467,7 @@ fn load_entrypoint_profile_draft(
     let mut relation_work = DetailedRelationWork::default();
     let mut first_anchor = None;
     let mut authored_purpose_revision = 0;
+    let mut purpose_revision_initialized = false;
     let mut complete = true;
     let mut reached_limits = Vec::new();
 
@@ -1511,8 +1512,15 @@ fn load_entrypoint_profile_draft(
                     });
                 }
                 first_anchor.get_or_insert_with(|| report.anchor.clone());
-                authored_purpose_revision =
-                    authored_purpose_revision.max(report.authored_purpose_revision);
+                if purpose_revision_initialized
+                    && report.authored_purpose_revision != authored_purpose_revision
+                {
+                    return Err(ServiceError::RelationCursorStale {
+                        field: "entrypoint authored purpose revision",
+                    });
+                }
+                authored_purpose_revision = report.authored_purpose_revision;
+                purpose_revision_initialized = true;
                 add_relation_work(&mut relation_work, &report.work)?;
                 for limit in &report.reached_limits {
                     push_limit(&mut reached_limits, *limit);
@@ -1543,13 +1551,25 @@ fn load_entrypoint_profile_draft(
                         insert_node(&mut reachable, target);
                         if resolved {
                             let target_key = target.entity.key().canonical_identity().to_string();
-                            if visited.insert(target_key)
-                                && let Some(target_anchor) =
-                                    relation_anchor_for_entity(&target.entity)
-                                && let Ok(anchor_key) = serde_json::to_string(&target_anchor)
-                                && scheduled_anchors.insert(anchor_key)
-                            {
-                                next_frontier.push(target_anchor);
+                            if visited.insert(target_key) {
+                                match relation_anchor_for_entity(&target.entity) {
+                                    Some(target_anchor) => {
+                                        if let Ok(anchor_key) =
+                                            serde_json::to_string(&target_anchor)
+                                            && scheduled_anchors.insert(anchor_key)
+                                        {
+                                            next_frontier.push(target_anchor);
+                                        }
+                                    }
+                                    None if !matches!(
+                                        target.entity.selector(),
+                                        EntitySelector::External { .. }
+                                    ) =>
+                                    {
+                                        complete = false;
+                                    }
+                                    None => {}
+                                }
                             }
                         }
                     }
@@ -1593,19 +1613,24 @@ fn load_entrypoint_profile_draft(
         ServiceError::InvalidInput("entrypoint profile resolved no anchors".to_string())
     })?;
     let entity_limit = budget.nodes();
-    let read_budget = RepositoryGraphReadBudget::new(
-        1,
-        entity_limit.saturating_add(1),
-        budget
-            .intermediate_bytes()
-            .clamp(1, RepositoryGraphReadBudget::MAX_DECODED_BYTES),
-        entity_limit.saturating_add(1).saturating_mul(2),
-        entity_limit.saturating_add(1).saturating_mul(2),
-    )
-    .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
     let reachable_keys = reachable.keys().cloned().collect::<BTreeSet<_>>();
     let mut unreachable = BTreeMap::new();
+    let remaining_intermediate = budget
+        .intermediate_bytes()
+        .saturating_sub(relation_work.intermediate_bytes);
+    if remaining_intermediate == 0 {
+        complete = false;
+        push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
+    }
     if complete {
+        let read_budget = RepositoryGraphReadBudget::new(
+            1,
+            entity_limit.saturating_add(1),
+            remaining_intermediate.min(RepositoryGraphReadBudget::MAX_DECODED_BYTES),
+            entity_limit.saturating_add(1).saturating_mul(2),
+            entity_limit.saturating_add(1).saturating_mul(2),
+        )
+        .map_err(|error| ServiceError::InvalidInput(error.to_string()))?;
         let all_entities = store.repository_graph_entities_page_bounded(
             generation_project(&anchor.entity),
             generation,
@@ -1689,6 +1714,16 @@ fn load_entrypoint_profile_draft(
                     candidate_query.budget = step_budget;
                     let candidate_report =
                         load_detailed_relations(store, &candidate_query, control)?;
+                    if candidate_report.generation != generation {
+                        return Err(ServiceError::RelationCursorStale {
+                            field: "entrypoint graph generation",
+                        });
+                    }
+                    if candidate_report.authored_purpose_revision != authored_purpose_revision {
+                        return Err(ServiceError::RelationCursorStale {
+                            field: "entrypoint authored purpose revision",
+                        });
+                    }
                     add_relation_work(&mut relation_work, &candidate_report.work)?;
                     if relation_work.inspected_edges > budget.edges() {
                         complete = false;

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -97,7 +97,7 @@ use projectatlas_core::graph::{
     GraphIdentityText, GraphLimitKind, GraphLimits, GraphRelationKind, ProjectInstanceId,
     RelationResolution,
 };
-use projectatlas_core::language::ContentSelection;
+use projectatlas_core::language::{ContentClassification, ContentSelection};
 use projectatlas_core::symbols::{CodeSymbol, RelationKind};
 use projectatlas_core::{
     CanonicalProjectRoot, IndexCancellation, IndexWorkControl, IndexWorkStage,
@@ -1657,18 +1657,22 @@ fn load_entrypoint_profile_draft(
             complete = false;
             push_limit(&mut reached_limits, GraphLimitKind::Nodes);
         }
-        let candidate_entities = all_entities.rows.iter().filter(|entity| {
-            matches!(
-                entity.selector(),
-                EntitySelector::File { .. } | EntitySelector::Symbol { .. }
-            ) && !reachable_keys.contains(entity.key().canonical_identity())
-        });
+        let candidate_entities = all_entities
+            .rows
+            .iter()
+            .filter(|entity| {
+                matches!(
+                    entity.selector(),
+                    EntitySelector::File { .. } | EntitySelector::Symbol { .. }
+                ) && !reachable_keys.contains(entity.key().canonical_identity())
+            })
+            .collect::<Vec<_>>();
         let candidate_classifications = if complete
             && query.relations.content_selection != ContentSelection::UnspecifiedLegacy
         {
             if let Some(classifications) = load_entrypoint_candidate_classifications(
                 store,
-                candidate_entities,
+                candidate_entities.iter().copied(),
                 budget,
                 &mut relation_work,
                 control,
@@ -1683,26 +1687,18 @@ fn load_entrypoint_profile_draft(
             BTreeMap::new()
         };
         if complete {
-            for entity in all_entities.rows {
+            for entity in candidate_entities.into_iter().filter(|entity| {
+                entity_matches_selection(
+                    entity,
+                    &candidate_classifications,
+                    query.relations.content_selection,
+                )
+            }) {
                 check_control(control)?;
                 if !complete {
                     break;
                 }
-                if !matches!(
-                    entity.selector(),
-                    EntitySelector::File { .. } | EntitySelector::Symbol { .. }
-                ) || reachable_keys.contains(entity.key().canonical_identity())
-                {
-                    continue;
-                }
-                if !entity_matches_selection(
-                    &entity,
-                    &candidate_classifications,
-                    query.relations.content_selection,
-                ) {
-                    continue;
-                }
-                let candidate_anchor = relation_anchor_for_entity(&entity).ok_or_else(|| {
+                let candidate_anchor = relation_anchor_for_entity(entity).ok_or_else(|| {
                     ServiceError::InvalidInput(
                         "entrypoint candidate is not addressable by an exact anchor".to_string(),
                     )
@@ -1816,7 +1812,7 @@ fn load_entrypoint_profile_draft(
         relations: profile.relations.clone(),
         coverage,
         reachable: u32::try_from(reachable_nodes.len()).unwrap_or(u32::MAX),
-        unreachable_candidates: u32::try_from(unreachable_nodes.len()).unwrap_or(u32::MAX),
+        unreachable_candidates: 0,
     };
     let mut work = RelationAnalysisWork {
         relations: relation_work,
@@ -1836,7 +1832,10 @@ fn load_entrypoint_profile_draft(
         work.composition_truncated = true;
         push_limit(&mut reached_limits, GraphLimitKind::IntermediateBytes);
     }
-    if !complete {
+    if complete {
+        profile_result.unreachable_candidates =
+            u32::try_from(unreachable_nodes.len()).unwrap_or(u32::MAX);
+    } else {
         profile_result.coverage = EntrypointProfileCoverage::Partial;
         for finding in &mut findings {
             finding.status = AnalysisStatus::Inconclusive;
@@ -2023,6 +2022,14 @@ fn load_entrypoint_candidate_classifications<'entity>(
         analysis_test_observer::notify(
             analysis_test_observer::AnalysisPhaseEvent::ClassificationHydration,
         );
+        let row_upper_bound = classification_rows_upper_bound(chunk, control)?;
+        if relation_work
+            .intermediate_bytes
+            .checked_add(row_upper_bound)
+            .is_none_or(|bytes| bytes > budget.intermediate_bytes())
+        {
+            return Ok(None);
+        }
         let rows = store.file_content_classifications_for_paths(chunk)?;
         check_control(control)?;
         let decoded_bytes = classification_rows_bytes(&rows, control)?;
@@ -2068,6 +2075,30 @@ fn classification_path_bytes(path: &str) -> ServiceResult<u64> {
         .ok()
         .and_then(|bytes| bytes.checked_add(8))
         .ok_or_else(entrypoint_work_overflow)
+}
+
+/// Bound one classification batch before materializing its database rows.
+fn classification_rows_upper_bound(
+    paths: &[String],
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<u64> {
+    let maximum_classification_bytes = ContentClassification::ALL
+        .iter()
+        .map(|classification| classification.as_str().len())
+        .max()
+        .map_or(0, |bytes| u64::try_from(bytes).unwrap_or(u64::MAX));
+    paths.iter().try_fold(0_u64, |bytes, path| {
+        check_control(control)?;
+        let row_bytes = u64::try_from(path.len())
+            .ok()
+            .and_then(|path_bytes| path_bytes.checked_add(maximum_classification_bytes))
+            .and_then(|row_bytes| row_bytes.checked_add(8))
+            .and_then(|row_bytes| row_bytes.checked_mul(2))
+            .ok_or_else(entrypoint_work_overflow)?;
+        bytes
+            .checked_add(row_bytes)
+            .ok_or_else(entrypoint_work_overflow)
+    })
 }
 
 /// Count conservative decoded and retained bytes for one classification batch.

--- a/crates/projectatlas-service/src/analysis.rs
+++ b/crates/projectatlas-service/src/analysis.rs
@@ -1828,15 +1828,27 @@ fn load_entrypoint_profile_draft(
                         &candidate_report,
                         &retained_candidate_keys,
                     ));
-                    if candidate_unretained_keys.len()
-                        > usize::try_from(budget.nodes().saturating_sub(
-                            u32::try_from(retained_candidate_keys.len()).unwrap_or(u32::MAX),
-                        ))
-                        .unwrap_or(usize::MAX)
-                    {
+                    let remaining_candidate_capacity =
+                        u32::try_from(retained_candidate_keys.len()).unwrap_or(u32::MAX);
+                    let remaining_nodes = usize::try_from(
+                        budget.nodes().saturating_sub(remaining_candidate_capacity),
+                    )
+                    .unwrap_or(usize::MAX);
+                    let remaining_visited = usize::try_from(
+                        budget
+                            .visited()
+                            .saturating_sub(remaining_candidate_capacity),
+                    )
+                    .unwrap_or(usize::MAX);
+                    if candidate_unretained_keys.len() > remaining_nodes {
                         complete = false;
                         push_limit(&mut reached_limits, GraphLimitKind::Nodes);
+                    }
+                    if candidate_unretained_keys.len() > remaining_visited {
+                        complete = false;
                         push_limit(&mut reached_limits, GraphLimitKind::Visited);
+                    }
+                    if !complete {
                         break;
                     }
                     for limit in &candidate_report.reached_limits {

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1006,6 +1006,75 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
         "ambiguous or dynamic references became a confident entrypoint result",
     )?;
 
+    let mut over_budget = query.clone();
+    over_budget.entrypoint_profile = Some(EntrypointProfile {
+        name: "over-budget".to_string(),
+        anchors: vec![
+            RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            },
+            RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("src/b.rs"))?,
+            },
+        ],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    over_budget.relations.budget = over_budget.relations.budget.with_aggregate_limits(
+        Some(10),
+        Some(1),
+        Some(1),
+        None,
+        Some(256 * 1_024),
+        None,
+    )?;
+    let preflight_seen = Rc::new(Cell::new(false));
+    let preflight_seen_observer = Rc::clone(&preflight_seen);
+    let over_budget_result = observe_analysis_phase(
+        move |event| {
+            if event == AnalysisPhaseEvent::Traversal {
+                preflight_seen_observer.set(true);
+            }
+        },
+        || load_relation_analysis(&store, &over_budget, None),
+    );
+    let preflight_error = over_budget_result.as_ref().err().map(ToString::to_string);
+    require(
+        !preflight_seen.get()
+            && preflight_error
+                .as_deref()
+                .is_some_and(|error| error.contains("anchor count exceeds the node budget")),
+        "over-budget entrypoint anchors entered traversal before typed rejection",
+    )?;
+
+    let publication_before_cancel = store.index_publication()?;
+    let cancellation = IndexCancellation::new();
+    let cancel_seen = Rc::new(Cell::new(false));
+    let cancel_seen_observer = Rc::clone(&cancel_seen);
+    let cancellation_for_observer = cancellation.clone();
+    let cancel_control = IndexWorkControl::with_deadline(
+        cancellation.clone(),
+        Instant::now() + std::time::Duration::from_secs(5),
+    );
+    let cancelled = observe_analysis_phase(
+        move |event| {
+            if event == AnalysisPhaseEvent::Traversal && !cancel_seen_observer.replace(true) {
+                cancellation_for_observer.cancel();
+            }
+        },
+        || load_relation_analysis(&store, &query, Some(&cancel_control)),
+    );
+    require(
+        cancel_seen.get()
+            && matches!(
+                cancelled,
+                Err(ServiceError::Db(DbError::IndexWork(
+                    projectatlas_core::IndexWorkFailure::Cancelled { .. }
+                )))
+            )
+            && store.index_publication()? == publication_before_cancel,
+        "cancelled entrypoint traversal returned a partial result or changed publication",
+    )?;
+
     let (_stale_temp, stale_store) = analysis_store()?;
     let root = _stale_temp.path().join("analysis-service");
     let database = root.join("projectatlas.db");
@@ -1082,6 +1151,11 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
         ))
         .into());
     }
+    let cycle_replay = fitted_report(&store, &cycle)?;
+    require(
+        cycle_report == cycle_replay,
+        "identical multi-anchor entrypoint requests were not deterministic",
+    )?;
 
     let mut bounded = query;
     bounded.relations.budget = bounded.relations.budget.with_aggregate_limits(

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -2,7 +2,7 @@ use super::analysis_test_observer::{AnalysisPhaseEvent, observe_analysis_phase};
 use super::*;
 use projectatlas_core::graph::{
     CoverageRecord, CoverageScope, CoverageState, GraphIdentityText, LogicalRelation,
-    RelationResolution, RepositoryFilePath, RepositoryNodePath, SymbolSelector,
+    PackageSelector, RelationResolution, RepositoryFilePath, RepositoryNodePath, SymbolSelector,
 };
 use projectatlas_core::language::ContentClassification;
 use projectatlas_core::symbols::{ParserKind, SymbolGraph, SymbolKind};
@@ -882,6 +882,251 @@ fn entrypoint_profile_reports_reachable_and_unreachable_without_persistence()
     require(
         store.index_publication()? == before,
         "entrypoint profile changed the authoritative publication",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_marks_unanchorable_local_targets_inconclusive() -> Result<(), Box<dyn Error>>
+{
+    let selectors = [
+        EntitySelector::Folder {
+            path: RepositoryNodePath::new(Path::new("src"))?,
+        },
+        EntitySelector::Package {
+            package: PackageSelector {
+                manager: GraphIdentityText::new("cargo")?,
+                name: GraphIdentityText::new("analysis-service")?,
+                manifest: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            },
+        },
+    ];
+    for selector in selectors {
+        let (_temp, store) = analysis_store_with_target(selector)?;
+        let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+        query.relations.resolution = RelationResolutionFilter::Any;
+        query.relations.budget = query.relations.budget.with_aggregate_limits(
+            Some(100),
+            Some(20),
+            Some(20),
+            Some(100),
+            Some(256 * 1024),
+            None,
+        )?;
+        query.include_communities = false;
+        query.include_cycles = false;
+        query.entrypoint_profile = Some(EntrypointProfile {
+            name: "unanchorable-local".to_string(),
+            anchors: vec![RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            }],
+            relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+        });
+        let report = fitted_report(&store, &query)?;
+        require(
+            report
+                .entrypoint_profile
+                .as_ref()
+                .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+                && report.findings.iter().all(|finding| {
+                    finding.kind == AnalysisFindingKind::EntrypointReachability
+                        && finding.status == AnalysisStatus::Inconclusive
+                })
+                && report
+                    .entrypoint_profile
+                    .as_ref()
+                    .is_some_and(|profile| profile.unreachable_candidates == 0),
+            "an unanchorable local target produced a confident entrypoint result",
+        )?;
+    }
+
+    let (_temp, store) = analysis_store()?;
+    let project = store
+        .project_instance_id()?
+        .ok_or("analysis fixture project identity missing")?;
+    let project_entity =
+        GraphEntity::new(project, EntitySelector::Project, IndexGeneration::new(1))?;
+    require(
+        RelationResolution::resolved(&project_entity).is_err(),
+        "the project aggregate became a directly resolvable entrypoint target",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_rejects_candidate_generation_and_purpose_changes()
+-> Result<(), Box<dyn Error>> {
+    let candidate_query = || -> Result<RelationAnalysisQuery, Box<dyn Error>> {
+        let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+        query.relations.resolution = RelationResolutionFilter::Any;
+        query.relations.budget = query.relations.budget.with_aggregate_limits(
+            Some(100),
+            Some(20),
+            Some(20),
+            Some(100),
+            Some(256 * 1024),
+            None,
+        )?;
+        query.include_communities = false;
+        query.include_cycles = false;
+        query.entrypoint_profile = Some(EntrypointProfile {
+            name: "candidate-stale".to_string(),
+            anchors: vec![RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            }],
+            relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+        });
+        Ok(query)
+    };
+
+    let (temp, stale_store) = analysis_store()?;
+    let root = temp.path().join("analysis-service");
+    let database = root.join("projectatlas.db");
+    stale_store.finish_index_read_snapshot()?;
+    let writer = Rc::new(RefCell::new(Some(AtlasStore::open_for_project(
+        &database, &root,
+    )?)));
+    let refreshed = Rc::new(Cell::new(false));
+    let writer_for_observer = Rc::clone(&writer);
+    let refreshed_for_observer = Rc::clone(&refreshed);
+    let generation_query = candidate_query()?;
+    let generation_stale = observe_analysis_phase(
+        move |event| {
+            if event == AnalysisPhaseEvent::CandidateTraversal
+                && !refreshed_for_observer.replace(true)
+            {
+                if let Some(mut writer) = writer_for_observer.borrow_mut().take() {
+                    if let Ok(refresh) = writer.begin_index_projection_refresh("analysis-service") {
+                        let _ = refresh.complete();
+                    }
+                }
+            }
+        },
+        || load_relation_analysis(&stale_store, &generation_query, None),
+    );
+    if !(refreshed.get()
+        && generation_stale
+            .as_ref()
+            .err()
+            .is_some_and(|error| error.to_string().contains("typed graph generation")))
+    {
+        return Err(io::Error::other(format!(
+            "candidate generation transition was not refused: refreshed={}, error={:?}",
+            refreshed.get(),
+            generation_stale.as_ref().err().map(ToString::to_string)
+        ))
+        .into());
+    }
+
+    let (temp, stale_store) = analysis_store()?;
+    let root = temp.path().join("analysis-service");
+    let database = root.join("projectatlas.db");
+    stale_store.finish_index_read_snapshot()?;
+    let writer = Rc::new(RefCell::new(Some(AtlasStore::open_for_project(
+        &database, &root,
+    )?)));
+    let revised = Rc::new(Cell::new(false));
+    let writer_for_observer = Rc::clone(&writer);
+    let revised_for_observer = Rc::clone(&revised);
+    let purpose_query = candidate_query()?;
+    let purpose_stale = observe_analysis_phase(
+        move |event| {
+            if event == AnalysisPhaseEvent::CandidateTraversal
+                && !revised_for_observer.replace(true)
+            {
+                if let Some(writer) = writer_for_observer.borrow_mut().take() {
+                    let _ = writer.set_purpose(
+                        "src/a.rs",
+                        "purpose changed during analysis",
+                        PurposeSource::Agent,
+                    );
+                }
+            }
+        },
+        || load_relation_analysis(&stale_store, &purpose_query, None),
+    );
+    require(
+        revised.get()
+            && matches!(
+                purpose_stale,
+                Err(ServiceError::RelationCursorStale {
+                    field: "entrypoint authored purpose revision"
+                })
+            ),
+        "candidate purpose revision transition was not refused at the candidate boundary",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_bounds_candidate_entity_hydration_by_remaining_bytes()
+-> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(100),
+        Some(20),
+        Some(20),
+        Some(100),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "candidate-byte-budget".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let remaining = Rc::new(Cell::new(None));
+    let remaining_for_observer = Rc::clone(&remaining);
+    let report = observe_analysis_phase(
+        move |event| {
+            if let AnalysisPhaseEvent::CandidateEntityHydration {
+                remaining_intermediate_bytes,
+            } = event
+            {
+                remaining_for_observer.set(Some(remaining_intermediate_bytes));
+            }
+        },
+        || load_relation_analysis(&store, &query, None),
+    )?;
+    let remaining = remaining
+        .get()
+        .ok_or("candidate entity hydration did not expose its remaining budget")?;
+    require(
+        remaining < query.relations.budget.intermediate_bytes()
+            && report.report.work.relations.intermediate_bytes
+                <= query.relations.budget.intermediate_bytes(),
+        "candidate entity hydration did not consume only the remaining profile budget",
+    )?;
+
+    let mut bounded = query;
+    bounded.relations.budget = bounded.relations.budget.with_aggregate_limits(
+        None,
+        None,
+        None,
+        None,
+        Some(64 * 1024),
+        None,
+    )?;
+    let bounded = fitted_report(&store, &bounded)?;
+    require(
+        bounded
+            .entrypoint_profile
+            .as_ref()
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+            && bounded
+                .reached_limits
+                .contains(&GraphLimitKind::IntermediateBytes)
+            && bounded.findings.iter().all(|finding| {
+                finding.kind == AnalysisFindingKind::EntrypointReachability
+                    && finding.status == AnalysisStatus::Inconclusive
+            }),
+        "a byte-limited candidate scope produced confident reachability output",
     )?;
     Ok(())
 }
@@ -2989,6 +3234,19 @@ fn analysis_store() -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
 fn analysis_store_with_coverage(
     include_tools_coverage: bool,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
+    analysis_store_with_options(include_tools_coverage, None)
+}
+
+fn analysis_store_with_target(
+    target_selector: EntitySelector,
+) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
+    analysis_store_with_options(true, Some(target_selector))
+}
+
+fn analysis_store_with_options(
+    include_tools_coverage: bool,
+    target_selector: Option<EntitySelector>,
+) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let root = temp.path().join("analysis-service");
     fs::create_dir_all(root.join("src"))?;
@@ -3017,6 +3275,9 @@ fn analysis_store_with_coverage(
     let b = entity("src/b.rs")?;
     let c = entity("tools/c.rs")?;
     let guide = entity("docs/guide.md")?;
+    let extra_target = target_selector
+        .map(|selector| GraphEntity::new(project, selector, generation))
+        .transpose()?;
     let symbol_entity = |path: &str, name: &str, signature: &str| {
         GraphEntity::new(
             project,
@@ -3046,7 +3307,7 @@ fn analysis_store_with_coverage(
             generation,
         )
     };
-    let relations = vec![
+    let mut relations = vec![
         relation(&a, &b, GraphRelationKind::Legacy(RelationKind::Calls))?,
         relation(&b, &a, GraphRelationKind::Legacy(RelationKind::Calls))?,
         relation(&a, &c, GraphRelationKind::Legacy(RelationKind::Contains))?,
@@ -3098,6 +3359,13 @@ fn analysis_store_with_coverage(
             generation,
         )?,
     ];
+    if let Some(target) = extra_target.as_ref() {
+        relations.push(relation(
+            &a,
+            target,
+            GraphRelationKind::Legacy(RelationKind::Calls),
+        )?);
+    }
     let mut coverage = ["src/a.rs", "src/b.rs", "tools/c.rs", "docs/guide.md"]
         .into_iter()
         .filter(|path| include_tools_coverage || *path != "tools/c.rs")
@@ -3206,13 +3474,11 @@ fn analysis_store_with_coverage(
         )],
         relations: Vec::new(),
     })?;
-    publication.replace_repository_graph(
-        project,
-        &[a, b, c, guide, a_long, d_unused, b_hub, c_aux],
-        &relations,
-        &[],
-        &coverage,
-    )?;
+    let mut entities = vec![a, b, c, guide, a_long, d_unused, b_hub, c_aux];
+    if let Some(target) = extra_target {
+        entities.push(target);
+    }
+    publication.replace_repository_graph(project, &entities, &relations, &[], &coverage)?;
     publication.complete()?;
     store.set_purpose("src/a.rs", "负责核心调用", PurposeSource::Agent)?;
     store.set_purpose("src/b.rs", "负责核心调用", PurposeSource::Agent)?;

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1332,6 +1332,100 @@ fn entrypoint_profile_filters_non_candidate_entities_before_node_limit()
 }
 
 #[test]
+fn entrypoint_profile_falls_back_before_exceeding_composition_budget() -> Result<(), Box<dyn Error>>
+{
+    let (temp, initial_store) = analysis_store()?;
+    let root = temp.path().join("analysis-service");
+    let database = root.join("projectatlas.db");
+    drop(initial_store);
+    let writable = AtlasStore::open_for_project(&database, &root)?;
+    writable.set_purpose(
+        "src/a.rs",
+        &format!("composition boundary {}", "x".repeat(20_000)),
+        PurposeSource::Agent,
+    )?;
+    drop(writable);
+    let store = AtlasStore::open_read_only_for_project(&database, &root)?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget =
+        DetailedRelationBudget::from_graph_limits(GraphLimits::new(50, 1, 3, 1024 * 1024)?)
+            .with_aggregate_limits(
+                None,
+                None,
+                None,
+                None,
+                Some(DetailedRelationBudget::MAX_INTERMEDIATE_BYTES),
+                None,
+            )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "composition-boundary".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+
+    let complete = load_relation_analysis(&store, &query, None)?;
+    let complete_profile = complete
+        .report
+        .entrypoint_profile
+        .as_ref()
+        .ok_or("complete entrypoint profile missing")?;
+    let complete_composition =
+        serialized_bytes_controlled(&(&complete.report.findings, complete_profile), None)?;
+    let mut fallback_findings = complete.report.findings.clone();
+    for finding in &mut fallback_findings {
+        finding.status = AnalysisStatus::Inconclusive;
+        finding.nodes.clear();
+    }
+    let mut fallback_profile = complete_profile.clone();
+    fallback_profile.coverage = EntrypointProfileCoverage::Partial;
+    fallback_profile.unreachable_candidates = 0;
+    let fallback_composition =
+        serialized_bytes_controlled(&(&fallback_findings, &fallback_profile), None)?;
+    require(
+        complete_profile.coverage == EntrypointProfileCoverage::Complete
+            && complete_profile.unreachable_candidates > 0
+            && complete_composition > fallback_composition,
+        "entrypoint fixture did not produce a larger complete composition",
+    )?;
+    let boundary_budget = complete
+        .report
+        .work
+        .peak_intermediate_bytes
+        .saturating_sub(1);
+    let mut boundary_query = query;
+    boundary_query.relations.budget = boundary_query.relations.budget.with_aggregate_limits(
+        None,
+        None,
+        None,
+        None,
+        Some(boundary_budget),
+        None,
+    )?;
+    let boundary = load_relation_analysis(&store, &boundary_query, None)?.report;
+    require(
+        boundary.entrypoint_profile.as_ref().is_some_and(|profile| {
+            profile.coverage == EntrypointProfileCoverage::Partial
+                && profile.unreachable_candidates == 0
+        }) && boundary.work.composition_truncated
+            && boundary
+                .reached_limits
+                .contains(&GraphLimitKind::IntermediateBytes)
+            && boundary
+                .findings
+                .iter()
+                .all(|finding| finding.status == AnalysisStatus::Inconclusive)
+            && boundary.work.peak_intermediate_bytes <= boundary_budget,
+        "entrypoint composition fallback exceeded its declared byte budget",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn entrypoint_classification_hydration_honors_control_and_byte_budget() -> Result<(), Box<dyn Error>>
 {
     let (_temp, store) = analysis_store()?;

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1231,7 +1231,7 @@ fn entrypoint_profile_rejects_generation_change_after_empty_candidate_page()
 #[test]
 fn entrypoint_profile_does_not_use_disabled_occurrences_as_row_budget() -> Result<(), Box<dyn Error>>
 {
-    let (_temp, store) = analysis_store()?;
+    let (_temp, store) = analysis_store_with_external_candidate()?;
     let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
     query.relations.resolution = RelationResolutionFilter::Any;
     query.relations.budget = query.relations.budget.with_aggregate_limits(
@@ -1239,7 +1239,7 @@ fn entrypoint_profile_does_not_use_disabled_occurrences_as_row_budget() -> Resul
         Some(20),
         Some(20),
         Some(1),
-        Some(256 * 1024),
+        Some(1024 * 1024),
         None,
     )?;
     query.include_communities = false;
@@ -1249,15 +1249,122 @@ fn entrypoint_profile_does_not_use_disabled_occurrences_as_row_budget() -> Resul
         anchors: vec![RelationAnchor::File {
             file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
         }],
-        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+        relations: vec![
+            GraphRelationKind::Legacy(RelationKind::Calls),
+            GraphRelationKind::Legacy(RelationKind::Contains),
+            GraphRelationKind::Legacy(RelationKind::DependsOn),
+        ],
     });
     let report = fitted_report(&store, &query)?;
+    require(
+        report.entrypoint_profile.as_ref().is_some_and(|profile| {
+            profile.coverage == EntrypointProfileCoverage::Complete
+                && profile.unreachable_candidates > 0
+        }) && !report.reached_limits.contains(&GraphLimitKind::Rows)
+            && !report.reached_limits.contains(&GraphLimitKind::Occurrences),
+        "disabled occurrence collection incorrectly constrained entrypoint relation rows",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_inspects_retained_frontier_at_exact_node_limit() -> Result<(), Box<dyn Error>>
+{
+    let (_temp, store) = analysis_store()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.content_selection = projectatlas_core::language::ContentSelection::Source;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(100),
+        Some(7),
+        Some(7),
+        Some(100),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "retained-frontier-at-node-limit".to_string(),
+        anchors: vec![
+            RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            },
+            RelationAnchor::Symbol {
+                file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+                name: "d_unused".to_string(),
+                symbol_kind: Some(SymbolKind::Function),
+                parent: None,
+                signature: Some("fn d_unused()".to_string()),
+            },
+        ],
+        relations: vec![
+            GraphRelationKind::Legacy(RelationKind::Calls),
+            GraphRelationKind::Legacy(RelationKind::Contains),
+            GraphRelationKind::Legacy(RelationKind::DependsOn),
+        ],
+    });
+    let report = fitted_report(&store, &query)?;
+    require(
+        report.entrypoint_profile.as_ref().is_some_and(|profile| {
+            profile.coverage == EntrypointProfileCoverage::Complete
+                && profile.unreachable_candidates == 0
+        }) && !report.reached_limits.contains(&GraphLimitKind::Nodes)
+            && !report.reached_limits.contains(&GraphLimitKind::Visited),
+        "a retained frontier anchor was refused at the exact node limit",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_drops_nodes_from_overflowing_retained_frontier() -> Result<(), Box<dyn Error>>
+{
+    let (_temp, store) = analysis_store()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.content_selection = projectatlas_core::language::ContentSelection::Source;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(100),
+        Some(5),
+        Some(5),
+        Some(100),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "overflowing-retained-frontier".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![
+            GraphRelationKind::Legacy(RelationKind::Calls),
+            GraphRelationKind::Legacy(RelationKind::Contains),
+            GraphRelationKind::Legacy(RelationKind::DependsOn),
+        ],
+    });
+    let report = fitted_report(&store, &query)?;
+    let c_aux_present = report.findings.iter().any(|finding| {
+        finding.nodes.iter().any(|node| {
+            matches!(
+                node.node.entity.selector(),
+                EntitySelector::Symbol { symbol } if symbol.name.as_str() == "c_aux"
+            )
+        })
+    });
     require(
         report
             .entrypoint_profile
             .as_ref()
-            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Complete),
-        "disabled occurrence collection incorrectly constrained entrypoint relation rows",
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+            && report.reached_limits.contains(&GraphLimitKind::Nodes)
+            && report
+                .findings
+                .iter()
+                .all(|finding| finding.status == AnalysisStatus::Inconclusive)
+            && !c_aux_present,
+        "a node discovered beyond the retained frontier budget was published",
     )?;
     Ok(())
 }
@@ -3884,6 +3991,20 @@ fn analysis_store_with_options(
             )
         })
         .transpose()?;
+    let candidate_external_second = external_candidate
+        .then(|| {
+            GraphEntity::new(
+                project,
+                EntitySelector::External {
+                    external: ExternalSelector {
+                        system: GraphIdentityText::new("crates.io")?,
+                        identity: GraphIdentityText::new("candidate@2")?,
+                    },
+                },
+                generation,
+            )
+        })
+        .transpose()?;
     let symbol_entity = |path: &str, name: &str, signature: &str| {
         GraphEntity::new(
             project,
@@ -3990,6 +4111,16 @@ fn analysis_store_with_options(
         relations.push(relation);
     }
     if let Some(target) = candidate_external.as_ref() {
+        relations.push(LogicalRelation::new(
+            &d_unused,
+            GraphRelationKind::Legacy(RelationKind::Calls),
+            RelationResolution::external(target)?,
+            ConfidenceClass::Exact,
+            Completeness::Complete,
+            generation,
+        )?);
+    }
+    if let Some(target) = candidate_external_second.as_ref() {
         relations.push(LogicalRelation::new(
             &d_unused,
             GraphRelationKind::Legacy(RelationKind::Calls),
@@ -4122,6 +4253,9 @@ fn analysis_store_with_options(
         entities.push(target);
     }
     if let Some(target) = candidate_external {
+        entities.push(target);
+    }
+    if let Some(target) = candidate_external_second {
         entities.push(target);
     }
     publication.replace_repository_graph(project, &entities, &relations, &[], &coverage)?;

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1293,6 +1293,45 @@ fn entrypoint_profile_honors_content_and_confidence_filters() -> Result<(), Box<
 }
 
 #[test]
+fn entrypoint_profile_filters_non_candidate_entities_before_node_limit()
+-> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store_with_external_candidate()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.content_selection = ContentSelection::Source;
+    query.relations.budget = DetailedRelationBudget::from_graph_limits(
+        projectatlas_core::graph::GraphLimits::new(50, 1, 3, 256 * 1_024)?,
+    )
+    .with_aggregate_limits(
+        Some(100),
+        Some(8),
+        Some(100),
+        Some(100),
+        Some(256 * 1_024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "candidate-page-filter".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+
+    let report = fitted_report(&store, &query)?;
+    require(
+        report.entrypoint_profile.as_ref().is_some_and(|profile| {
+            profile.coverage == EntrypointProfileCoverage::Complete
+                && profile.unreachable_candidates > 0
+        }) && !report.reached_limits.contains(&GraphLimitKind::Nodes),
+        "non-candidate graph entities consumed the entrypoint candidate limit",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn entrypoint_classification_hydration_honors_control_and_byte_budget() -> Result<(), Box<dyn Error>>
 {
     let (_temp, store) = analysis_store()?;
@@ -1695,25 +1734,12 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
             ExtendedRelationKind::References,
         )],
     });
-    let candidate_limit_seen = Rc::new(Cell::new(false));
-    let candidate_limit_observer = Rc::clone(&candidate_limit_seen);
-    let candidate_limit_report = observe_analysis_phase(
-        move |event| {
-            if let AnalysisPhaseEvent::CandidateReport {
-                has_edges_limit, ..
-            } = event
-            {
-                candidate_limit_observer.set(candidate_limit_observer.get() || has_edges_limit);
-            }
-        },
-        || fitted_report(&store, &candidate_limits),
-    )?;
+    let candidate_limit_report = fitted_report(&store, &candidate_limits)?;
     require(
-        candidate_limit_seen.get()
-            && candidate_limit_report
-                .reached_limits
-                .contains(&GraphLimitKind::Edges),
-        "candidate traversal truncation did not preserve its typed limit reason",
+        candidate_limit_report
+            .reached_limits
+            .contains(&GraphLimitKind::Edges),
+        "candidate traversal did not preserve its typed edge limit reason",
     )?;
 
     let report = fitted_report(&store, &bounded)?;

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -983,12 +983,112 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
         "entrypoint output refusal did not identify the typed output boundary",
     )?;
 
+    let mut uncertain = query.clone();
+    uncertain.entrypoint_profile = Some(EntrypointProfile {
+        name: "dynamic-reference".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Extended(
+            ExtendedRelationKind::References,
+        )],
+    });
+    let uncertain_report = fitted_report(&store, &uncertain)?;
+    require(
+        uncertain_report
+            .entrypoint_profile
+            .as_ref()
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+            && uncertain_report.findings.iter().all(|finding| {
+                finding.kind == AnalysisFindingKind::EntrypointReachability
+                    && finding.status == AnalysisStatus::Inconclusive
+            }),
+        "ambiguous or dynamic references became a confident entrypoint result",
+    )?;
+
+    let (_stale_temp, stale_store) = analysis_store()?;
+    let root = _stale_temp.path().join("analysis-service");
+    let database = root.join("projectatlas.db");
+    stale_store.finish_index_read_snapshot()?;
+    let writer = Rc::new(RefCell::new(Some(AtlasStore::open_for_project(
+        &database, &root,
+    )?)));
+    let refreshed = Rc::new(Cell::new(false));
+    let writer_for_observer = Rc::clone(&writer);
+    let refreshed_for_observer = Rc::clone(&refreshed);
+    let stale = observe_analysis_phase(
+        move |event| {
+            if event == AnalysisPhaseEvent::Traversal && !refreshed_for_observer.replace(true) {
+                let mut writer = writer_for_observer
+                    .borrow_mut()
+                    .take()
+                    .expect("generation test writer already consumed");
+                writer
+                    .begin_index_projection_refresh("analysis-service")
+                    .expect("generation test refresh could not start")
+                    .complete()
+                    .expect("generation test refresh could not publish");
+            }
+        },
+        || load_relation_analysis(&stale_store, &query, None),
+    );
+    let stale_error = stale.as_ref().err().map(ToString::to_string);
+    require(
+        refreshed.get()
+            && stale_error
+                .as_deref()
+                .is_some_and(|error| error.contains("typed graph generation")),
+        "entrypoint traversal did not reject a generation transition",
+    )?;
+
+    let mut cycle = query.clone();
+    cycle.entrypoint_profile = Some(EntrypointProfile {
+        name: "cycle".to_string(),
+        anchors: vec![
+            RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            },
+            RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("src/b.rs"))?,
+            },
+        ],
+        relations: vec![
+            GraphRelationKind::Legacy(RelationKind::Contains),
+            GraphRelationKind::Legacy(RelationKind::Calls),
+            GraphRelationKind::Legacy(RelationKind::DependsOn),
+        ],
+    });
+    cycle.relations.budget = cycle.relations.budget.with_aggregate_limits(
+        Some(10),
+        Some(20),
+        Some(10),
+        Some(20),
+        Some(256 * 1_024),
+        None,
+    )?;
+    let cycle_report = fitted_report(&store, &cycle)?;
+    if !(cycle_report
+        .entrypoint_profile
+        .as_ref()
+        .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Complete)
+        && cycle_report.work.relations.inspected_edges == 9
+        && !cycle_report.reached_limits.contains(&GraphLimitKind::Edges))
+    {
+        return Err(io::Error::other(format!(
+            "a tight cyclic profile re-expanded an original anchor: coverage={:?}, limits={:?}, work={:?}",
+            cycle_report.entrypoint_profile.as_ref().map(|profile| profile.coverage),
+            cycle_report.reached_limits,
+            cycle_report.work.relations,
+        ))
+        .into());
+    }
+
     let mut bounded = query;
     bounded.relations.budget = bounded.relations.budget.with_aggregate_limits(
         Some(2),
         Some(4),
         Some(4),
-        Some(8),
+        Some(10),
         Some(64 * 1_024),
         None,
     )?;
@@ -1012,6 +1112,22 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
             && report.work.relations.visited_nodes <= 4
             && report.work.peak_intermediate_bytes <= 64 * 1_024,
         "entrypoint traversal crossed a caller aggregate ceiling",
+    )?;
+
+    let mut node_bounded = bounded.clone();
+    node_bounded.relations.budget = node_bounded.relations.budget.with_aggregate_limits(
+        Some(100),
+        Some(1),
+        Some(100),
+        Some(100),
+        Some(256 * 1_024),
+        None,
+    )?;
+    let node_report = fitted_report(&store, &node_bounded)?;
+    require(
+        node_report.reached_limits.contains(&GraphLimitKind::Nodes)
+            && !node_report.reached_limits.contains(&GraphLimitKind::Edges),
+        "node exhaustion was reported as an edge limit",
     )?;
     Ok(())
 }

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1378,6 +1378,58 @@ fn entrypoint_profile_reuses_retained_candidate_endpoints() -> Result<(), Box<dy
 }
 
 #[test]
+fn entrypoint_profile_reconciles_candidate_node_and_visited_limits_independently()
+-> Result<(), Box<dyn Error>> {
+    for (nodes, visited, expected_limit, unexpected_limit) in [
+        (8, 7, GraphLimitKind::Visited, GraphLimitKind::Nodes),
+        (7, 8, GraphLimitKind::Nodes, GraphLimitKind::Visited),
+    ] {
+        let (_temp, store) = analysis_store_with_candidate_relation("new")?;
+        let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+        query.relations.content_selection = ContentSelection::Source;
+        query.relations.resolution = RelationResolutionFilter::Any;
+        query.relations.budget = query.relations.budget.with_aggregate_limits(
+            Some(100),
+            Some(nodes),
+            Some(visited),
+            Some(100),
+            Some(256 * 1024),
+            None,
+        )?;
+        query.include_communities = false;
+        query.include_cycles = false;
+        query.entrypoint_profile = Some(EntrypointProfile {
+            name: format!("candidate-asymmetric-{nodes}-{visited}"),
+            anchors: vec![RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            }],
+            relations: vec![
+                GraphRelationKind::Legacy(RelationKind::Calls),
+                GraphRelationKind::Legacy(RelationKind::Contains),
+                GraphRelationKind::Legacy(RelationKind::DependsOn),
+            ],
+        });
+        let report = fitted_report(&store, &query)?;
+        require(
+            report.entrypoint_profile.as_ref().is_some_and(|profile| {
+                profile.coverage == EntrypointProfileCoverage::Partial
+                    && profile.unreachable_candidates == 0
+            }) && report.reached_limits.contains(&expected_limit)
+                && !report.reached_limits.contains(&unexpected_limit),
+            "candidate validation did not reconcile node and visited limits independently",
+        )?;
+        require(
+            report
+                .findings
+                .iter()
+                .all(|finding| finding.status == AnalysisStatus::Inconclusive),
+            "asymmetric candidate limit retained a confirmed entrypoint finding",
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
 fn entrypoint_profile_scopes_coverage_to_admitted_relations() -> Result<(), Box<dyn Error>> {
     let run = |partial_calls| -> Result<RelationAnalysisReport, Box<dyn Error>> {
         let (_temp, store) = analysis_store_with_relation_coverage(partial_calls)?;

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -4,6 +4,7 @@ use projectatlas_core::graph::{
     CoverageRecord, CoverageScope, CoverageState, GraphIdentityText, LogicalRelation,
     RelationResolution, RepositoryFilePath, RepositoryNodePath, SymbolSelector,
 };
+use projectatlas_core::language::ContentClassification;
 use projectatlas_core::symbols::{ParserKind, SymbolGraph, SymbolKind};
 use projectatlas_core::{IndexGeneration, Node, NodeKind, PurposeSource};
 use std::cell::{Cell, RefCell};
@@ -13,6 +14,7 @@ use std::io;
 use std::num::NonZeroU32;
 use std::path::Path;
 use std::rc::Rc;
+use std::time::{Duration, Instant};
 
 #[cfg(unix)]
 #[test]
@@ -885,6 +887,155 @@ fn entrypoint_profile_reports_reachable_and_unreachable_without_persistence()
 }
 
 #[test]
+fn entrypoint_profile_honors_content_and_confidence_filters() -> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store()?;
+    let mut source_only = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    source_only.relations.resolution = RelationResolutionFilter::Any;
+    source_only.relations.content_selection = ContentSelection::Source;
+    source_only.include_communities = false;
+    source_only.include_cycles = false;
+    source_only.entrypoint_profile = Some(EntrypointProfile {
+        name: "source-only".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let source_report = fitted_report(&store, &source_only)?;
+    require(
+        source_report
+            .entrypoint_profile
+            .as_ref()
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Complete)
+            && source_report.findings.iter().all(|finding| {
+                finding.nodes.iter().all(|node| {
+                    !matches!(
+                        node.node.entity.selector(),
+                        EntitySelector::File { path } if path.as_str() == "docs/guide.md"
+                    )
+                })
+            }),
+        "source-only entrypoint profile admitted a documentation candidate",
+    )?;
+
+    let mut exact = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    exact.relations.resolution = RelationResolutionFilter::Any;
+    exact.relations.minimum_confidence = ConfidenceClass::Exact;
+    exact.include_communities = false;
+    exact.include_cycles = false;
+    exact.entrypoint_profile = Some(EntrypointProfile {
+        name: "exact-confidence".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Extended(
+            ExtendedRelationKind::References,
+        )],
+    });
+    let exact_report = fitted_report(&store, &exact)?;
+    let mut low = exact;
+    low.relations.minimum_confidence = ConfidenceClass::Low;
+    let low_report = fitted_report(&store, &low)?;
+    require(
+        exact_report
+            .entrypoint_profile
+            .as_ref()
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Complete)
+            && low_report
+                .entrypoint_profile
+                .as_ref()
+                .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+            && exact_report
+                .findings
+                .iter()
+                .all(|finding| finding.status != AnalysisStatus::Inconclusive)
+            && low_report
+                .findings
+                .iter()
+                .all(|finding| finding.status == AnalysisStatus::Inconclusive),
+        "entrypoint profile did not preserve the requested minimum confidence",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_classification_hydration_honors_control_and_byte_budget() -> Result<(), Box<dyn Error>>
+{
+    let (_temp, store) = analysis_store()?;
+    let project = store
+        .project_instance_id()?
+        .ok_or("analysis fixture project identity missing")?;
+    let generation = store
+        .repository_graph_generation()?
+        .ok_or("analysis fixture graph generation missing")?;
+    let entity = GraphEntity::new(
+        project,
+        EntitySelector::File {
+            path: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        },
+        generation,
+    )?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.content_selection = ContentSelection::Source;
+    let budget = query.relations.budget;
+
+    let cancellation = IndexCancellation::new();
+    let control = IndexWorkControl::with_deadline(
+        cancellation.clone(),
+        Instant::now() + Duration::from_secs(5),
+    );
+    let cancelled = cancel_at_analysis_phase(
+        AnalysisPhaseEvent::ClassificationHydration,
+        cancellation,
+        || {
+            super::load_entrypoint_candidate_classifications(
+                &store,
+                std::slice::from_ref(&entity),
+                budget,
+                &mut DetailedRelationWork::default(),
+                Some(&control),
+            )
+        },
+    )?;
+    require(
+        matches!(
+            cancelled,
+            Err(ServiceError::Db(DbError::IndexWork(
+                projectatlas_core::IndexWorkFailure::Cancelled { .. }
+            )))
+        ),
+        "classification hydration ignored cancellation",
+    )?;
+
+    let mut work = DetailedRelationWork {
+        intermediate_bytes: budget
+            .intermediate_bytes()
+            .saturating_sub(super::classification_path_bytes("src/a.rs")?),
+        ..DetailedRelationWork::default()
+    };
+    let bounded = super::load_entrypoint_candidate_classifications(
+        &store,
+        std::slice::from_ref(&entity),
+        budget,
+        &mut work,
+        None,
+    )?;
+    require(
+        bounded.is_none(),
+        "classification hydration accepted data beyond the intermediate-byte budget",
+    )?;
+    require(
+        work.database_requested_rows == 1
+            && work.database_returned_rows == 1
+            && work.database_decoded_bytes > 0
+            && work.hydrated_classification_paths == 1
+            && work.intermediate_bytes == budget.intermediate_bytes(),
+        "rejected classification work was omitted from the returned ledger",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn entrypoint_profile_rejects_ambiguous_cursor_and_wrong_scope_and_stays_inconclusive()
 -> Result<(), Box<dyn Error>> {
     let (_temp, store) = analysis_store()?;
@@ -983,6 +1134,23 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
             .to_string()
             .contains("entrypoint profile output"),
         "entrypoint output refusal did not identify the typed output boundary",
+    )?;
+
+    let mut oversized_construction = load_relation_analysis(&store, &query, None)?;
+    let construction_budget = oversized_construction.budget.intermediate_bytes();
+    oversized_construction.report.work.peak_intermediate_bytes = construction_budget + 1;
+    let Err(construction_error) =
+        oversized_construction.fit_output::<_, ServiceError, _>(|report, _control| {
+            serde_json::to_vec(report).map_err(ServiceError::from)
+        })
+    else {
+        return Err("entrypoint output fitting ignored construction work".into());
+    };
+    require(
+        construction_error
+            .to_string()
+            .contains("aggregate intermediate-byte budget"),
+        "entrypoint output fitting did not preserve the construction peak",
     )?;
 
     let mut uncertain = query.clone();
@@ -1202,10 +1370,21 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
         Some(256 * 1_024),
         None,
     )?;
-    let node_report = fitted_report(&store, &node_bounded)?;
+    node_bounded.relations.content_selection = ContentSelection::Source;
+    let classification_seen = Rc::new(Cell::new(false));
+    let classification_seen_observer = Rc::clone(&classification_seen);
+    let node_report = observe_analysis_phase(
+        move |event| {
+            if event == AnalysisPhaseEvent::ClassificationHydration {
+                classification_seen_observer.set(true);
+            }
+        },
+        || fitted_report(&store, &node_bounded),
+    )?;
     require(
         node_report.reached_limits.contains(&GraphLimitKind::Nodes)
-            && !node_report.reached_limits.contains(&GraphLimitKind::Edges),
+            && !node_report.reached_limits.contains(&GraphLimitKind::Edges)
+            && !classification_seen.get(),
         "node exhaustion was reported as an edge limit",
     )?;
     Ok(())
@@ -2814,9 +2993,11 @@ fn analysis_store_with_coverage(
     let root = temp.path().join("analysis-service");
     fs::create_dir_all(root.join("src"))?;
     fs::create_dir_all(root.join("tools"))?;
+    fs::create_dir_all(root.join("docs"))?;
     fs::write(root.join("src/a.rs"), "pub fn a() {}\n")?;
     fs::write(root.join("src/b.rs"), "pub fn b() {}\n")?;
     fs::write(root.join("tools/c.rs"), "pub fn c() {}\n")?;
+    fs::write(root.join("docs/guide.md"), "# Guide\n")?;
     let database = root.join("projectatlas.db");
     let mut store = AtlasStore::open_for_project(&database, &root)?;
     let project = store
@@ -2835,6 +3016,7 @@ fn analysis_store_with_coverage(
     let a = entity("src/a.rs")?;
     let b = entity("src/b.rs")?;
     let c = entity("tools/c.rs")?;
+    let guide = entity("docs/guide.md")?;
     let symbol_entity = |path: &str, name: &str, signature: &str| {
         GraphEntity::new(
             project,
@@ -2916,7 +3098,7 @@ fn analysis_store_with_coverage(
             generation,
         )?,
     ];
-    let mut coverage = ["src/a.rs", "src/b.rs", "tools/c.rs"]
+    let mut coverage = ["src/a.rs", "src/b.rs", "tools/c.rs", "docs/guide.md"]
         .into_iter()
         .filter(|path| include_tools_coverage || *path != "tools/c.rs")
         .map(|path| {
@@ -2936,7 +3118,7 @@ fn analysis_store_with_coverage(
         })
         .collect::<Result<Vec<_>, Box<dyn Error>>>()?;
     coverage.extend(
-        ["src/a.rs", "src/b.rs", "tools/c.rs"]
+        ["src/a.rs", "src/b.rs", "tools/c.rs", "docs/guide.md"]
             .into_iter()
             .filter(|path| include_tools_coverage || *path != "tools/c.rs")
             .map(|path| {
@@ -2961,9 +3143,29 @@ fn analysis_store_with_coverage(
     publication.upsert_scan_node_batch(&[
         test_folder_node("src"),
         test_folder_node("tools"),
+        test_folder_node("docs"),
         test_node("src/a.rs", "hash-a"),
         test_node("src/b.rs", "hash-b"),
         test_node_in("tools/c.rs", "tools", "hash-c"),
+        classified_test_node("docs/guide.md", "hash-guide", ".md", "markdown"),
+    ])?;
+    publication.upsert_file_content_classification_batch(&[
+        projectatlas_db::FileContentClassification {
+            path: "src/a.rs".to_string(),
+            classification: ContentClassification::Source,
+        },
+        projectatlas_db::FileContentClassification {
+            path: "src/b.rs".to_string(),
+            classification: ContentClassification::Source,
+        },
+        projectatlas_db::FileContentClassification {
+            path: "tools/c.rs".to_string(),
+            classification: ContentClassification::Source,
+        },
+        projectatlas_db::FileContentClassification {
+            path: "docs/guide.md".to_string(),
+            classification: ContentClassification::Documentation,
+        },
     ])?;
     publication.finish_scan_replacement()?;
     publication.replace_symbol_graph(&SymbolGraph {
@@ -3006,7 +3208,7 @@ fn analysis_store_with_coverage(
     })?;
     publication.replace_repository_graph(
         project,
-        &[a, b, c, a_long, d_unused, b_hub, c_aux],
+        &[a, b, c, guide, a_long, d_unused, b_hub, c_aux],
         &relations,
         &[],
         &coverage,
@@ -3067,6 +3269,19 @@ fn test_node_in(path: &str, parent: &str, hash: &str) -> Node {
         extension: Some(".rs".to_string()),
         language: Some("rust".to_string()),
         size_bytes: Some(16),
+        mtime_ns: Some(1),
+        content_hash: Some(hash.to_string()),
+    }
+}
+
+fn classified_test_node(path: &str, hash: &str, extension: &str, language: &str) -> Node {
+    Node {
+        path: path.to_string(),
+        kind: NodeKind::File,
+        parent_path: Some("docs".to_string()),
+        extension: Some(extension.to_string()),
+        language: Some(language.to_string()),
+        size_bytes: Some(8),
         mtime_ns: Some(1),
         content_hash: Some(hash.to_string()),
     }

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1133,6 +1133,136 @@ fn entrypoint_profile_rejects_candidate_generation_and_purpose_changes()
 }
 
 #[test]
+fn entrypoint_profile_rejects_generation_change_after_empty_candidate_page()
+-> Result<(), Box<dyn Error>> {
+    let (temp, stale_store) = analysis_store()?;
+    let root = temp.path().join("analysis-service");
+    let database = root.join("projectatlas.db");
+    stale_store.finish_index_read_snapshot()?;
+    let writer = Rc::new(RefCell::new(Some(AtlasStore::open_for_project(
+        &database, &root,
+    )?)));
+    let refreshed = Rc::new(Cell::new(false));
+    let writer_for_observer = Rc::clone(&writer);
+    let refreshed_for_observer = Rc::clone(&refreshed);
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.content_selection = projectatlas_core::language::ContentSelection::Source;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(100),
+        Some(30),
+        Some(30),
+        Some(100),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "empty-candidate-page-stale".to_string(),
+        anchors: vec![
+            RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            },
+            RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("src/b.rs"))?,
+            },
+            RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("tools/c.rs"))?,
+            },
+            RelationAnchor::Symbol {
+                file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+                name: "a_long".to_string(),
+                symbol_kind: Some(SymbolKind::Function),
+                parent: None,
+                signature: Some("fn a_long()".to_string()),
+            },
+            RelationAnchor::Symbol {
+                file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+                name: "d_unused".to_string(),
+                symbol_kind: Some(SymbolKind::Function),
+                parent: None,
+                signature: Some("fn d_unused()".to_string()),
+            },
+            RelationAnchor::Symbol {
+                file: RepositoryFilePath::new(Path::new("src/b.rs"))?,
+                name: "b_hub".to_string(),
+                symbol_kind: Some(SymbolKind::Function),
+                parent: None,
+                signature: Some("fn b_hub()".to_string()),
+            },
+            RelationAnchor::Symbol {
+                file: RepositoryFilePath::new(Path::new("tools/c.rs"))?,
+                name: "c_aux".to_string(),
+                symbol_kind: Some(SymbolKind::Function),
+                parent: None,
+                signature: Some("fn c_aux()".to_string()),
+            },
+        ],
+        relations: vec![
+            GraphRelationKind::Legacy(RelationKind::Calls),
+            GraphRelationKind::Legacy(RelationKind::Contains),
+            GraphRelationKind::Legacy(RelationKind::DependsOn),
+        ],
+    });
+    let stale = observe_analysis_phase(
+        move |event| {
+            if event == AnalysisPhaseEvent::CandidateEnumeration
+                && !refreshed_for_observer.replace(true)
+                && let Some(mut writer) = writer_for_observer.borrow_mut().take()
+                && let Ok(refresh) = writer.begin_index_projection_refresh("analysis-service")
+            {
+                drop(refresh.complete());
+            }
+        },
+        || load_relation_analysis(&stale_store, &query, None),
+    );
+    require(
+        refreshed.get()
+            && stale
+                .as_ref()
+                .err()
+                .is_some_and(|error| error.to_string().contains("typed graph generation")),
+        "empty candidate enumeration did not reject a generation transition",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_does_not_use_disabled_occurrences_as_row_budget() -> Result<(), Box<dyn Error>>
+{
+    let (_temp, store) = analysis_store()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(100),
+        Some(20),
+        Some(20),
+        Some(1),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "disabled-occurrence-row-budget".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let report = fitted_report(&store, &query)?;
+    require(
+        report
+            .entrypoint_profile
+            .as_ref()
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Complete),
+        "disabled occurrence collection incorrectly constrained entrypoint relation rows",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn entrypoint_profile_bounds_candidate_entity_hydration_by_remaining_bytes()
 -> Result<(), Box<dyn Error>> {
     let (_temp, store) = analysis_store()?;

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1203,7 +1203,10 @@ fn entrypoint_profile_bounds_candidate_entity_hydration_by_remaining_bytes()
                 .report
                 .entrypoint_profile
                 .as_ref()
-                .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+                .is_some_and(|profile| {
+                    profile.coverage == EntrypointProfileCoverage::Partial
+                        && profile.unreachable_candidates == 0
+                })
             && bounded_report
                 .report
                 .reached_limits
@@ -1356,12 +1359,12 @@ fn entrypoint_classification_hydration_honors_control_and_byte_budget() -> Resul
         "classification hydration accepted data beyond the intermediate-byte budget",
     )?;
     require(
-        work.database_requested_rows == 1
-            && work.database_returned_rows == 1
-            && work.database_decoded_bytes > 0
-            && work.hydrated_classification_paths == 1
+        work.database_requested_rows == 0
+            && work.database_returned_rows == 0
+            && work.database_decoded_bytes == 0
+            && work.hydrated_classification_paths == 0
             && work.intermediate_bytes == budget.intermediate_bytes(),
-        "rejected classification work was omitted from the returned ledger",
+        "classification hydration materialized a batch beyond its remaining budget",
     )?;
     Ok(())
 }

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -810,6 +810,128 @@ fn analysis_modes_are_closed_and_partial_evidence_stays_inconclusive() -> Result
 }
 
 #[test]
+fn entrypoint_profile_reports_reachable_and_unreachable_without_persistence()
+-> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "public-rust".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![
+            GraphRelationKind::Legacy(RelationKind::Contains),
+            GraphRelationKind::Legacy(RelationKind::Calls),
+            GraphRelationKind::Legacy(RelationKind::DependsOn),
+        ],
+    });
+    let before = store.index_publication()?;
+    let report = fitted_report(&store, &query)?;
+    let profile = report
+        .entrypoint_profile
+        .as_ref()
+        .ok_or("entrypoint profile metadata missing")?;
+    require(
+        profile.coverage == EntrypointProfileCoverage::Complete
+            && profile.reachable > 0
+            && profile.unreachable_candidates > 0,
+        "entrypoint profile did not classify a complete reachable and unreachable scope",
+    )?;
+    require(
+        report.findings.iter().any(|finding| {
+            finding.kind == AnalysisFindingKind::EntrypointReachability
+                && finding.status == AnalysisStatus::Candidate
+                && finding.nodes.iter().any(|node| {
+                    matches!(
+                        node.node.entity.selector(),
+                        EntitySelector::Symbol { symbol }
+                            if symbol.name.as_str() == "d_unused"
+                    )
+                })
+        }),
+        "entrypoint profile omitted the unreachable candidate finding",
+    )?;
+    require(
+        store.index_publication()? == before,
+        "entrypoint profile changed the authoritative publication",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_rejects_ambiguous_cursor_and_wrong_scope_and_stays_inconclusive()
+-> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store()?;
+    let file_anchor = |path: &str| {
+        Ok::<_, Box<dyn Error>>(RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new(path))?,
+        })
+    };
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "invalid".to_string(),
+        anchors: vec![file_anchor("src/a.rs")?, file_anchor("src/a.rs")?],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    require(
+        load_relation_analysis(&store, &query, None).is_err(),
+        "duplicate entrypoint anchors were accepted",
+    )?;
+
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "wrong-root".to_string(),
+        anchors: vec![file_anchor("missing.rs")?],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    require(
+        load_relation_analysis(&store, &query, None).is_err(),
+        "a wrong-root entrypoint was accepted",
+    )?;
+
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "cursor".to_string(),
+        anchors: vec![file_anchor("src/a.rs")?],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    query.relations.cursor = Some("stale".to_string());
+    let cursor_result = load_relation_analysis(&store, &query, None);
+    let cursor_error = cursor_result.err().map(|error| error.to_string());
+    require(
+        cursor_error
+            .as_deref()
+            .is_some_and(|error| error.contains("relation cursors")),
+        "entrypoint profiles accepted a replay cursor",
+    )?;
+
+    let (_partial_temp, partial_store) = analysis_store_with_coverage(false)?;
+    query.relations.cursor = None;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "partial".to_string(),
+        anchors: vec![file_anchor("tools/c.rs")?],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let report = fitted_report(&partial_store, &query)?;
+    require(
+        report
+            .entrypoint_profile
+            .as_ref()
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+            && report.findings.iter().all(|finding| {
+                finding.kind == AnalysisFindingKind::EntrypointReachability
+                    && finding.status == AnalysisStatus::Inconclusive
+            }),
+        "incomplete entrypoint coverage produced a confident finding",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn community_closure_scopes_scope_gaps_to_admitted_relations() -> Result<(), Box<dyn Error>> {
     let (_temp, store) = analysis_store()?;
     let mut all_relations = analysis_query(RelationAnalysisMode::Architecture)?;
@@ -2354,6 +2476,7 @@ fn analysis_query(mode: RelationAnalysisMode) -> Result<RelationAnalysisQuery, B
         include_communities: true,
         include_cycles: true,
         include_dead_code: false,
+        entrypoint_profile: None,
     })
 }
 

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -888,6 +888,50 @@ fn entrypoint_profile_reports_reachable_and_unreachable_without_persistence()
 }
 
 #[test]
+fn entrypoint_profile_rechecks_terminal_frontier_at_exact_edge_limit() -> Result<(), Box<dyn Error>>
+{
+    let (_temp, store) = terminal_entrypoint_store(false)?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(1),
+        Some(8),
+        Some(8),
+        Some(100),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "terminal-edge-bound".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let report = fitted_report(&store, &query)?;
+    require(
+        report.entrypoint_profile.as_ref().is_some_and(|profile| {
+            profile.coverage == EntrypointProfileCoverage::Complete && profile.reachable == 2
+        }) && !report.reached_limits.contains(&GraphLimitKind::Edges),
+        "an empty terminal frontier was rejected at the exact edge limit",
+    )?;
+
+    let (_temp, store) = terminal_entrypoint_store(true)?;
+    let report = fitted_report(&store, &query)?;
+    require(
+        report
+            .entrypoint_profile
+            .as_ref()
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+            && report.reached_limits.contains(&GraphLimitKind::Edges),
+        "a pending terminal edge was not retained as an edge-limit truncation",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn entrypoint_profile_marks_unanchorable_local_targets_inconclusive() -> Result<(), Box<dyn Error>>
 {
     let selectors = [
@@ -4121,6 +4165,101 @@ fn initialize_git_fixture(root: &Path) -> Result<(), Box<dyn Error>> {
 
 fn analysis_store() -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
     analysis_store_with_coverage(true)
+}
+
+fn terminal_entrypoint_store(
+    include_terminal_edge: bool,
+) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let root = temp.path().join("terminal-entrypoint");
+    fs::create_dir_all(root.join("src"))?;
+    for (path, contents) in [
+        ("src/a.rs", "pub fn a() {}\n"),
+        ("src/b.rs", "pub fn b() {}\n"),
+    ] {
+        fs::write(root.join(path), contents)?;
+    }
+    if include_terminal_edge {
+        fs::write(root.join("src/c.rs"), "pub fn c() {}\n")?;
+    }
+    let database = root.join("projectatlas.db");
+    let mut store = AtlasStore::open_for_project(&database, &root)?;
+    let project = store
+        .project_instance_id()?
+        .ok_or("terminal entrypoint project identity missing")?;
+    let generation = IndexGeneration::new(1);
+    let entity = |path: &str| {
+        GraphEntity::new(
+            project,
+            EntitySelector::File {
+                path: RepositoryFilePath::new(Path::new(path))?,
+            },
+            generation,
+        )
+    };
+    let a = entity("src/a.rs")?;
+    let b = entity("src/b.rs")?;
+    let c = include_terminal_edge
+        .then(|| entity("src/c.rs"))
+        .transpose()?;
+    let calls = GraphRelationKind::Legacy(RelationKind::Calls);
+    let relation = |source: &GraphEntity, target: &GraphEntity| {
+        LogicalRelation::new(
+            source,
+            calls,
+            RelationResolution::resolved(target)?,
+            ConfidenceClass::Exact,
+            Completeness::Complete,
+            generation,
+        )
+    };
+    let mut relations = vec![relation(&a, &b)?];
+    if let Some(c) = c.as_ref() {
+        relations.push(relation(&b, c)?);
+    }
+    let entities = c.as_ref().map_or_else(
+        || vec![a.clone(), b.clone()],
+        |c| vec![a.clone(), b.clone(), c.clone()],
+    );
+    let coverage = entities
+        .iter()
+        .map(|entity| {
+            let path = match entity.selector() {
+                EntitySelector::File { path } => path.as_str(),
+                _ => unreachable!("terminal fixture only contains files"),
+            };
+            CoverageRecord::new(
+                CoverageScope::Path {
+                    path: RepositoryNodePath::new(Path::new(path))?,
+                },
+                None,
+                CoverageState::Complete,
+                1,
+                0,
+                generation,
+                None,
+                None,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut publication = store.begin_index_publication("terminal-entrypoint")?;
+    publication.begin_scan_replacement()?;
+    let scan_nodes = entities
+        .iter()
+        .map(|entity| match entity.selector() {
+            EntitySelector::File { path } => test_node(path.as_str(), path.as_str()),
+            _ => unreachable!("terminal fixture only contains files"),
+        })
+        .collect::<Vec<_>>();
+    publication.upsert_scan_node_batch(&scan_nodes)?;
+    publication.finish_scan_replacement()?;
+    publication.replace_repository_graph(project, &entities, &relations, &[], &coverage)?;
+    publication.complete()?;
+    drop(store);
+    Ok((
+        temp,
+        AtlasStore::open_read_only_for_project(&database, &root)?,
+    ))
 }
 
 fn analysis_store_with_coverage(

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -932,6 +932,155 @@ fn entrypoint_profile_rechecks_terminal_frontier_at_exact_edge_limit() -> Result
 }
 
 #[test]
+fn entrypoint_profile_protects_files_owned_by_reachable_symbols() -> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "symbol-owner-protection".to_string(),
+        anchors: vec![RelationAnchor::Symbol {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            name: "a_long".to_string(),
+            symbol_kind: Some(SymbolKind::Function),
+            parent: None,
+            signature: Some("fn a_long()".to_string()),
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let report = fitted_report(&store, &query)?;
+    let owner_paths_are_absent = report
+        .findings
+        .iter()
+        .filter(|finding| finding.status == AnalysisStatus::Candidate)
+        .flat_map(|finding| &finding.nodes)
+        .all(|node| {
+            !matches!(
+                node.node.entity.selector(),
+                EntitySelector::File { path }
+                    if path.as_str() == "src/a.rs" || path.as_str() == "src/b.rs"
+            )
+        });
+    require(
+        report.entrypoint_profile.as_ref().is_some_and(|profile| {
+            profile.coverage == EntrypointProfileCoverage::Complete && profile.reachable >= 2
+        }) && owner_paths_are_absent,
+        "a reachable symbol left its owning file eligible as an unreachable candidate",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_binds_omitted_parent_to_resolved_symbol_identity()
+-> Result<(), Box<dyn Error>> {
+    let (_temp, store) = nested_symbol_entrypoint_store()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(4),
+        Some(1),
+        Some(1),
+        Some(100),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "nested-symbol-identity".to_string(),
+        anchors: vec![RelationAnchor::Symbol {
+            file: RepositoryFilePath::new(Path::new("src/nested.rs"))?,
+            name: "inner".to_string(),
+            symbol_kind: Some(SymbolKind::Function),
+            parent: None,
+            signature: Some("fn inner()".to_string()),
+        }],
+        relations: vec![
+            GraphRelationKind::Legacy(RelationKind::Calls),
+            GraphRelationKind::Legacy(RelationKind::DependsOn),
+        ],
+    });
+    let report = fitted_report(&store, &query)?;
+    require(
+        report.entrypoint_profile.as_ref().is_some_and(|profile| {
+            profile.coverage == EntrypointProfileCoverage::Complete && profile.reachable == 1
+        }) && !report.reached_limits.contains(&GraphLimitKind::Nodes)
+            && !report.reached_limits.contains(&GraphLimitKind::Visited),
+        "an omitted symbol parent was compared as selector syntax instead of resolved identity",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_keeps_zero_occurrence_rows_independent() -> Result<(), Box<dyn Error>> {
+    let (_temp, store) = branching_entrypoint_store(false)?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.include_occurrences = true;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(2),
+        Some(8),
+        Some(8),
+        Some(1),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "zero-occurrence-rows".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let report = fitted_report(&store, &query)?;
+    require(
+        report.entrypoint_profile.as_ref().is_some_and(|profile| {
+            profile.coverage == EntrypointProfileCoverage::Complete && profile.reachable == 3
+        }) && !report.reached_limits.contains(&GraphLimitKind::Rows)
+            && !report.reached_limits.contains(&GraphLimitKind::Occurrences),
+        "zero-occurrence relation rows were incorrectly capped by the occurrence budget",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_keeps_pending_candidate_edges_inconclusive() -> Result<(), Box<dyn Error>> {
+    let (_temp, store) = branching_entrypoint_store(true)?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(2),
+        Some(8),
+        Some(8),
+        Some(100),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "pending-candidate-edge".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let report = fitted_report(&store, &query)?;
+    require(
+        report
+            .entrypoint_profile
+            .as_ref()
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+            && report.reached_limits.contains(&GraphLimitKind::Edges),
+        "a pending disconnected candidate edge was treated as a terminal negative",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn entrypoint_profile_marks_unanchorable_local_targets_inconclusive() -> Result<(), Box<dyn Error>>
 {
     let selectors = [
@@ -1268,6 +1417,65 @@ fn entrypoint_profile_rejects_generation_change_after_empty_candidate_page()
                 .err()
                 .is_some_and(|error| error.to_string().contains("typed graph generation")),
         "empty candidate enumeration did not reject a generation transition",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_rejects_generation_change_after_terminal_probe() -> Result<(), Box<dyn Error>>
+{
+    let (temp, stale_store) = terminal_entrypoint_store(false)?;
+    let root = temp.path().join("terminal-entrypoint");
+    let database = root.join("projectatlas.db");
+    stale_store.finish_index_read_snapshot()?;
+    let writer = Rc::new(RefCell::new(Some(AtlasStore::open_for_project(
+        &database, &root,
+    )?)));
+    let probes = Rc::new(Cell::new(0_u32));
+    let writer_for_observer = Rc::clone(&writer);
+    let probes_for_observer = Rc::clone(&probes);
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(1),
+        Some(8),
+        Some(8),
+        Some(100),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "candidate-terminal-stale".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let stale = observe_analysis_phase(
+        move |event| {
+            if event == AnalysisPhaseEvent::TerminalProbe {
+                let count = probes_for_observer.get().saturating_add(1);
+                probes_for_observer.set(count);
+                if count == 2
+                    && let Some(mut writer) = writer_for_observer.borrow_mut().take()
+                    && let Ok(refresh) =
+                        writer.begin_index_projection_refresh("terminal-entrypoint")
+                {
+                    drop(refresh.complete());
+                }
+            }
+        },
+        || load_relation_analysis(&stale_store, &query, None),
+    );
+    require(
+        probes.get() == 2
+            && stale
+                .as_ref()
+                .err()
+                .is_some_and(|error| error.to_string().contains("typed graph generation")),
+        "candidate terminal probing did not reject a generation transition",
     )?;
     Ok(())
 }
@@ -4176,6 +4384,7 @@ fn terminal_entrypoint_store(
     for (path, contents) in [
         ("src/a.rs", "pub fn a() {}\n"),
         ("src/b.rs", "pub fn b() {}\n"),
+        ("src/d.rs", "pub fn d() {}\n"),
     ] {
         fs::write(root.join(path), contents)?;
     }
@@ -4199,6 +4408,7 @@ fn terminal_entrypoint_store(
     };
     let a = entity("src/a.rs")?;
     let b = entity("src/b.rs")?;
+    let d = entity("src/d.rs")?;
     let c = include_terminal_edge
         .then(|| entity("src/c.rs"))
         .transpose()?;
@@ -4217,10 +4427,10 @@ fn terminal_entrypoint_store(
     if let Some(c) = c.as_ref() {
         relations.push(relation(&b, c)?);
     }
-    let entities = c.as_ref().map_or_else(
-        || vec![a.clone(), b.clone()],
-        |c| vec![a.clone(), b.clone(), c.clone()],
-    );
+    let mut entities = vec![a, b, d];
+    if let Some(c) = c.as_ref() {
+        entities.push(c.clone());
+    }
     let coverage = entities
         .iter()
         .map(|entity| {
@@ -4254,6 +4464,166 @@ fn terminal_entrypoint_store(
     publication.upsert_scan_node_batch(&scan_nodes)?;
     publication.finish_scan_replacement()?;
     publication.replace_repository_graph(project, &entities, &relations, &[], &coverage)?;
+    publication.complete()?;
+    drop(store);
+    Ok((
+        temp,
+        AtlasStore::open_read_only_for_project(&database, &root)?,
+    ))
+}
+
+fn branching_entrypoint_store(
+    include_pending_candidate: bool,
+) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let root = temp.path().join("branching-entrypoint");
+    fs::create_dir_all(root.join("src"))?;
+    for (path, contents) in [
+        ("src/a.rs", "pub fn a() {}\n"),
+        ("src/b.rs", "pub fn b() {}\n"),
+        ("src/c.rs", "pub fn c() {}\n"),
+    ] {
+        fs::write(root.join(path), contents)?;
+    }
+    if include_pending_candidate {
+        fs::write(root.join("src/d.rs"), "pub fn d() {}\n")?;
+        fs::write(root.join("src/e.rs"), "pub fn e() {}\n")?;
+    }
+    let database = root.join("projectatlas.db");
+    let mut store = AtlasStore::open_for_project(&database, &root)?;
+    let project = store
+        .project_instance_id()?
+        .ok_or("branching entrypoint project identity missing")?;
+    let generation = IndexGeneration::new(1);
+    let entity = |path: &str| {
+        GraphEntity::new(
+            project,
+            EntitySelector::File {
+                path: RepositoryFilePath::new(Path::new(path))?,
+            },
+            generation,
+        )
+    };
+    let a = entity("src/a.rs")?;
+    let b = entity("src/b.rs")?;
+    let c = entity("src/c.rs")?;
+    let d = include_pending_candidate
+        .then(|| entity("src/d.rs"))
+        .transpose()?;
+    let e = include_pending_candidate
+        .then(|| entity("src/e.rs"))
+        .transpose()?;
+    let calls = GraphRelationKind::Legacy(RelationKind::Calls);
+    let relation = |target: &GraphEntity| {
+        LogicalRelation::new(
+            &a,
+            calls,
+            RelationResolution::resolved(target)?,
+            ConfidenceClass::Exact,
+            Completeness::Complete,
+            generation,
+        )
+    };
+    let mut relations = vec![relation(&b)?, relation(&c)?];
+    if let (Some(d), Some(e)) = (d.as_ref(), e.as_ref()) {
+        relations.push(LogicalRelation::new(
+            d,
+            calls,
+            RelationResolution::resolved(e)?,
+            ConfidenceClass::Exact,
+            Completeness::Complete,
+            generation,
+        )?);
+    }
+    let mut entities = vec![a, b, c];
+    if let Some(d) = d {
+        entities.push(d);
+    }
+    if let Some(e) = e {
+        entities.push(e);
+    }
+    let coverage = entities
+        .iter()
+        .map(|entity| {
+            let path = match entity.selector() {
+                EntitySelector::File { path } => path.as_str(),
+                _ => unreachable!("branching fixture only contains files"),
+            };
+            CoverageRecord::new(
+                CoverageScope::Path {
+                    path: RepositoryNodePath::new(Path::new(path))?,
+                },
+                None,
+                CoverageState::Complete,
+                1,
+                0,
+                generation,
+                None,
+                None,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut publication = store.begin_index_publication("branching-entrypoint")?;
+    publication.begin_scan_replacement()?;
+    let scan_nodes = entities
+        .iter()
+        .map(|entity| match entity.selector() {
+            EntitySelector::File { path } => test_node(path.as_str(), path.as_str()),
+            _ => unreachable!("branching fixture only contains files"),
+        })
+        .collect::<Vec<_>>();
+    publication.upsert_scan_node_batch(&scan_nodes)?;
+    publication.finish_scan_replacement()?;
+    publication.replace_repository_graph(project, &entities, &relations, &[], &coverage)?;
+    publication.complete()?;
+    drop(store);
+    Ok((
+        temp,
+        AtlasStore::open_read_only_for_project(&database, &root)?,
+    ))
+}
+
+fn nested_symbol_entrypoint_store() -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
+    let temp = tempfile::tempdir()?;
+    let root = temp.path().join("nested-symbol-entrypoint");
+    fs::create_dir_all(root.join("src"))?;
+    fs::write(root.join("src/nested.rs"), "fn inner() {}\n")?;
+    let database = root.join("projectatlas.db");
+    let mut store = AtlasStore::open_for_project(&database, &root)?;
+    let project = store
+        .project_instance_id()?
+        .ok_or("nested symbol project identity missing")?;
+    let generation = IndexGeneration::new(1);
+    let inner = GraphEntity::new(
+        project,
+        EntitySelector::Symbol {
+            symbol: SymbolSelector {
+                file: RepositoryFilePath::new(Path::new("src/nested.rs"))?,
+                name: GraphIdentityText::new("inner")?,
+                kind: SymbolKind::Function,
+                parent: Some(GraphIdentityText::new("Outer")?),
+                signature: GraphIdentityText::new("fn inner()")?,
+            },
+        },
+        generation,
+    )?;
+    let coverage = CoverageRecord::new(
+        CoverageScope::Path {
+            path: RepositoryNodePath::new(Path::new("src/nested.rs"))?,
+        },
+        None,
+        CoverageState::Complete,
+        1,
+        0,
+        generation,
+        None,
+        None,
+    )?;
+    let mut publication = store.begin_index_publication("nested-symbol-entrypoint")?;
+    publication.begin_scan_replacement()?;
+    publication.upsert_scan_node_batch(&[test_node("src/nested.rs", "src/nested.rs")])?;
+    publication.finish_scan_replacement()?;
+    publication.replace_repository_graph(project, &[inner], &[], &[], &[coverage])?;
     publication.complete()?;
     drop(store);
     Ok((

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -843,6 +843,29 @@ fn entrypoint_profile_reports_reachable_and_unreachable_without_persistence()
     require(
         report.findings.iter().any(|finding| {
             finding.kind == AnalysisFindingKind::EntrypointReachability
+                && finding.status == AnalysisStatus::Confirmed
+                && finding.nodes.iter().any(|node| {
+                    matches!(
+                        node.node.entity.selector(),
+                        EntitySelector::Symbol { symbol }
+                            if symbol.name.as_str() == "b_hub"
+                    )
+                })
+        }) && !report.findings.iter().any(|finding| {
+            finding.status == AnalysisStatus::Candidate
+                && finding.nodes.iter().any(|node| {
+                    matches!(
+                        node.node.entity.selector(),
+                        EntitySelector::Symbol { symbol }
+                            if symbol.name.as_str() == "b_hub"
+                    )
+                })
+        }),
+        "mixed admitted relation families did not preserve the node-simple union",
+    )?;
+    require(
+        report.findings.iter().any(|finding| {
+            finding.kind == AnalysisFindingKind::EntrypointReachability
                 && finding.status == AnalysisStatus::Candidate
                 && finding.nodes.iter().any(|node| {
                     matches!(
@@ -927,6 +950,68 @@ fn entrypoint_profile_rejects_ambiguous_cursor_and_wrong_scope_and_stays_inconcl
                     && finding.status == AnalysisStatus::Inconclusive
             }),
         "incomplete entrypoint coverage produced a confident finding",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
+-> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "bounded".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+
+    let output_error = load_relation_analysis(&store, &query, None)?
+        .fit_output::<_, ServiceError, _>(|report, _control| {
+            let _ = report;
+            Ok(vec![0_u8; 65_537])
+        })
+        .expect_err("entrypoint output unexpectedly accepted a non-replayable prefix");
+    require(
+        output_error
+            .to_string()
+            .contains("entrypoint profile output"),
+        "entrypoint output refusal did not identify the typed output boundary",
+    )?;
+
+    let mut bounded = query;
+    bounded.relations.budget = bounded.relations.budget.with_aggregate_limits(
+        Some(2),
+        Some(4),
+        Some(4),
+        Some(8),
+        Some(64 * 1_024),
+        None,
+    )?;
+    let report = fitted_report(&store, &bounded)?;
+    let profile = report
+        .entrypoint_profile
+        .as_ref()
+        .ok_or("bounded entrypoint profile metadata missing")?;
+    require(
+        profile.coverage == EntrypointProfileCoverage::Partial
+            && report.truncated
+            && report.findings.iter().all(|finding| {
+                finding.kind == AnalysisFindingKind::EntrypointReachability
+                    && finding.status == AnalysisStatus::Inconclusive
+            }),
+        "shared entrypoint limits produced confident or complete output",
+    )?;
+    require(
+        report.work.relations.inspected_edges <= 2
+            && report.work.analyzed_nodes <= 4
+            && report.work.relations.visited_nodes <= 4
+            && report.work.peak_intermediate_bytes <= 64 * 1_024,
+        "entrypoint traversal crossed a caller aggregate ceiling",
     )?;
     Ok(())
 }

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -970,12 +970,14 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
         relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
     });
 
-    let output_error = load_relation_analysis(&store, &query, None)?
+    let Err(output_error) = load_relation_analysis(&store, &query, None)?
         .fit_output::<_, ServiceError, _>(|report, _control| {
             let _ = report;
             Ok(vec![0_u8; 65_537])
         })
-        .expect_err("entrypoint output unexpectedly accepted a non-replayable prefix");
+    else {
+        return Err("entrypoint output unexpectedly accepted a non-replayable prefix".into());
+    };
     require(
         output_error
             .to_string()
@@ -1052,7 +1054,7 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
     let cancel_seen_observer = Rc::clone(&cancel_seen);
     let cancellation_for_observer = cancellation.clone();
     let cancel_control = IndexWorkControl::with_deadline(
-        cancellation.clone(),
+        cancellation,
         Instant::now() + std::time::Duration::from_secs(5),
     );
     let cancelled = observe_analysis_phase(
@@ -1075,28 +1077,30 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
         "cancelled entrypoint traversal returned a partial result or changed publication",
     )?;
 
-    let (_stale_temp, stale_store) = analysis_store()?;
-    let root = _stale_temp.path().join("analysis-service");
+    let (stale_temp, stale_store) = analysis_store()?;
+    let root = stale_temp.path().join("analysis-service");
     let database = root.join("projectatlas.db");
     stale_store.finish_index_read_snapshot()?;
     let writer = Rc::new(RefCell::new(Some(AtlasStore::open_for_project(
         &database, &root,
     )?)));
     let refreshed = Rc::new(Cell::new(false));
+    let refresh_succeeded = Rc::new(Cell::new(false));
     let writer_for_observer = Rc::clone(&writer);
     let refreshed_for_observer = Rc::clone(&refreshed);
+    let refresh_succeeded_for_observer = Rc::clone(&refresh_succeeded);
     let stale = observe_analysis_phase(
         move |event| {
             if event == AnalysisPhaseEvent::Traversal && !refreshed_for_observer.replace(true) {
-                let mut writer = writer_for_observer
-                    .borrow_mut()
-                    .take()
-                    .expect("generation test writer already consumed");
-                writer
-                    .begin_index_projection_refresh("analysis-service")
-                    .expect("generation test refresh could not start")
-                    .complete()
-                    .expect("generation test refresh could not publish");
+                let succeeded = if let Some(mut writer) = writer_for_observer.borrow_mut().take() {
+                    match writer.begin_index_projection_refresh("analysis-service") {
+                        Ok(refresh) => refresh.complete().is_ok(),
+                        Err(_) => false,
+                    }
+                } else {
+                    false
+                };
+                refresh_succeeded_for_observer.set(succeeded);
             }
         },
         || load_relation_analysis(&stale_store, &query, None),
@@ -1104,6 +1108,7 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
     let stale_error = stale.as_ref().err().map(ToString::to_string);
     require(
         refreshed.get()
+            && refresh_succeeded.get()
             && stale_error
                 .as_deref()
                 .is_some_and(|error| error.contains("typed graph generation")),
@@ -1188,7 +1193,7 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
         "entrypoint traversal crossed a caller aggregate ceiling",
     )?;
 
-    let mut node_bounded = bounded.clone();
+    let mut node_bounded = bounded;
     node_bounded.relations.budget = node_bounded.relations.budget.with_aggregate_limits(
         Some(100),
         Some(1),

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1,8 +1,9 @@
 use super::analysis_test_observer::{AnalysisPhaseEvent, observe_analysis_phase};
 use super::*;
 use projectatlas_core::graph::{
-    CoverageRecord, CoverageScope, CoverageState, GraphIdentityText, LogicalRelation,
-    PackageSelector, RelationResolution, RepositoryFilePath, RepositoryNodePath, SymbolSelector,
+    CoverageRecord, CoverageScope, CoverageState, ExternalSelector, GraphIdentityText,
+    LogicalRelation, PackageSelector, RelationResolution, RepositoryFilePath, RepositoryNodePath,
+    SymbolSelector,
 };
 use projectatlas_core::language::ContentClassification;
 use projectatlas_core::symbols::{ParserKind, SymbolGraph, SymbolKind};
@@ -950,6 +951,44 @@ fn entrypoint_profile_marks_unanchorable_local_targets_inconclusive() -> Result<
         RelationResolution::resolved(&project_entity).is_err(),
         "the project aggregate became a directly resolvable entrypoint target",
     )?;
+
+    let (_temp, store) = analysis_store_with_target(EntitySelector::External {
+        external: ExternalSelector {
+            system: GraphIdentityText::new("crates.io")?,
+            identity: GraphIdentityText::new("analysis-service@1")?,
+        },
+    })?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(100),
+        Some(20),
+        Some(20),
+        Some(100),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "external-control".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let report = fitted_report(&store, &query)?;
+    require(
+        report
+            .entrypoint_profile
+            .as_ref()
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Complete)
+            && report.findings.iter().all(|finding| {
+                finding.kind != AnalysisFindingKind::EntrypointReachability
+                    || finding.status != AnalysisStatus::Inconclusive
+            }),
+        "an external resolved target incorrectly made complete entrypoint coverage partial",
+    )?;
     Ok(())
 }
 
@@ -1104,8 +1143,8 @@ fn entrypoint_profile_bounds_candidate_entity_hydration_by_remaining_bytes()
         "candidate entity hydration did not consume only the remaining profile budget",
     )?;
 
-    let mut bounded = query;
-    bounded.relations.budget = bounded.relations.budget.with_aggregate_limits(
+    let mut bounded_query = query;
+    bounded_query.relations.budget = bounded_query.relations.budget.with_aggregate_limits(
         None,
         None,
         None,
@@ -1113,16 +1152,28 @@ fn entrypoint_profile_bounds_candidate_entity_hydration_by_remaining_bytes()
         Some(64 * 1024),
         None,
     )?;
-    let bounded = fitted_report(&store, &bounded)?;
+    let bounded_seen = Rc::new(Cell::new(false));
+    let bounded_seen_for_observer = Rc::clone(&bounded_seen);
+    let bounded_report = observe_analysis_phase(
+        move |event| {
+            if matches!(event, AnalysisPhaseEvent::CandidateEntityHydration { .. }) {
+                bounded_seen_for_observer.set(true);
+            }
+        },
+        || load_relation_analysis(&store, &bounded_query, None),
+    )?;
     require(
-        bounded
-            .entrypoint_profile
-            .as_ref()
-            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
-            && bounded
+        !bounded_seen.get()
+            && bounded_report
+                .report
+                .entrypoint_profile
+                .as_ref()
+                .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+            && bounded_report
+                .report
                 .reached_limits
                 .contains(&GraphLimitKind::IntermediateBytes)
-            && bounded.findings.iter().all(|finding| {
+            && bounded_report.report.findings.iter().all(|finding| {
                 finding.kind == AnalysisFindingKind::EntrypointReachability
                     && finding.status == AnalysisStatus::Inconclusive
             }),
@@ -3360,14 +3411,30 @@ fn analysis_store_with_options(
         )?,
     ];
     if let Some(target) = extra_target.as_ref() {
-        relations.push(relation(
-            &a,
-            target,
-            GraphRelationKind::Legacy(RelationKind::Calls),
-        )?);
+        let relation = if matches!(target.selector(), EntitySelector::External { .. }) {
+            LogicalRelation::new(
+                &a,
+                GraphRelationKind::Legacy(RelationKind::Calls),
+                RelationResolution::external(target)?,
+                ConfidenceClass::Exact,
+                Completeness::Complete,
+                generation,
+            )?
+        } else {
+            relation(&a, target, GraphRelationKind::Legacy(RelationKind::Calls))?
+        };
+        relations.push(relation);
     }
-    let mut coverage = ["src/a.rs", "src/b.rs", "tools/c.rs", "docs/guide.md"]
-        .into_iter()
+    let mut coverage_paths = vec!["src/a.rs", "src/b.rs", "tools/c.rs", "docs/guide.md"];
+    if extra_target
+        .as_ref()
+        .is_some_and(|target| matches!(target.selector(), EntitySelector::Folder { .. }))
+    {
+        coverage_paths.push("src");
+    }
+    let mut coverage = coverage_paths
+        .iter()
+        .copied()
         .filter(|path| include_tools_coverage || *path != "tools/c.rs")
         .map(|path| {
             CoverageRecord::new(
@@ -3386,8 +3453,9 @@ fn analysis_store_with_options(
         })
         .collect::<Result<Vec<_>, Box<dyn Error>>>()?;
     coverage.extend(
-        ["src/a.rs", "src/b.rs", "tools/c.rs", "docs/guide.md"]
-            .into_iter()
+        coverage_paths
+            .iter()
+            .copied()
             .filter(|path| include_tools_coverage || *path != "tools/c.rs")
             .map(|path| {
                 CoverageRecord::new(

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1664,7 +1664,7 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
         "identical multi-anchor entrypoint requests were not deterministic",
     )?;
 
-    let mut bounded = query;
+    let mut bounded = query.clone();
     bounded.relations.budget = bounded.relations.budget.with_aggregate_limits(
         Some(2),
         Some(4),
@@ -1673,6 +1673,49 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
         Some(64 * 1_024),
         None,
     )?;
+    let mut candidate_limits = query.clone();
+    candidate_limits.relations.budget = DetailedRelationBudget::from_graph_limits(
+        projectatlas_core::graph::GraphLimits::new(50, 1, 3, 256 * 1_024)?,
+    )
+    .with_aggregate_limits(
+        Some(1),
+        Some(100),
+        Some(100),
+        Some(100),
+        Some(256 * 1_024),
+        None,
+    )?;
+    candidate_limits.relations.content_selection = ContentSelection::Source;
+    candidate_limits.entrypoint_profile = Some(EntrypointProfile {
+        name: "candidate-limit-reason".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/b.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Extended(
+            ExtendedRelationKind::References,
+        )],
+    });
+    let candidate_limit_seen = Rc::new(Cell::new(false));
+    let candidate_limit_observer = Rc::clone(&candidate_limit_seen);
+    let candidate_limit_report = observe_analysis_phase(
+        move |event| {
+            if let AnalysisPhaseEvent::CandidateReport {
+                has_edges_limit, ..
+            } = event
+            {
+                candidate_limit_observer.set(candidate_limit_observer.get() || has_edges_limit);
+            }
+        },
+        || fitted_report(&store, &candidate_limits),
+    )?;
+    require(
+        candidate_limit_seen.get()
+            && candidate_limit_report
+                .reached_limits
+                .contains(&GraphLimitKind::Edges),
+        "candidate traversal truncation did not preserve its typed limit reason",
+    )?;
+
     let report = fitted_report(&store, &bounded)?;
     let profile = report
         .entrypoint_profile
@@ -1693,6 +1736,90 @@ fn entrypoint_profile_refuses_unreplayable_output_and_charges_shared_limits()
             && report.work.relations.visited_nodes <= 4
             && report.work.peak_intermediate_bytes <= 64 * 1_024,
         "entrypoint traversal crossed a caller aggregate ceiling",
+    )?;
+
+    let mut candidate_continuation = query.clone();
+    candidate_continuation.relations.budget = DetailedRelationBudget::from_graph_limits(
+        projectatlas_core::graph::GraphLimits::new(1, 1, 3, 256 * 1_024)?,
+    )
+    .with_aggregate_limits(
+        Some(100),
+        Some(100),
+        Some(100),
+        Some(100),
+        Some(256 * 1_024),
+        None,
+    )?;
+    candidate_continuation.entrypoint_profile = Some(EntrypointProfile {
+        name: "candidate-continuation".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("docs/guide.md"))?,
+        }],
+        relations: vec![GraphRelationKind::Extended(
+            ExtendedRelationKind::References,
+        )],
+    });
+    let candidate_continuation_seen = Rc::new(Cell::new(false));
+    let candidate_continuation_observer = Rc::clone(&candidate_continuation_seen);
+    let continuation_report = observe_analysis_phase(
+        move |event| {
+            if let AnalysisPhaseEvent::CandidateReport {
+                has_continuation: true,
+                ..
+            } = event
+            {
+                candidate_continuation_observer.set(true);
+            }
+        },
+        || fitted_report(&store, &candidate_continuation),
+    )?;
+    require(
+        candidate_continuation_seen.get()
+            && continuation_report
+                .reached_limits
+                .contains(&GraphLimitKind::Rows)
+            && continuation_report
+                .entrypoint_profile
+                .as_ref()
+                .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+            && continuation_report.findings.iter().all(|finding| {
+                finding.kind == AnalysisFindingKind::EntrypointReachability
+                    && finding.status == AnalysisStatus::Inconclusive
+            }),
+        "candidate continuation did not preserve the outer typed row limit",
+    )?;
+
+    let mut candidate_visited = query;
+    candidate_visited.entrypoint_profile = Some(EntrypointProfile {
+        name: "candidate-visited".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Extended(ExtendedRelationKind::Documents)],
+    });
+    candidate_visited.relations.budget = candidate_visited.relations.budget.with_aggregate_limits(
+        Some(100),
+        Some(100),
+        Some(2),
+        Some(100),
+        None,
+        None,
+    )?;
+    let candidate_visited_report = fitted_report(&store, &candidate_visited)?;
+    require(
+        candidate_visited_report
+            .entrypoint_profile
+            .as_ref()
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+            && candidate_visited_report
+                .reached_limits
+                .contains(&GraphLimitKind::Visited)
+            && candidate_visited_report.work.analyzed_nodes == 2
+            && candidate_visited_report.findings.iter().all(|finding| {
+                finding.kind == AnalysisFindingKind::EntrypointReachability
+                    && finding.status == AnalysisStatus::Inconclusive
+            }),
+        "validated disconnected candidates escaped the shared visited ceiling",
     )?;
 
     let mut node_bounded = bounded;

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1317,6 +1317,116 @@ fn entrypoint_profile_inspects_retained_frontier_at_exact_node_limit() -> Result
 }
 
 #[test]
+fn entrypoint_profile_reuses_retained_candidate_endpoints() -> Result<(), Box<dyn Error>> {
+    for (target, expected_coverage) in [
+        ("reachable", EntrypointProfileCoverage::Complete),
+        ("new", EntrypointProfileCoverage::Partial),
+    ] {
+        let (_temp, store) = analysis_store_with_candidate_relation(target)?;
+        let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+        query.relations.content_selection = ContentSelection::Source;
+        query.relations.resolution = RelationResolutionFilter::Any;
+        query.relations.budget = query.relations.budget.with_aggregate_limits(
+            Some(100),
+            Some(7),
+            Some(7),
+            Some(100),
+            Some(256 * 1024),
+            None,
+        )?;
+        query.include_communities = false;
+        query.include_cycles = false;
+        query.entrypoint_profile = Some(EntrypointProfile {
+            name: format!("candidate-endpoint-{target}"),
+            anchors: vec![RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            }],
+            relations: vec![
+                GraphRelationKind::Legacy(RelationKind::Calls),
+                GraphRelationKind::Legacy(RelationKind::Contains),
+                GraphRelationKind::Legacy(RelationKind::DependsOn),
+            ],
+        });
+        let report = fitted_report(&store, &query)?;
+        let profile = report
+            .entrypoint_profile
+            .as_ref()
+            .ok_or("candidate endpoint profile metadata missing")?;
+        if expected_coverage == EntrypointProfileCoverage::Complete {
+            require(
+                profile.coverage == expected_coverage
+                    && profile.unreachable_candidates == 1
+                    && !report.reached_limits.contains(&GraphLimitKind::Nodes)
+                    && !report.reached_limits.contains(&GraphLimitKind::Visited),
+                "a retained candidate endpoint consumed the global node or visited slot",
+            )?;
+        } else {
+            require(
+                profile.coverage == expected_coverage
+                    && profile.unreachable_candidates == 0
+                    && report.reached_limits.contains(&GraphLimitKind::Nodes)
+                    && report.reached_limits.contains(&GraphLimitKind::Visited)
+                    && report
+                        .findings
+                        .iter()
+                        .all(|finding| finding.status == AnalysisStatus::Inconclusive),
+                "a new candidate endpoint escaped the global node or visited bound",
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_scopes_coverage_to_admitted_relations() -> Result<(), Box<dyn Error>> {
+    let run = |partial_calls| -> Result<RelationAnalysisReport, Box<dyn Error>> {
+        let (_temp, store) = analysis_store_with_relation_coverage(partial_calls)?;
+        let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+        query.relations.resolution = RelationResolutionFilter::Any;
+        query.relations.budget = query.relations.budget.with_aggregate_limits(
+            Some(100),
+            Some(20),
+            Some(20),
+            Some(100),
+            Some(256 * 1024),
+            None,
+        )?;
+        query.include_communities = false;
+        query.include_cycles = false;
+        query.entrypoint_profile = Some(EntrypointProfile {
+            name: "calls-coverage-scope".to_string(),
+            anchors: vec![RelationAnchor::File {
+                file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            }],
+            relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+        });
+        fitted_report(&store, &query)
+    };
+
+    let complete = run(false)?;
+    require(
+        complete
+            .entrypoint_profile
+            .as_ref()
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Complete),
+        "unrelated partial Documents coverage poisoned a Calls-only profile",
+    )?;
+    let partial = run(true)?;
+    require(
+        partial
+            .entrypoint_profile
+            .as_ref()
+            .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+            && partial.findings.iter().all(|finding| {
+                finding.kind == AnalysisFindingKind::EntrypointReachability
+                    && finding.status == AnalysisStatus::Inconclusive
+            }),
+        "partial admitted Calls coverage did not remain inconclusive",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn entrypoint_profile_drops_nodes_from_overflowing_retained_frontier() -> Result<(), Box<dyn Error>>
 {
     let (_temp, store) = analysis_store()?;
@@ -3964,28 +4074,40 @@ fn analysis_store() -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
 fn analysis_store_with_coverage(
     include_tools_coverage: bool,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
-    analysis_store_with_options(include_tools_coverage, None, false, 0, false)
+    analysis_store_with_options(include_tools_coverage, None, false, 0, false, None, None)
 }
 
 fn analysis_store_with_target(
     target_selector: EntitySelector,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
-    analysis_store_with_options(true, Some(target_selector), false, 0, false)
+    analysis_store_with_options(true, Some(target_selector), false, 0, false, None, None)
 }
 
 fn analysis_store_with_external_candidate()
 -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
-    analysis_store_with_options(true, None, true, 0, false)
+    analysis_store_with_options(true, None, true, 0, false, None, None)
 }
 
 fn analysis_store_with_large_candidates() -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>>
 {
-    analysis_store_with_options(true, None, false, 20, false)
+    analysis_store_with_options(true, None, false, 20, false, None, None)
 }
 
 fn analysis_store_with_document_relation() -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>>
 {
-    analysis_store_with_options(true, None, false, 0, true)
+    analysis_store_with_options(true, None, false, 0, true, None, None)
+}
+
+fn analysis_store_with_candidate_relation(
+    target: &str,
+) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
+    analysis_store_with_options(true, None, false, 0, false, Some(target), None)
+}
+
+fn analysis_store_with_relation_coverage(
+    partial_calls: bool,
+) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
+    analysis_store_with_options(true, None, false, 0, false, None, Some(partial_calls))
 }
 
 fn analysis_store_with_options(
@@ -3994,6 +4116,8 @@ fn analysis_store_with_options(
     external_candidate: bool,
     large_candidate_count: usize,
     document_relation: bool,
+    candidate_relation_target: Option<&str>,
+    relation_coverage_partial_calls: Option<bool>,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let root = temp.path().join("analysis-service");
@@ -4073,6 +4197,25 @@ fn analysis_store_with_options(
     let d_unused = symbol_entity("src/a.rs", "d_unused", "fn d_unused()")?;
     let b_hub = symbol_entity("src/b.rs", "b_hub", "fn b_hub()")?;
     let c_aux = symbol_entity("tools/c.rs", "c_aux", "fn c_aux()")?;
+    let candidate_relation_target = candidate_relation_target
+        .map(|target| -> Result<GraphEntity, Box<dyn Error>> {
+            match target {
+                "reachable" => Ok(a.clone()),
+                "new" => Ok(GraphEntity::new(
+                    project,
+                    EntitySelector::Package {
+                        package: PackageSelector {
+                            manager: GraphIdentityText::new("cargo")?,
+                            name: GraphIdentityText::new("candidate-package")?,
+                            manifest: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+                        },
+                    },
+                    generation,
+                )?),
+                _ => Err(io::Error::other("unknown candidate relation target").into()),
+            }
+        })
+        .transpose()?;
     let large_candidates = (0..large_candidate_count)
         .map(|index| {
             symbol_entity(
@@ -4189,6 +4332,13 @@ fn analysis_store_with_options(
             generation,
         )?);
     }
+    if let Some(target) = candidate_relation_target.as_ref() {
+        relations.push(relation(
+            &d_unused,
+            target,
+            GraphRelationKind::Legacy(RelationKind::Calls),
+        )?);
+    }
     let mut coverage_paths = vec!["src/a.rs", "src/b.rs", "tools/c.rs", "docs/guide.md"];
     if extra_target
         .as_ref()
@@ -4238,6 +4388,42 @@ fn analysis_store_with_options(
             })
             .collect::<Result<Vec<_>, Box<dyn Error>>>()?,
     );
+    if let Some(partial_calls) = relation_coverage_partial_calls {
+        let (calls_state, calls_covered, calls_omitted, calls_reason) = if partial_calls {
+            (
+                CoverageState::Partial,
+                1,
+                1,
+                Some(GraphIdentityText::new("partial calls fixture")?),
+            )
+        } else {
+            (CoverageState::Complete, 1, 0, None)
+        };
+        coverage.push(CoverageRecord::new(
+            CoverageScope::Path {
+                path: RepositoryNodePath::new(Path::new("src/a.rs"))?,
+            },
+            Some(GraphRelationKind::Legacy(RelationKind::Calls)),
+            calls_state,
+            calls_covered,
+            calls_omitted,
+            generation,
+            calls_reason,
+            None,
+        )?);
+        coverage.push(CoverageRecord::new(
+            CoverageScope::Path {
+                path: RepositoryNodePath::new(Path::new("src/a.rs"))?,
+            },
+            Some(GraphRelationKind::Extended(ExtendedRelationKind::Documents)),
+            CoverageState::Partial,
+            1,
+            1,
+            generation,
+            Some(GraphIdentityText::new("partial documents fixture")?),
+            None,
+        )?);
+    }
     let mut publication = store.begin_index_publication("analysis-service")?;
     publication.begin_scan_replacement()?;
     publication.upsert_scan_node_batch(&[
@@ -4309,6 +4495,9 @@ fn analysis_store_with_options(
     let mut entities = vec![a, b, c, guide, a_long, d_unused, b_hub, c_aux];
     entities.extend(large_candidates);
     if let Some(target) = extra_target {
+        entities.push(target);
+    }
+    if let Some(target) = candidate_relation_target {
         entities.push(target);
     }
     if let Some(target) = candidate_external {

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -989,6 +989,44 @@ fn entrypoint_profile_marks_unanchorable_local_targets_inconclusive() -> Result<
             }),
         "an external resolved target incorrectly made complete entrypoint coverage partial",
     )?;
+
+    let (_temp, store) = analysis_store_with_external_candidate()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(100),
+        Some(20),
+        Some(20),
+        Some(100),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "external-candidate-control".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let report = fitted_report(&store, &query)?;
+    require(
+        report.entrypoint_profile.as_ref().is_some_and(|profile| {
+            profile.coverage == EntrypointProfileCoverage::Complete
+                && profile.unreachable_candidates > 0
+        }) && report.findings.iter().any(|finding| {
+            finding.status == AnalysisStatus::Candidate
+                && finding.nodes.iter().any(|node| {
+                    matches!(
+                        node.node.entity.selector(),
+                        EntitySelector::Symbol { symbol }
+                            if symbol.name.as_str() == "d_unused"
+                    )
+                })
+        }),
+        "an external candidate relation did not remain valid negative evidence",
+    )?;
     Ok(())
 }
 
@@ -3285,18 +3323,24 @@ fn analysis_store() -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
 fn analysis_store_with_coverage(
     include_tools_coverage: bool,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
-    analysis_store_with_options(include_tools_coverage, None)
+    analysis_store_with_options(include_tools_coverage, None, false)
 }
 
 fn analysis_store_with_target(
     target_selector: EntitySelector,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
-    analysis_store_with_options(true, Some(target_selector))
+    analysis_store_with_options(true, Some(target_selector), false)
+}
+
+fn analysis_store_with_external_candidate()
+-> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
+    analysis_store_with_options(true, None, true)
 }
 
 fn analysis_store_with_options(
     include_tools_coverage: bool,
     target_selector: Option<EntitySelector>,
+    external_candidate: bool,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let root = temp.path().join("analysis-service");
@@ -3328,6 +3372,20 @@ fn analysis_store_with_options(
     let guide = entity("docs/guide.md")?;
     let extra_target = target_selector
         .map(|selector| GraphEntity::new(project, selector, generation))
+        .transpose()?;
+    let candidate_external = external_candidate
+        .then(|| {
+            GraphEntity::new(
+                project,
+                EntitySelector::External {
+                    external: ExternalSelector {
+                        system: GraphIdentityText::new("crates.io")?,
+                        identity: GraphIdentityText::new("candidate@1")?,
+                    },
+                },
+                generation,
+            )
+        })
         .transpose()?;
     let symbol_entity = |path: &str, name: &str, signature: &str| {
         GraphEntity::new(
@@ -3424,6 +3482,16 @@ fn analysis_store_with_options(
             relation(&a, target, GraphRelationKind::Legacy(RelationKind::Calls))?
         };
         relations.push(relation);
+    }
+    if let Some(target) = candidate_external.as_ref() {
+        relations.push(LogicalRelation::new(
+            &d_unused,
+            GraphRelationKind::Legacy(RelationKind::Calls),
+            RelationResolution::external(target)?,
+            ConfidenceClass::Exact,
+            Completeness::Complete,
+            generation,
+        )?);
     }
     let mut coverage_paths = vec!["src/a.rs", "src/b.rs", "tools/c.rs", "docs/guide.md"];
     if extra_target
@@ -3544,6 +3612,9 @@ fn analysis_store_with_options(
     })?;
     let mut entities = vec![a, b, c, guide, a_long, d_unused, b_hub, c_aux];
     if let Some(target) = extra_target {
+        entities.push(target);
+    }
+    if let Some(target) = candidate_external {
         entities.push(target);
     }
     publication.replace_repository_graph(project, &entities, &relations, &[], &coverage)?;

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1525,9 +1525,14 @@ fn entrypoint_profile_falls_back_before_exceeding_composition_budget() -> Result
                 .reached_limits
                 .contains(&GraphLimitKind::IntermediateBytes)
             && boundary
-                .findings
-                .iter()
-                .all(|finding| finding.status == AnalysisStatus::Inconclusive)
+                .entrypoint_profile
+                .as_ref()
+                .is_some_and(|profile| profile.reachable == 0)
+            && boundary.findings.iter().all(|finding| {
+                finding.status == AnalysisStatus::Inconclusive
+                    && finding.metric.is_none()
+                    && finding.nodes.is_empty()
+            })
             && boundary.work.peak_intermediate_bytes <= boundary_budget,
         "entrypoint composition fallback exceeded its declared byte budget",
     )?;

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1071,12 +1071,10 @@ fn entrypoint_profile_rejects_candidate_generation_and_purpose_changes()
         move |event| {
             if event == AnalysisPhaseEvent::CandidateTraversal
                 && !refreshed_for_observer.replace(true)
+                && let Some(mut writer) = writer_for_observer.borrow_mut().take()
+                && let Ok(refresh) = writer.begin_index_projection_refresh("analysis-service")
             {
-                if let Some(mut writer) = writer_for_observer.borrow_mut().take() {
-                    if let Ok(refresh) = writer.begin_index_projection_refresh("analysis-service") {
-                        let _ = refresh.complete();
-                    }
-                }
+                drop(refresh.complete());
             }
         },
         || load_relation_analysis(&stale_store, &generation_query, None),
@@ -1110,14 +1108,13 @@ fn entrypoint_profile_rejects_candidate_generation_and_purpose_changes()
         move |event| {
             if event == AnalysisPhaseEvent::CandidateTraversal
                 && !revised_for_observer.replace(true)
+                && let Some(writer) = writer_for_observer.borrow_mut().take()
             {
-                if let Some(writer) = writer_for_observer.borrow_mut().take() {
-                    let _ = writer.set_purpose(
-                        "src/a.rs",
-                        "purpose changed during analysis",
-                        PurposeSource::Agent,
-                    );
-                }
+                drop(writer.set_purpose(
+                    "src/a.rs",
+                    "purpose changed during analysis",
+                    PurposeSource::Agent,
+                ));
             }
         },
         || load_relation_analysis(&stale_store, &purpose_query, None),

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1639,6 +1639,49 @@ fn entrypoint_profile_honors_content_and_confidence_filters() -> Result<(), Box<
 }
 
 #[test]
+fn entrypoint_profile_keeps_cross_class_document_targets_out_of_frontier()
+-> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store_with_document_relation()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.content_selection = ContentSelection::Documentation;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(100),
+        Some(20),
+        Some(20),
+        Some(100),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "documentation-cross-class-frontier".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("docs/guide.md"))?,
+        }],
+        relations: vec![GraphRelationKind::Extended(ExtendedRelationKind::Documents)],
+    });
+    let report = fitted_report(&store, &query)?;
+    let source_target_present = report.findings.iter().any(|finding| {
+        finding.nodes.iter().any(|node| {
+            matches!(
+                node.node.entity.selector(),
+                EntitySelector::File { path } if path.as_str() == "src/a.rs"
+            )
+        })
+    });
+    require(
+        report.entrypoint_profile.as_ref().is_some_and(|profile| {
+            profile.coverage == EntrypointProfileCoverage::Complete && profile.reachable == 1
+        }) && !report.reached_limits.contains(&GraphLimitKind::Depth)
+            && !source_target_present,
+        "documentation entrypoint traversal admitted a cross-class source target",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn entrypoint_profile_filters_non_candidate_entities_before_node_limit()
 -> Result<(), Box<dyn Error>> {
     let (_temp, store) = analysis_store_with_external_candidate()?;
@@ -3921,23 +3964,28 @@ fn analysis_store() -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
 fn analysis_store_with_coverage(
     include_tools_coverage: bool,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
-    analysis_store_with_options(include_tools_coverage, None, false, 0)
+    analysis_store_with_options(include_tools_coverage, None, false, 0, false)
 }
 
 fn analysis_store_with_target(
     target_selector: EntitySelector,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
-    analysis_store_with_options(true, Some(target_selector), false, 0)
+    analysis_store_with_options(true, Some(target_selector), false, 0, false)
 }
 
 fn analysis_store_with_external_candidate()
 -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
-    analysis_store_with_options(true, None, true, 0)
+    analysis_store_with_options(true, None, true, 0, false)
 }
 
 fn analysis_store_with_large_candidates() -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>>
 {
-    analysis_store_with_options(true, None, false, 20)
+    analysis_store_with_options(true, None, false, 20, false)
+}
+
+fn analysis_store_with_document_relation() -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>>
+{
+    analysis_store_with_options(true, None, false, 0, true)
 }
 
 fn analysis_store_with_options(
@@ -3945,6 +3993,7 @@ fn analysis_store_with_options(
     target_selector: Option<EntitySelector>,
     external_candidate: bool,
     large_candidate_count: usize,
+    document_relation: bool,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let root = temp.path().join("analysis-service");
@@ -4095,6 +4144,16 @@ fn analysis_store_with_options(
             generation,
         )?,
     ];
+    if document_relation {
+        relations.push(LogicalRelation::new(
+            &guide,
+            GraphRelationKind::Extended(ExtendedRelationKind::Documents),
+            RelationResolution::resolved(&a)?,
+            ConfidenceClass::Exact,
+            Completeness::Complete,
+            generation,
+        )?);
+    }
     if let Some(target) = extra_target.as_ref() {
         let relation = if matches!(target.selector(), EntitySelector::External { .. }) {
             LogicalRelation::new(

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -1221,6 +1221,115 @@ fn entrypoint_profile_bounds_candidate_entity_hydration_by_remaining_bytes()
 }
 
 #[test]
+fn entrypoint_profile_translates_candidate_decoded_byte_exhaustion() -> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store_with_large_candidates()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(100),
+        Some(30),
+        Some(30),
+        Some(100),
+        Some(DetailedRelationBudget::MAX_INTERMEDIATE_BYTES),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "candidate-decoded-byte-boundary".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+
+    let remaining = Rc::new(Cell::new(None));
+    let remaining_for_observer = Rc::clone(&remaining);
+    observe_analysis_phase(
+        move |event| {
+            if let AnalysisPhaseEvent::CandidateEntityHydration {
+                remaining_intermediate_bytes,
+            } = event
+            {
+                remaining_for_observer.set(Some(remaining_intermediate_bytes));
+            }
+        },
+        || load_relation_analysis(&store, &query, None),
+    )?;
+    let remaining = remaining
+        .get()
+        .ok_or("candidate entity hydration did not expose its remaining budget")?;
+    let pre_candidate_work = query
+        .relations
+        .budget
+        .intermediate_bytes()
+        .checked_sub(remaining)
+        .ok_or("candidate byte probe exceeded its budget")?;
+    let bounded_budget = pre_candidate_work
+        .checked_add(64 * 1024)
+        .ok_or("candidate byte boundary overflowed")?;
+    let mut bounded_query = query;
+    bounded_query.relations.budget = bounded_query.relations.budget.with_aggregate_limits(
+        None,
+        None,
+        None,
+        None,
+        Some(bounded_budget),
+        None,
+    )?;
+    let report = load_relation_analysis(&store, &bounded_query, None)?.report;
+    require(
+        remaining > 0
+            && report.entrypoint_profile.as_ref().is_some_and(|profile| {
+                profile.coverage == EntrypointProfileCoverage::Partial
+                    && profile.unreachable_candidates == 0
+            })
+            && report
+                .reached_limits
+                .contains(&GraphLimitKind::IntermediateBytes)
+            && report
+                .findings
+                .iter()
+                .all(|finding| finding.status == AnalysisStatus::Inconclusive)
+            && report.work.peak_intermediate_bytes <= bounded_budget,
+        "candidate decoded-byte exhaustion escaped as an error or exceeded its budget",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_candidate_page_filters_content_before_truncation_sentinel()
+-> Result<(), Box<dyn Error>> {
+    let (_temp, store) = analysis_store_with_external_candidate()?;
+    let project = store
+        .project_instance_id()?
+        .ok_or("analysis fixture project identity missing")?;
+    let generation = store
+        .repository_graph_generation()?
+        .ok_or("analysis fixture graph generation missing")?;
+    let page = store.repository_graph_entrypoint_candidates_page_bounded(
+        project,
+        generation,
+        7,
+        ContentSelection::Source,
+        RepositoryGraphReadBudget::new(1, 7, 256 * 1024, 16, 16)?,
+        None,
+    )?;
+    require(
+        !page.page.truncated
+            && page.page.rows.len() == 7
+            && page.page.rows.iter().all(|entity| {
+                !matches!(
+                    entity.selector(),
+                    EntitySelector::File { path } if path.as_str() == "docs/guide.md"
+                )
+            }),
+        "content filtering was applied after the candidate-page sentinel",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn entrypoint_profile_honors_content_and_confidence_filters() -> Result<(), Box<dyn Error>> {
     let (_temp, store) = analysis_store()?;
     let mut source_only = analysis_query(RelationAnalysisMode::Entrypoint)?;
@@ -3570,24 +3679,30 @@ fn analysis_store() -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
 fn analysis_store_with_coverage(
     include_tools_coverage: bool,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
-    analysis_store_with_options(include_tools_coverage, None, false)
+    analysis_store_with_options(include_tools_coverage, None, false, 0)
 }
 
 fn analysis_store_with_target(
     target_selector: EntitySelector,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
-    analysis_store_with_options(true, Some(target_selector), false)
+    analysis_store_with_options(true, Some(target_selector), false, 0)
 }
 
 fn analysis_store_with_external_candidate()
 -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
-    analysis_store_with_options(true, None, true)
+    analysis_store_with_options(true, None, true, 0)
+}
+
+fn analysis_store_with_large_candidates() -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>>
+{
+    analysis_store_with_options(true, None, false, 20)
 }
 
 fn analysis_store_with_options(
     include_tools_coverage: bool,
     target_selector: Option<EntitySelector>,
     external_candidate: bool,
+    large_candidate_count: usize,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let root = temp.path().join("analysis-service");
@@ -3653,6 +3768,15 @@ fn analysis_store_with_options(
     let d_unused = symbol_entity("src/a.rs", "d_unused", "fn d_unused()")?;
     let b_hub = symbol_entity("src/b.rs", "b_hub", "fn b_hub()")?;
     let c_aux = symbol_entity("tools/c.rs", "c_aux", "fn c_aux()")?;
+    let large_candidates = (0..large_candidate_count)
+        .map(|index| {
+            symbol_entity(
+                "src/a.rs",
+                &format!("byte_candidate_{index}"),
+                &format!("candidate_{index}_{}", "x".repeat(4_000)),
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
     let relation = |source: &GraphEntity, target: &GraphEntity, kind| {
         LogicalRelation::new(
             source,
@@ -3858,6 +3982,7 @@ fn analysis_store_with_options(
         relations: Vec::new(),
     })?;
     let mut entities = vec![a, b, c, guide, a_long, d_unused, b_hub, c_aux];
+    entities.extend(large_candidates);
     if let Some(target) = extra_target {
         entities.push(target);
     }

--- a/crates/projectatlas-service/src/analysis/tests.rs
+++ b/crates/projectatlas-service/src/analysis/tests.rs
@@ -2,8 +2,8 @@ use super::analysis_test_observer::{AnalysisPhaseEvent, observe_analysis_phase};
 use super::*;
 use projectatlas_core::graph::{
     CoverageRecord, CoverageScope, CoverageState, ExternalSelector, GraphIdentityText,
-    LogicalRelation, PackageSelector, RelationResolution, RepositoryFilePath, RepositoryNodePath,
-    SymbolSelector,
+    LogicalRelation, PackageSelector, RelationOccurrence, RelationResolution, RepositoryFilePath,
+    RepositoryNodePath, SourceSpan, SymbolSelector,
 };
 use projectatlas_core::language::ContentClassification;
 use projectatlas_core::symbols::{ParserKind, SymbolGraph, SymbolKind};
@@ -1013,8 +1013,57 @@ fn entrypoint_profile_binds_omitted_parent_to_resolved_symbol_identity()
 }
 
 #[test]
+fn entrypoint_profile_rejects_initial_anchors_with_duplicate_resolved_identity()
+-> Result<(), Box<dyn Error>> {
+    let (_temp, store) = nested_symbol_entrypoint_store()?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "duplicate-nested-symbol-identity".to_string(),
+        anchors: vec![
+            RelationAnchor::Symbol {
+                file: RepositoryFilePath::new(Path::new("src/nested.rs"))?,
+                name: "inner".to_string(),
+                symbol_kind: Some(SymbolKind::Function),
+                parent: None,
+                signature: Some("fn inner()".to_string()),
+            },
+            RelationAnchor::Symbol {
+                file: RepositoryFilePath::new(Path::new("src/nested.rs"))?,
+                name: "inner".to_string(),
+                symbol_kind: Some(SymbolKind::Function),
+                parent: Some("Outer".to_string()),
+                signature: Some("fn inner()".to_string()),
+            },
+        ],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let traversals = Rc::new(Cell::new(0_u32));
+    let observed_traversals = Rc::clone(&traversals);
+    let result = observe_analysis_phase(
+        move |event| {
+            if event == AnalysisPhaseEvent::Traversal {
+                observed_traversals.set(observed_traversals.get().saturating_add(1));
+            }
+        },
+        || load_relation_analysis(&store, &query, None),
+    );
+    require(
+        matches!(
+            result,
+            Err(ServiceError::InvalidInput(message))
+                if message.contains("anchors must resolve to unique entities")
+        ) && traversals.get() == 0,
+        "distinct selector shapes were allowed to traverse the same resolved anchor",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn entrypoint_profile_keeps_zero_occurrence_rows_independent() -> Result<(), Box<dyn Error>> {
-    let (_temp, store) = branching_entrypoint_store(false)?;
+    let (_temp, store) = branching_entrypoint_store(false, 0)?;
     let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
     query.relations.resolution = RelationResolutionFilter::Any;
     query.relations.include_occurrences = true;
@@ -1047,8 +1096,86 @@ fn entrypoint_profile_keeps_zero_occurrence_rows_independent() -> Result<(), Box
 }
 
 #[test]
+fn entrypoint_profile_reports_occurrence_exhaustion_as_typed_limit() -> Result<(), Box<dyn Error>> {
+    let (_temp, store) = branching_entrypoint_store(false, 1)?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.include_occurrences = true;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(3),
+        Some(8),
+        Some(8),
+        Some(1),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "occurrence-exhaustion-zero-row".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![
+            GraphRelationKind::Legacy(RelationKind::Calls),
+            GraphRelationKind::Legacy(RelationKind::DependsOn),
+        ],
+    });
+    let result = fitted_report(&store, &query);
+    require(
+        result.as_ref().is_ok_and(|report| {
+            report
+                .entrypoint_profile
+                .as_ref()
+                .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+                && report.reached_limits.contains(&GraphLimitKind::Occurrences)
+        }),
+        "occurrence exhaustion after a retained row became an invalid-input failure",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn entrypoint_profile_reports_occurrence_row_exhaustion_as_typed_limit()
+-> Result<(), Box<dyn Error>> {
+    let (_temp, store) = branching_entrypoint_store(false, 2)?;
+    let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
+    query.relations.resolution = RelationResolutionFilter::Any;
+    query.relations.include_occurrences = true;
+    query.relations.budget = query.relations.budget.with_aggregate_limits(
+        Some(2),
+        Some(8),
+        Some(8),
+        Some(1),
+        Some(256 * 1024),
+        None,
+    )?;
+    query.include_communities = false;
+    query.include_cycles = false;
+    query.entrypoint_profile = Some(EntrypointProfile {
+        name: "occurrence-exhaustion-next-row".to_string(),
+        anchors: vec![RelationAnchor::File {
+            file: RepositoryFilePath::new(Path::new("src/a.rs"))?,
+        }],
+        relations: vec![GraphRelationKind::Legacy(RelationKind::Calls)],
+    });
+    let result = fitted_report(&store, &query);
+    require(
+        result.as_ref().is_ok_and(|report| {
+            report
+                .entrypoint_profile
+                .as_ref()
+                .is_some_and(|profile| profile.coverage == EntrypointProfileCoverage::Partial)
+                && report.reached_limits.contains(&GraphLimitKind::Occurrences)
+        }),
+        "a row needing another occurrence became an invalid-input failure",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn entrypoint_profile_keeps_pending_candidate_edges_inconclusive() -> Result<(), Box<dyn Error>> {
-    let (_temp, store) = branching_entrypoint_store(true)?;
+    let (_temp, store) = branching_entrypoint_store(true, 0)?;
     let mut query = analysis_query(RelationAnalysisMode::Entrypoint)?;
     query.relations.resolution = RelationResolutionFilter::Any;
     query.relations.budget = query.relations.budget.with_aggregate_limits(
@@ -4474,6 +4601,7 @@ fn terminal_entrypoint_store(
 
 fn branching_entrypoint_store(
     include_pending_candidate: bool,
+    occurrence_count: u8,
 ) -> Result<(tempfile::TempDir, AtlasStore), Box<dyn Error>> {
     let temp = tempfile::tempdir()?;
     let root = temp.path().join("branching-entrypoint");
@@ -4535,6 +4663,23 @@ fn branching_entrypoint_store(
             generation,
         )?);
     }
+    let mut occurrences = Vec::new();
+    if occurrence_count >= 1 {
+        occurrences.push(RelationOccurrence::new(
+            &relations[0],
+            RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            SourceSpan::new(1, 0, 1, 4)?,
+            generation,
+        )?);
+    }
+    if occurrence_count >= 2 {
+        occurrences.push(RelationOccurrence::new(
+            &relations[1],
+            RepositoryFilePath::new(Path::new("src/a.rs"))?,
+            SourceSpan::new(1, 5, 1, 9)?,
+            generation,
+        )?);
+    }
     let mut entities = vec![a, b, c];
     if let Some(d) = d {
         entities.push(d);
@@ -4574,7 +4719,13 @@ fn branching_entrypoint_store(
         .collect::<Vec<_>>();
     publication.upsert_scan_node_batch(&scan_nodes)?;
     publication.finish_scan_replacement()?;
-    publication.replace_repository_graph(project, &entities, &relations, &[], &coverage)?;
+    publication.replace_repository_graph(
+        project,
+        &entities,
+        &relations,
+        &occurrences,
+        &coverage,
+    )?;
     publication.complete()?;
     drop(store);
     Ok((

--- a/crates/projectatlas-service/src/federation.rs
+++ b/crates/projectatlas-service/src/federation.rs
@@ -1544,6 +1544,7 @@ mod tests {
                 include_communities: false,
                 include_cycles: false,
                 include_dead_code: false,
+                entrypoint_profile: None,
             },
             None,
         )?;
@@ -1599,6 +1600,7 @@ mod tests {
                 include_communities: false,
                 include_cycles: false,
                 include_dead_code: false,
+                entrypoint_profile: None,
             },
             None,
         )?;

--- a/crates/projectatlas-service/src/lib.rs
+++ b/crates/projectatlas-service/src/lib.rs
@@ -7,9 +7,10 @@ mod import_aliases;
 mod relations;
 
 pub use analysis::{
-    AnalysisFinding, AnalysisFindingKind, AnalysisNode, AnalysisStatus, GitImpactSelection,
-    RelationAnalysisDraft, RelationAnalysisMode, RelationAnalysisQuery, RelationAnalysisReport,
-    RelationAnalysisWork, VcsImpact, load_relation_analysis,
+    AnalysisFinding, AnalysisFindingKind, AnalysisNode, AnalysisStatus, EntrypointProfile,
+    EntrypointProfileCoverage, EntrypointProfileResult, GitImpactSelection, RelationAnalysisDraft,
+    RelationAnalysisMode, RelationAnalysisQuery, RelationAnalysisReport, RelationAnalysisWork,
+    VcsImpact, load_relation_analysis,
 };
 pub use federation::{
     FederatedAnalysisDraft, FederatedAnalysisReport, FederatedDetailedRelationDraft,

--- a/crates/projectatlas-service/src/relations.rs
+++ b/crates/projectatlas-service/src/relations.rs
@@ -1861,6 +1861,38 @@ fn resolve_anchor(
     }
 }
 
+/// Resolve one entrypoint anchor before profile traversal and expose its read ledger.
+pub(super) fn resolve_relation_anchor_for_analysis(
+    store: &AtlasStore,
+    project: projectatlas_core::graph::ProjectInstanceId,
+    generation: IndexGeneration,
+    anchor: &RelationAnchor,
+    budget: DetailedRelationBudget,
+    control: Option<&IndexWorkControl>,
+) -> ServiceResult<(GraphEntity, DetailedRelationWork)> {
+    let mut database_work = RelationDatabaseWork::default();
+    let entity = resolve_anchor(
+        store,
+        project,
+        generation,
+        anchor,
+        budget,
+        &mut database_work,
+        control,
+    )?;
+    Ok((
+        entity,
+        DetailedRelationWork {
+            database_requested_rows: database_work.requested_rows,
+            database_returned_rows: database_work.returned_rows,
+            database_decoded_bytes: database_work.decoded_bytes,
+            hydrated_entities: database_work.hydrated_entities,
+            hydrated_purpose_paths: database_work.hydrated_paths,
+            ..DetailedRelationWork::default()
+        },
+    ))
+}
+
 /// Test one normalized relation against the service-owned trust filters.
 pub(super) fn relation_matches(relation: &LogicalRelation, query: &DetailedRelationQuery) -> bool {
     query.relation.is_none_or(|kind| relation.kind() == kind)

--- a/crates/projectatlas-service/src/relations.rs
+++ b/crates/projectatlas-service/src/relations.rs
@@ -871,7 +871,7 @@ struct SerializedByteCounter {
 }
 
 /// Return the exact admitted file path that owns an entity classification.
-fn classification_path(entity: &GraphEntity) -> Option<String> {
+pub(super) fn classification_path(entity: &GraphEntity) -> Option<String> {
     match entity.selector() {
         EntitySelector::File { path } => Some(path.as_str().to_string()),
         EntitySelector::Package { package } => Some(package.manifest.as_str().to_string()),
@@ -906,7 +906,7 @@ fn load_entity_classifications<'entity>(
 }
 
 /// Return whether one local file-bearing entity belongs to the selection.
-fn entity_matches_selection(
+pub(super) fn entity_matches_selection(
     entity: &GraphEntity,
     classifications: &BTreeMap<String, ContentClassification>,
     selection: ContentSelection,

--- a/docs/v050-cli-e2e-inventory.json
+++ b/docs/v050-cli-e2e-inventory.json
@@ -3,10 +3,10 @@
   "source_contract": {
     "normalization": "UTF-8 source with CRLF and CR normalized to LF; relative binary keys only; no absolute paths or line metadata",
     "files": {
-      "crates/projectatlas-cli/tests/e2e_delivery.rs": "4c72e4f5e9e51753fd7e74d87a202cc8b882e8b392f32c4d1b9271e3f378738a",
+      "crates/projectatlas-cli/tests/e2e_delivery.rs": "ef2a17540d305565bced95a68db61fbf17e089bcf60a05e9cb1a1be58f2eccf8",
       "crates/projectatlas-cli/tests/e2e_lifecycle.rs": "b2691058f2324abbccd250c9541ec762bf302f1f1e5f93f0455ece8729e5c21f",
       "crates/projectatlas-cli/tests/e2e_maintenance.rs": "0fca4b81eccb59fcb208b5c8a409cbf120ffc40f0f0b4d01dda5c582274ea0ec",
-      "crates/projectatlas-cli/tests/e2e_navigation.rs": "7be2d40d611935b8e9a5d420dcfd6cf94703011e601aa5f890467999ead9fb22",
+      "crates/projectatlas-cli/tests/e2e_navigation.rs": "27db9846d4cba4af8e5ee6c6bb077a019610b4fbbfa79f794565b0e8338eec64",
       "crates/projectatlas-cli/tests/e2e_worktrees.rs": "46609fba4c5930d24ff497638c294497e38a91eecdabd0a47191b6161a985ecd"
     }
   },
@@ -14,7 +14,7 @@
   "source": "crates/projectatlas-cli/tests/e2e.rs",
   "source_sha256_baseline": "e26c7b9d450b105e09c2259b243f95a1fddb26cd8b64e176379149ca8050b43c",
   "source_sha256_before_deletion": "942b802ab4c215f1742d2c41f35eb29654946da8e8372218e0d1a787cc3c4757",
-  "test_count": 193,
+  "test_count": 194,
   "symbol_count": 431,
   "binaries": {
     "e2e_lifecycle": "lifecycle and database contracts",
@@ -38,6 +38,13 @@
     },
     {
       "name": "composer_shaped_php_cli_mcp_and_incremental_refresh_agree",
+      "owner": "e2e_navigation",
+      "attributes": [
+        "#[test]"
+      ]
+    },
+    {
+      "name": "entrypoint_analysis_cli_and_mcp_share_profile_result_and_rejections",
       "owner": "e2e_navigation",
       "attributes": [
         "#[test]"

--- a/docs/v050-cli-e2e-inventory.json
+++ b/docs/v050-cli-e2e-inventory.json
@@ -3,7 +3,7 @@
   "source_contract": {
     "normalization": "UTF-8 source with CRLF and CR normalized to LF; relative binary keys only; no absolute paths or line metadata",
     "files": {
-      "crates/projectatlas-cli/tests/e2e_delivery.rs": "1e804fd630c69a4a8cdc3fdc17f21438b891b9acde855280a52f9f7c06c4afb0",
+      "crates/projectatlas-cli/tests/e2e_delivery.rs": "de155b4541c68a726519292644b489292742d5b26f774e3b4b17ea76569d0e82",
       "crates/projectatlas-cli/tests/e2e_lifecycle.rs": "b2691058f2324abbccd250c9541ec762bf302f1f1e5f93f0455ece8729e5c21f",
       "crates/projectatlas-cli/tests/e2e_maintenance.rs": "0fca4b81eccb59fcb208b5c8a409cbf120ffc40f0f0b4d01dda5c582274ea0ec",
       "crates/projectatlas-cli/tests/e2e_navigation.rs": "ebf6762b94065c955bf4526269917ee6516ec5722a79ec0d596faf3cef54169a",

--- a/docs/v050-cli-e2e-inventory.json
+++ b/docs/v050-cli-e2e-inventory.json
@@ -6,7 +6,7 @@
       "crates/projectatlas-cli/tests/e2e_delivery.rs": "1e804fd630c69a4a8cdc3fdc17f21438b891b9acde855280a52f9f7c06c4afb0",
       "crates/projectatlas-cli/tests/e2e_lifecycle.rs": "b2691058f2324abbccd250c9541ec762bf302f1f1e5f93f0455ece8729e5c21f",
       "crates/projectatlas-cli/tests/e2e_maintenance.rs": "0fca4b81eccb59fcb208b5c8a409cbf120ffc40f0f0b4d01dda5c582274ea0ec",
-      "crates/projectatlas-cli/tests/e2e_navigation.rs": "27db9846d4cba4af8e5ee6c6bb077a019610b4fbbfa79f794565b0e8338eec64",
+      "crates/projectatlas-cli/tests/e2e_navigation.rs": "ebf6762b94065c955bf4526269917ee6516ec5722a79ec0d596faf3cef54169a",
       "crates/projectatlas-cli/tests/e2e_worktrees.rs": "46609fba4c5930d24ff497638c294497e38a91eecdabd0a47191b6161a985ecd"
     }
   },

--- a/docs/v050-cli-e2e-inventory.json
+++ b/docs/v050-cli-e2e-inventory.json
@@ -3,7 +3,7 @@
   "source_contract": {
     "normalization": "UTF-8 source with CRLF and CR normalized to LF; relative binary keys only; no absolute paths or line metadata",
     "files": {
-      "crates/projectatlas-cli/tests/e2e_delivery.rs": "ef2a17540d305565bced95a68db61fbf17e089bcf60a05e9cb1a1be58f2eccf8",
+      "crates/projectatlas-cli/tests/e2e_delivery.rs": "1e804fd630c69a4a8cdc3fdc17f21438b891b9acde855280a52f9f7c06c4afb0",
       "crates/projectatlas-cli/tests/e2e_lifecycle.rs": "b2691058f2324abbccd250c9541ec762bf302f1f1e5f93f0455ece8729e5c21f",
       "crates/projectatlas-cli/tests/e2e_maintenance.rs": "0fca4b81eccb59fcb208b5c8a409cbf120ffc40f0f0b4d01dda5c582274ea0ec",
       "crates/projectatlas-cli/tests/e2e_navigation.rs": "27db9846d4cba4af8e5ee6c6bb077a019610b4fbbfa79f794565b0e8338eec64",

--- a/openspec/changes/complete-v050-release-readiness/tasks.md
+++ b/openspec/changes/complete-v050-release-readiness/tasks.md
@@ -42,10 +42,10 @@
 
 ## 7. Entrypoint-aware dead-code profiles (#384)
 
-- [ ] 7.1 Define the non-persistent typed `EntrypointProfile` request contract, exact file/symbol anchors, supported resolved relation families, profile/input/output bounds, graph-coverage prerequisites, cursor binding, and typed uncertainty; reuse existing graph storage and reject empty, stale, wrong-root, ambiguous, unsupported, or over-budget profiles before traversal.
-- [ ] 7.2 Extend the existing bounded analysis service with node-simple reachability from every accepted entrypoint and classify reachable, evidence-backed unreachable candidate, and inconclusive; adapters only decode/serialize the shared typed contract and never claim deletion safety.
-- [ ] 7.3 Cover reachable, unreachable, cyclic, disconnected, multi-entrypoint, duplicate/invalid anchor, dynamic uncertainty, incomplete relation coverage, stale generation/cursor, truncation, cancellation, wrong root, deterministic replay, CLI/MCP parity, and representative Rust/PHP repository tasks with exact source evidence.
-- [ ] 7.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
+- [x] 7.1 Define the non-persistent typed `EntrypointProfile` request contract, exact file/symbol anchors, supported resolved relation families, profile/input/output bounds, graph-coverage prerequisites, cursor binding, and typed uncertainty; reuse existing graph storage and reject empty, stale, wrong-root, ambiguous, unsupported, or over-budget profiles before traversal.
+- [x] 7.2 Extend the existing bounded analysis service with node-simple reachability from every accepted entrypoint and classify reachable, evidence-backed unreachable candidate, and inconclusive; adapters only decode/serialize the shared typed contract and never claim deletion safety.
+- [x] 7.3 Cover reachable, unreachable, cyclic, disconnected, multi-entrypoint, duplicate/invalid anchor, dynamic uncertainty, incomplete relation coverage, stale generation/cursor, truncation, cancellation, wrong root, deterministic replay, CLI/MCP parity, and representative Rust/PHP repository tasks with exact source evidence.
+- [x] 7.4 Review the final implementation against the architecture diagrams, update the diagrams or implementation until they agree, or reconfirm the reasoned N/A.
 
 ## 8. npm native distribution (#388)
 


### PR DESCRIPTION
## Problem
Agents need a bounded, typed reachability profile from explicit entrypoints. Generic graph neighborhoods can turn incomplete relation coverage into an unsafe dead-code conclusion.

## Change
- Add non-persistent `EntrypointProfile` analysis with exact file/symbol anchors, admitted relation families, graph-generation and coverage checks, and typed reachable, unreachable-candidate, or inconclusive results.
- Reuse the existing bounded graph service with node-simple traversal, shared budgets, deterministic replay, cancellation, and atomic output refusal.
- Expose the same contract through CLI and MCP, including wrong-root and unsupported-control rejection and representative Rust/PHP parity coverage.
- Keep frozen v0.4 MCP fixtures immutable while normalizing only the additive v0.5 `analysis_mode` description in current compatibility checks; synchronize source-contract digests.
- Align the release architecture diagram and CLI E2E inventory with the delivered boundary.

## Validation
- `cargo fmt --all -- --check`
- Focused entrypoint service, CLI/MCP parity, frozen MCP compatibility, and inventory contract tests
- Workspace pre-push hook: formatting, locked check/clippy/deny, strict strings, all workspace tests and docs, IssueOps, scan, and lint

Closes #384